### PR TITLE
chore: reflect accepted trademark status and mark brand surfaces with ™

### DIFF
--- a/docs/legal/brand-and-trademarks.md
+++ b/docs/legal/brand-and-trademarks.md
@@ -1,6 +1,6 @@
 # Castwright — brand & trademarks
 
-The **Castwright** name, the "Castwave" mark, wordmarks, logos, icons, the colour
+The **Castwright™** name, the "Castwave" mark, wordmarks, logos, icons, the colour
 system, and related identity assets are **all rights reserved**, Copyright © 2026
 Mikhail Dudarenok.
 
@@ -9,8 +9,10 @@ License — see [`/LICENSE`](../../LICENSE)), and the asset source files are **n
 distributed in this repository**. A licence to the code is not a licence to the
 identity.
 
-"Castwright" is an unregistered trade mark of the copyright holder; trade-mark
-registration is in progress.
+"Castwright" is a trade mark of Mikhail Dudarenok. Its Australian trade-mark
+application (IP Australia no. 2662523, classes 9 and 42) has been examined and
+**accepted**, and is pending registration. Until the mark registers, it is used
+as "Castwright™"; the ® symbol will apply only once registration is granted.
 
 ## You may
 

--- a/src/views/about.test.tsx
+++ b/src/views/about.test.tsx
@@ -30,6 +30,13 @@ describe('AboutView', () => {
     expect(screen.getByText(MANIFESTO)).toBeInTheDocument();
   });
 
+  it('marks the brand-page heading with ™ (accepted, pre-registration — never ®)', () => {
+    renderAbout();
+    const heading = screen.getByRole('heading', { level: 1 });
+    expect(heading).toHaveTextContent(/Castwright™/);
+    expect(heading).not.toHaveTextContent(/Castwright®/);
+  });
+
   it('renders the teaser WITH its in-development flag (teaser rule)', () => {
     renderAbout();
     expect(screen.getByText(TEASER)).toBeInTheDocument();

--- a/src/views/about.tsx
+++ b/src/views/about.tsx
@@ -38,7 +38,7 @@ export function AboutView() {
       <div className="mb-8">
         <SectionLabel>About</SectionLabel>
         <div className="mt-4">
-          <MixedHeading regular="About" bold="Castwright" level="h1" />
+          <MixedHeading regular="About" bold="Castwright™" level="h1" />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Castwright's Australian trade-mark application (IP Australia no. 2662523, classes 9 + 42) was examined and **accepted early** (3 Jul 2026); registration is pending until ~Feb 2027. The prior legal wording ("unregistered … registration is in progress") now *understates* where the mark actually is.

- **docs/legal/brand-and-trademarks.md** — "unregistered / in progress" → "accepted, pending registration" with the IP Australia application number + classes; ™ on first-use of the name.
- **src/views/about.tsx** — ™ on the About-page H1 (the app's canonical brand surface / most prominent wordmark instance).
- The registered-mark symbol (®) stays off every surface until registration is granted — using it now would be a false registration claim.

™ is applied on prominent first-use only (per brand restraint), not sprayed across every inline mention.

Out of scope (needs separate handling): matching edits on the public castwright.ai site (separate repo), and whether to bake ™ into the logo lockup asset.

## Test plan

- `src/views/about.test.tsx` — new assertion: About H1 carries ™ and never ®. All 9 About tests green; full frontend suite green (3616 passed) via the pre-commit gate.

Closes #1431