### PR TITLE
chore: bump version to 1.12.2

### DIFF
--- a/apps/android/pubspec.yaml
+++ b/apps/android/pubspec.yaml
@@ -21,7 +21,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # 3-digit build-iteration band so successive Play uploads of the same marketing
 # version take base+1, base+2, … via `flutter build … --build-number=<N>`).
 # Plan 188.
-version: 1.12.1+11201000
+version: 1.12.2+11202000
 
 environment:
   sdk: ^3.12.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "castwright",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "castwright",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "castwright",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "private": true,
   "type": "commonjs",
   "engines": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "castwright-server",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "castwright-server",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "dependencies": {
         "@google/genai": "^2.7.0",
         "@lingo-reader/mobi-parser": "^0.4.6",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "castwright-server",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/tts-sidecar/version.py
+++ b/server/tts-sidecar/version.py
@@ -7,4 +7,4 @@ SIDECAR_PROTOCOL_VERSION in main.py: the protocol version gates adopt/replace of
 a running sidecar, while __version__ is purely informational.
 """
 
-__version__ = "1.12.1"
+__version__ = "1.12.2"


### PR DESCRIPTION
## Summary
- Bumps `package.json` / `server/package.json` / `server/tts-sidecar/version.py` / `apps/android/pubspec.yaml` from 1.12.1 → 1.12.2 (patch).
- Cross-OS gate passed (macOS + Windows verify/build + mobile e2e) on the same `origin/main` this commit is based on, before the tag was created.
- Patch release to ship the Pinokio server-`.env`-cwd fix (#1513/#1514) so a clean Install → Start comes up fully configured.

## Test plan
- [x] Cross-OS gate (`cross-os.yml`) green on `origin/main` before the bump.
- [x] Version-only diff (6 files, 8/8 insertions/deletions) — no runtime surface.

Closes #1515

🤖 Generated with [Claude Code](https://claude.com/claude-code)