### PR TITLE
chore: bump version to 1.12.0

### DIFF
--- a/apps/android/pubspec.yaml
+++ b/apps/android/pubspec.yaml
@@ -21,7 +21,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # 3-digit build-iteration band so successive Play uploads of the same marketing
 # version take base+1, base+2, … via `flutter build … --build-number=<N>`).
 # Plan 188.
-version: 1.11.0+11100000
+version: 1.12.0+11200000
 
 environment:
   sdk: ^3.12.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "castwright",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "castwright",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "castwright",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "private": true,
   "type": "commonjs",
   "engines": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "castwright-server",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "castwright-server",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "dependencies": {
         "@google/genai": "^2.7.0",
         "@lingo-reader/mobi-parser": "^0.4.6",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "castwright-server",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/tts-sidecar/version.py
+++ b/server/tts-sidecar/version.py
@@ -7,4 +7,4 @@ SIDECAR_PROTOCOL_VERSION in main.py: the protocol version gates adopt/replace of
 a running sidecar, while __version__ is purely informational.
 """
 
-__version__ = "1.11.0"
+__version__ = "1.12.0"


### PR DESCRIPTION
## Summary

Version bump commit for the v1.12.0 release cut (`scripts/bump-version.mjs --level minor`). Bumps root + server `package.json` (1.11.0 → 1.12.0), `server/tts-sidecar/version.py`, and `apps/android/pubspec.yaml` in lockstep, plus refreshes the `brand/project-narrative.md` code-stats block.

Routed through a PR because `main` blocks direct pushes — the `v1.12.0` annotated tag (from `docs/release-notes-next.md`) is created locally and will be pushed after this merges, so it's reachable as a merge-parent commit.

**Cross-OS gate already verified on this exact commit** before the bump: `cross-os.yml` run [29080856443](https://github.com/dudarenok-maker/Castwright/actions/runs/29080856443) (macOS + Windows verify/build + mobile e2e) — all 4 jobs green. `--skip-cross-os` was passed to avoid re-running an already-passed gate on an unchanged SHA; local `test`/`test:server`/`test:sidecar`/`build` all passed during the bump + this push.

## Test plan

- [x] `npm test` — 3776/3776 passing (during the bump commit's pre-commit hook).
- [x] `cd server && npm test` — 4423 passing / 8 skipped (during the bump commit's pre-commit hook).
- [x] `npm run test:sidecar` — passing (during this branch's pre-push hook).
- [x] `npm run build` — clean.
- [x] `cross-os.yml` green on the pre-bump commit (4431f01c) — see run linked above.

Closes #1501