### PR TITLE
docs(docs): refresh README front door for the community launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 > _Any book, performed by a full cast — kept true, kept yours, book after book._
 
+**▶ Hear a 90-second sample** — the same passage as one narrator, then the full cast: **[castwright.ai/#demo](https://www.castwright.ai/#demo)**.
+
 Turn a manuscript into a finished, **full-cast** audiobook on your own machine —
 every character in their own voice, consistent across a whole series. Castwright
 runs locally end-to-end; nothing leaves your computer unless you opt into a cloud
@@ -22,9 +24,8 @@ or MP3.
   series, even when an author renames someone mid-series. *(No other tool does
   this for readers.)*
 - **Designed voices** — every character gets a unique voice designed from its persona, kept consistent across the series. (Cloning a voice from your own sample is the next major release.)
-- **Quality gate** — every line is acoustically checked, transcript-verified, and drift-checked
-  before a chapter is assembled, and any that fail are re-recorded automatically; the plainly
-  broken lines never reach your ears.
+- **Five languages** — performs English, Russian, Spanish, French, and German end-to-end, with the manuscript's language detected on import. A cast never crosses languages within a book.
+- **Quality-checked automatically** — every chapter is gated before it's assembled: acoustic checks (dead air, over-long lines, timing drift), optional word-for-word ASR transcript verification, and an opt-in speaker-fingerprint check that catches a voice drifting out of character even when the words are right. Flagged takes are surfaced on the waveform and re-recorded automatically.
 - **On-device by default** — analysis and speech run on your machine; cloud is
   opt-in.
 - **You own the files** — export standard M4B / MP3 / AAC / Opus and keep them.


### PR DESCRIPTION
## Summary
- Add a "Hear a 90-second sample" link above the fold, linking `castwright.ai/#demo`
- Add a **Five languages** bullet to "What you get" (English, Russian, Spanish, French, German)
- Upgrade the existing **Quality gate** bullet in place with richer detail (ASR verification, speaker-fingerprint drift check) — the handoff doc asked for a *new* bullet after "Series memory", but README already had a quality-gate bullet after "Designed voices"; adding both would have produced two near-duplicate bullets, so this upgrades the existing one instead

## Not done (flagged back to maintainer, out of scope for this PR)
- The handoff doc's Task 3.4 (Export bullet naming Audiobookshelf) and 3.5 (Voice engines line noting the five languages) reference a `## Features` section / Export bullet / Voice engines bullet that don't exist in the current README — that detail apparently lives on the wiki now. Skipped rather than inventing new sections.

## Release notes
No entry in `docs/release-notes-next.md` / `RELEASE_NOTES.md` — no shippable delta. Five-language support and the automated quality gate were already shipped and already covered by their own prior release-notes entries; this PR only documents that existing behaviour more fully in the README front door.

## Test plan
- [x] `grep -iE "effortlessly|local-first|seamless|revolutionary"` on README.md returns nothing
- [x] Docs-only push — pre-push fast-path confirmed skipping the test battery (no runtime surface changed)
- [ ] Visual check of rendered README on GitHub

Closes #1427