### PR TITLE
docs(docs): resolve fs-72 id collision, rename #845 to fs-74

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -323,7 +323,7 @@ _Full detail + acceptance:_ [#1239](https://github.com/dudarenok-maker/Castwrigh
 - _Benefit:_ server-side enforcement that no `--no-verify` local bypass or fresh clone can sidestep; the local guard (plan 163) becomes belt-and-suspenders. Required status checks deliberately excluded (would deadlock doc-only PRs that skip `verify.yml`).
 _Full detail + acceptance:_ [#429](https://github.com/dudarenok-maker/Castwright/issues/429).
 
-#### `fs-72` — VRAM MB-accounting policy + two-model-split UI (Wave 4 — beta 12/16GB cards) ([#845](https://github.com/dudarenok-maker/Castwright/issues/845))
+#### `fs-74` — VRAM MB-accounting policy + two-model-split UI (Wave 4 — beta 12/16GB cards) ([#845](https://github.com/dudarenok-maker/Castwright/issues/845))
 
 - _What:_ Wave 1 already gives 12/16GB cards coexistence via the gpu.safeCoexistMb threshold (a roomy card doesn't evict). Wave 4 refines this for beta testers who run better cards than the 8GB dev box: (1) per-(engine,mode) MB cost table vs detected VRAM (non-additive Qwen synth/design modes) so a 12GB card with a heavy combo that passes the coarse threshold but would overcommit is caught; (2) two-model analysis-split warn+confirm UI when phase0/phase1 use two different local models that won't co-fit. Design: docs/superpowers/specs/2026-06-16-vram-budget-aware-gpu-policy-design.md §7; context in docs/features/222.
 - _Benefit:_ Beta testers on 12/16GB cards get accurate overcommit protection (not just the coarse 8GB-dev-box threshold) and a clear warning instead of a silent OOM when two local models cannot co-fit during analysis.


### PR DESCRIPTION
## Summary
- Issue #1449 (scoreBook incremental writes/resumability/live progress, shipped in v1.11.0) and issue #845 (VRAM MB-accounting policy, still open) were both assigned the `fs-72` id.
- #1449's `fs-72` id is already baked into merged commits, `docs/features/archive/246-fs51-qa-report.md`, and shipped release-notes entries — not safe to touch.
- Renamed #845's GitHub issue title and its `docs/BACKLOG.md` row to `fs-74` (next free id — `fs-73` is Cast Pass) instead.

## Test plan
- [x] Docs-only change — no runtime surface to test.
- [x] Confirmed `fs-74` is unused elsewhere (`fs-73` is the only higher id, already assigned).
- [x] GitHub issue #845 title updated to match.

Refs #845