### PR TITLE
docs(frontend,docs): reconcile 6 GB GPU entry-point copy across app and docs

### DIFF
--- a/docs/local-llm.md
+++ b/docs/local-llm.md
@@ -46,7 +46,12 @@ and the policy is documented at the top of the same file.
 
 ## The VRAM budget — the actual constraint
 
-8 GB total on the dev box. Three things compete for it:
+8 GB total on the dev box — the site's "sweet spot" tier (`HARDWARE_LINE` in
+`src/lib/brand.ts`). The site's entry-point tier is 6 GB (`GPU_VRAM_BUDGET`
+drops to `6` there, per INSTALL.md's config table); the budget below scales
+down accordingly — expect the 9B/8B analyzer options and Coqui to no longer
+co-reside with anything else, and more frequent cross-engine eviction via
+`withGpuLoad`. Three things compete for the 8 GB case:
 
 | Tenant                 | Resident size     | When it's loaded                    |
 | ---------------------- | ----------------- | ----------------------------------- |

--- a/src/components/device-panel.tsx
+++ b/src/components/device-panel.tsx
@@ -94,8 +94,9 @@ export function DevicePanel() {
       )}
       {!devices && hw && (hw.platform === 'win32' || hw.platform === 'linux') && (
         <p className="mt-2 text-xs text-ink/60">
-          With an 8&nbsp;GB NVIDIA GPU you get near-realtime rendering; without one, Castwright
-          falls back to the CPU (slower). Load a voice to confirm which device is in use.
+          A 6&nbsp;GB NVIDIA GPU gets you started; 8&nbsp;GB is the sweet spot for near-realtime
+          rendering. Without a GPU, Castwright falls back to the CPU (slower). Load a voice to
+          confirm which device is in use.
         </p>
       )}
     </section>


### PR DESCRIPTION
## Summary
- `device-panel.tsx`'s no-GPU-detected tooltip framed 8 GB as the floor for near-realtime rendering, missing the 6 GB entry-point tier already established in `HARDWARE_LINE` (`src/lib/brand.ts`) and the wiki Home page ("A 6 GB GPU gets you started; 8 GB is the sweet spot").
- `docs/local-llm.md`'s VRAM-budget deep-dive was framed entirely around the 8 GB dev box; added a note reconciling it with the 6 GB entry-point tier (`GPU_VRAM_BUDGET=6`, per INSTALL.md) and the practical consequence (9B/8B analyzer + Coqui stop co-residing, more frequent cross-engine eviction).

## Test plan
- [x] `npx vitest run src/components/device-panel.test.tsx` — 8/8 passing (existing assertion on `/falls back to the CPU/` unaffected)
- [x] `npm run verify:fast:branch` — lint, typecheck, test, build all green (pre-push gate)

Closes #1440