### PR TITLE
fix(ci): diff against the merge-base, not the raw PR base, for scope detection

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -96,7 +96,19 @@ jobs:
           fi
           BASE="${{ github.event.pull_request.base.sha }}"
           HEAD="${{ github.event.pull_request.head.sha }}"
-          FILES="$(git diff --name-only "$BASE" "$HEAD")"
+          # Merge-base, not BASE itself: a PR branch created from a stale
+          # local `origin/<default-branch>` (e.g. right after a `gh pr merge`
+          # that doesn't update local refs) can be a strict ancestor of BASE
+          # rather than a descendant. A literal `git diff BASE HEAD` in that
+          # case treats every file BASE moved past HEAD's fork point as
+          # "changed in this PR", spuriously widening scope (a docs-only PR
+          # tripping the full frontend battery). Diffing from the actual
+          # merge-base is what the diff is meant to mean regardless of how
+          # stale the branch's fork point drifted. Falls back to BASE itself
+          # if the merge-base can't be resolved (shouldn't happen — Checkout
+          # above pulls full history — but conservative on any surprise).
+          MERGE_BASE="$(git merge-base "$BASE" "$HEAD" 2>/dev/null || echo "$BASE")"
+          FILES="$(git diff --name-only "$MERGE_BASE" "$HEAD")"
           echo "Changed files in this PR:"
           echo "$FILES"
           echo "---"


### PR DESCRIPTION
## Summary

- `verify.yml`'s "Detect changed scopes" step diffed HEAD directly against `pull_request.base.sha`, assuming it's always an ancestor of HEAD. A PR branch created from a stale local `origin/<default-branch>` ref (e.g. right after a `gh pr merge`, which doesn't update local refs) can instead be a strict ancestor of that base sha — so the literal two-dot diff picks up every file the base moved past the branch's real fork point, spuriously widening scope.
- Caught live on PR #1421 (a pure `docs/wiki/*.md` change): the raw diff against base included every file from the unrelated, already-merged #1418 too, tripping `frontend=true` and running the full lint/typecheck/test/e2e battery (~18 min) instead of skipping it in seconds.
- Fix: diff from the actual `git merge-base "$BASE" "$HEAD"` instead of `$BASE` directly, with a fallback to `$BASE` if the merge-base can't be resolved (shouldn't happen — `Checkout` already pulls full history).

## Test plan

- [x] Reproduced the exact bug locally using the real commits from #1421 and #1418 — the raw two-dot diff spuriously included 17 files; diffing from the computed merge-base correctly reports the one real file.
- [x] This is CI-YAML-only — no application test suite covers embedded workflow bash. Requesting a manual full-battery dispatch (`gh workflow run verify.yml --ref chore/ci-verify-scope-mergebase`) before merge, since this PR's own diff (`.github/workflows/**`) isn't itself in any of the frontend/server/e2e/etc scope regexes, so the automatic PR-triggered run won't exercise the changed logic end-to-end on its own branch.
- [x] Local `npm run verify:fast:branch` (lint, typecheck, full frontend suite, build) green.

Closes #1425.