### PR TITLE
fix(server): never let voice design cross a language or book boundary

### DIFF
--- a/server/src/routes/cast-design.ts
+++ b/server/src/routes/cast-design.ts
@@ -367,9 +367,17 @@ async function runDesignJob(
 
           if (!emotion) {
             /* Base path — persist the override exactly as the drawer does. Match
-               key is the character's voiceId/id, the name is the `qwen-…` id. */
+               key is the character's voiceId/id, the name is the `qwen-…` id.
+               fs-61 — pass job.bookId so a standalone (no seriesFilter) writes
+               ONLY this book instead of sweeping every book in the workspace
+               sharing the same bare character id (e.g. "narrator"). */
             const matchKey = character.voiceId ?? character.id;
-            await applyOverrideToCastFiles(matchKey, { engine: 'qwen', name: voiceId }, seriesFilter);
+            await applyOverrideToCastFiles(
+              matchKey,
+              { engine: 'qwen', name: voiceId },
+              seriesFilter,
+              job.bookId,
+            );
             job.done += 1;
             broadcast(job, { type: 'character_designed', characterId, voiceId });
           } else {

--- a/server/src/routes/cast-design.ts
+++ b/server/src/routes/cast-design.ts
@@ -368,7 +368,7 @@ async function runDesignJob(
           if (!emotion) {
             /* Base path — persist the override exactly as the drawer does. Match
                key is the character's voiceId/id, the name is the `qwen-…` id.
-               fs-61 — pass job.bookId so a standalone (no seriesFilter) writes
+               fs-61 — pass job.bookDir so a standalone (no seriesFilter) writes
                ONLY this book instead of sweeping every book in the workspace
                sharing the same bare character id (e.g. "narrator"). */
             const matchKey = character.voiceId ?? character.id;
@@ -376,7 +376,7 @@ async function runDesignJob(
               matchKey,
               { engine: 'qwen', name: voiceId },
               seriesFilter,
-              job.bookId,
+              job.bookDir,
             );
             job.done += 1;
             broadcast(job, { type: 'character_designed', characterId, voiceId });

--- a/server/src/routes/single-design.test.ts
+++ b/server/src/routes/single-design.test.ts
@@ -153,6 +153,7 @@ describe('single-design job — first design', () => {
       'c1', // matchKey = character.voiceId ?? character.id
       { engine: 'qwen', name: 'qwen-c1' },
       expect.anything(),
+      BOOK_ID, // fs-61 — book-scoped fallback when there's no seriesFilter
     );
   });
 });

--- a/server/src/routes/single-design.test.ts
+++ b/server/src/routes/single-design.test.ts
@@ -153,7 +153,7 @@ describe('single-design job — first design', () => {
       'c1', // matchKey = character.voiceId ?? character.id
       { engine: 'qwen', name: 'qwen-c1' },
       expect.anything(),
-      BOOK_ID, // fs-61 — book-scoped fallback when there's no seriesFilter
+      bookDir, // fs-61 — book-scoped fallback when there's no seriesFilter
     );
   });
 });

--- a/server/src/routes/single-design.ts
+++ b/server/src/routes/single-design.ts
@@ -170,7 +170,7 @@ async function runSingleDesign(
     }
 
     /* First design: auto-persist exactly as the bulk job does. fs-61 —
-       pass job.bookId so a standalone (no seriesFilter) writes ONLY this
+       pass job.bookDir so a standalone (no seriesFilter) writes ONLY this
        book instead of sweeping every book in the workspace sharing the
        same bare character id (e.g. "narrator"). */
     const matchKey = character.voiceId ?? character.id;
@@ -178,7 +178,7 @@ async function runSingleDesign(
       matchKey,
       { engine: 'qwen', name: voiceId },
       seriesFilter,
-      job.bookId,
+      job.bookDir,
     );
     endJob(job, {
       type: 'designed',

--- a/server/src/routes/single-design.ts
+++ b/server/src/routes/single-design.ts
@@ -169,9 +169,17 @@ async function runSingleDesign(
       return;
     }
 
-    /* First design: auto-persist exactly as the bulk job does. */
+    /* First design: auto-persist exactly as the bulk job does. fs-61 —
+       pass job.bookId so a standalone (no seriesFilter) writes ONLY this
+       book instead of sweeping every book in the workspace sharing the
+       same bare character id (e.g. "narrator"). */
     const matchKey = character.voiceId ?? character.id;
-    await applyOverrideToCastFiles(matchKey, { engine: 'qwen', name: voiceId }, seriesFilter);
+    await applyOverrideToCastFiles(
+      matchKey,
+      { engine: 'qwen', name: voiceId },
+      seriesFilter,
+      job.bookId,
+    );
     endJob(job, {
       type: 'designed',
       characterId: job.characterId,

--- a/server/src/routes/voice-match.test.ts
+++ b/server/src/routes/voice-match.test.ts
@@ -46,6 +46,7 @@ function writeBookOnDisk(
   bookId: string,
   cast: PriorCast['characters'],
   castConfirmed: boolean,
+  language?: string,
 ) {
   const bookDir = join(workspace, 'books', author, series, title);
   mkdirSync(join(bookDir, '.audiobook'), { recursive: true });
@@ -65,6 +66,7 @@ function writeBookOnDisk(
       coverGradient: ['#000', '#fff'],
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
+      ...(language ? { language } : {}),
     }),
   );
   writeFileSync(join(bookDir, 'manuscript.txt'), 'placeholder');
@@ -165,6 +167,21 @@ beforeAll(async () => {
     makeBookId('Derek Landy', 'Skulduggery Pleasant', 'Scepter of the Ancients'),
     [{ id: 'narrator', name: 'Narrator', voiceId: 'v_narr_skul', gender: 'neutral' }],
     true,
+  );
+
+  /* fs-61 — a same-author/same-series sibling designed in a different
+     language. A Qwen voice bakes its design language into the .pt, so it
+     must never surface as a candidate for the (English, default) current
+     book even though the name matches exactly. */
+  writeBookOnDisk(
+    workspaceRoot,
+    AUTHOR,
+    SERIES,
+    'Book Four Spanish',
+    makeBookId(AUTHOR, SERIES, 'Book Four Spanish'),
+    [{ id: 'marlow', name: 'Marlow', voiceId: 'v_marlow_es', gender: 'male', ageRange: 'teen' }],
+    true,
+    'es',
   );
 
   /* The current book being analysed — a real The Hollow Tide-series book on disk so the
@@ -428,5 +445,23 @@ describe('voice-match router', () => {
     expect(res.status).toBe(200);
     const voiceIds = res.body.matches[0].candidates.map((c: { voiceId: string }) => c.voiceId);
     expect(voiceIds.some((v: string) => v === 'v_marlow' || v === 'v_marlow_alt')).toBe(true);
+  });
+
+  /* fs-61 regression (2026-07-07): the per-language Coalfall demo books share
+     one author + the synthetic "Standalones" series, but even within a REAL
+     series a language-mismatched sibling must never surface as a candidate —
+     Qwen bakes its design language into the .pt, so reusing it reads the new
+     book's text in the wrong phoneme set (garbled audio). */
+  it('a same-series sibling in a DIFFERENT language never surfaces as a candidate', async () => {
+    const res = await callMatch(CURRENT_BOOK_ID, {
+      characters: [
+        { id: 'marlow', name: 'Marlow', attributes: [], gender: 'male', ageRange: 'teen' },
+      ],
+    });
+    expect(res.status).toBe(200);
+    const voiceIds = res.body.matches[0].candidates.map((c: { voiceId: string }) => c.voiceId);
+    expect(voiceIds).not.toContain('v_marlow_es');
+    /* Same-language siblings are unaffected. */
+    expect(voiceIds).toContain('v_marlow');
   });
 });

--- a/server/src/routes/voice-match.ts
+++ b/server/src/routes/voice-match.ts
@@ -32,7 +32,10 @@ import {
   scanLibraryCharacters,
   type LibraryCharacterRecord,
 } from '../workspace/library-cast-scan.js';
-import { scanSeriesCharactersForBookId } from '../workspace/series-cast-scan.js';
+import {
+  scanSeriesCharactersForBookId,
+  resolveBookLanguageForBookId,
+} from '../workspace/series-cast-scan.js';
 import { jaccard, nameTokens, normaliseForMatch } from '../util/text-match.js';
 
 export const voiceMatchRouter = Router();
@@ -294,6 +297,21 @@ voiceMatchRouter.post('/:bookId/voice-match', async (req: Request, res: Response
       (await scanSeriesCharactersForBookId(bookId)).map((r) => r.bookId),
     );
 
+    /* fs-61 — never auto-match across a language boundary. A Qwen voice
+       bakes its design language into the on-disk .pt, so reusing a voice
+       designed for a different-language book reads the new text in the
+       wrong phoneme set (garbled audio). This is a hard veto independent
+       of the same-series scoping above: two series-mates in different
+       languages must not silently share a voice. Computed once per request
+       (not per character) since it depends only on the candidate bookId. */
+    const currentBookLanguage = await resolveBookLanguageForBookId(bookId);
+    const sameLanguageBookIds = new Set<string>();
+    for (const mateBookId of seriesMateBookIds) {
+      if ((await resolveBookLanguageForBookId(mateBookId)) === currentBookLanguage) {
+        sameLanguageBookIds.add(mateBookId);
+      }
+    }
+
     const matches = characters.map((c) => {
       const scored: Candidate[] = [];
       for (const v of voices) {
@@ -304,7 +322,7 @@ voiceMatchRouter.post('/:bookId/voice-match', async (req: Request, res: Response
            "Pell Hollis" claiming Della Renwick's "Pell"). Cross-series reuse
            stays available as an explicit Voice-library assignment; it is never
            a silent auto-match. */
-        if (!seriesMateBookIds.has(v.bookId)) continue;
+        if (!sameLanguageBookIds.has(v.bookId)) continue;
         const cand = scoreOne(c, v);
         if (cand) scored.push(cand);
       }

--- a/server/src/routes/voices.test.ts
+++ b/server/src/routes/voices.test.ts
@@ -33,6 +33,9 @@ let applyTierToCastFiles: (
   ttsModelKey: 'qwen3-tts-1.7b' | null,
   seriesFilter?: { author: string; series: string },
 ) => Promise<number>;
+let applyOverrideToCastFiles: typeof import('./voices.js').applyOverrideToCastFiles;
+let standaloneA: { bookId: string };
+let standaloneB: { bookId: string };
 
 function writeBookOnDisk(
   workspace: string,
@@ -79,12 +82,17 @@ beforeAll(async () => {
   workspaceRoot = mkdtempSync(join(tmpdir(), 'audiobook-voices-test-'));
   process.env.WORKSPACE_DIR = workspaceRoot;
 
-  const [{ voicesRouter, applyTierToCastFiles: atcf }, paths, baseVoices] = await Promise.all([
+  const [
+    { voicesRouter, applyTierToCastFiles: atcf, applyOverrideToCastFiles: aotcf },
+    paths,
+    baseVoices,
+  ] = await Promise.all([
     import('./voices.js'),
     import('../workspace/paths.js'),
     import('../tts/base-voices.js'),
   ]);
   applyTierToCastFiles = atcf;
+  applyOverrideToCastFiles = aotcf;
   invalidateBaseVoiceCache = baseVoices.invalidateBaseVoiceCache;
   bookOneId = paths.makeBookId(AUTHOR, SERIES, BOOK_ONE);
   bookTwoId = paths.makeBookId(AUTHOR, SERIES, BOOK_TWO);
@@ -143,6 +151,35 @@ beforeAll(async () => {
       },
     ],
   );
+
+  /* fs-61 — two UNRELATED standalone books that both happen to use the bare
+     id "narrator" (no explicit voiceId — the common case for a fresh,
+     undesigned character). Every standalone shares the same synthetic
+     (author, series) = ("Castwright", "Standalones") pair, so a caller with
+     no seriesFilter must scope to exactly one bookId — otherwise designing
+     "narrator" in one book silently overwrites the other's. */
+  const standaloneABookId = paths.makeBookId('Castwright', 'Standalones', 'Standalone A');
+  const standaloneBBookId = paths.makeBookId('Castwright', 'Standalones', 'Standalone B');
+  writeBookOnDisk(
+    workspaceRoot,
+    'Castwright',
+    'Standalones',
+    'Standalone A',
+    standaloneABookId,
+    [{ id: 'narrator', name: 'Narrator', ttsEngine: 'qwen' }],
+    true,
+  );
+  writeBookOnDisk(
+    workspaceRoot,
+    'Castwright',
+    'Standalones',
+    'Standalone B',
+    standaloneBBookId,
+    [{ id: 'narrator', name: 'Narrator', ttsEngine: 'qwen' }],
+    true,
+  );
+  standaloneA = { bookId: standaloneABookId };
+  standaloneB = { bookId: standaloneBBookId };
 
   app = express();
   app.use(express.json());
@@ -1207,5 +1244,65 @@ describe('applyTierToCastFiles', () => {
     await applyTierToCastFiles('v_brann', 'qwen3-tts-1.7b', { author: AUTHOR, series: SERIES });
     const other = readCastFromDisk(workspaceRoot, AUTHOR, OTHER_SERIES, OTHER_BOOK);
     expect(other.characters[0].ttsModelKey).toBeUndefined();
+  });
+});
+
+/* fs-61 regression (2026-07-07): designing a character's voice in a
+   standalone book computes no seriesFilter (a standalone has no series
+   continuity) — before this fix, `applyOverrideToCastFiles` fell through to
+   its workspace-wide walk, matching on the character's bare id ("narrator")
+   and silently overwriting every OTHER standalone book's same-id character
+   too, including a different-language one (a Qwen voice bakes its design
+   language into the .pt, so this produced garbled audio). The design-flow
+   callers (single-design.ts, cast-design.ts) now pass the calling book's id
+   so the write stays scoped to exactly that book. */
+describe('applyOverrideToCastFiles — standalone book-scoping (fs-61)', () => {
+  afterEach(async () => {
+    /* Reset both standalones' narrator override between cases. */
+    await applyOverrideToCastFiles('narrator', null, undefined, standaloneA.bookId);
+    await applyOverrideToCastFiles('narrator', null, undefined, standaloneB.bookId);
+  });
+
+  it('with no seriesFilter but an onlyBookId, touches only that book', async () => {
+    const n = await applyOverrideToCastFiles(
+      'narrator',
+      { engine: 'qwen', name: 'qwen-standalone-a-voice' },
+      undefined,
+      standaloneA.bookId,
+    );
+    expect(n).toBe(1);
+
+    const a = readCastFromDisk(workspaceRoot, 'Castwright', 'Standalones', 'Standalone A');
+    expect(
+      (a.characters[0].overrideTtsVoices as { qwen?: { name?: string } } | undefined)?.qwen?.name,
+    ).toBe('qwen-standalone-a-voice');
+
+    /* The sibling standalone — same bare id "narrator", unrelated book —
+       must be untouched. This is the exact regression: before the fix this
+       would also read 'qwen-standalone-a-voice'. */
+    const b = readCastFromDisk(workspaceRoot, 'Castwright', 'Standalones', 'Standalone B');
+    expect(b.characters[0].overrideTtsVoices).toBeUndefined();
+  });
+
+  it('with neither seriesFilter nor onlyBookId, still sweeps the whole workspace (unchanged default)', async () => {
+    const n = await applyOverrideToCastFiles('narrator', {
+      engine: 'qwen',
+      name: 'qwen-workspace-wide',
+    });
+    /* Both standalones share the bare id "narrator" — the explicit,
+       genuinely-global scope (only used by PUT /:voiceId/override's
+       'workspace' scope) still matches every one, deliberately. (Other
+       unrelated fixtures elsewhere in this file also use the bare id
+       "narrator" and share this workspace, so `n` counts more than just
+       our two — assert our two specifically, not the total.) */
+    expect(n).toBeGreaterThanOrEqual(2);
+    const a = readCastFromDisk(workspaceRoot, 'Castwright', 'Standalones', 'Standalone A');
+    const b = readCastFromDisk(workspaceRoot, 'Castwright', 'Standalones', 'Standalone B');
+    expect(
+      (a.characters[0].overrideTtsVoices as { qwen?: { name?: string } } | undefined)?.qwen?.name,
+    ).toBe('qwen-workspace-wide');
+    expect(
+      (b.characters[0].overrideTtsVoices as { qwen?: { name?: string } } | undefined)?.qwen?.name,
+    ).toBe('qwen-workspace-wide');
   });
 });

--- a/server/src/routes/voices.test.ts
+++ b/server/src/routes/voices.test.ts
@@ -34,8 +34,8 @@ let applyTierToCastFiles: (
   seriesFilter?: { author: string; series: string },
 ) => Promise<number>;
 let applyOverrideToCastFiles: typeof import('./voices.js').applyOverrideToCastFiles;
-let standaloneA: { bookId: string };
-let standaloneB: { bookId: string };
+let standaloneA: { bookDir: string };
+let standaloneB: { bookDir: string };
 
 function writeBookOnDisk(
   workspace: string,
@@ -156,8 +156,8 @@ beforeAll(async () => {
      id "narrator" (no explicit voiceId — the common case for a fresh,
      undesigned character). Every standalone shares the same synthetic
      (author, series) = ("Castwright", "Standalones") pair, so a caller with
-     no seriesFilter must scope to exactly one bookId — otherwise designing
-     "narrator" in one book silently overwrites the other's. */
+     no seriesFilter must scope to exactly one book directory — otherwise
+     designing "narrator" in one book silently overwrites the other's. */
   const standaloneABookId = paths.makeBookId('Castwright', 'Standalones', 'Standalone A');
   const standaloneBBookId = paths.makeBookId('Castwright', 'Standalones', 'Standalone B');
   writeBookOnDisk(
@@ -178,8 +178,8 @@ beforeAll(async () => {
     [{ id: 'narrator', name: 'Narrator', ttsEngine: 'qwen' }],
     true,
   );
-  standaloneA = { bookId: standaloneABookId };
-  standaloneB = { bookId: standaloneBBookId };
+  standaloneA = { bookDir: join(workspaceRoot, 'books', 'Castwright', 'Standalones', 'Standalone A') };
+  standaloneB = { bookDir: join(workspaceRoot, 'books', 'Castwright', 'Standalones', 'Standalone B') };
 
   app = express();
   app.use(express.json());
@@ -1254,21 +1254,22 @@ describe('applyTierToCastFiles', () => {
    and silently overwriting every OTHER standalone book's same-id character
    too, including a different-language one (a Qwen voice bakes its design
    language into the .pt, so this produced garbled audio). The design-flow
-   callers (single-design.ts, cast-design.ts) now pass the calling book's id
-   so the write stays scoped to exactly that book. */
+   callers (single-design.ts, cast-design.ts) now pass the calling book's
+   directory so the write stays scoped to exactly that book (and skips the
+   workspace walk entirely). */
 describe('applyOverrideToCastFiles — standalone book-scoping (fs-61)', () => {
   afterEach(async () => {
     /* Reset both standalones' narrator override between cases. */
-    await applyOverrideToCastFiles('narrator', null, undefined, standaloneA.bookId);
-    await applyOverrideToCastFiles('narrator', null, undefined, standaloneB.bookId);
+    await applyOverrideToCastFiles('narrator', null, undefined, standaloneA.bookDir);
+    await applyOverrideToCastFiles('narrator', null, undefined, standaloneB.bookDir);
   });
 
-  it('with no seriesFilter but an onlyBookId, touches only that book', async () => {
+  it('with no seriesFilter but an onlyBookDir, touches only that book', async () => {
     const n = await applyOverrideToCastFiles(
       'narrator',
       { engine: 'qwen', name: 'qwen-standalone-a-voice' },
       undefined,
-      standaloneA.bookId,
+      standaloneA.bookDir,
     );
     expect(n).toBe(1);
 
@@ -1284,7 +1285,7 @@ describe('applyOverrideToCastFiles — standalone book-scoping (fs-61)', () => {
     expect(b.characters[0].overrideTtsVoices).toBeUndefined();
   });
 
-  it('with neither seriesFilter nor onlyBookId, still sweeps the whole workspace (unchanged default)', async () => {
+  it('with neither seriesFilter nor onlyBookDir, still sweeps the whole workspace (unchanged default)', async () => {
     const n = await applyOverrideToCastFiles('narrator', {
       engine: 'qwen',
       name: 'qwen-workspace-wide',

--- a/server/src/routes/voices.ts
+++ b/server/src/routes/voices.ts
@@ -653,16 +653,35 @@ export async function forEachMatchingCastCharacter(
   voiceId: string,
   seriesFilter: { author: string; series: string } | undefined,
   mutate: (character: CastCharacter) => CastCharacter,
-  /* fs-61 — when `seriesFilter` is absent, restrict the walk to exactly this
-     bookId instead of the whole workspace. Every standalone book resolves to
-     the same synthetic (author: X, series: "Standalones") pair, so a caller
-     with "this book has no series" (isStandalone → seriesFilter omitted)
-     must NOT fall through to a workspace-wide match on a bare character id
-     like "narrator" — that silently overwrites the SAME id in every other
-     unrelated (or different-language) standalone book. Omit only for the
-     genuinely-global PUT /:voiceId/override 'workspace' scope. */
-  onlyBookId?: string,
+  /* fs-61 — when `seriesFilter` is absent, restrict the write to exactly this
+     book's directory instead of the whole workspace. Every standalone book
+     resolves to the same synthetic (author: X, series: "Standalones") pair,
+     so a caller with "this book has no series" (isStandalone → seriesFilter
+     omitted) must NOT fall through to a workspace-wide match on a bare
+     character id like "narrator" — that silently overwrites the SAME id in
+     every other unrelated (or different-language) standalone book. Taking
+     the directory (not just a bookId) lets this skip the workspace walk
+     entirely — the caller already has it in hand (job.bookDir) for every
+     real call site. Omit only for the genuinely-global
+     PUT /:voiceId/override 'workspace' scope. */
+  onlyBookDir?: string,
 ): Promise<number> {
+  if (!seriesFilter && onlyBookDir) {
+    const cast = await readJson<CastJson>(castJsonPath(onlyBookDir));
+    if (!cast?.characters?.length) return 0;
+    let updated = 0;
+    let dirty = false;
+    for (let i = 0; i < cast.characters.length; i++) {
+      const original = cast.characters[i];
+      const id = original.voiceId ?? original.id;
+      if (id !== voiceId) continue;
+      cast.characters[i] = mutate(original);
+      dirty = true;
+      updated += 1;
+    }
+    if (dirty) await writeJsonAtomic(castJsonPath(onlyBookDir), cast);
+    return updated;
+  }
   let updated = 0;
   for (const authorName of listDirs(BOOKS_ROOT)) {
     for (const seriesName of listDirs(join(BOOKS_ROOT, authorName))) {
@@ -674,8 +693,6 @@ export async function forEachMatchingCastCharacter(
           if (state.isStandalone === true) continue;
           if (state.author !== seriesFilter.author || state.series !== seriesFilter.series)
             continue;
-        } else if (onlyBookId) {
-          if (state.bookId !== onlyBookId) continue;
         }
         const cast = await readJson<CastJson>(castJsonPath(bookDir));
         if (!cast?.characters?.length) continue;
@@ -719,12 +736,12 @@ export async function applyOverrideToCastFiles(
      excluded from a series scope (a standalone's cast isn't series
      continuity). Omit for the original workspace-wide behaviour. */
   seriesFilter?: { author: string; series: string },
-  /* fs-61 — pass the calling book's id when `seriesFilter` is omitted
+  /* fs-61 — pass the calling book's directory when `seriesFilter` is omitted
      because the book has no series (e.g. a standalone design action), so
      the write stays book-scoped instead of sweeping every book in the
      workspace sharing the same bare character id. Only the genuinely-global
      PUT /:voiceId/override 'workspace' scope should omit both. */
-  onlyBookId?: string,
+  onlyBookDir?: string,
 ): Promise<number> {
   const updated = await forEachMatchingCastCharacter(
     voiceId,
@@ -755,7 +772,7 @@ export async function applyOverrideToCastFiles(
       delete replacement.overrideTtsVoice;
       return replacement;
     },
-    onlyBookId,
+    onlyBookDir,
   );
   /* Override changes don't affect the base-voice catalog itself, but call
      this anyway so a future invocation refreshes /speakers cleanly if the

--- a/server/src/routes/voices.ts
+++ b/server/src/routes/voices.ts
@@ -653,6 +653,15 @@ export async function forEachMatchingCastCharacter(
   voiceId: string,
   seriesFilter: { author: string; series: string } | undefined,
   mutate: (character: CastCharacter) => CastCharacter,
+  /* fs-61 — when `seriesFilter` is absent, restrict the walk to exactly this
+     bookId instead of the whole workspace. Every standalone book resolves to
+     the same synthetic (author: X, series: "Standalones") pair, so a caller
+     with "this book has no series" (isStandalone → seriesFilter omitted)
+     must NOT fall through to a workspace-wide match on a bare character id
+     like "narrator" — that silently overwrites the SAME id in every other
+     unrelated (or different-language) standalone book. Omit only for the
+     genuinely-global PUT /:voiceId/override 'workspace' scope. */
+  onlyBookId?: string,
 ): Promise<number> {
   let updated = 0;
   for (const authorName of listDirs(BOOKS_ROOT)) {
@@ -665,6 +674,8 @@ export async function forEachMatchingCastCharacter(
           if (state.isStandalone === true) continue;
           if (state.author !== seriesFilter.author || state.series !== seriesFilter.series)
             continue;
+        } else if (onlyBookId) {
+          if (state.bookId !== onlyBookId) continue;
         }
         const cast = await readJson<CastJson>(castJsonPath(bookDir));
         if (!cast?.characters?.length) continue;
@@ -708,33 +719,44 @@ export async function applyOverrideToCastFiles(
      excluded from a series scope (a standalone's cast isn't series
      continuity). Omit for the original workspace-wide behaviour. */
   seriesFilter?: { author: string; series: string },
+  /* fs-61 — pass the calling book's id when `seriesFilter` is omitted
+     because the book has no series (e.g. a standalone design action), so
+     the write stays book-scoped instead of sweeping every book in the
+     workspace sharing the same bare character id. Only the genuinely-global
+     PUT /:voiceId/override 'workspace' scope should omit both. */
+  onlyBookId?: string,
 ): Promise<number> {
-  const updated = await forEachMatchingCastCharacter(voiceId, seriesFilter, (original) => {
-    const normalised = normaliseCastCharacter(original);
-    const replacement: CastCharacter = { ...normalised };
-    if (override === null) {
-      delete replacement.overrideTtsVoices;
-    } else {
-      const map = { ...(normalised.overrideTtsVoices ?? {}) };
-      /* Preserve any existing slot detail (notably qwen emotion `variants`)
-         when (re)assigning the base name — a base re-design, or its series
-         propagation, must NOT wipe designed variants. */
-      map[override.engine] = { ...(map[override.engine] ?? {}), name: override.name };
-      replacement.overrideTtsVoices = map;
-      /* Setting a per-engine voice override is a deliberate "use this
-         engine for this character" action (the only callers — the cast
-         picker + the series rebaseline — only write when switching the
-         character TO that engine). Pin `ttsEngine` so the switch
-         propagates across the series: otherwise other books get the
-         voice slot but keep the wrong active engine (plan 108 — "wrong
-         model in this book"). */
-      replacement.ttsEngine = override.engine;
-    }
-    /* Always remove the legacy singular field — normaliseCastCharacter
-       already folded it into the map. */
-    delete replacement.overrideTtsVoice;
-    return replacement;
-  });
+  const updated = await forEachMatchingCastCharacter(
+    voiceId,
+    seriesFilter,
+    (original) => {
+      const normalised = normaliseCastCharacter(original);
+      const replacement: CastCharacter = { ...normalised };
+      if (override === null) {
+        delete replacement.overrideTtsVoices;
+      } else {
+        const map = { ...(normalised.overrideTtsVoices ?? {}) };
+        /* Preserve any existing slot detail (notably qwen emotion `variants`)
+           when (re)assigning the base name — a base re-design, or its series
+           propagation, must NOT wipe designed variants. */
+        map[override.engine] = { ...(map[override.engine] ?? {}), name: override.name };
+        replacement.overrideTtsVoices = map;
+        /* Setting a per-engine voice override is a deliberate "use this
+           engine for this character" action (the only callers — the cast
+           picker + the series rebaseline — only write when switching the
+           character TO that engine). Pin `ttsEngine` so the switch
+           propagates across the series: otherwise other books get the
+           voice slot but keep the wrong active engine (plan 108 — "wrong
+           model in this book"). */
+        replacement.ttsEngine = override.engine;
+      }
+      /* Always remove the legacy singular field — normaliseCastCharacter
+         already folded it into the map. */
+      delete replacement.overrideTtsVoice;
+      return replacement;
+    },
+    onlyBookId,
+  );
   /* Override changes don't affect the base-voice catalog itself, but call
      this anyway so a future invocation refreshes /speakers cleanly if the
      sidecar was bounced in between. Cheap and side-effect free. */

--- a/server/src/workspace/series-cast-scan.ts
+++ b/server/src/workspace/series-cast-scan.ts
@@ -20,6 +20,7 @@ import { BOOKS_ROOT, stateJsonPath } from './paths.js';
 import { join } from 'node:path';
 import { readJson } from './state-io.js';
 import type { BookStateJson } from './scan.js';
+import { bookStateLanguage } from './scan.js';
 
 export interface ScanSeriesOptions {
   /** Optional bookId to exclude from the scan (the book about to use
@@ -39,9 +40,7 @@ export interface ScanSeriesOptions {
    book whose state.json was just written but state.castConfirmed is
    still false — already excluded by scanLibraryCharacters but caller
    may still pass us its bookId). */
-export async function findAuthorSeriesForBookId(
-  targetBookId: string,
-): Promise<{ author: string; series: string } | null> {
+async function findBookStateForBookId(targetBookId: string): Promise<BookStateJson | null> {
   const { existsSync, readdirSync } = await import('node:fs');
   if (!existsSync(BOOKS_ROOT)) return null;
   const authors = readdirSync(BOOKS_ROOT, { withFileTypes: true })
@@ -59,13 +58,42 @@ export async function findAuthorSeriesForBookId(
         const state = await readJson<BookStateJson>(
           stateJsonPath(join(BOOKS_ROOT, authorName, seriesName, titleName)),
         );
-        if (state?.bookId === targetBookId) {
-          return { author: state.author, series: state.series };
-        }
+        if (state?.bookId === targetBookId) return state;
       }
     }
   }
   return null;
+}
+
+export async function findAuthorSeriesForBookId(
+  targetBookId: string,
+): Promise<{ author: string; series: string } | null> {
+  const state = await findBookStateForBookId(targetBookId);
+  return state ? { author: state.author, series: state.series } : null;
+}
+
+/** Whether a book is a standalone (`state.isStandalone === true`). Every
+    standalone book is filed under the same synthetic `series: "Standalones"`
+    folder name, so an (author, series) match alone does NOT prove two
+    standalones share continuity — callers that reuse voices/links across
+    books (series-reuse-link.ts) must additionally exclude standalone targets,
+    the same way scanSeriesCharacters already does for the roster-scan path.
+    Returns `false` for an unresolvable bookId (conservative: don't block a
+    link on a scan failure). */
+export async function isStandaloneBookId(targetBookId: string): Promise<boolean> {
+  const state = await findBookStateForBookId(targetBookId);
+  return state?.isStandalone === true;
+}
+
+/** A book's normalised BCP-47 language (fs-2's `bookStateLanguage`, default
+    `'en'`). Used to veto cross-language voice reuse: a Qwen voice bakes its
+    design language into the on-disk .pt, so matching a character to a
+    voice from a different-language book produces garbled audio (fs-61).
+    Returns `'en'` for an unresolvable bookId — the same conservative
+    default `bookStateLanguage` applies to a book with no `language` field. */
+export async function resolveBookLanguageForBookId(targetBookId: string): Promise<string> {
+  const state = await findBookStateForBookId(targetBookId);
+  return state ? bookStateLanguage(state) : 'en';
 }
 
 /* Filter scanLibraryCharacters to a single (author, series) slice.

--- a/server/src/workspace/series-reuse-link.test.ts
+++ b/server/src/workspace/series-reuse-link.test.ts
@@ -247,6 +247,40 @@ describe('linkSeriesReuseAtAnalysis (plan 126 Facet A)', () => {
     expect(characters[0].matchedFrom).toBeUndefined();
   });
 
+  /* fs-61 regression (2026-07-07): the per-language Coalfall demo books all
+     share `author: "Castwright"` + the synthetic `series: "Standalones"`
+     folder name, so an (author, series) match alone treated them as series-
+     mates — auto-linking a Spanish/Russian character to the English book's
+     Qwen voice. Qwen bakes its design language into the .pt, so the reused
+     voice read the wrong language (garbled audio). isStandaloneBookId must
+     veto the link even when author+series otherwise match. */
+  it('never links between two standalones sharing the synthetic "Standalones" series', async () => {
+    const characters: LinkableCharacter[] = [
+      { id: 'wren-new', name: 'Wren', gender: 'female', ageRange: 'teen' },
+    ];
+    const linked = await linkSeriesReuseAtAnalysis(BOOK2, characters, {
+      ...baseOptions(),
+      isStandaloneBookId: async () => true,
+    });
+    expect(linked).toBe(0);
+    expect(characters[0].matchedFrom).toBeUndefined();
+  });
+
+  /* fs-61 defense-in-depth: a language mismatch vetoes a link even between
+     two REAL (non-standalone) series-mates — Qwen bakes its design language
+     into the .pt, so this must never depend solely on the standalone check. */
+  it('never links across a language boundary, even within a real series', async () => {
+    const characters: LinkableCharacter[] = [
+      { id: 'wren-new', name: 'Wren', gender: 'female', ageRange: 'teen' },
+    ];
+    const linked = await linkSeriesReuseAtAnalysis(BOOK2, characters, {
+      ...baseOptions(),
+      resolveBookLanguage: async (id) => (id === BOOK1 ? 'en' : 'es'),
+    });
+    expect(linked).toBe(0);
+    expect(characters[0].matchedFrom).toBeUndefined();
+  });
+
   /* srv-13 — the fresh analyzer roster carries NO notLinkedTo, so without the
      pre-seed the link pass re-links a pair the user separated on a prior run.
      Seeding the guard fields from the prior cast first must prevent that. */
@@ -422,6 +456,60 @@ describe('pruneStaleReuseLinks', () => {
   it('is a no-op when there are no links to check', async () => {
     const chars: LinkableCharacter[] = [{ id: 'oduvan', name: 'Oduvan', voiceState: 'generated' }];
     expect(await pruneStaleReuseLinks(COALFALL, chars, opts())).toBe(0);
+  });
+
+  /* fs-61 regression (2026-07-07): two DIFFERENT standalone books (e.g. the
+     English and Spanish Coalfall demo books) both resolve to the same
+     (author: "Castwright", series: "Standalones") pair — that placeholder
+     match must never count as "same series" continuity. Without the
+     isStandaloneBookId veto, this stale link would be KEPT (sameSeries
+     would be true) instead of dropped. */
+  it('drops a stale link between two standalones sharing the synthetic series', async () => {
+    const SIBLING = 'castwright__standalones__el-encargo-de-coalfall';
+    const chars: LinkableCharacter[] = [
+      {
+        id: 'narrator',
+        name: 'Narrador',
+        voiceState: 'reused',
+        ttsEngine: 'qwen',
+        overrideTtsVoices: { qwen: { name: 'qwen-narrator' } },
+        matchedFrom: {
+          bookId: SIBLING,
+          characterId: 'narrator',
+          bookTitle: 'El Encargo de Coalfall',
+          confidence: 1,
+        },
+      },
+    ];
+    const dropped = await pruneStaleReuseLinks(COALFALL, chars, {
+      ...opts(),
+      resolveAuthorSeries: async (id) =>
+        id === SIBLING ? { author: 'Castwright', series: 'Standalones' } : (META[id] ?? null),
+      isStandaloneBookId: async (id) => id === COALFALL || id === SIBLING,
+    });
+    expect(dropped).toBe(1);
+    expect(chars[0].matchedFrom).toBeFalsy();
+    expect(chars[0].voiceState).toBe('generated');
+  });
+
+  /* fs-61 defense-in-depth: a stale link across a language boundary must be
+     dropped even between two real (non-standalone) same-series books — the
+     language veto is independent of the standalone/author/series checks. */
+  it('drops a stale link across a language boundary within a real series', async () => {
+    const chars: LinkableCharacter[] = [
+      {
+        id: 'wren',
+        name: 'Wren',
+        voiceState: 'reused',
+        matchedFrom: { bookId: KEEPER1, characterId: 'wren', bookTitle: 'Book One', confidence: 1 },
+      },
+    ];
+    const dropped = await pruneStaleReuseLinks(KEEPER2, chars, {
+      ...opts(),
+      resolveBookLanguage: async (id) => (id === KEEPER1 ? 'fr' : 'en'),
+    });
+    expect(dropped).toBe(1);
+    expect(chars[0].matchedFrom).toBeFalsy();
   });
 });
 

--- a/server/src/workspace/series-reuse-link.ts
+++ b/server/src/workspace/series-reuse-link.ts
@@ -43,6 +43,25 @@ import { resolveReusedVoiceFields, type CastLoader } from '../tts/hydrate-reused
 import { createWorkspaceCastLoader } from '../tts/hydrate-reused-voice-workspace.js';
 import type { TtsEngine } from '../tts/index.js';
 
+/* Memoize a per-bookId async lookup within one linkSeriesReuseAtAnalysis /
+   pruneStaleReuseLinks call. Each of resolveAuthorSeries/isStandaloneBookId/
+   resolveBookLanguageForBookId re-walks the ENTIRE workspace tree to find one
+   bookId's state.json (see findBookStateForBookId in series-cast-scan.ts) —
+   with many characters sharing the same bookId (a typical book has a dozen),
+   calling all three per character multiplied that walk 3x per character
+   instead of once per distinct book. */
+function memoizeAsync<T>(fn: (bookId: string) => Promise<T>): (bookId: string) => Promise<T> {
+  const cache = new Map<string, Promise<T>>();
+  return (bookId: string) => {
+    let cached = cache.get(bookId);
+    if (!cached) {
+      cached = fn(bookId);
+      cache.set(bookId, cached);
+    }
+    return cached;
+  };
+}
+
 const SKIP_IDS = new Set(['unknown-male', 'unknown-female']);
 
 /** The reuse-relevant slice of a freshly-detected character. Kept structural
@@ -204,9 +223,11 @@ export async function pruneStaleReuseLinks(
   const linked = characters.filter((c) => c.matchedFrom?.bookId);
   if (linked.length === 0) return 0;
 
-  const resolveAuthorSeries = options.resolveAuthorSeries ?? findAuthorSeriesForBookId;
-  const isStandalone = options.isStandaloneBookId ?? isStandaloneBookId;
-  const resolveBookLanguage = options.resolveBookLanguage ?? resolveBookLanguageForBookId;
+  const resolveAuthorSeries = memoizeAsync(options.resolveAuthorSeries ?? findAuthorSeriesForBookId);
+  const isStandalone = memoizeAsync(options.isStandaloneBookId ?? isStandaloneBookId);
+  const resolveBookLanguage = memoizeAsync(
+    options.resolveBookLanguage ?? resolveBookLanguageForBookId,
+  );
   const meta = await resolveAuthorSeries(bookId);
   if (!meta) return 0; // can't resolve the current book — don't guess
   const myLanguage = await resolveBookLanguage(bookId);
@@ -248,9 +269,11 @@ export async function linkSeriesReuseAtAnalysis(
 ): Promise<number> {
   if (!bookId || characters.length === 0) return 0;
 
-  const resolveAuthorSeries = options.resolveAuthorSeries ?? findAuthorSeriesForBookId;
-  const isStandalone = options.isStandaloneBookId ?? isStandaloneBookId;
-  const resolveBookLanguage = options.resolveBookLanguage ?? resolveBookLanguageForBookId;
+  const resolveAuthorSeries = memoizeAsync(options.resolveAuthorSeries ?? findAuthorSeriesForBookId);
+  const isStandalone = memoizeAsync(options.isStandaloneBookId ?? isStandaloneBookId);
+  const resolveBookLanguage = memoizeAsync(
+    options.resolveBookLanguage ?? resolveBookLanguageForBookId,
+  );
   const meta = await resolveAuthorSeries(bookId);
   if (!meta) return 0; // not in library / standalone resolves elsewhere
   const myLanguage = await resolveBookLanguage(bookId);

--- a/server/src/workspace/series-reuse-link.ts
+++ b/server/src/workspace/series-reuse-link.ts
@@ -28,7 +28,11 @@
 
    Additive: the client `applyVoiceMatches` path stays as a fallback. */
 
-import { findAuthorSeriesForBookId } from './series-cast-scan.js';
+import {
+  findAuthorSeriesForBookId,
+  isStandaloneBookId,
+  resolveBookLanguageForBookId,
+} from './series-cast-scan.js';
 import { scanLibraryCharacters, type LibraryCharacterRecord } from './library-cast-scan.js';
 import { BOOKS_ROOT, stateJsonPath } from './paths.js';
 import { join } from 'node:path';
@@ -151,6 +155,17 @@ export interface LinkSeriesReuseOptions {
   ) => Promise<{ author: string; series: string } | null>;
   positions?: () => Promise<Map<string, number | null>>;
   castLoader?: CastLoader;
+  /** Whether a bookId is a standalone (`state.isStandalone === true`) — every
+      standalone shares the synthetic `series: "Standalones"` folder name, so
+      an (author, series) match alone must never be treated as proof of
+      continuity between two standalones. Defaults to the real workspace
+      check (`isStandaloneBookId`). */
+  isStandaloneBookId?: (bookId: string) => Promise<boolean>;
+  /** A book's normalised language — defaults to `resolveBookLanguageForBookId`.
+      A Qwen voice bakes its design language into the .pt, so a cross-language
+      reuse produces garbled audio; every link/prune check vetoes a language
+      mismatch regardless of what the author/series/standalone checks say. */
+  resolveBookLanguage?: (bookId: string) => Promise<string>;
 }
 
 /* Revert a stale-linked character. A pure reuse row's voice was denormalised
@@ -190,8 +205,11 @@ export async function pruneStaleReuseLinks(
   if (linked.length === 0) return 0;
 
   const resolveAuthorSeries = options.resolveAuthorSeries ?? findAuthorSeriesForBookId;
+  const isStandalone = options.isStandaloneBookId ?? isStandaloneBookId;
+  const resolveBookLanguage = options.resolveBookLanguage ?? resolveBookLanguageForBookId;
   const meta = await resolveAuthorSeries(bookId);
   if (!meta) return 0; // can't resolve the current book — don't guess
+  const myLanguage = await resolveBookLanguage(bookId);
 
   const positions = await (options.positions ?? seriesPositionByBookId)();
   const myPos = positions.get(bookId) ?? null;
@@ -201,7 +219,11 @@ export async function pruneStaleReuseLinks(
     const targetBookId = c.matchedFrom!.bookId!;
     const targetMeta = await resolveAuthorSeries(targetBookId);
     const sameSeries =
-      !!targetMeta && targetMeta.author === meta.author && targetMeta.series === meta.series;
+      !!targetMeta &&
+      targetMeta.author === meta.author &&
+      targetMeta.series === meta.series &&
+      !(await isStandalone(targetBookId)) &&
+      (await resolveBookLanguage(targetBookId)) === myLanguage;
     /* Earlier-only guard mirrors the linker: a same-series link is valid only
        when the target is a strictly-lower position. Unknown positions can't
        prove "earlier", so they're treated as acceptable (conservative keep). */
@@ -227,8 +249,11 @@ export async function linkSeriesReuseAtAnalysis(
   if (!bookId || characters.length === 0) return 0;
 
   const resolveAuthorSeries = options.resolveAuthorSeries ?? findAuthorSeriesForBookId;
+  const isStandalone = options.isStandaloneBookId ?? isStandaloneBookId;
+  const resolveBookLanguage = options.resolveBookLanguage ?? resolveBookLanguageForBookId;
   const meta = await resolveAuthorSeries(bookId);
   if (!meta) return 0; // not in library / standalone resolves elsewhere
+  const myLanguage = await resolveBookLanguage(bookId);
 
   const positions = await (options.positions ?? seriesPositionByBookId)();
   const myPosition = positions.get(bookId) ?? null;
@@ -248,6 +273,17 @@ export async function linkSeriesReuseAtAnalysis(
     if (record.bookId === bookId) continue;
     const recMeta = await resolveAuthorSeries(record.bookId);
     if (!recMeta || recMeta.author !== meta.author || recMeta.series !== meta.series) continue;
+    /* A standalone's cast is never part of a series' continuity — every
+       standalone shares the synthetic 'Standalones' folder as its `series`,
+       so the (author, series) check above alone would treat unrelated (or
+       different-language) standalone siblings as series-mates and auto-link
+       their voices (fs-61 regression: a Qwen voice bakes its design language
+       into the .pt, so cross-language reuse produces garbled audio). */
+    if (await isStandalone(record.bookId)) continue;
+    /* fs-61 defense-in-depth: never carry a Qwen voice across a language
+       boundary, even between two "real" series-mates — the .pt is baked
+       to its design language. */
+    if ((await resolveBookLanguage(record.bookId)) !== myLanguage) continue;
     const pos = positions.get(record.bookId) ?? null;
     /* Earlier-book guard: link only against a strictly-lower seriesPosition.
        Unknown positions (null) on either side can't establish "earlier", so


### PR DESCRIPTION
## Summary

Two related fixes for cross-book Qwen voice contamination surfaced while investigating garbled audio in the per-language Coalfall demo books (Spanish/Russian narrators reading in the wrong language):

- **`linkSeriesReuseAtAnalysis` / `pruneStaleReuseLinks`** (`series-reuse-link.ts`): every standalone book shares the synthetic `series: "Standalones"` folder name, so an (author, series) match alone treated unrelated/different-language standalones as continuity-mates. Added an `isStandaloneBookId` veto plus a general `resolveBookLanguage` veto (never link/keep a link across a language boundary, even within a real series). Same hardening added to the confirm-cast client matcher (`voice-match.ts`).
- **`applyOverrideToCastFiles`** (`voices.ts`) — the actual active root cause: a standalone book's design action computes no `seriesFilter` (no series to scope to), which fell through to a **workspace-wide** write matching every confirmed cast.json by bare character id (`voiceId ?? id`). Since undesigned characters commonly share ids like `"narrator"`, and the demo books deliberately reuse the English book's ids, designing any character in any standalone book silently overwrote the same-id character in every other standalone book — including different-language ones. Added an `onlyBookId` scoping parameter, wired through `single-design.ts` and `cast-design.ts`, so a standalone's write stays book-scoped. `PUT /:voiceId/override`'s explicit `scope: 'workspace'` behavior is unchanged (deliberate, user-facing feature).

Closes #1419
Closes #1422

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] New regression tests: standalone-vs-standalone and cross-language-within-a-real-series for the linker/pruner and the client matcher; standalone book-scoping vs. the unchanged workspace-wide default for `applyOverrideToCastFiles`
- [x] Full `server/src/workspace/` + `server/src/routes/` suites green (1673 tests)
- [x] `npm run typecheck` (frontend+server) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UShZNYXyoVqizwP1tUQg7D