### PR TITLE
ci(ci): parallelize verify.yml legs into concurrent jobs

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -337,14 +337,14 @@ jobs:
     if: always()
     steps:
       - name: Check leg results
+        # Fails on 'failure' OR 'cancelled' OR 'skipped' — not just the first
+        # two — so an upstream `detect` failure (which SKIPS every leg job
+        # rather than failing it, since they `needs: detect`) still fails
+        # this aggregator instead of silently reporting green.
         run: |
-          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
-            echo "One or more verify legs failed:"
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}" == "true" ]]; then
+            echo "One or more verify legs did not succeed:"
             echo '${{ toJSON(needs) }}'
-            exit 1
-          fi
-          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
-            echo "One or more verify legs were cancelled."
             exit 1
           fi
           echo "All verify legs passed."

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,29 +10,45 @@ name: Verify
 # on `main`'s branch-protection ruleset — closing the gap where local
 # pre-push was previously the only thing that refused to push on a red leg.
 #
-# It runs only the LEGS whose scope actually changed. A single job does setup
-# once, detects which scopes the PR touched (git diff against the PR base),
-# then gates each expensive leg (server tests, e2e, build, …) behind an `if:`
-# on that scope. A PR that touches only `src/**` skips the server tests; a
+# It runs only the LEGS whose scope actually changed (git diff against the PR
+# base) — a PR that touches only `src/**` skips the server tests; a
 # server-only PR skips the frontend unit suite + Playwright e2e; etc. Local
 # pre-push now only runs a fast, branch-diff-scoped subset
 # (`verify:fast:branch`) — this cloud run is the actual enforcement gate for
 # everything else, not redundant insurance.
 #
-# Why one job with conditional steps (not a job-per-leg matrix): GitHub bills
-# each job's wall-clock separately, summed, rounded UP to the minute per job.
-# Parallel jobs would duplicate `npm ci` + pay a 1-min floor each. One job →
-# setup paid once, skipped legs cost ~0. (Billing is no longer the primary
-# driver now that Actions minutes are free on this public repo, but the
-# single-job shape is still the simpler design.)
+# JOB-PER-LEG, NOT ONE JOB (2026-07-10 — supersedes the single-job design):
+# originally every leg ran as a sequential step inside one job, because
+# GitHub used to bill each job's wall-clock separately, rounded UP to the
+# minute, and N parallel jobs would each re-pay a `npm ci` + 1-min floor.
+# Now that Actions minutes are free/uncapped on this public repo, that
+# tradeoff flips: end-to-end PR latency (wall-clock to a green check) matters
+# more than total minutes billed, and a sequential single job pays the SUM of
+# every in-scope leg instead of the MAX. Split into independent jobs — each
+# repeats checkout + `Setup Node + deps` (cheap: the composite's node_modules
+# cache means most jobs skip `npm ci` entirely on a warm hit) — so
+# lint/typecheck, frontend tests, server tests, e2e+visual, and build all run
+# concurrently; end-to-end time collapses to roughly the slowest single leg
+# (typically e2e+visual or server fast+slow) instead of their sum.
+#
+# `detect` runs once and fans its scope booleans out via `needs:`/`outputs:`
+# to every other job's step-level `if:` — same per-leg scoping as before,
+# just consumed across jobs instead of within one.
+#
+# The trailing `verify` job (needs: every leg job, `if: always()`) is a thin
+# aggregator that exists ONLY to keep the "npm run verify" status-check name
+# stable — that name is wired into `main`'s required-status-check ruleset,
+# and renaming/removing it would silently detach the gate. The actual work
+# happens in the named leg jobs above it; the aggregator just fails if any of
+# them failed or was cancelled.
 #
 # No `paths-ignore` here (deliberately removed — see design spec): keeping it
 # while this is a required status check would deadlock every docs-only PR,
 # since a required check that never fires blocks merge forever. Every leg's
 # own `if:` scope condition already evaluates false for a docs-only diff, so
-# the job still completes in roughly the time of "Setup Node + deps" alone
-# and reports green — no deadlock, negligible added time. Same reasoning is
-# why the job no longer gates on PR `draft` status either — a draft-gated
+# every job still completes in roughly the time of "Setup Node + deps" alone
+# and the aggregator reports green — no deadlock, negligible added time. Same
+# reasoning is why no job gates on PR `draft` status either — a draft-gated
 # required check would deadlock every draft PR the same way.
 
 on:
@@ -49,27 +65,30 @@ permissions:
   contents: read
 
 # Cancel an in-flight run when the PR is updated; the new commit's run
-# supersedes any prior one for the same PR.
+# supersedes any prior one for the same PR. Applies workflow-wide — every job
+# in a superseded run is cancelled, not just one leg.
 concurrency:
   group: verify-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  verify:
-    # NOTE: the `name:` "npm run verify" is the historical status-check name.
-    # This check IS required on `main`'s branch-protection ruleset (see the
-    # design spec) — keep this name stable, since renaming the job would
-    # silently detach the required-check rule from it.
-    name: npm run verify
+  # Detect which scopes the PR touched by diffing the merge base against the
+  # PR head. Each output is a literal 'true'/'false' string consumed by the
+  # `if:` on every leg job/step below. Pure bash + git — no third-party
+  # action, matching this repo's all-first-party (actions/*) convention.
+  detect:
+    name: Detect changed scopes
     runs-on: ubuntu-latest
-    # 30 (was 20): a run that dies AT the cap bills the full cap for nothing and
-    # forces a re-run = double charge, so the cap must clear the SLOWEST real run.
-    # Full-scope runs were ~13-15 min historically, but a full-stack PR (frontend +
-    # server + e2e) on a cold cloud runner now lands ~20+ min (the suite has grown
-    # — e.g. fs-58 added server + e2e coverage), so 20 was being hit mid-battery
-    # while green. Headroom is bounded by the cancel-in-progress concurrency above.
-    # See docs/features/118-ci-cost-round-2.md.
-    timeout-minutes: 30
+    timeout-minutes: 5
+    outputs:
+      frontend: ${{ steps.changes.outputs.frontend }}
+      server: ${{ steps.changes.outputs.server }}
+      sidecar: ${{ steps.changes.outputs.sidecar }}
+      e2e: ${{ steps.changes.outputs.e2e }}
+      scripts: ${{ steps.changes.outputs.scripts }}
+      hooks: ${{ steps.changes.outputs.hooks }}
+      pinokio: ${{ steps.changes.outputs.pinokio }}
+      shared: ${{ steps.changes.outputs.shared }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -78,10 +97,6 @@ jobs:
           # its base commit. A shallow clone wouldn't have the base reachable.
           fetch-depth: 0
 
-      # Detect which scopes the PR touched by diffing the merge base against
-      # the PR head. Each output is a literal 'true'/'false' string consumed
-      # by the `if:` on every leg below. Pure bash + git — no third-party
-      # action, matching this repo's all-first-party (actions/*) convention.
       - name: Detect changed scopes
         id: changes
         run: |
@@ -130,30 +145,35 @@ jobs:
             echo "scope $k=${!k}"
           done
 
-      # Node 24 (matches the dev box, plan 81 / wave 1) + npm download cache +
-      # node_modules cache + conditional `npm ci`. Extracted to a composite so
-      # a Node-major bump is a one-file edit shared with cross-os.yml (plan
-      # 106). MUST run after Checkout — the action file only exists post-clone.
+  lint-and-checks:
+    name: Lint, typecheck & fast checks
+    needs: detect
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Setup Node + deps
         uses: ./.github/actions/setup
 
       - name: Lint
-        if: steps.changes.outputs.frontend == 'true' || steps.changes.outputs.server == 'true' || steps.changes.outputs.scripts == 'true' || steps.changes.outputs.shared == 'true'
+        if: needs.detect.outputs.frontend == 'true' || needs.detect.outputs.server == 'true' || needs.detect.outputs.scripts == 'true' || needs.detect.outputs.shared == 'true'
         run: npm run lint
 
       - name: Typecheck
-        if: steps.changes.outputs.frontend == 'true' || steps.changes.outputs.server == 'true' || steps.changes.outputs.shared == 'true'
+        if: needs.detect.outputs.frontend == 'true' || needs.detect.outputs.server == 'true' || needs.detect.outputs.shared == 'true'
         run: npm run typecheck
 
       # Drift guard: fails if server/.env.example is out of sync with the
       # config registry. Previously ONLY ran via local `npm run verify` — see
       # docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md §3.
       - name: Config check
-        if: steps.changes.outputs.server == 'true' || steps.changes.outputs.shared == 'true'
+        if: needs.detect.outputs.server == 'true' || needs.detect.outputs.shared == 'true'
         run: npm run config:check
 
       - name: Hooks tests
-        if: steps.changes.outputs.hooks == 'true' || steps.changes.outputs.scripts == 'true' || steps.changes.outputs.shared == 'true'
+        if: needs.detect.outputs.hooks == 'true' || needs.detect.outputs.scripts == 'true' || needs.detect.outputs.shared == 'true'
         run: npm run test:hooks
 
       - name: PowerShell-helper tests (Pester)
@@ -161,14 +181,31 @@ jobs:
         # ubuntu image ships pwsh but not Pester 5), exactly as the old
         # `npm run verify` leg did. Kept gated on `scripts` so it provides
         # real coverage if/when Pester 5 is bootstrapped on the runner.
-        if: steps.changes.outputs.scripts == 'true'
+        if: needs.detect.outputs.scripts == 'true'
         run: npm run test:scripts
 
       # Previously ONLY ran via local `npm run verify` — see
       # docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md §3.
       - name: Pinokio tests
-        if: steps.changes.outputs.pinokio == 'true' || steps.changes.outputs.shared == 'true'
+        if: needs.detect.outputs.pinokio == 'true' || needs.detect.outputs.shared == 'true'
         run: npm run test:pinokio
+
+  frontend-tests:
+    name: Frontend tests + a11y
+    needs: detect
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # Full history: `vitest run --changed <base>` below needs the BASE
+          # commit reachable in the local git object DB — a shallow (depth-1)
+          # clone wouldn't have it, and `--changed` would fail to resolve it.
+          fetch-depth: 0
+
+      - name: Setup Node + deps
+        uses: ./.github/actions/setup
 
       # `--changed <base>` narrows the frontend vitest run to only the tests
       # whose module graph touches this PR's diff (CI cost round 2). Reliable
@@ -179,18 +216,34 @@ jobs:
       # default triggers. test:a11y stays always-on as a cheap core-view gate.
       # See docs/features/118-ci-cost-round-2.md.
       - name: Frontend tests + a11y
-        if: steps.changes.outputs.frontend == 'true' || steps.changes.outputs.e2e == 'true' || steps.changes.outputs.shared == 'true'
+        if: needs.detect.outputs.frontend == 'true' || needs.detect.outputs.e2e == 'true' || needs.detect.outputs.shared == 'true'
         run: |
           BASE="${{ github.event.pull_request.base.sha }}"
           # On a manual dispatch BASE is empty (no PR) → run the full suite.
           if [ -n "$BASE" ]; then npx vitest run --changed "$BASE"; else npx vitest run; fi
           npm run test:a11y
 
+  server-tests:
+    name: Server tests (fast + slow)
+    needs: detect
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # Full history: `vitest run --changed <base>` below needs the BASE
+          # commit reachable in the local git object DB — a shallow (depth-1)
+          # clone wouldn't have it, and `--changed` would fail to resolve it.
+          fetch-depth: 0
+
+      - name: Setup Node + deps
+        uses: ./.github/actions/setup
+
       # ffmpeg is needed by the server MP3 encoder (server/src/tts/mp3.ts
-      # shells out to it) and by the e2e suite's audio paths. Install it only
-      # when a leg that needs it will run.
+      # shells out to it). Install it only when this job's leg will run.
       - name: Install ffmpeg
-        if: steps.changes.outputs.server == 'true' || steps.changes.outputs.sidecar == 'true' || steps.changes.outputs.e2e == 'true' || steps.changes.outputs.shared == 'true'
+        if: needs.detect.outputs.server == 'true' || needs.detect.outputs.sidecar == 'true' || needs.detect.outputs.shared == 'true'
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
 
       # `--changed <base>` narrows both server configs to diff-affected tests
@@ -200,7 +253,7 @@ jobs:
       # run here, which is correct (server tests mock the Python sidecar).
       # See docs/features/118-ci-cost-round-2.md.
       - name: Server tests (fast + slow)
-        if: steps.changes.outputs.server == 'true' || steps.changes.outputs.sidecar == 'true' || steps.changes.outputs.shared == 'true'
+        if: needs.detect.outputs.server == 'true' || needs.detect.outputs.sidecar == 'true' || needs.detect.outputs.shared == 'true'
         run: |
           cd server
           BASE="${{ github.event.pull_request.base.sha }}"
@@ -213,8 +266,25 @@ jobs:
             npx vitest run --config vitest.config.slow.ts
           fi
 
+  e2e:
+    name: E2E + visual baselines (chromium)
+    needs: detect
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node + deps
+        uses: ./.github/actions/setup
+
+      # ffmpeg is needed by the e2e suite's audio paths.
+      - name: Install ffmpeg
+        if: needs.detect.outputs.frontend == 'true' || needs.detect.outputs.e2e == 'true' || needs.detect.outputs.shared == 'true'
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
       - name: Cache Playwright browsers
-        if: steps.changes.outputs.frontend == 'true' || steps.changes.outputs.e2e == 'true' || steps.changes.outputs.shared == 'true'
+        if: needs.detect.outputs.frontend == 'true' || needs.detect.outputs.e2e == 'true' || needs.detect.outputs.shared == 'true'
         id: playwright-cache
         uses: actions/cache@v5
         with:
@@ -224,11 +294,11 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install Playwright chromium
-        if: (steps.changes.outputs.frontend == 'true' || steps.changes.outputs.e2e == 'true' || steps.changes.outputs.shared == 'true') && steps.playwright-cache.outputs.cache-hit != 'true'
+        if: (needs.detect.outputs.frontend == 'true' || needs.detect.outputs.e2e == 'true' || needs.detect.outputs.shared == 'true') && steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
       - name: E2E (chromium)
-        if: steps.changes.outputs.frontend == 'true' || steps.changes.outputs.e2e == 'true' || steps.changes.outputs.shared == 'true'
+        if: needs.detect.outputs.frontend == 'true' || needs.detect.outputs.e2e == 'true' || needs.detect.outputs.shared == 'true'
         run: npm run test:e2e
 
       # Visual snapshots run as their own serial step (workers=1) so they can't
@@ -238,9 +308,43 @@ jobs:
       # past every PR and only surface at release time (release.yml runs the full
       # `npm run verify`, which includes this leg, on Ubuntu).
       - name: E2E visual baselines (chromium)
-        if: steps.changes.outputs.frontend == 'true' || steps.changes.outputs.e2e == 'true' || steps.changes.outputs.shared == 'true'
+        if: needs.detect.outputs.frontend == 'true' || needs.detect.outputs.e2e == 'true' || needs.detect.outputs.shared == 'true'
         run: npm run test:e2e:visual
 
+  build:
+    name: Build
+    needs: detect
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node + deps
+        uses: ./.github/actions/setup
+
       - name: Build
-        if: steps.changes.outputs.frontend == 'true' || steps.changes.outputs.server == 'true' || steps.changes.outputs.shared == 'true'
+        if: needs.detect.outputs.frontend == 'true' || needs.detect.outputs.server == 'true' || needs.detect.outputs.shared == 'true'
         run: npm run build
+
+  # Thin aggregator — see the top-of-file comment. Keeps the "npm run verify"
+  # status-check name (required on main's branch-protection ruleset) stable
+  # while the real work runs concurrently in the named jobs above.
+  verify:
+    name: npm run verify
+    needs: [lint-and-checks, frontend-tests, server-tests, e2e, build]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check leg results
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "One or more verify legs failed:"
+            echo '${{ toJSON(needs) }}'
+            exit 1
+          fi
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more verify legs were cancelled."
+            exit 1
+          fi
+          echo "All verify legs passed."


### PR DESCRIPTION
## Summary
- Splits `verify.yml`'s single sequential job into independent jobs
  (`lint-and-checks`, `frontend-tests`, `server-tests`, `e2e`, `build`) that
  all fan out from a shared `detect` scope-diff job and run concurrently.
- Adds a thin `verify` aggregator job (`needs:` every leg, `if: always()`)
  that keeps the "npm run verify" required-status-check name stable for
  main's branch-protection ruleset, while the real work happens in the named
  leg jobs.
- Preserves all existing per-leg scope-gating (`if:` conditions unchanged in
  substance, just reading `needs.detect.outputs.*` instead of
  `steps.changes.outputs.*`), the docs-only fast path, and the
  workflow_dispatch full-battery behavior.
- `frontend-tests` and `server-tests` each need their own `fetch-depth: 0`
  checkout now (previously shared the single job's full-history checkout)
  since both run `vitest run --changed <base>`, which needs the PR base
  commit reachable in git history.

Rationale: Actions minutes are free/uncapped on this public repo now, but the
single-job design still pays the *sum* of every in-scope leg's wall-clock
since steps run sequentially within one job. Splitting into concurrent jobs
collapses end-to-end PR check time to roughly the *slowest single leg*
instead (typically e2e+visual or server fast+slow).

## Test plan
- [x] Validated the new workflow YAML parses and the job/needs graph is as
      intended (`python3 -c "import yaml; ..."`).
- [ ] Cloud `verify.yml` itself (required check on this PR) exercises the new
      job graph end-to-end — this is CI config, so the real test is watching
      it run green on this very PR.
- No behavior change to what runs or when relative to PR scope — only *where*
  (which job) each leg executes, so no new frontend/server/e2e test coverage
  applies here (CI-only, `chore`/`ci`-shaped change).

Closes #1486