### PR TITLE
chore: bump version to 1.12.3

### DIFF
--- a/apps/android/pubspec.yaml
+++ b/apps/android/pubspec.yaml
@@ -21,7 +21,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # 3-digit build-iteration band so successive Play uploads of the same marketing
 # version take base+1, base+2, … via `flutter build … --build-number=<N>`).
 # Plan 188.
-version: 1.12.2+11202000
+version: 1.12.3+11203000
 
 environment:
   sdk: ^3.12.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "castwright",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "castwright",
-      "version": "1.12.2",
+      "version": "1.12.3",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "castwright",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "private": true,
   "type": "commonjs",
   "engines": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "castwright-server",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "castwright-server",
-      "version": "1.12.2",
+      "version": "1.12.3",
       "dependencies": {
         "@google/genai": "^2.7.0",
         "@lingo-reader/mobi-parser": "^0.4.6",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "castwright-server",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/tts-sidecar/version.py
+++ b/server/tts-sidecar/version.py
@@ -7,4 +7,4 @@ SIDECAR_PROTOCOL_VERSION in main.py: the protocol version gates adopt/replace of
 a running sidecar, while __version__ is purely informational.
 """
 
-__version__ = "1.12.2"
+__version__ = "1.12.3"


### PR DESCRIPTION
## Summary

Version bump to **1.12.3** — the consolidated Pinokio-installer patch (the reserved-folder rename + schema bump from #1529, rolling up the v1.12.1/v1.12.2 fixes). Bumps root + server `package.json` (+ lockfiles), the sidecar `version.py`, and the companion `pubspec.yaml` in lockstep. The annotated `v1.12.3` tag is created from the consolidated `docs/release-notes-next.md`; it's pushed after this merges so `release.yml` runs full verify + cross-OS + mobile before publishing.

Cross-OS gate was run via `--skip-cross-os` (redundant with `release.yml`'s authoritative on-tag gate; this release is launcher/config/docs only).

## Test plan

- `release.yml` on the `v1.12.3` tag is the authoritative gate (full verify + cross-OS + mobile) before the GitHub release publishes.

Refs #822