### PR TITLE
fix(frontend): wait for granularity-reset render in captions test

### DIFF
--- a/src/modals/export-audiobook.test.tsx
+++ b/src/modals/export-audiobook.test.tsx
@@ -740,14 +740,14 @@ describe('ExportAudiobookModal — Captions (fs-52)', () => {
     );
 
     fireEvent.click(screen.getByTestId('export-format-captions'));
-    await waitFor(() => expect(screen.getByTestId('captions-granularity-word')).toBeDisabled());
-    /* The Word→Sentence reset (export-audiobook.tsx's second effect, keyed on
-       whisperAvailable) commits a render AFTER the one that disables Word —
-       it doesn't land in the same commit, so it needs its own wait rather
-       than a synchronous assertion right after the toBeDisabled() above. */
-    await waitFor(() =>
-      expect(screen.getByTestId('captions-granularity-sentence').className).toContain('bg-white'),
-    );
+    /* Word-disabled and the Sentence-selected reset land in the same commit
+       (export-audiobook.tsx sets whisperAvailable and resets
+       captionGranularity together in one state update), so one waitFor
+       covering both is enough — no need for a second, separate wait. */
+    await waitFor(() => {
+      expect(screen.getByTestId('captions-granularity-word')).toBeDisabled();
+      expect(screen.getByTestId('captions-granularity-sentence').className).toContain('bg-white');
+    });
     expect(screen.getByTestId('captions-granularity-word').className).not.toContain('bg-white');
   });
 });

--- a/src/modals/export-audiobook.test.tsx
+++ b/src/modals/export-audiobook.test.tsx
@@ -741,7 +741,13 @@ describe('ExportAudiobookModal — Captions (fs-52)', () => {
 
     fireEvent.click(screen.getByTestId('export-format-captions'));
     await waitFor(() => expect(screen.getByTestId('captions-granularity-word')).toBeDisabled());
-    expect(screen.getByTestId('captions-granularity-sentence').className).toContain('bg-white');
+    /* The Word→Sentence reset (export-audiobook.tsx's second effect, keyed on
+       whisperAvailable) commits a render AFTER the one that disables Word —
+       it doesn't land in the same commit, so it needs its own wait rather
+       than a synchronous assertion right after the toBeDisabled() above. */
+    await waitFor(() =>
+      expect(screen.getByTestId('captions-granularity-sentence').className).toContain('bg-white'),
+    );
     expect(screen.getByTestId('captions-granularity-word').className).not.toContain('bg-white');
   });
 });

--- a/src/modals/export-audiobook.tsx
+++ b/src/modals/export-audiobook.tsx
@@ -208,14 +208,26 @@ export function ExportAudiobookModal({
   /* fs-52 — hydrate whether the sidecar's Whisper package is installed so
      the Captions "Word" granularity option can be disabled when it isn't.
      Re-probed each time the modal opens (cheap health check, no caching
-     needed like the LAN URLs above). */
+     needed like the LAN URLs above). If Word was already selected and the
+     probe resolves unavailable, reset the selection in the SAME state
+     update (not a second effect keyed off whisperAvailable) — two effects
+     would commit in separate renders, leaving a real intermediate frame
+     where the Word pill is already disabled but captionGranularity is
+     still 'word', which handleSubmit reads with no re-validation. Setting
+     both together lets React batch them into one commit, so no such frame
+     ever exists. */
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
     api
       .getSidecarHealth()
       .then((h) => {
-        if (!cancelled) setWhisperAvailable(h.whisperPackageInstalled !== false);
+        if (cancelled) return;
+        const available = h.whisperPackageInstalled !== false;
+        setWhisperAvailable(available);
+        if (!available) {
+          setCaptionGranularity((g) => (g === 'word' ? 'sentence' : g));
+        }
       })
       .catch(() => {
         /* swallow — Word stays enabled optimistically if the probe fails */
@@ -224,18 +236,6 @@ export function ExportAudiobookModal({
       cancelled = true;
     };
   }, [open]);
-
-  /* fs-52 final-review fix — stale-selection hardening. If Word was
-     already selected and a re-probe (the effect above, e.g. on reopen)
-     resolves `whisperAvailable` to false, the Word pill goes disabled but
-     the already-selected value would otherwise persist, letting the user
-     submit a granularity the server will 400 on. Reset to the default
-     the moment availability flips false while 'word' is selected. */
-  useEffect(() => {
-    if (!whisperAvailable && captionGranularity === 'word') {
-      setCaptionGranularity('sentence');
-    }
-  }, [whisperAvailable, captionGranularity]);
 
   /* Reset transient UI state on close so the next open is a clean slate.
      Prefill (when set) overrides the per-open defaults — so the Voice tile


### PR DESCRIPTION
## Summary

The v1.12.0 release-cut cross-OS gate failed on the macOS leg with a test-synchronization issue that turned out to trace back to a real, if narrow, production race condition (#1499).

**Root cause:** `export-audiobook.tsx`'s Whisper-unavailable → captionGranularity reset lived in a *second* `useEffect` keyed off `whisperAvailable`. Passive effects flush after paint, so that second effect committed in a separate, visible render AFTER the one that disabled the Word pill — a real intermediate frame where Word is disabled but `captionGranularity` is still `'word'`. `handleSubmit` reads `captionGranularity` from the render closure with no re-validation at submit time, so a fast click on Export during that window could submit `'word'` after Whisper had gone unavailable — reproducing the exact 400 the reset effect's own comment says it exists to prevent.

Caught by an adversarial code-review pass on the initial (test-only) fix — full mechanism verified against the actual submit path and effect scheduling, not assumed.

## Fix

1. **Production fix:** merge the two effects. `whisperAvailable` and the `captionGranularity` reset now set together inside the same health-probe effect, so React batches them into one commit — no commit ever has Word disabled while `captionGranularity` is still `'word'`. Closes the race for every caller, not just the test.
2. **Test simplified accordingly:** since both conditions now land in the same commit, the test collapses back to a single `waitFor` covering both, rather than two sequential waits.

## Test plan

- [x] `npx vitest run src/modals/export-audiobook.test.tsx` — 29/29 passing locally.
- [x] `npx tsc --noEmit` — clean.
- [x] Full `verify.yml` battery (frontend tests, lint/typecheck, e2e, server tests) green on this PR.

Closes #1499