### PR TITLE
docs(frontend): add a captions/subtitles export Help topic

### DIFF
--- a/src/data/help-topics.ts
+++ b/src/data/help-topics.ts
@@ -242,6 +242,17 @@ export const HELP_TOPICS: HelpTopic[] = [
       'it up on its next scheduled library scan.',
   },
   {
+    id: 'caption-export',
+    title: 'Can I get captions or subtitles for a book?',
+    body:
+      'Yes — on the Listen view, under "Or download a file", the Captions tile writes an .srt or ' +
+      '.vtt file alongside the audio. Choose the granularity — line, sentence, or word — and the ' +
+      'scope — the whole book or a single chapter. Line and sentence captions are read straight ' +
+      "from the book's own alignment, so there's nothing to re-render; word-level timing runs the " +
+      'chapter through the local Whisper model for the finer grain a demo clip wants. The file ' +
+      "lands in the book's folder with the rest of your exports.",
+  },
+  {
     id: 'analysis-reloads-or-gpu-busy',
     title: 'Analysis keeps reloading the model, or says "GPU busy"',
     body:


### PR DESCRIPTION
## Summary
- Adds a `caption-export` Help topic (`src/data/help-topics.ts`) answering "Can I get captions or subtitles for a book?" — how to export SRT/VTT (line/sentence/word granularity, whole-book or per-chapter) from the Listen view's "Or download a file" → **Captions** tile, with the word-level Whisper caveat.
- Mirrors the marketing site's captions claim, matching fs-52 (shipped v1.12.0). Website side already merged (Castwright-Website PR #117).

## Test plan
- [x] `npm run lint` — pass
- [x] `npm run typecheck` — pass
- [x] `npm run test` — pass (cached)
- [x] `npm run build` — pass
- [ ] Manual: Help view renders the new topic

Refs #975