### PR TITLE
fix(ci): auto-archive Done board items after every release publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -411,7 +411,10 @@ jobs:
     name: Archive Done board items
     needs: publish
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # 10 (not the usual 5): archiving is one sequential `gh` CLI call per item
+    # (no batching) — generous headroom in case a backlog piles up again
+    # (e.g. this job itself gets skipped for a cycle) before the next tag.
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -398,6 +398,36 @@ jobs:
             "companion-apk/castwright-${{ github.ref_name }}.aab" \
             "companion-apk/castwright-${{ github.ref_name }}.aab.sha256" --clobber
 
+  # Ties the release-cut recipe's "clear the board's Done lane" step
+  # (CONTRIBUTING.md Recipe step 8) to the pipeline itself. Previously this was
+  # a manual `node scripts/clear-done-project-items.mjs --apply` a human had to
+  # remember to run after every tag — it was forgotten for v1.11.0 (63 Done
+  # items piled up unarchived). Running it here, gated on `publish`, matches
+  # the recipe's own ordering ("after the tag is pushed and the release is
+  # published") without adding new *scheduled* automation (spec §E in
+  # docs/superpowers/specs/2026-07-05-github-issues-kanban-design.md still
+  # holds — this fires once per release tag, not on a cron).
+  clear-done-board-items:
+    name: Archive Done board items
+    needs: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Archive Done items
+        # The default GITHUB_TOKEN can't write a user-owned Projects v2 board
+        # (same constraint as add-to-project.yml) — reuse ADD_TO_PROJECT_PAT.
+        env:
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+        run: node scripts/clear-done-project-items.mjs --apply
+
   # NOTE: the per-release iOS build (unsigned, "app-12 prep") was REMOVED to save
   # ~80-120 macOS-billed minutes/tag (macOS is 10×). It produced an un-installable
   # unsigned archive that nothing consumes (no iOS distribution exists yet), and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -772,6 +772,9 @@ still hold:
    (`node scripts/bump-version.mjs --notes-file <path>`); the release workflow
    publishes it verbatim. (Releases predating this format were refreshed
    directly via `gh release edit`.)
-8. After the tag is pushed and the release is published, clear the board's
-   `Done` lane: `node scripts/clear-done-project-items.mjs --apply`
-   (dry-run first without `--apply` to review what would archive).
+8. Once the tag is pushed, `release.yml`'s `clear-done-board-items` job
+   archives the board's `Done` lane automatically after `publish` succeeds —
+   no manual step needed. If that job didn't run (e.g. the release published
+   via a path that bypassed the workflow) run it yourself:
+   `node scripts/clear-done-project-items.mjs --apply` (dry-run first without
+   `--apply` to review what would archive).

--- a/docs/features/archive/241-github-projects-kanban-board.md
+++ b/docs/features/archive/241-github-projects-kanban-board.md
@@ -54,7 +54,12 @@ owner: null
 
 ## Out of scope (matches the spec)
 
-- Time-based auto-archive for `Done` (cron-based) — `clear-done-project-items.mjs` is a manual release-cut step only.
+- Time-based auto-archive for `Done` (cron-based) — still out of scope.
+  `clear-done-project-items.mjs` now runs automatically as the
+  `clear-done-board-items` job in `.github/workflows/release.yml`, gated on
+  each tag's `publish` job succeeding — release-tied, not a schedule (a
+  human forgetting the formerly-manual step let 63 items pile up before
+  v1.11.0; see PR #1476). The script remains runnable by hand too.
 - Bot-enforced "Parked needs a comment" check — process-mandatory, not automated.
 - A recurring (not just one-time) branch/worktree hygiene sweep — `audit-branches-worktrees.mjs` is a report-only tool run on demand, not scheduled.
 

--- a/scripts/clear-done-project-items.mjs
+++ b/scripts/clear-done-project-items.mjs
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 // Release-cut tool (ops-25 rollout step 9): archive every board item whose
-// Status is Done. Run manually as a step in the release-cut recipe
-// (CONTRIBUTING.md "Release notes" Recipe) — no scheduled automation (spec §E).
+// Status is Done. Run automatically by .github/workflows/release.yml's
+// `clear-done-board-items` job after every tag's `publish` job succeeds
+// (CONTRIBUTING.md "Release notes" Recipe step 8) — no *scheduled*
+// automation beyond that (spec §E). Safe to run manually too, e.g. if a
+// release published via a path that bypassed the workflow.
 //
 // Usage:
 //   node scripts/clear-done-project-items.mjs           (dry-run — lists Done items)

--- a/scripts/clear-done-project-items.mjs
+++ b/scripts/clear-done-project-items.mjs
@@ -11,7 +11,7 @@
 //   node scripts/clear-done-project-items.mjs --apply   (archives them)
 
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { appendFileSync, existsSync, readFileSync, realpathSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
@@ -22,6 +22,15 @@ const PROJECT_OWNER = 'dudarenok-maker';
 
 function info(msg) { process.stdout.write(`${msg}\n`); }
 function die(msg) { process.stderr.write(`[FAIL] ${msg}\n`); process.exit(1); }
+// Surfaces what was archived on the GitHub Actions run summary page (not just
+// buried step logs) — the release.yml job runs --apply unattended on every
+// tag with no human dry-run checkpoint, so this is the audit trail for
+// catching an item that was wrongly Done. No-op outside CI (env var unset).
+function writeStepSummary(lines) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+  appendFileSync(summaryPath, `${lines.join('\n')}\n`);
+}
 function gh(args) { return execFileSync('gh', args, { cwd: repoRoot, encoding: 'utf8' }); }
 function ghAvailable() {
   const r = spawnSync('gh', ['--version'], { stdio: 'ignore' });
@@ -109,6 +118,11 @@ async function main() {
     info(`  archived #${item.content.number}`);
   }
   info(`\n[OK] archived ${doneItems.length} Done item(s).`);
+
+  writeStepSummary([
+    `## Archived ${doneItems.length} Done board item(s)`,
+    ...doneItems.map((item) => `- #${item.content.number} ${item.content.title}`),
+  ]);
 }
 
 const invokedHref = process.argv[1] ? pathToFileURL(realpathSync(process.argv[1])).href : '';


### PR DESCRIPTION
## Summary
- v1.11.0 (tagged 2026-07-08) shipped without clearing the board's `Done`
  lane — 63 items piled up unarchived.
- Root cause: `scripts/clear-done-project-items.mjs` was only ever run
  manually, as Recipe step 8 in CONTRIBUTING.md's release-notes recipe.
  Nothing in `release.yml` invoked it, so it depended on a human
  remembering a checklist item after the tag was already pushed.
- Fix: add a `clear-done-board-items` job to `release.yml`, gated on
  `publish`, that runs the archiving script automatically via the
  existing `ADD_TO_PROJECT_PAT` secret (same one `add-to-project.yml`
  uses, since the default `GITHUB_TOKEN` can't write a user-owned
  Projects v2 board). Updated CONTRIBUTING.md's recipe step to describe
  the automatic behaviour, with the manual command kept as a documented
  fallback.
- Already archived the 63 stuck items directly (dry-run confirmed 0
  remaining Done items on the board).

Closes #1475

## Test plan
- [x] `node scripts/clear-done-project-items.mjs` (dry-run) confirms 0
      Done items remain after the manual `--apply` run
- [x] `node --test scripts/tests/clear-done-project-items.test.mjs` — 4/4
      pass (unchanged pure-function coverage)
- [x] `npm run verify:fast:branch` (pre-push) — lint passes, other legs
      out of scope for this diff
- [ ] Next tag push will exercise the new `clear-done-board-items` job
      end-to-end (can't dry-run a workflow job locally; it's a thin
      wrapper around the already-tested script + secret reuse pattern
      proven by `add-to-project.yml`)