### PR TITLE
docs(docs): refresh wiki for fs-52 captions, FA2 cross-platform, fs-58 persistence

### DIFF
--- a/docs/wiki/Exporting.md
+++ b/docs/wiki/Exporting.md
@@ -30,6 +30,16 @@ Nothing here locks you in — six listener apps get one-tap tiles, each opening 
   <img alt="Send to Audiobookshelf dialog — folder path, M4B/MP3 folder toggle" src="images/exporting/03-export-listener-apps.png">
 </picture>
 
+## Captions
+
+A finished book can also leave as **captions** — `.srt` or `.vtt` files built straight from the book's own performance, no re-recording needed. The Captions tile sits alongside the download tiles, with three granularities to pick from:
+
+- **Line** — short cues (capped at 7s / 200 characters) that always break on a speaker change, good for burning subtitles onto a video clip.
+- **Sentence** — one cue per sentence, read from your current manuscript text rather than the analysis cache, so an edit you made after generating still shows up correctly.
+- **Word** — per-word timing via a dedicated Whisper pass over the chapter's audio, for tools that want tight word-level alignment.
+
+Export whole-book or per-chapter, same as the audio formats. If a chapter's audio predates Castwright's newer render-integrity tracking, the export still completes but the queue row carries an amber "unverifiable" warning instead of a hard failure — a nudge to regenerate that chapter if you want the captions guaranteed to match.
+
 ## Export queue
 
 Every export you start is tracked here — queued, running, done, or failed, filterable by status with live counts — and it survives a reload, so kicking off a long export and closing the tab doesn't lose it. Each row carries **Download**, **Copy link**, **Remove**, and **Retry** (for a failed export, without starting over from the format picker).

--- a/docs/wiki/Installing-Castwright.md
+++ b/docs/wiki/Installing-Castwright.md
@@ -286,13 +286,19 @@ node server/tts-sidecar/scripts/install-qwen3.mjs
 
 Cross-platform Node ESM — same command on Windows / macOS / Linux. Idempotent (pip is a no-op when already satisfied; the model download is a no-op when the Hugging Face cache already has the snapshot). Fetches the Base (synth) + VoiceDesign models into `server/tts-sidecar/voices/qwen/hf`. Add `--skip-design` to skip the VoiceDesign model (saves ~1.7 GB on machines that won't host the cast-review design step); add `--cpu` to force CPU-only torch on a box without a CUDA GPU.
 
-**Optional — FlashAttention-2 wheel (Windows-only).** SDPA is the default attention impl and benchmarked at parity with FA2 on TTS-decode-bound workloads, so skipping FA2 costs nothing measurable. To install the wheel anyway (e.g. for a benchmark):
+**Optional — FlashAttention-2.** SDPA is the default attention impl and benchmarked at parity with FA2 on TTS-decode-bound workloads, so skipping FA2 costs nothing measurable. To opt in anyway (e.g. for a benchmark):
 
 ```sh
 node server/tts-sidecar/scripts/install-qwen3.mjs --flash-attn
 ```
 
-The pinned prebuilt wheel is `cp311 + torch-2.6 + cu124`-only, so the script **auto-skips on the current Python 3.12 (cp312) stack** (and on macOS / Linux) — a wheel that can't load doesn't get installed, and Qwen runs on SDPA. When a compatible wheel is installed, activate it via `QWEN_ATTN_IMPL=flash_attention_2` in `server/.env`.
+The installer checks any platform first: if `flash_attn` is already importable in the sidecar venv, it skips straight to telling you how to activate it — no reinstall attempt. Otherwise the path depends on your OS:
+
+- **Windows** installs a prebuilt wheel, but it's pinned to `cp311 + torch-2.6 + cu124` — the script **auto-skips on the current Python 3.12 (cp312) stack**, and Qwen runs on SDPA instead.
+- **Linux** attempts an unpinned `pip install flash-attn --no-build-isolation` build when the standalone NVIDIA CUDA Toolkit (`nvcc`) is on `PATH`; without the toolkit it skips cleanly rather than starting a doomed compile.
+- **macOS** always skips — no FA2 path there.
+
+When a compatible build is present (however it got there), activate it via `QWEN_ATTN_IMPL=flash_attention_2` in `server/.env`.
 
 **Switch a book to Qwen3.** Start the app and go to **Account → Defaults for new books → Voice engine** → "Local (free)" → **Voice model** → pick the Qwen3 entry. Save. For an existing book opened under Kokoro / Coqui, use the cast view's "Rebaseline the series" modal to design Qwen voices for the principal cast before regenerating.
 

--- a/docs/wiki/Installing-Castwright.md
+++ b/docs/wiki/Installing-Castwright.md
@@ -294,7 +294,7 @@ node server/tts-sidecar/scripts/install-qwen3.mjs --flash-attn
 
 The installer checks any platform first: if `flash_attn` is already importable in the sidecar venv, it skips straight to telling you how to activate it — no reinstall attempt. Otherwise the path depends on your OS:
 
-- **Windows** installs a prebuilt wheel, but it's pinned to `cp311 + torch-2.6 + cu124` — the script **auto-skips on the current Python 3.12 (cp312) stack**, and Qwen runs on SDPA instead.
+- **Windows** installs a prebuilt wheel, but that specific wheel's own build tag is `cp311 + torch-2.6 + cu124` — it can't load on the sidecar's actual **cp312 + torch 2.11 + cu128** stack, so the script **auto-skips** and Qwen runs on SDPA instead. A native wheel for the real stack is tracked separately (side-22, #1001).
 - **Linux** attempts an unpinned `pip install flash-attn --no-build-isolation` build when the standalone NVIDIA CUDA Toolkit (`nvcc`) is on `PATH`; without the toolkit it skips cleanly rather than starting a doomed compile.
 - **macOS** always skips — no FA2 path there.
 

--- a/docs/wiki/Manuscript-Management.md
+++ b/docs/wiki/Manuscript-Management.md
@@ -37,6 +37,8 @@ Beyond fixing lines one at a time, **Review Script** sends a chapter (or the who
   <img alt="Review Script diff — grouped strip-tag, reassign, and exclude suggestions with per-row checkboxes" src="images/manuscript-management/review-script-diff.png">
 </picture>
 
+Findings survive you — reload the page, close the tab, or come back tomorrow, and a chapter's proposed fixes are still sitting there untouched. Closing the diff view never discards them; only an explicit "Dismiss all" does. If you start a fresh review over a chapter that still has findings waiting on you, Castwright asks you to confirm first rather than quietly reviewing over the top of them.
+
 Below, Chapter 3's suggestions grouped by kind — strip a stray dialogue tag, reassign a line to a speaker outside the detected cast, or exclude a page-number artefact — with **Select all** per group and a running count of what's checked, so you accept exactly the fixes you want in one **Apply** click.
 
 ## Two more editing tools in the same header


### PR DESCRIPTION
## Summary

Pre-release wiki audit against everything merged since v1.11.0 turned up 3 pages that had drifted behind shipped v1.12.0 behavior:

- **`Exporting.md`** never mentioned the new Captions export (fs-52, #1497) — added a section covering line/sentence/word granularity, whole-book/per-chapter scope, and the staleness-warning behavior.
- **`Installing-Castwright.md`**'s FlashAttention-2 section was factually wrong — still described the old Windows-only pinned-wheel path. Rewritten to reflect the cross-platform detect + Linux opt-in install (side-21, #1000/#1492).
- **`Manuscript-Management.md`**'s Review Script section didn't mention findings now persist across reload / non-destructive close / re-run confirm gate (fs-58, #1479).

Docs-only diff (`docs/wiki/**`), so no code/test surface to exercise.

## Test plan

- [x] Manually cross-checked each edit against the shipped behavior described in `docs/release-notes-next.md` and the merged PRs (#1497, #1492, #1479).
- N/A — docs-only, no automated test surface.

Refs #1352