### PR TITLE
fix(scripts): archive board items via raw GraphQL, not owner-resolving CLI

### DIFF
--- a/scripts/clear-done-project-items.mjs
+++ b/scripts/clear-done-project-items.mjs
@@ -67,11 +67,18 @@ export function buildArchiveMutationArgs(projectId, itemId) {
   return ['api', 'graphql', '-f', `query=${mutation}`, '-f', `projectId=${projectId}`, '-f', `itemId=${itemId}`];
 }
 
+// Returns { projectId, items } — projectId comes from THIS query (the same
+// board projectNumber+PROJECT_OWNER resolve to), not the config file's
+// separately-recorded projectId. Deriving it here rather than trusting
+// config.projectId as a second source of truth means a stale/hand-edited
+// config value can't send the archive mutation below at a different project
+// than the one Done items were actually listed from.
 function listDoneItems(config) {
   const query = `
     query($login: String!, $number: Int!, $after: String) {
       user(login: $login) {
         projectV2(number: $number) {
+          id
           items(first: 100, after: $after) {
             pageInfo { hasNextPage endCursor }
             nodes {
@@ -89,17 +96,19 @@ function listDoneItems(config) {
   // once the board grows past 100 total items (85 issues + initiative
   // parents + whatever accumulates in Done between releases).
   const results = [];
+  let projectId = null;
   let after = null;
   for (;;) {
     const args = ['api', 'graphql', '-f', `query=${query}`, '-f', `login=${PROJECT_OWNER}`, '-F', `number=${config.projectNumber}`];
     if (after) args.push('-f', `after=${after}`);
     const raw = gh(args);
-    const data = JSON.parse(raw).data.user.projectV2.items;
-    results.push(...data.nodes);
-    if (!data.pageInfo.hasNextPage) break;
-    after = data.pageInfo.endCursor;
+    const projectV2 = JSON.parse(raw).data.user.projectV2;
+    projectId = projectV2.id;
+    results.push(...projectV2.items.nodes);
+    if (!projectV2.items.pageInfo.hasNextPage) break;
+    after = projectV2.items.pageInfo.endCursor;
   }
-  return results.filter(isArchivable);
+  return { projectId, items: results.filter(isArchivable) };
 }
 
 function parseArgs(argv) {
@@ -120,7 +129,7 @@ async function main() {
   if (!ghAvailable()) die('`gh` not found. Install the GitHub CLI + `gh auth login`.');
 
   const config = JSON.parse(readFileSync(CONFIG_PATH, 'utf8'));
-  const doneItems = listDoneItems(config);
+  const { projectId, items: doneItems } = listDoneItems(config);
 
   info(`${doneItems.length} Done item(s):`);
   for (const item of doneItems) info(`  #${item.content.number} ${item.content.title}`);
@@ -131,7 +140,7 @@ async function main() {
   }
 
   for (const item of doneItems) {
-    gh(buildArchiveMutationArgs(config.projectId, item.id));
+    gh(buildArchiveMutationArgs(projectId, item.id));
     info(`  archived #${item.content.number}`);
   }
   info(`\n[OK] archived ${doneItems.length} Done item(s).`);

--- a/scripts/clear-done-project-items.mjs
+++ b/scripts/clear-done-project-items.mjs
@@ -50,6 +50,23 @@ export function isArchivable(node) {
   return !labels.includes('moscow:wont');
 }
 
+// `gh project item-archive --owner <login>` resolves the owner's account type
+// (User vs Organization) via its own internal GraphQL query before archiving.
+// That resolution needs more than the `project`+`repo` scopes the CI PAT
+// carries (ADD_TO_PROJECT_PAT — see CONTRIBUTING.md) and fails with the
+// unhelpful "unknown owner type" (gh's generic fallback for a resolution it
+// can't classify) — see #1503. A raw `archiveProjectV2Item` mutation against
+// the project's node ID sidesteps owner resolution entirely and needs only
+// `project` scope, matching how listDoneItems() above already reads via raw
+// GraphQL instead of `gh project item-list --owner`.
+export function buildArchiveMutationArgs(projectId, itemId) {
+  const mutation = `
+    mutation($projectId: ID!, $itemId: ID!) {
+      archiveProjectV2Item(input: { projectId: $projectId, itemId: $itemId }) { item { id } }
+    }`;
+  return ['api', 'graphql', '-f', `query=${mutation}`, '-f', `projectId=${projectId}`, '-f', `itemId=${itemId}`];
+}
+
 function listDoneItems(config) {
   const query = `
     query($login: String!, $number: Int!, $after: String) {
@@ -114,7 +131,7 @@ async function main() {
   }
 
   for (const item of doneItems) {
-    gh(['project', 'item-archive', String(config.projectNumber), '--owner', PROJECT_OWNER, '--id', item.id]);
+    gh(buildArchiveMutationArgs(config.projectId, item.id));
     info(`  archived #${item.content.number}`);
   }
   info(`\n[OK] archived ${doneItems.length} Done item(s).`);

--- a/scripts/tests/clear-done-project-items.test.mjs
+++ b/scripts/tests/clear-done-project-items.test.mjs
@@ -4,7 +4,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { isArchivable } from '../clear-done-project-items.mjs';
+import { isArchivable, buildArchiveMutationArgs } from '../clear-done-project-items.mjs';
 
 test('isArchivable excludes a moscow:wont issue even when its Status is Done', () => {
   const node = {
@@ -33,4 +33,24 @@ test('isArchivable excludes a non-Done item', () => {
 test('isArchivable excludes a node with no content (e.g. a draft item)', () => {
   const node = { status: { name: 'Done' }, content: null };
   assert.equal(isArchivable(node), false);
+});
+
+// Regression for #1503: `gh project item-archive --owner <login>` fails in
+// CI with "unknown owner type" because the ADD_TO_PROJECT_PAT (project+repo
+// scopes only) can't satisfy gh's internal owner-type resolution. The fix
+// archives via a raw `archiveProjectV2Item` GraphQL mutation instead, which
+// needs only the project ID — never an owner login.
+test('buildArchiveMutationArgs never invokes the owner-resolving CLI form', () => {
+  const args = buildArchiveMutationArgs('PVT_kwHOEOX6_c4Bcf9a', 'PVTI_lAHOEOX6_c4Bcf9azgySYBo');
+  assert.ok(!args.includes('--owner'), 'must not pass --owner (triggers gh CLI owner-type resolution)');
+  assert.ok(!args.includes('item-archive'), 'must not use the `gh project item-archive` subcommand');
+});
+
+test('buildArchiveMutationArgs issues a raw archiveProjectV2Item mutation with the project + item IDs', () => {
+  const args = buildArchiveMutationArgs('PVT_kwHOEOX6_c4Bcf9a', 'PVTI_lAHOEOX6_c4Bcf9azgySYBo');
+  assert.deepEqual(args.slice(0, 2), ['api', 'graphql']);
+  const queryArg = args.find((a) => a.startsWith('query='));
+  assert.ok(queryArg?.includes('archiveProjectV2Item'));
+  assert.ok(args.includes('projectId=PVT_kwHOEOX6_c4Bcf9a'));
+  assert.ok(args.includes('itemId=PVTI_lAHOEOX6_c4Bcf9azgySYBo'));
 });


### PR DESCRIPTION
## Summary
- \`release.yml\`'s \`clear-done-board-items\` job called \`gh project item-archive --owner dudarenok-maker\`, which fails in CI with \`unknown owner type\` (#1503).
- Root cause: that CLI subcommand internally resolves \`--owner\`'s account type (User vs Organization) via its own GraphQL query, which needs more scope than \`ADD_TO_PROJECT_PAT\` (classic PAT, \`project\`+\`repo\` only) grants. gh's owner-resolution code falls back to a generic \`unknown owner type\` error rather than surfacing the real permission gap. Confirmed by comparing against the same script's \`listDoneItems()\`, which already succeeds under the same restricted token via a *raw* \`gh api graphql\` read (proving the token itself has sufficient Projects v2 access) — the CI log shows all 17 Done items listed successfully right before the crash.
- Fix: archive via a raw \`archiveProjectV2Item\` GraphQL mutation against the project's node ID (already stored in \`docs/backlog-project-config.json\`), matching the existing raw-GraphQL read pattern and needing only \`project\` scope — no owner login, no owner-type resolution.
- Verified the mutation's shape directly against the live API with a bogus item ID (got the expected "could not resolve node" error, not a permission/syntax error) before writing any code.

## Test plan
- [x] New regression tests in \`scripts/tests/clear-done-project-items.test.mjs\` assert the built args never include \`--owner\` / \`item-archive\`, and correctly shape the raw mutation.
- [x] \`npm run test:hooks\` — 564/564 pass.
- [x] \`npm run verify:fast:branch\` — lint pass, test:hooks pass, rest out of scope for this diff.
- [x] No product/release-notes delta — this is CI/internal-tooling only (the board-archive step of the release pipeline), no user- or operator-visible behavior change, so \`RELEASE_NOTES.md\`/\`release-notes-next.md\` are intentionally not touched per the "no shippable delta" exemption.
- [x] No \`docs/features/\` plan doc — small/localized fix, issue body + paired test is the spec per CLAUDE.md.

Closes #1503

🤖 Generated with [Claude Code](https://claude.com/claude-code)