### PR TITLE
fix(server): harden cast design job against GPU contention

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+# Castwright 1.13.0
+
+- **Designing your whole cast at once no longer stalls silently on a busy GPU.** If something else was using the GPU while you designed voices for every character at once, the process used to fail on every remaining character one after another — and the progress bar kept climbing the whole time, even though nothing was actually finishing. It now gives itself a moment to recover, and if the GPU is still busy after that, it stops cleanly and tells you what happened and how far it got, instead of quietly failing its way to the end. The progress bar itself is now honest too — it only counts characters that actually finished.
+
 # Castwright 1.12.3
 
 - **The one-click Pinokio install now works end to end.** This patch rolls up the run of fixes that stood between a fresh Pinokio download and a working Castwright. The Install button would appear but quietly do nothing — our launcher lived in a folder named `pinokio`, a name Pinokio reserves for itself, so the button couldn't fire our installer; moving it out of that reserved name lets Install run the moment you click it. From there, the installer's own setup scripts had been running from the wrong folder, so the very first step failed before anything could install; and once past that, the server came up from the wrong place and quietly ran on default settings instead of your own. All three are fixed — click Install in Pinokio and it now runs all the way through and starts up fully configured, from the first click.

--- a/docs/release-notes-next.md
+++ b/docs/release-notes-next.md
@@ -16,30 +16,23 @@ The marker is what bump-version checks: if it doesn't match the version being
 cut, the bump refuses (so a stale file can't ship as the body). The
 user-facing, brand-voice notes live separately in RELEASE_NOTES.md (#/release-notes).
 
-release-notes-next-version: 1.12.3
+release-notes-next-version: 1.13.0
 
-DRAFT IN PROGRESS — v1.12.3 is the single, consolidated Pinokio-installer
-patch. It supersedes the v1.12.1 and v1.12.2 patches, which are DELETED at
-cut (releases + tags), so the changelog base is v1.12.0 (v1.12.0...v1.12.3)
-and the body below rolls up all three fixes: reserved-folder-name + schema
-version (this release), the installer shell-cwd fix (was v1.12.1), and the
-server .env-cwd fix (was v1.12.2). Authored consolidated per CONTRIBUTING.md
-"Release notes"; the delist→relist itself is gated on the fresh-install
-acceptance test passing.
+DRAFT IN PROGRESS — first PR of the v1.13.0 cycle (v1.12.3 shipped as the
+consolidated Pinokio-installer patch, superseding v1.12.1/v1.12.2).
+Bootstrapped per CONTRIBUTING.md "Release notes": marker bumped forward,
+stale v1.12.3 body cleared, this PR's own entry opens the fresh draft.
+Diffed against v1.12.3 (the previous public release).
 -->
 
-**A patch release: the one-click Pinokio install now works end to end.** v1.12.3 consolidates the run of installer fixes since v1.12.0 — it supersedes and replaces the v1.12.1 and v1.12.2 patches. A fresh Pinokio Download → Install → Start now goes all the way through: the Install button fires the installer, every setup step runs from the right directory, and the server starts fully configured from its own `server/.env`.
-
-> **Migration:** this release relocates the launcher directory (`pinokio/` → `pinokio-scripts/`). Pinokio's in-app **Update** cannot cross a launcher-dir rename — an existing v1.12.x install's frozen `resolve-release.js` guards the old path and aborts. **Existing Pinokio users must reinstall fresh**, not Update. (Blast radius is minimal: the app was delisted across the 1.12.x installer patches, so few installs exist; the v1.12.1/v1.12.2 releases are deleted at cut.)
+**Ongoing hardening.** *(placeholder theme — refine at cut time once the full v1.13.0 scope is known.)*
 
 ---
 
-## 🚀 Onboarding
+## 🎙️ Voice design & casting
 
-- **The Pinokio Install button now auto-fires the installer on first activation.** The launcher scripts lived under a folder named `pinokio/` — a name the current Pinokio runtime reserves internally — so the download-screen Install button rendered but never triggered `install.js` (running it by hand from inside the app still worked, which is why installs completed when triggered manually but looked broken to first-time users). Renamed the launcher subtree to `pinokio-scripts/`, bumped its script schema version `1.0` → `7.0` to match every shipping Pinokio app, and added structural tests that load the real launcher and assert the folder isn't a reserved name, the schema version is current, and every menu action resolves to a real script. (#1529)
-- **The installer's own setup steps now run from the app root, not the launcher folder** _(was v1.12.1)._ Every `shell.run`/`fs.rm` step defaulted its working directory to the script's own launcher folder rather than the app root, so the very first setup step (the conda env) resolved one directory too deep and failed before anything installed. Each step now sets `path: '..'` to reach the app root. (#1508, #1509)
-- **A Pinokio-launched server no longer boots on bare defaults** _(was v1.12.2)._ Once install ran, Start launched the server from the app's top folder instead of its `server/` folder, so it couldn't find its own `.env` — workspace location, worker counts, GPU memory budget, analyzer settings — and quietly fell back to defaults. It now launches from `server/` (matching how the desktop app has always started it), so a Pinokio install comes up with its real settings from the first run. (#1513, #1514)
+- **"Design full cast" no longer silently grinds through GPU contention.** If another job was using the GPU while a bulk cast design was running, every remaining character used to fail identically, one after another, with the progress pill misleadingly climbing toward 100% the whole time (even reading "0/16 · 94%" — zero characters designed, but nearly "complete"). The sidecar now recognizes this specific contention and triggers its existing self-recovery restart (matching how it already handles other transient failures); the job rides out a brief pause before halting with a clear message naming the cause and how far it got, instead of grinding through every remaining character. The progress pill's percent no longer counts failures as progress, and now shows the failure count inline while the job is still running. (#1533)
 
 ---
 
-**Full changelog:** v1.12.0...v1.12.3
+**Full changelog:** v1.12.3...v1.13.0

--- a/docs/superpowers/plans/2026-07-11-cast-design-job-hardening.md
+++ b/docs/superpowers/plans/2026-07-11-cast-design-job-hardening.md
@@ -736,7 +736,8 @@ wait silently dropped a character's accounting."
 - [ ] **Step 1: Write the failing test — component level (top-bar.test.tsx)**
 
 In `src/components/top-bar.test.tsx`, inside the `describe('DesignPill', ...)` block, add right after
-the existing `'renders the running summary "Designing · done/total · percent"'` test (after line 485):
+the existing `'renders the running summary "Designing · done/total · percent"'` test (that test's
+closing `});` is at line 485 — insert the new test after it, not inside it):
 
 ```ts
   it('surfaces the failure count inline while running (not just in the terminal summary)', () => {

--- a/docs/superpowers/plans/2026-07-11-cast-design-job-hardening.md
+++ b/docs/superpowers/plans/2026-07-11-cast-design-job-hardening.md
@@ -1,0 +1,940 @@
+# Cast Design Job Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the "Design full cast" bulk voice-design job from silently grinding through every
+remaining character with the same doomed GPU-contention error, and stop its status pill from showing a
+climbing percent while zero characters are actually succeeding.
+
+**Architecture:** Three independent-but-related fixes, landed in dependency order. (1)+(2) bring
+`/qwen/design-voice` and `/qwen/mint-variant` in `server/tts-sidecar/main.py` up to the same
+CUDA-poison-detection standard four sibling routes already use, so a GPU-OOM triggers the sidecar's
+existing supervised-restart mechanism instead of a swallowed generic 500. (3) widens
+`server/src/routes/cast-design.ts`'s per-character retry loop to recognize two systemic-error classes —
+"sidecar restarting" (reuses the existing health-poll ride-out) and "GPU busy, no restart" (a new short
+bounded sleep) — riding each out briefly before halting the whole job with a clear message, instead of
+recording 15 identical failures one by one. (4) fixes the status pill's percent formula
+(`src/components/layout.tsx`) so a failure no longer counts as "progress," and surfaces the failure count
+inline in the running-state label (`src/components/top-bar.tsx`).
+
+**Tech Stack:** Python/FastAPI (sidecar), Node/Express/TypeScript (server), React/Redux Toolkit
+(frontend). Sidecar tests: pytest + `fastapi.testclient.TestClient`. Server tests: Vitest + supertest.
+Frontend tests: Vitest + React Testing Library.
+
+## Global Constraints
+
+- Spec of record: `docs/superpowers/specs/2026-07-11-cast-design-job-hardening-design.md` (read this
+  first for the full rationale — this plan is the "how," that doc is the "why").
+- Two `endJob` error `code`s stay separate per explicit user decision: `sidecar_unavailable` (sidecar
+  restarting — connection-down OR the new CUDA-poison-restart case) and `gpu_contention` (GPU busy, no
+  restart involved — the Node-side `GpuBusyError` eviction refusal).
+- The Node-side classifier keys on specific `code` values (`gpu_poisoned`, `GPU_BUSY`), never a blanket
+  `status === 503` — `/qwen/mint-variant`'s existing `base17-unavailable` 503 is a *permanent* condition
+  (1.7B-Base not installed/corrupt) that must never be treated as retryable contention.
+- No new configurability beyond what's specified below — in particular, the new GPU-busy ride-out delay
+  is a single hardcoded constant, not a user/registry setting.
+- Every step below traces to a section of the spec; don't add scope beyond what's written here.
+
+---
+
+## Task 1: Sidecar — classify CUDA poison in `/qwen/design-voice`
+
+**Files:**
+- Modify: `server/tts-sidecar/main.py:5587-5589`
+- Test: `server/tts-sidecar/tests/test_qwen_design_poison.py` (new)
+
+**Interfaces:**
+- Consumes: existing `_CUDA_POISON_RE` (module-level regex, `main.py:498-505`) and `_mark_cuda_poisoned`
+  (module-level function, `main.py:580-589`) — both already defined, used verbatim, no changes to either.
+- Produces: on a CUDA-poison-shaped exception, `/qwen/design-voice` now returns
+  `{"detail": "GPU is out of memory — likely another job (generation/analysis/design) is using it. Free
+  up GPU memory and try again.", "poisoned": true, "code": "gpu_poisoned"}` at HTTP 503 (previously: a
+  bare `{"detail": "Internal error."}` at 500 for every exception, poison included). Non-poison
+  exceptions are UNCHANGED (still the generic 500). Task 3 consumes the `"code": "gpu_poisoned"` string.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/tts-sidecar/tests/test_qwen_design_poison.py`:
+
+```python
+"""CUDA-poison classification for /qwen/design-voice and /qwen/mint-variant
+(issue: the bulk 'Design full cast' job silently ground through every
+character on GPU contention because these two routes never checked
+_CUDA_POISON_RE like /transcribe and /embed already do — see
+docs/superpowers/specs/2026-07-11-cast-design-job-hardening-design.md)."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+import main
+
+
+def _reset_poison_guards(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mirrors test_speaker_embed.py's test_embed_load_poison_is_fenced: clear
+    both guard flags so the route reaches the design call, and stub
+    _mark_cuda_poisoned so the test process never schedules a real
+    threading.Timer-based os._exit."""
+    monkeypatch.setattr(main, "_process_poisoned", False, raising=False)
+    monkeypatch.setattr(main, "_restart_pending", False, raising=False)
+    monkeypatch.setattr(main, "_mark_cuda_poisoned", lambda reason: None)
+
+
+class _FakeQwenOom(main.QwenEngine):
+    def __init__(self):
+        pass  # skip the real heavy __init__; the route only calls design_voice
+
+    def design_voice(self, voice_id, instruct, language, calibration_text, voice_uuid=None, report_progress=None, mint_method=None, fallback_for=None):
+        raise RuntimeError(
+            "CUDA out of memory. Tried to allocate 20.00 MiB (GPU 0; 8.00 GiB total capacity; "
+            "7.90 GiB already allocated)"
+        )
+
+
+class _FakeQwenOther(main.QwenEngine):
+    def __init__(self):
+        pass
+
+    def design_voice(self, voice_id, instruct, language, calibration_text, voice_uuid=None, report_progress=None, mint_method=None, fallback_for=None):
+        raise RuntimeError("some unrelated, unclassified failure")
+
+
+def test_design_voice_oom_returns_classified_503(monkeypatch: pytest.MonkeyPatch):
+    _reset_poison_guards(monkeypatch)
+    monkeypatch.setitem(main.ENGINES, "qwen", _FakeQwenOom())
+
+    client = TestClient(main.app)
+    res = client.post("/qwen/design-voice", json={"voiceId": "qwen-x", "instruct": "warm"})
+
+    assert res.status_code == 503
+    body = res.json()
+    assert body["code"] == "gpu_poisoned"
+    assert body["poisoned"] is True
+    assert "GPU is out of memory" in body["detail"]
+    assert body["detail"] != "Internal error."
+
+
+def test_design_voice_non_poison_exception_stays_generic_500(monkeypatch: pytest.MonkeyPatch):
+    _reset_poison_guards(monkeypatch)
+    monkeypatch.setitem(main.ENGINES, "qwen", _FakeQwenOther())
+
+    client = TestClient(main.app)
+    res = client.post("/qwen/design-voice", json={"voiceId": "qwen-x", "instruct": "warm"})
+
+    assert res.status_code == 500
+    assert res.json() == {"detail": "Internal error."}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server/tts-sidecar && .venv\Scripts\python.exe -m pytest tests/test_qwen_design_poison.py -v`
+(or `npm run test:sidecar -- test_qwen_design_poison.py` from repo root)
+Expected: FAIL — `test_design_voice_oom_returns_classified_503` asserts `res.status_code == 503` but gets
+`500` with `body == {"detail": "Internal error."}` (today's unconditional generic catch).
+
+- [ ] **Step 3: Implement — classify the poison before the generic catch**
+
+In `server/tts-sidecar/main.py`, replace lines 5587-5589:
+
+```python
+    except Exception:
+        log.exception("/qwen/design-voice failed (voiceId=%s)", voice_id)
+        return JSONResponse({"detail": "Internal error."}, status_code=500)
+```
+
+with:
+
+```python
+    except Exception as e:
+        err_str = f"{e}"
+        if _CUDA_POISON_RE.search(err_str):
+            log.warning("/qwen/design-voice CUDA poison (voiceId=%s): %s", voice_id, e)
+            _mark_cuda_poisoned(err_str)
+            return JSONResponse(
+                {
+                    "detail": (
+                        "GPU is out of memory — likely another job (generation/analysis/design) "
+                        "is using it. Free up GPU memory and try again."
+                    ),
+                    "poisoned": True,
+                    "code": "gpu_poisoned",
+                },
+                status_code=503,
+            )
+        log.exception("/qwen/design-voice failed (voiceId=%s)", voice_id)
+        return JSONResponse({"detail": "Internal error."}, status_code=500)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server/tts-sidecar && .venv\Scripts\python.exe -m pytest tests/test_qwen_design_poison.py -v`
+Expected: both tests PASS.
+
+- [ ] **Step 5: Run the full sidecar suite to check for regressions**
+
+Run: `npm run test:sidecar` (from repo root)
+Expected: PASS (or the pre-existing SKIP banner if the venv isn't bootstrapped — in which case ask the
+user to bootstrap it before continuing, per CLAUDE.md's testing discipline).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/tts-sidecar/main.py server/tts-sidecar/tests/test_qwen_design_poison.py
+git commit -m "fix(sidecar): classify CUDA-OOM as poison in /qwen/design-voice
+
+Brings this route to parity with /transcribe, /embed, and two other
+sidecar routes that already trigger the supervised restart on a
+poisoning CUDA error instead of swallowing it into a generic 500."
+```
+
+---
+
+## Task 2: Sidecar — classify CUDA poison in `/qwen/mint-variant`
+
+**Files:**
+- Modify: `server/tts-sidecar/main.py:5679-5681`
+- Test: `server/tts-sidecar/tests/test_qwen_design_poison.py` (same file as Task 1 — same bug class, one
+  more route)
+
+**Interfaces:**
+- Consumes: same `_CUDA_POISON_RE` / `_mark_cuda_poisoned` as Task 1.
+- Produces: identical response shape to Task 1 (`code: "gpu_poisoned"`, `poisoned: true`, 503) from
+  `/qwen/mint-variant`'s generic exception handler. `_ensure_base17_for_mint`'s existing OOM re-raise
+  (`main.py:2158-2166`, unmodified) lands exactly here, so this closes the gap for both the base-design
+  and mint-variant paths.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/tts-sidecar/tests/test_qwen_design_poison.py`:
+
+```python
+class _FakeQwenMintOom(main.QwenEngine):
+    def __init__(self):
+        pass
+
+    def mint_variant(self, base_voice_id, variant_voice_id, emotion_instruct, language=None, calibration_text=None, voice_uuid=None, report_progress=None):
+        raise RuntimeError("CUDA out of memory. Tried to allocate 20.00 MiB (GPU 0; 8.00 GiB total capacity)")
+
+
+class _FakeQwenMintOther(main.QwenEngine):
+    def __init__(self):
+        pass
+
+    def mint_variant(self, base_voice_id, variant_voice_id, emotion_instruct, language=None, calibration_text=None, voice_uuid=None, report_progress=None):
+        raise RuntimeError("some unrelated, unclassified failure")
+
+
+def _mint_body():
+    return {
+        "baseVoiceId": "qwen-base",
+        "variantVoiceId": "qwen-base__angry",
+        "emotionInstruct": "Delivered angrily, with raised intensity and edge.",
+    }
+
+
+def test_mint_variant_oom_returns_classified_503(monkeypatch: pytest.MonkeyPatch):
+    _reset_poison_guards(monkeypatch)
+    monkeypatch.setitem(main.ENGINES, "qwen", _FakeQwenMintOom())
+
+    client = TestClient(main.app)
+    res = client.post("/qwen/mint-variant", json=_mint_body())
+
+    assert res.status_code == 503
+    body = res.json()
+    assert body["code"] == "gpu_poisoned"
+    assert body["poisoned"] is True
+    assert "GPU is out of memory" in body["detail"]
+
+
+def test_mint_variant_non_poison_exception_stays_generic_500(monkeypatch: pytest.MonkeyPatch):
+    _reset_poison_guards(monkeypatch)
+    monkeypatch.setitem(main.ENGINES, "qwen", _FakeQwenMintOther())
+
+    client = TestClient(main.app)
+    res = client.post("/qwen/mint-variant", json=_mint_body())
+
+    assert res.status_code == 500
+    assert res.json() == {"detail": "Internal error."}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server/tts-sidecar && .venv\Scripts\python.exe -m pytest tests/test_qwen_design_poison.py -v`
+Expected: the two new `test_mint_variant_*` tests FAIL (same reason as Task 1 — the route's generic
+catch swallows the poison into a plain 500).
+
+- [ ] **Step 3: Implement — classify the poison before the generic catch**
+
+In `server/tts-sidecar/main.py`, replace lines 5679-5681:
+
+```python
+    except Exception:
+        log.exception("/qwen/mint-variant failed (baseVoiceId=%s)", base_voice_id)
+        return JSONResponse({"detail": "Internal error."}, status_code=500)
+```
+
+with:
+
+```python
+    except Exception as e:
+        err_str = f"{e}"
+        if _CUDA_POISON_RE.search(err_str):
+            log.warning("/qwen/mint-variant CUDA poison (baseVoiceId=%s): %s", base_voice_id, e)
+            _mark_cuda_poisoned(err_str)
+            return JSONResponse(
+                {
+                    "detail": (
+                        "GPU is out of memory — likely another job (generation/analysis/design) "
+                        "is using it. Free up GPU memory and try again."
+                    ),
+                    "poisoned": True,
+                    "code": "gpu_poisoned",
+                },
+                status_code=503,
+            )
+        log.exception("/qwen/mint-variant failed (baseVoiceId=%s)", base_voice_id)
+        return JSONResponse({"detail": "Internal error."}, status_code=500)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server/tts-sidecar && .venv\Scripts\python.exe -m pytest tests/test_qwen_design_poison.py -v`
+Expected: all four tests in the file PASS.
+
+- [ ] **Step 5: Run the full sidecar suite to check for regressions**
+
+Run: `npm run test:sidecar` (from repo root)
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/tts-sidecar/main.py server/tts-sidecar/tests/test_qwen_design_poison.py
+git commit -m "fix(sidecar): classify CUDA-OOM as poison in /qwen/mint-variant
+
+Same fix as the prior design-voice commit, applied to the sibling
+mint-variant route — _ensure_base17_for_mint's existing OOM re-raise
+lands in this route's generic except block."
+```
+
+---
+
+## Task 3: Server — two-branch systemic-error ride-out in the bulk design loop
+
+**Files:**
+- Modify: `server/src/routes/cast-design.ts:93-97` (constants), `:363-437` (per-character retry loop)
+- Test: `server/src/routes/cast-design.test.ts`
+
+**Interfaces:**
+- Consumes: `code: "gpu_poisoned"` on the sidecar's 503 response (Task 1/2 — reaches Node as
+  `SidecarDesignError.code`, already parsed by the existing fetch path in `qwen-voice.ts:382-391`, no
+  changes needed there); the existing `GpuBusyError` class (`server/src/gpu/gpu-load.js`, `.code ===
+  'GPU_BUSY'`); the existing `ensureSidecarEngineReady` (`server/src/tts/ensure-sidecar-loaded.js`).
+- Produces: `endJob(job, { type: 'error', code: 'sidecar_unavailable' | 'gpu_contention', message })` on
+  ride-out exhaustion — unchanged shape/consumers (the existing `onError` handler in
+  `cast-design-stream-middleware.ts` already dispatches `halt` + a toast for any `endJob` error event
+  regardless of `code`, so no client-side change is needed there).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `server/src/routes/cast-design.test.ts`, inside the existing
+`describe('POST /api/books/:bookId/cast/design', ...)` block, right after the existing "halts with
+sidecar_unavailable only after the ride-out retries are exhausted" test (after line 387):
+
+```ts
+  it('rides out the recycling drain-fence message too (widened SIDECAR_DOWN_RE)', async () => {
+    /* Pre-existing gap found during spec review: "Voice engine is recycling to
+       free memory; retry shortly." never matched the old SIDECAR_DOWN_RE, so
+       this transient case was ALSO wrongly treated as an ordinary per-character
+       failure before this fix. */
+    const ensureSpy = vi
+      .spyOn(ensureMod, 'ensureSidecarEngineReady')
+      .mockResolvedValue(undefined);
+    const designSpy = vi
+      .spyOn(qwenVoiceMod, 'designQwenVoiceForCharacter')
+      .mockRejectedValueOnce(new Error('Voice engine is recycling to free memory; retry shortly.'))
+      .mockResolvedValue({ voiceId: 'qwen-v_aria' } as Awaited<
+        ReturnType<typeof qwenVoiceMod.designQwenVoiceForCharacter>
+      >);
+
+    const res = await request(app)
+      .post(`/api/books/${bookId}/cast/design`)
+      .send({ characterIds: ['aria'], modelKey: QWEN_KEY });
+
+    const events = parseSse(res.text);
+    expect(events.find((e) => e.type === 'error')).toBeUndefined();
+    expect(events.find((e) => e.type === 'idle')).toMatchObject({ done: 1, total: 1 });
+    expect(ensureSpy).toHaveBeenCalled();
+
+    ensureSpy.mockRestore();
+    designSpy.mockRestore();
+  });
+
+  it('rides out a gpu_poisoned sidecar response via the health-poll wait, then completes', async () => {
+    const ensureSpy = vi
+      .spyOn(ensureMod, 'ensureSidecarEngineReady')
+      .mockResolvedValue(undefined); // sidecar reports ready again
+    const designSpy = vi
+      .spyOn(qwenVoiceMod, 'designQwenVoiceForCharacter')
+      .mockRejectedValueOnce(
+        Object.assign(new Error('GPU is out of memory — likely another job is using it.'), {
+          code: 'gpu_poisoned',
+          status: 503,
+        }),
+      )
+      .mockResolvedValue({ voiceId: 'qwen-v_aria' } as Awaited<
+        ReturnType<typeof qwenVoiceMod.designQwenVoiceForCharacter>
+      >);
+
+    const res = await request(app)
+      .post(`/api/books/${bookId}/cast/design`)
+      .send({ characterIds: ['aria'], modelKey: QWEN_KEY });
+
+    const events = parseSse(res.text);
+    expect(events.find((e) => e.type === 'error')).toBeUndefined();
+    expect(events.find((e) => e.type === 'idle')).toMatchObject({ done: 1, total: 1 });
+    expect(ensureSpy).toHaveBeenCalled(); // used the health-poll wait, not a raw sleep
+    expect(designSpy).toHaveBeenCalledTimes(2);
+
+    ensureSpy.mockRestore();
+    designSpy.mockRestore();
+  });
+
+  it('halts with gpu_contention (not sidecar_unavailable) after a GPU_BUSY ride-out is exhausted', async () => {
+    const ensureSpy = vi.spyOn(ensureMod, 'ensureSidecarEngineReady');
+    const designSpy = vi
+      .spyOn(qwenVoiceMod, 'designQwenVoiceForCharacter')
+      .mockRejectedValue(
+        Object.assign(new Error('GPU busy with analysis — try again once it finishes.'), {
+          code: 'GPU_BUSY',
+        }),
+      );
+
+    const res = await request(app)
+      .post(`/api/books/${bookId}/cast/design`)
+      .send({ characterIds: ['aria', 'brann'], modelKey: QWEN_KEY });
+
+    const events = parseSse(res.text);
+    const errorEvent = events.find((e) => e.type === 'error');
+    expect(errorEvent?.code).toBe('gpu_contention');
+    expect(errorEvent?.message).toContain('0 of 2 designed');
+    expect(events.some((e) => e.type === 'character_designed')).toBe(false);
+    expect(designSpy).toHaveBeenCalledTimes(1 + MAX_RECYCLE_RIDEOUTS);
+    /* GPU_BUSY uses the new bounded sleep, NOT the sidecar health-poll wait —
+       ensureSidecarEngineReady must never be called for this class. */
+    expect(ensureSpy).not.toHaveBeenCalled();
+
+    ensureSpy.mockRestore();
+    designSpy.mockRestore();
+  }, 10_000);
+
+  it('base17-unavailable is NOT treated as systemic — records a per-character failure and continues', async () => {
+    const ensureSpy = vi.spyOn(ensureMod, 'ensureSidecarEngineReady');
+    const designSpy = vi
+      .spyOn(qwenVoiceMod, 'designQwenVoiceForCharacter')
+      .mockRejectedValueOnce(
+        Object.assign(new Error("Qwen 1.7B-Base unavailable (not-installed)."), {
+          code: 'base17-unavailable',
+          status: 503,
+        }),
+      )
+      .mockResolvedValue({ voiceId: 'qwen-v_brann' } as Awaited<
+        ReturnType<typeof qwenVoiceMod.designQwenVoiceForCharacter>
+      >);
+
+    const res = await request(app)
+      .post(`/api/books/${bookId}/cast/design`)
+      .send({ characterIds: ['aria', 'brann'], modelKey: QWEN_KEY });
+
+    const events = parseSse(res.text);
+    expect(events.find((e) => e.type === 'error')).toBeUndefined();
+    expect(events.some((e) => e.type === 'character_failed' && e.characterId === 'aria')).toBe(true);
+    expect(events.some((e) => e.type === 'character_designed' && e.characterId === 'brann')).toBe(true);
+    /* No ride-out attempted for a permanent condition. */
+    expect(designSpy).toHaveBeenCalledTimes(2); // one failed attempt (aria) + one success (brann)
+    expect(ensureSpy).not.toHaveBeenCalled();
+
+    ensureSpy.mockRestore();
+    designSpy.mockRestore();
+  });
+
+  it('regression: a non-abort error during the sidecar-restart wait retries instead of silently dropping the character', async () => {
+    /* Bug found during spec review: the OLD code's `catch { break }` around
+       ensureSidecarEngineReady treated ANY thrown error there as a clean
+       pause and silently exited without recording done/skipped/failures.
+       ensureSidecarEngineReady wraps withGpuLoad, which CAN throw
+       GpuBusyError (analysis contention) during the wait itself — that must
+       NOT be treated as a run-level abort. */
+    const ensureSpy = vi
+      .spyOn(ensureMod, 'ensureSidecarEngineReady')
+      .mockRejectedValueOnce(
+        Object.assign(new Error('GPU busy with analysis — try again once it finishes.'), {
+          code: 'GPU_BUSY',
+        }),
+      )
+      .mockResolvedValue(undefined); // second ride-out's wait succeeds
+    const designSpy = vi
+      .spyOn(qwenVoiceMod, 'designQwenVoiceForCharacter')
+      .mockRejectedValueOnce(new Error('TTS sidecar (http://localhost:9000) is unreachable'))
+      .mockResolvedValue({ voiceId: 'qwen-v_aria' } as Awaited<
+        ReturnType<typeof qwenVoiceMod.designQwenVoiceForCharacter>
+      >);
+
+    const res = await request(app)
+      .post(`/api/books/${bookId}/cast/design`)
+      .send({ characterIds: ['aria'], modelKey: QWEN_KEY });
+
+    const events = parseSse(res.text);
+    const idle = events.find((e) => e.type === 'idle');
+    /* The character must be accounted for — either designed here (this test's
+       retry path succeeds) or, at minimum, never silently vanish from
+       done+skipped+failures. */
+    expect(idle).toBeDefined();
+    expect((idle!.done as number) + (idle!.skipped as number) + (idle!.failures as unknown[]).length).toBe(1);
+
+    ensureSpy.mockRestore();
+    designSpy.mockRestore();
+  });
+```
+
+Add these two lines near the top of the file's shared imports/setup (they're new named exports Step 3
+adds to `cast-design.ts`) — find the existing `MAX_RECYCLE_RIDEOUTS = castDesign.MAX_RECYCLE_RIDEOUTS;`
+line (line 205) and confirm no change is needed there (it already reads the export live) — no edit
+required for this step, just noting the dependency.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd server && npx vitest run src/routes/cast-design.test.ts`
+Expected: FAIL — the four new systemic-path tests fail because `code: 'gpu_poisoned'` and `code:
+'GPU_BUSY'` aren't recognized yet (today's code only checks `SIDECAR_DOWN_RE` against the message, so
+these all fall through to "per-character failure, record and continue" — e.g. the `gpu_contention` halt
+test will find no `error` event at all). The `base17-unavailable` test may already pass today (it's a
+regression guard, not a new behavior) — that's fine, it just won't have been exercised before.
+
+- [ ] **Step 3: Implement — widen the regex, add classifiers, add the sleep helper, restructure the retry loop**
+
+In `server/src/routes/cast-design.ts`, replace lines 93-97:
+
+```ts
+export const MAX_RECYCLE_RIDEOUTS = 2;
+
+/* The error-message shapes that mean "the sidecar is down / recycling" (vs. a
+   per-character synthesis failure that should be recorded and skipped past). */
+const SIDECAR_DOWN_RE = /unreachable|did not complete within|stopped responding/i;
+```
+
+with:
+
+```ts
+export const MAX_RECYCLE_RIDEOUTS = 2;
+
+/* The error-message shapes that mean "the sidecar is down / recycling" (vs. a
+   per-character synthesis failure that should be recorded and skipped past).
+   Widened to also recognize the existing drain-fence "recycling" 503
+   ("Voice engine is recycling to free memory; retry shortly.") — that
+   transient case never matched this regex before and was wrongly treated as
+   an ordinary per-character failure (found auditing every 503 shape this
+   route can return, see the design spec's review-findings section). */
+const SIDECAR_DOWN_RE = /unreachable|did not complete within|stopped responding|recycling/i;
+
+/* Bounded pause between GPU-busy ride-out retries. Deliberately short and
+   NOT test-configurable (kept simple per the spec's non-goals) — real
+   contention from another job almost always outlasts any reasonable
+   constant anyway, so this only meaningfully helps a brief, sub-second
+   blip; its main job is to not hammer the same busy resource in a tight
+   loop before giving up and halting with a clear message. */
+const GPU_BUSY_RIDEOUT_MS = 1_000;
+
+/* Abort-aware setTimeout — same idiom as ensure-sidecar-loaded.ts:217,
+   retry.ts:103, analyzer/gemini.ts:821 (each file keeps its own local copy
+   rather than a shared export, matching this codebase's existing
+   convention for this exact helper). */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new DOMException('cast-design GPU-busy ride-out sleep aborted', 'AbortError'));
+    };
+    if (signal) signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/* "Sidecar is down or restarting" — a connection-level failure OR the
+   sidecar's own CUDA-poison classification (which schedules a supervised
+   restart, see server/tts-sidecar/main.py's _mark_cuda_poisoned). The
+   existing ensureSidecarEngineReady health-poll is the right wait for both:
+   it already treats a `poisoned: true` /health response as "keep waiting". */
+function isSidecarRestartClass(e: unknown, message: string): boolean {
+  return SIDECAR_DOWN_RE.test(message) || (e as { code?: string } | null)?.code === 'gpu_poisoned';
+}
+
+/* "GPU busy, no sidecar restart involved" — the Node-side GpuBusyError
+   thrown by withGpuLoad when the local Ollama analyzer is resident and busy.
+   Reusing ensureSidecarEngineReady for this would immediately re-throw
+   ANOTHER GpuBusyError (it wraps the same withGpuLoad check), not resolve
+   "ready" — so this class gets its own short explicit sleep instead. */
+function isGpuBusyClass(e: unknown): boolean {
+  return (e as { code?: string } | null)?.code === 'GPU_BUSY';
+}
+```
+
+Then replace lines 402-436 (the whole `catch (e) { ... }` block):
+
+```ts
+        } catch (e) {
+          const message = (e as Error).message || 'Voice design failed.';
+          if (SIDECAR_DOWN_RE.test(message)) {
+            /* Sidecar down/recycling. Ride out the respawn and retry this
+               character — unless we've exhausted the budget (genuinely dead) or
+               the job was cancelled, in which case stop the run. */
+            if (!job.controller.signal.aborted && rideouts < MAX_RECYCLE_RIDEOUTS) {
+              rideouts += 1;
+              broadcast(job, { type: 'heartbeat', characterId }); // keep the pill alive through the respawn
+              try {
+                await ensureSidecarEngineReady('qwen', job.controller.signal);
+              } catch {
+                /* aborted (pause) during the wait — stop cleanly; the outer
+                   loop's abort-check ends the job. */
+                break;
+              }
+              continue; // sidecar should be back — retry this character
+            }
+            /* Exhausted ride-outs (or aborted): a still-down sidecar would fail
+               every remaining character identically — stop with a catastrophic
+               error instead of grinding through N timeouts. */
+            clearInterval(heartbeat);
+            endJob(job, { type: 'error', code: 'sidecar_unavailable', message });
+            return;
+          }
+          /* Per-character synthesis failure — record it and move on. */
+          job.failures.push({ characterId, name: character.name ?? characterId, error: message });
+          broadcast(job, {
+            type: 'character_failed',
+            characterId,
+            name: character.name ?? characterId,
+            errorReason: message,
+          });
+          break;
+        }
+```
+
+with:
+
+```ts
+        } catch (e) {
+          const message = (e as Error).message || 'Voice design failed.';
+          if (isSidecarRestartClass(e, message)) {
+            /* Sidecar down/recycling/poison-restarting. Ride out the respawn
+               and retry this character — unless we've exhausted the budget
+               (genuinely dead) or the job was cancelled, in which case stop
+               the run. */
+            if (!job.controller.signal.aborted && rideouts < MAX_RECYCLE_RIDEOUTS) {
+              rideouts += 1;
+              broadcast(job, { type: 'heartbeat', characterId }); // keep the pill alive through the respawn
+              try {
+                await ensureSidecarEngineReady('qwen', job.controller.signal);
+              } catch {
+                /* Only a genuine run-level abort is a clean stop here — the
+                   outer loop's abort-check ends the job. Anything else (e.g.
+                   ensureSidecarEngineReady's own withGpuLoad wrap throwing a
+                   GpuBusyError mid-wait) falls through to retry instead of
+                   silently dropping this character's accounting (bug found
+                   during spec review — the old code broke unconditionally on
+                   ANY throw here). rideouts is already bounded above. */
+                if (job.controller.signal.aborted) break;
+              }
+              continue; // retry this character
+            }
+            /* Exhausted ride-outs (or aborted): a still-down sidecar would fail
+               every remaining character identically — stop with a catastrophic
+               error instead of grinding through N timeouts. */
+            clearInterval(heartbeat);
+            endJob(job, {
+              type: 'error',
+              code: 'sidecar_unavailable',
+              message: `${message} (${job.done} of ${job.total} designed before this happened.)`,
+            });
+            return;
+          }
+          if (isGpuBusyClass(e)) {
+            /* GPU busy (no restart involved) — a short bounded pause, then
+               retry; NOT the sidecar health-poll (that would just re-throw
+               the same GpuBusyError immediately, not actually wait). */
+            if (!job.controller.signal.aborted && rideouts < MAX_RECYCLE_RIDEOUTS) {
+              rideouts += 1;
+              broadcast(job, { type: 'heartbeat', characterId });
+              try {
+                await sleep(GPU_BUSY_RIDEOUT_MS, job.controller.signal);
+              } catch {
+                break; // aborted during the wait — clean stop
+              }
+              continue; // retry this character
+            }
+            clearInterval(heartbeat);
+            endJob(job, {
+              type: 'error',
+              code: 'gpu_contention',
+              message: `${message} (${job.done} of ${job.total} designed before this happened.)`,
+            });
+            return;
+          }
+          /* Per-character synthesis failure — record it and move on. */
+          job.failures.push({ characterId, name: character.name ?? characterId, error: message });
+          broadcast(job, {
+            type: 'character_failed',
+            characterId,
+            name: character.name ?? characterId,
+            errorReason: message,
+          });
+          break;
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd server && npx vitest run src/routes/cast-design.test.ts`
+Expected: all tests in the file PASS, including the four new ones and the pre-existing suite (the
+existing "rides out a mid-bulk sidecar recycle" and "halts with sidecar_unavailable" tests must still
+pass unchanged — `isSidecarRestartClass` is a strict superset of the old `SIDECAR_DOWN_RE`-only check for
+those message shapes).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd server && npm run typecheck` (or `npm run typecheck` from repo root, which covers both)
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/routes/cast-design.ts server/src/routes/cast-design.test.ts
+git commit -m "fix(server): ride out GPU contention in the bulk design job instead of grinding through it
+
+Two systemic-error classes now get a bounded ride-out before the job
+halts with a clear message: sidecar-restarting (widened SIDECAR_DOWN_RE
++ the new gpu_poisoned code, reusing the existing health-poll wait) and
+GPU-busy-no-restart (GpuBusyError, a new short explicit sleep). Also
+fixes a latent bug where any non-abort error during the health-poll
+wait silently dropped a character's accounting."
+```
+
+---
+
+## Task 4: Frontend — stop counting failures as progress, surface the failure count while running
+
+**Files:**
+- Modify: `src/components/layout.tsx:1449-1450`, `src/components/top-bar.tsx:1053`
+- Test: `src/components/layout.test.tsx`, `src/components/top-bar.test.tsx`
+
+**Interfaces:**
+- Consumes: nothing new — `DesignPillData.failureCount` already exists and is already threaded through
+  (`top-bar.tsx:1016`), just not rendered in the `'running'` branch yet.
+- Produces: nothing new consumed elsewhere — purely a display fix.
+
+- [ ] **Step 1: Write the failing test — component level (top-bar.test.tsx)**
+
+In `src/components/top-bar.test.tsx`, inside the `describe('DesignPill', ...)` block, add right after
+the existing `'renders the running summary "Designing · done/total · percent"'` test (after line 485):
+
+```ts
+  it('surfaces the failure count inline while running (not just in the terminal summary)', () => {
+    render(
+      <DesignPill
+        data={{
+          state: 'running',
+          done: 2,
+          total: 6,
+          percent: 83,
+          skipped: 3,
+          failureCount: 1,
+          onClick: vi.fn(),
+        }}
+      />,
+    );
+    expect(screen.getByTestId('design-pill')).toHaveTextContent('2/6 · 1 failed · 83%');
+  });
+
+  it('omits the failed segment when nothing has failed', () => {
+    render(
+      <DesignPill
+        data={{
+          state: 'running',
+          done: 3,
+          total: 8,
+          percent: 38,
+          skipped: 0,
+          failureCount: 0,
+          onClick: vi.fn(),
+        }}
+      />,
+    );
+    expect(screen.getByTestId('design-pill')).toHaveTextContent('3/8 · 38%');
+    expect(screen.getByTestId('design-pill')).not.toHaveTextContent('failed');
+  });
+```
+
+- [ ] **Step 2: Write the failing test — selector level (layout.test.tsx)**
+
+In `src/components/layout.test.tsx`, add a new describe block right after the existing `describe('Layout
+— Export status pill (fs-54)', ...)` block (after line 713):
+
+```ts
+describe('Layout — Design status pill percent excludes failures (issue: "0/16 · 94%")', () => {
+  it('does not inflate percent when every processed character has failed', async () => {
+    const store = makeStore();
+    store.dispatch(
+      castDesignSlice.actions.begin({
+        bookId: 'b1',
+        total: 16,
+        currentName: 'Narrator',
+        lastTickAt: Date.parse('2026-01-01T00:00:00Z'),
+      }),
+    );
+    for (let i = 0; i < 15; i += 1) {
+      store.dispatch(
+        castDesignSlice.actions.charFailed({
+          bookId: 'b1',
+          characterId: `char_${i}`,
+          name: `Char ${i}`,
+          error: 'GPU is out of memory — likely another job is using it.',
+          lastTickAt: Date.parse('2026-01-01T00:00:00Z'),
+        }),
+      );
+    }
+
+    const { findByTestId } = render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/books']}>
+          <Routes>
+            <Route path="/books" element={<Layout />} />
+          </Routes>
+        </MemoryRouter>
+      </Provider>,
+    );
+
+    fireEvent.click(await findByTestId('status-pill'));
+    const pill = await findByTestId('design-pill');
+    expect(pill).toHaveTextContent('0/16');
+    expect(pill).toHaveTextContent('15 failed');
+    /* The bug: this used to read "94%" (15 failures / 16 counted as
+       "progress"). Failures no longer count toward percent. */
+    expect(pill).not.toHaveTextContent('94%');
+    expect(pill).toHaveTextContent('0%');
+  });
+});
+```
+
+Confirm `castDesignSlice` is already imported in this file (it is, per line 33 — `import {
+castDesignSlice } from '../store/cast-design-slice';`) and that `fireEvent` is already imported from
+`@testing-library/react` (check the existing imports near the top of the file; the "Export status pill"
+block above already uses it, so it must already be imported — no new import needed).
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `npx vitest run src/components/top-bar.test.tsx src/components/layout.test.tsx`
+Expected: FAIL — `top-bar.test.tsx`'s new "surfaces the failure count inline" test fails because the
+running-branch summary doesn't include `failureCount` yet; `layout.test.tsx`'s new test fails because the
+pill currently shows `94%`, not `0%`.
+
+- [ ] **Step 4: Implement — layout.tsx percent formula**
+
+In `src/components/layout.tsx`, replace lines 1449-1450:
+
+```ts
+    const completed = done + skipped + failures.length;
+    const percent = total > 0 ? Math.round((completed / total) * 100) : 0;
+```
+
+with:
+
+```ts
+    const completed = done + skipped;
+    const percent = total > 0 ? Math.round((completed / total) * 100) : 0;
+```
+
+- [ ] **Step 5: Implement — top-bar.tsx running-state summary**
+
+In `src/components/top-bar.tsx`, replace line 1053:
+
+```ts
+      : `${done}/${total}${total > 0 ? ` · ${percent}%` : ''}`;
+```
+
+with:
+
+```ts
+      : `${done}/${total}${failureCount > 0 ? ` · ${failureCount} failed` : ''}${total > 0 ? ` · ${percent}%` : ''}`;
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npx vitest run src/components/top-bar.test.tsx src/components/layout.test.tsx`
+Expected: all tests PASS, including the pre-existing DesignPill/Layout tests (the running-summary test
+for `failureCount: 0` must render identically to before — verify `'renders the running summary
+"Designing · done/total · percent"'` still passes unchanged).
+
+- [ ] **Step 7: Run the full frontend suite to check for regressions**
+
+Run: `npm run test`
+Expected: PASS.
+
+- [ ] **Step 8: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/components/layout.tsx src/components/top-bar.tsx src/components/layout.test.tsx src/components/top-bar.test.tsx
+git commit -m "fix(frontend): stop counting design-job failures as progress
+
+The Design pill's percent silently included failures.length in its
+numerator while the visible X/Y text showed only successes — a run
+failing almost everything still read as nearly complete ('0/16 · 94%').
+Failures no longer inflate percent; the running-state label also now
+surfaces the failure count inline instead of hiding it until the
+terminal toast."
+```
+
+---
+
+## After all tasks: branch-level verification
+
+- [ ] **Step 1: Run the branch-scoped verify battery**
+
+Run: `npm run verify:fast:branch`
+Expected: PASS (lint, typecheck, test, test:server, build, and test:sidecar since this branch touches
+`server/tts-sidecar/**`).
+
+- [ ] **Step 2: Update the regression plan**
+
+This work has no existing `docs/features/*.md` plan to update (it's a bug-hardening fix, not a new
+feature) — per CLAUDE.md's before-shipping checklist, small/localized items skip the plan doc; the spec
+at `docs/superpowers/specs/2026-07-11-cast-design-job-hardening-design.md` plus the paired tests above
+are the spec of record. Note this explicitly in the PR description rather than silently omitting it.
+
+- [ ] **Step 3: Update release notes**
+
+Append an entry to `docs/release-notes-next.md` (technical register) and a matching user-facing,
+brand-voice line to the in-progress version section at the top of `RELEASE_NOTES.md`, per CLAUDE.md's
+"Update the two release-notes documents" step. Read both files' current top section first to match
+existing entry style/tone before appending.
+
+- [ ] **Step 4: File and link the GitHub issue, open the PR**
+
+Per CLAUDE.md: this is bug-shaped work, so it gets the standalone `bug` label. File the issue (title
+summarizing the "0/16 · 94%" + silent-grind symptom), then open the PR with `Closes #NN` in the body.
+PR title must match the commit-convention subject format; since this PR spans three scopes
+(sidecar/server/frontend), CONTRIBUTING.md's multi-scope guidance suggests the commits stay separately
+scoped (as done above) while the PR title itself picks the dominant scope — use `fix(server): harden
+cast design job against GPU contention` as the PR title, with the frontend/sidecar detail in the PR
+body's Summary section.
+
+- [ ] **Step 5: Mandatory independent code-review pass**
+
+Per CLAUDE.md's Model routing → Mandatory independent review gate: this is a multi-scope PR (sidecar +
+server + frontend), so it gets **high** effort. Run the `code-review` skill (no `--fix`) once the branch
+is pushed, before merge. Triage and fold findings.

--- a/docs/superpowers/specs/2026-07-11-cast-design-job-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-11-cast-design-job-hardening-design.md
@@ -1,0 +1,381 @@
+---
+status: draft
+---
+
+# Cast design job — GPU-contention hardening and honest progress display
+
+## 1. Summary
+
+Observed live (screenshot, book "La Commande de Coalfall", a French manuscript): the "Design full
+cast" bulk job's status pill read **"Designing · 0/16 · 94%"** — zero characters actually designed,
+yet the progress bar read as nearly complete. Root-caused via static code investigation to two
+separate defects that compound:
+
+1. **Display defect.** `DesignPill`'s `percent` (`src/components/layout.tsx:1449-1450`) is computed
+   from `(done + skipped + failures.length) / total`, but the `X/Y` text next to it shows `done/total`
+   only. When a run is failing almost every character, `done` stays near 0 while `percent` still climbs
+   toward 100 — the two numbers in one label tell contradictory stories.
+2. **Hardening defect (the actual bug worth fixing).** `/qwen/design-voice`
+   (`server/tts-sidecar/main.py:5514-5589`) catches *any* exception from `design_voice`, including a
+   `torch.cuda.OutOfMemoryError` caused by VRAM contention (e.g. another session's generation/analysis
+   run holding the GPU) — and unlike four sibling sidecar routes, never checks whether that error should
+   trigger the sidecar's own CUDA-poison-recovery restart. It collapses straight to
+   `{"detail": "Internal error."}` / 500. The real cause is logged server-side (`log.exception`) but
+   never reaches the client, and the restart that would let the *next* attempt succeed never fires. On
+   the Node side,
+   `cast-design.ts`'s bulk-job loop only recognizes *connection-level* failures
+   (`SIDECAR_DOWN_RE = /unreachable|did not complete within|stopped responding/i`) as "systemic — worth
+   riding out"; a GPU-OOM/contention failure doesn't match, so it's recorded as an ordinary per-character
+   failure and the loop moves on to the next character — which fails identically, all the way through
+   the queue, silently, with no clear signal to the user about why.
+
+This spec fixes both, reusing existing plumbing rather than inventing new mechanisms. **Revised after an
+adversarial `assumption-checker` pass** (see §6) that found the original draft invented a "plain,
+non-poisoning OOM" category that contradicts this codebase's own established policy: `_CUDA_POISON_RE`
+(`main.py:498-503`) already classifies *any* `"CUDA out of memory"`-shaped message as poison, requiring
+the existing supervised-restart mechanism (`_mark_cuda_poisoned`, exit code 42) — the same four other
+call sites (`/transcribe`, `/embed`, and two more) already do this. The revised design brings
+`/qwen/design-voice` **and** `/qwen/mint-variant` (both currently missing this check entirely — a wider
+pre-existing gap than first thought) up to that same standard, with one deliberate, small deviation: a
+clearer, more actionable `detail` message than those routes' generic `"Internal error."`, since a
+16-character bulk job silently grinding on this is much higher-stakes than a single transcribe/embed
+call. Separately, the Node-side `GpuBusyError` class (no sidecar restart involved — just a same-process
+eviction refusal) gets its own short, explicit, bounded wait, because reusing the sidecar's
+health-poll ride-out for it would either not wait at all (health is already "ready") or, worse, risk
+silently dropping the character's accounting if a second `GpuBusyError` fires during that wait (a
+latent bug the review surfaced in the existing ride-out's abort-handling, fixed here as it's directly in
+the code path being extended).
+
+## 2. Goals
+
+- A GPU-contention failure during "Design full cast" produces a **clear, actionable, user-facing
+  message** ("GPU is out of memory — likely another job is using it. Free up GPU memory and try
+  again.") instead of a silent string of per-character failures or an opaque "Internal error."
+- The job **rides out a brief, bounded contention** before giving up — a few seconds/tens-of-seconds of
+  contention from another job finishing up (or a poison-triggered sidecar respawn) shouldn't abort a
+  whole 16-character run. Bounded by the existing `MAX_RECYCLE_RIDEOUTS = 2` retry-the-current-character
+  loop either way; the two systemic-error classes (§4.2) each get a wait mechanism that actually fits
+  what they're waiting for — polling `/health` for a sidecar restart, an explicit short sleep for a
+  same-process GPU-busy refusal.
+- If contention persists past the ride-out, the job **halts the whole run** rather than grinding through
+  every remaining character with the same doomed attempt — mirroring the existing `sidecar_unavailable`
+  halt path exactly, just with a second, distinct cause/code for the GPU-busy class.
+- Genuinely per-character failures (bad persona text, an encode failure, a validation error) are
+  **unaffected** — still recorded, job keeps going, exactly like today. The breaker only trips on the
+  classified systemic-error family.
+- The status pill's percentage **never implies progress a failed attempt didn't make** — a failure no
+  longer inflates `percent`, and the running-state label surfaces the failure count inline instead of
+  hiding it until the terminal toast.
+
+## 3. Non-goals
+
+- **No pre-flight capacity/health check before the job starts.** Considered and rejected (see design
+  discussion) — it can't help with contention that begins *mid-run* (the actual scenario here: another
+  session starts a GPU job after "Design full cast" is already under way), so it adds a new check
+  surface for narrow extra coverage. The ride-out-then-halt loop already covers both the "busy at start"
+  and "busy partway through" cases uniformly.
+- **No automatic retry of a halted job.** Once halted, the user re-triggers "Design full cast" manually
+  (already-designed characters are freshness-skipped on the retry — no wasted work, per the existing
+  `job.skipped` mechanism).
+- **No change to single-character design** (`beginSingle`/the cast-drawer flow). Its failure mode is
+  different — a single attempt either succeeds or the user sees one error immediately; there's no
+  "silently grind through 16 more" scenario to harden against. Out of scope.
+- **No change to `_ensure_base17_for_mint`'s own OOM re-raise** (`main.py:2149-2166`) — it already does
+  the right thing (re-raises OOM unchanged instead of masking it as a fallback-eligible
+  `Base17UnavailableError`). This spec adds a poison check to the route handler the re-raise lands in
+  (`/qwen/mint-variant`'s outer `except Exception`, §4.1) — it doesn't touch the re-raise itself.
+- **No new mechanism for `base17-unavailable` (not-installed/corrupt 1.7B-Base).** That's a permanent
+  condition, not transient contention — retrying it can never succeed, so it must stay classified as an
+  ordinary per-character failure. §4.2's classifier is deliberately precise (`code === 'gpu_poisoned'` /
+  `'GPU_BUSY'`, not a blanket "any 503") specifically so it never misclassifies this.
+- **No e2e/on-box live-GPU-contention regression test.** Reliably forcing real VRAM contention in CI is
+  flaky and slow to reproduce on demand; coverage is via mocked/injected error responses at the sidecar
+  HTTP layer and the Node job-loop layer (see §5).
+
+## 4. Architecture
+
+### 4.1 Sidecar — bring OOM/poison handling to parity across all four `qwen.py` route handlers (`server/tts-sidecar/main.py`)
+
+`/qwen/design-voice` (~line 5573-5589) and `/qwen/mint-variant` (~line 5679-5681) are, today, the *only*
+two of the sidecar's six exception-prone routes with **no `_CUDA_POISON_RE` check at all** —
+`/transcribe`, `/embed`, and two others already classify a poisoning CUDA error (which includes any
+`"CUDA out of memory"`-shaped message — see `_CUDA_POISON_RE`, `main.py:498-503`) and call
+`_mark_cuda_poisoned` to schedule the supervised exit-42 restart. Both design routes instead swallow
+*any* exception, poison included, into a bare `{"detail": "Internal error."}` 500 — so today a GPU-OOM
+during "Design full cast" doesn't even trigger the restart that would let the *next* attempt succeed
+once the contending job frees memory; the sidecar just sits there with a doomed embedding half-done, and
+every remaining character in the queue repeats the identical failure.
+
+Fix: add the same check, verbatim pattern, to both routes' `except Exception` blocks — with one
+deliberate deviation from the other four sites' `detail` text (`"Internal error."`), since a silent
+16-character bulk job is much higher-stakes than a single transcribe/embed call:
+
+```python
+# server/tts-sidecar/main.py — qwen_design_voice's except block (~5587) and
+# qwen_mint_variant's except block (~5679), same snippet in both:
+except Exception as e:
+    err_str = f"{e}"
+    if _CUDA_POISON_RE.search(err_str):
+        log.warning("/qwen/design-voice CUDA poison (voiceId=%s): %s", voice_id, e)
+        _mark_cuda_poisoned(err_str)
+        return JSONResponse(
+            {
+                "detail": (
+                    "GPU is out of memory — likely another job (generation/analysis/design) "
+                    "is using it. Free up GPU memory and try again."
+                ),
+                "poisoned": True,
+                "code": "gpu_poisoned",
+            },
+            status_code=503,
+        )
+    log.exception("/qwen/design-voice failed (voiceId=%s)", voice_id)
+    return JSONResponse({"detail": "Internal error."}, status_code=500)
+```
+
+(`/qwen/mint-variant`'s copy logs with `baseVoiceId=%s` instead, matching its existing log line.)
+
+`code: "gpu_poisoned"` is new — added purely so the Node classifier in §4.2 can key on it precisely,
+same idiom `base17-unavailable` already uses for its own `code`. `poisoned: true` is kept alongside it
+only for consistency with the other four sites' existing shape (harmless, not required by any Node
+logic).
+
+This is genuinely a **poison** classification, not a "stays up, just wait" one: `_CUDA_POISON_RE`
+already treats `"CUDA out of memory"` as corrupting the shared process-wide CUDA context (the file's own
+comment, `main.py:495-497`, is explicit that over-classifying here is deliberate and harmless — "we
+never want to MISS a poison"). `_mark_cuda_poisoned` is documented as "safe to call from any engine /
+any concurrent in-flight request" (`main.py:582-583`), so calling it from these two routes is exactly
+the pattern it was built for, not a new one. `/health`'s existing `poisoned` field
+(already polled by `ensureSidecarEngineReady`, see §4.2) means the restart-and-recover cycle Just
+Works once these two routes start participating in it.
+
+`_ensure_base17_for_mint`'s existing OOM re-raise (`main.py:2158-2166`, unchanged by this spec) lands in
+`/qwen/mint-variant`'s outer `except Exception` — so hardening that one handler covers both the
+base-design and the mint-variant path with the same fix.
+
+Everything that isn't a poison match keeps falling through to the existing generic 500 (still fully
+logged server-side via `log.exception`) — an unexpected, unclassified bug should NOT trip the new
+systemic-halt breaker in §4.2; it stays a per-character failure like today.
+
+### 4.2 Node — two ride-out paths for two genuinely different systemic-error shapes (`server/src/routes/cast-design.ts`)
+
+The bulk job loop already has the right shape for this (comment at `cast-design.ts:86-92` documents
+the exact rationale this spec extends): a per-character `catch` classifies the error, and either rides
+it out (retry same character, bounded by `MAX_RECYCLE_RIDEOUTS = 2`) or records-and-continues. Today
+only `SIDECAR_DOWN_RE`-matching messages trigger the ride-out path. This spec recognizes two more,
+**each needing a different wait mechanism** because they mean different things:
+
+1. **Sidecar restarting** — `SIDECAR_DOWN_RE` match (widened below) OR the new `code === 'gpu_poisoned'`
+   (§4.1). The sidecar process is down or about to be; the right wait is the *existing*
+   `ensureSidecarEngineReady` health-poll, which already treats a `poisoned: true` `/health` response as
+   "keep waiting" — no new wait mechanism needed here, the existing one already does the right thing
+   once §4.1 makes the sidecar actually report this class correctly.
+2. **GPU busy, no restart involved** — `code === 'GPU_BUSY'`, the Node-side `GpuBusyError` thrown by
+   `withGpuLoad` (`server/src/gpu/gpu-load.ts:10-16`) when the design call can't even get GPU room
+   because the local Ollama analyzer is resident and busy. The sidecar was never contacted and isn't
+   restarting, so polling its `/health` would resolve "ready" near-instantly — not a real wait, and not
+   what Goal 2 means by "ride out a brief contention." This class gets an explicit, bounded sleep instead
+   (new, small, matches the existing abort-aware `sleep(ms, signal)` idiom already duplicated in
+   `ensure-sidecar-loaded.ts:217`, `retry.ts:103`, `analyzer/gemini.ts:821` — one more local copy,
+   following the same established per-file convention rather than introducing a shared export).
+
+```ts
+// SIDECAR_DOWN_RE (cast-design.ts:97) widens to also recognize the existing
+// drain-fence "recycling" 503 (main.py:5567-5571 / 5644-5648) — its message
+// ("Voice engine is recycling to free memory; retry shortly.") doesn't match
+// today's pattern, so that transient case is ALSO currently mis-treated as an
+// ordinary per-character failure; a one-token fix, verified while auditing
+// every 503 shape this route can return (per the assumption-checker pass).
+const SIDECAR_DOWN_RE = /unreachable|did not complete within|stopped responding|recycling/i;
+
+const GPU_BUSY_RIDEOUT_MS = 5_000; // one short wait between the two bounded retries
+
+function isSidecarRestartClass(e: unknown, message: string): boolean {
+  return SIDECAR_DOWN_RE.test(message) || (e as { code?: string })?.code === 'gpu_poisoned';
+}
+function isGpuBusyClass(e: unknown): boolean {
+  return (e as { code?: string })?.code === 'GPU_BUSY';
+}
+```
+
+Deliberately **not** a blanket `status === 503` check — `/qwen/mint-variant`'s existing
+`base17-unavailable` response (`main.py:5669-5678`) is *also* a 503, but it means "the 1.7B-Base model
+isn't installed or is corrupt," a permanent condition retrying can never fix. Keying on the specific
+`code` values instead of the HTTP status keeps that case correctly falling through to the ordinary
+per-character failure path, unaffected by this spec (see Non-goals).
+
+The existing per-character retry loop (`cast-design.ts:404` onward) restructures from one branch to
+two:
+
+```ts
+if (isSidecarRestartClass(e, message)) {
+  if (!job.controller.signal.aborted && rideouts < MAX_RECYCLE_RIDEOUTS) {
+    rideouts += 1;
+    broadcast(job, { type: 'heartbeat', characterId });
+    try {
+      await ensureSidecarEngineReady('qwen', job.controller.signal);
+    } catch (waitErr) {
+      // Bug fix (found during review): the original code unconditionally
+      // treated ANY throw from the wait as "run was paused/cancelled" and
+      // broke out silently — dropping this character from done/skipped/
+      // failures entirely. ensureSidecarEngineReady wraps withGpuLoad, which
+      // CAN throw GpuBusyError (analysis contention) during the wait itself,
+      // not just an AbortError. Only a genuine run-level abort is a clean
+      // stop; anything else just retries (rideouts is already bounded above).
+      if (job.controller.signal.aborted) break;
+    }
+    continue; // retry this character
+  }
+  clearInterval(heartbeat);
+  endJob(job, {
+    type: 'error',
+    code: 'sidecar_unavailable',
+    message: `${message} (${job.done} of ${job.total} designed before this happened.)`,
+  });
+  return;
+} else if (isGpuBusyClass(e)) {
+  if (!job.controller.signal.aborted && rideouts < MAX_RECYCLE_RIDEOUTS) {
+    rideouts += 1;
+    broadcast(job, { type: 'heartbeat', characterId });
+    try {
+      await sleep(GPU_BUSY_RIDEOUT_MS, job.controller.signal);
+    } catch {
+      break; // aborted during the wait — clean stop, outer loop's abort-check ends the job
+    }
+    continue; // retry this character
+  }
+  clearInterval(heartbeat);
+  endJob(job, {
+    type: 'error',
+    code: 'gpu_contention',
+    message: `${message} (${job.done} of ${job.total} designed before this happened.)`,
+  });
+  return;
+}
+/* Per-character failure — record it and move on. (unchanged) */
+job.failures.push({ characterId, name: character.name ?? characterId, error: message });
+```
+
+Two distinct `code`s are kept on the final `endJob` — `sidecar_unavailable` (unchanged name; now also
+covers the poison-restart case, which conceptually *is* "the sidecar is down/restarting") and
+`gpu_contention` (new, GPU-busy-no-restart case) — per explicit decision, useful for logs/tests to tell
+the two apart even though client-side handling is identical either way. The completion-count suffix on
+both messages is the concrete answer to "should fail nicely and tell the user": the halt message says
+both *why* and *how far it got*.
+
+No other client-side change is needed for the halt itself: `onError` in
+`cast-design-stream-middleware.ts:131-140` already dispatches `castDesignActions.halt(...)` and a
+`pushToast({ kind: 'error', message, ... })` for any `endJob` error event, regardless of `code` — the
+existing rose-colored "Halted" pill state and error toast just start firing correctly for both new
+cases.
+
+Non-systemic errors (anything not matching either classifier — including `base17-unavailable`, bad
+persona text, an encode failure) are completely unaffected: `job.failures.push(...)`,
+`character_failed` broadcast, loop continues — identical to today.
+
+### 4.3 Frontend — stop counting failures as progress (`src/components/layout.tsx`, `src/components/top-bar.tsx`)
+
+`layout.tsx:1449-1450`:
+
+```ts
+// before
+const completed = done + skipped + failures.length;
+const percent = total > 0 ? Math.round((completed / total) * 100) : 0;
+
+// after
+const completed = done + skipped;
+const percent = total > 0 ? Math.round((completed / total) * 100) : 0;
+```
+
+A skip is still legitimate completion (the character already had a voice — no work was needed, per the
+existing intent documented at `cast-design-slice.ts:64-66`). A failure is not completion and must not
+inflate the bar.
+
+`top-bar.tsx:1043-1053`, the running-state summary gains the failure count inline instead of hiding it
+until the terminal toast:
+
+```ts
+// before
+: `${done}/${total}${total > 0 ? ` · ${percent}%` : ''}`;
+
+// after
+: `${done}/${total}${failureCount > 0 ? ` · ${failureCount} failed` : ''}${total > 0 ? ` · ${percent}%` : ''}`;
+```
+
+`failureCount` is already threaded into `DesignPillData` (`data.failureCount`, used today only in the
+terminal `'done'` branch) — this just also renders it in the `'running'` branch.
+
+With §4.1-4.2 landed, a systemic run now halts after at most a few characters instead of grinding to
+~94% — so this display fix mainly matters for the legitimate "job keeps going with a handful of
+unrelated per-character failures" case. It's cheap and correct to fix regardless of how rare the
+misleading-94% case becomes.
+
+## 5. Testing
+
+- **Sidecar (pytest, `server/tts-sidecar/tests/`):**
+  - `design_voice` raises a `torch.cuda.OutOfMemoryError`-shaped exception (mocking the underlying call,
+    same style as existing poison-path tests for `/transcribe`/`/embed`) → asserts the HTTP response is
+    503 with `code: "gpu_poisoned"`, `poisoned: true`, and the new clear detail — not the generic 500
+    "Internal error." — and that `_mark_cuda_poisoned` was actually invoked (process-poisoned state
+    flips, matching the existing assertions used for `/transcribe`'s equivalent test).
+  - Same case repeated for `mint_variant` (via `/qwen/mint-variant`) — confirms the fix covers both
+    routes, not just design-voice (the gap the review surfaced was wider than the original draft).
+  - A non-OOM, non-poison exception on both routes still returns the generic 500 unchanged (regression
+    guard for the narrow `_CUDA_POISON_RE` classification — an unrelated bug must not trip the restart).
+- **Server (Vitest, `server/src/routes/cast-design.test.ts` or sibling):**
+  - A design job where every sidecar attempt returns the new 503/`gpu_poisoned` response, with a mocked
+    `/health` that reports `poisoned: true` then flips to ready after N polls: assert it rides out
+    `MAX_RECYCLE_RIDEOUTS` times via `ensureSidecarEngineReady` (not a raw sleep), then — if still
+    failing — halts via `endJob` with `code: 'sidecar_unavailable'`, a message containing the
+    `done`/`total` counts, and confirms the remaining characters in the queue were never attempted.
+  - A parallel case where `designQwenVoiceForCharacter` throws `GpuBusyError` (`code: 'GPU_BUSY'`):
+    asserts the ride-out uses the new bounded `sleep`, not `ensureSidecarEngineReady`, then halts with
+    `code: 'gpu_contention'` after exhausting retries.
+  - **Regression test for the abort-handling bug found in review:** during a sidecar-restart ride-out's
+    wait, `ensureSidecarEngineReady` throws a non-abort error (e.g. `GpuBusyError`, simulating analysis
+    contention firing mid-wait) while `job.controller.signal` is NOT aborted — asserts the character is
+    retried (not silently dropped: `job.done + job.failures.length` must eventually account for it,
+    never vanish from the total).
+  - A regression case: `base17-unavailable` (503, from a real `/qwen/mint-variant` response) is NOT
+    treated as systemic — records to `job.failures` immediately, no ride-out attempted, loop continues.
+  - A regression case: a per-character failure with an unrelated message/status (e.g. a validation-style
+    error) still records to `job.failures` and the loop continues to the next character, unaffected.
+- **Frontend (Vitest, `layout.tsx`/`top-bar.test.tsx`):** percent-formula test — `done=0, skipped=0,
+  failures.length=15, total=16` → `percent` is `0`, not `94`; a mixed case (`done=2, skipped=3,
+  failures.length=1, total=6`) confirms skips still count (`percent = 83`) and the running label shows
+  `"2/6 · 1 failed · 83%"`.
+- No e2e coverage added — see §3 (non-goals) for why.
+
+## 6. Adversarial review findings
+
+An Opus `assumption-checker` pass (per CLAUDE.md's mandatory Premium-tier spec-review gate) verified
+every cited file/line/code-shape claim against the real code (all confirmed accurate) and the "0/16 ·
+94%" display-bug arithmetic (confirmed exact). It surfaced three issues that reshaped §4, all folded into
+the sections above rather than left as open questions:
+
+1. **The reused ride-out wait didn't actually wait, for the case the spec cared about most.**
+   `ensureSidecarEngineReady` only polls `/health`; a plain (non-restarting) OOM leaves the sidecar
+   reporting "ready" instantly, so the original design's "ride out briefly" was, in practice, two
+   near-instant retries. Resolved by finding #2 below rather than by inventing a new wait for this case.
+2. **The original "non-poisoning OOM" category contradicted the codebase's own policy.** `_CUDA_POISON_RE`
+   already treats any `"CUDA out of memory"` message as poison, process-wide, at four other call sites.
+   The spec now brings `/qwen/design-voice` and `/qwen/mint-variant` to that same standard instead of
+   diverging (§4.1) — which also resolves #1, since a poison-triggered restart is exactly what
+   `ensureSidecarEngineReady`'s health-poll is built to wait through.
+3. **A latent accounting bug in the existing ride-out's abort handling**, made meaningfully more
+   reachable by this spec widening how often ride-out fires: `catch { break }` around the wait treated
+   *any* thrown error as a clean pause, silently dropping the in-progress character's accounting if the
+   thrown error was actually a `GpuBusyError` (via `ensureSidecarEngineReady`'s own `withGpuLoad` wrap)
+   rather than a genuine run-level abort. Fixed in §4.2 (only a real `job.controller.signal.aborted`
+   breaks cleanly now) and covered by a dedicated regression test in §5.
+
+Two more findings were considered and addressed by narrowing the design rather than expanding it:
+mint-variant's `base17-unavailable` 503 could have been misclassified as GPU contention under a naive
+"any 503 is systemic" rule — the classifier keys on specific `code` values instead (§4.2); and the
+mint-variant OOM path (originally a stated non-goal) is now in scope for the same fix as design-voice,
+since the review confirmed it shares the identical gap and the real screenshot that motivated this spec
+involved a scope mixing both base and variant work.
+
+## 7. Ship notes
+
+_(filled in at merge time)_

--- a/docs/superpowers/specs/2026-07-11-cast-design-job-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-11-cast-design-job-hardening-design.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: active
 ---
 
 # Cast design job — GPU-contention hardening and honest progress display
@@ -16,7 +16,7 @@ separate defects that compound:
    only. When a run is failing almost every character, `done` stays near 0 while `percent` still climbs
    toward 100 — the two numbers in one label tell contradictory stories.
 2. **Hardening defect (the actual bug worth fixing).** `/qwen/design-voice`
-   (`server/tts-sidecar/main.py:5514-5589`) catches *any* exception from `design_voice`, including a
+   (`server/tts-sidecar/main.py:5514-5600`) catches *any* exception from `design_voice`, including a
    `torch.cuda.OutOfMemoryError` caused by VRAM contention (e.g. another session's generation/analysis
    run holding the GPU) — and unlike four sibling sidecar routes, never checks whether that error should
    trigger the sidecar's own CUDA-poison-recovery restart. It collapses straight to
@@ -32,7 +32,7 @@ separate defects that compound:
 This spec fixes both, reusing existing plumbing rather than inventing new mechanisms. **Revised after an
 adversarial `assumption-checker` pass** (see §6) that found the original draft invented a "plain,
 non-poisoning OOM" category that contradicts this codebase's own established policy: `_CUDA_POISON_RE`
-(`main.py:498-503`) already classifies *any* `"CUDA out of memory"`-shaped message as poison, requiring
+(`main.py:498-505`) already classifies *any* `"CUDA out of memory"`-shaped message as poison, requiring
 the existing supervised-restart mechanism (`_mark_cuda_poisoned`, exit code 42) — the same four other
 call sites (`/transcribe`, `/embed`, and two more) already do this. The revised design brings
 `/qwen/design-voice` **and** `/qwen/mint-variant` (both currently missing this check entirely — a wider
@@ -96,10 +96,10 @@ the code path being extended).
 
 ### 4.1 Sidecar — bring OOM/poison handling to parity across all four `qwen.py` route handlers (`server/tts-sidecar/main.py`)
 
-`/qwen/design-voice` (~line 5573-5589) and `/qwen/mint-variant` (~line 5679-5681) are, today, the *only*
-two of the sidecar's six exception-prone routes with **no `_CUDA_POISON_RE` check at all** —
+`/qwen/design-voice` (handler spans ~5514-5600) and `/qwen/mint-variant` (~5595-5690) are, today, the
+*only* two of the sidecar's six exception-prone routes with **no `_CUDA_POISON_RE` check at all** —
 `/transcribe`, `/embed`, and two others already classify a poisoning CUDA error (which includes any
-`"CUDA out of memory"`-shaped message — see `_CUDA_POISON_RE`, `main.py:498-503`) and call
+`"CUDA out of memory"`-shaped message — see `_CUDA_POISON_RE`, `main.py:498-505`) and call
 `_mark_cuda_poisoned` to schedule the supervised exit-42 restart. Both design routes instead swallow
 *any* exception, poison included, into a bare `{"detail": "Internal error."}` 500 — so today a GPU-OOM
 during "Design full cast" doesn't even trigger the restart that would let the *next* attempt succeed
@@ -170,14 +170,18 @@ only `SIDECAR_DOWN_RE`-matching messages trigger the ride-out path. This spec re
    `ensureSidecarEngineReady` health-poll, which already treats a `poisoned: true` `/health` response as
    "keep waiting" — no new wait mechanism needed here, the existing one already does the right thing
    once §4.1 makes the sidecar actually report this class correctly.
-2. **GPU busy, no restart involved** — `code === 'GPU_BUSY'`, the Node-side `GpuBusyError` thrown by
-   `withGpuLoad` (`server/src/gpu/gpu-load.ts:10-16`) when the design call can't even get GPU room
-   because the local Ollama analyzer is resident and busy. The sidecar was never contacted and isn't
-   restarting, so polling its `/health` would resolve "ready" near-instantly — not a real wait, and not
-   what Goal 2 means by "ride out a brief contention." This class gets an explicit, bounded sleep instead
-   (new, small, matches the existing abort-aware `sleep(ms, signal)` idiom already duplicated in
-   `ensure-sidecar-loaded.ts:217`, `retry.ts:103`, `analyzer/gemini.ts:821` — one more local copy,
-   following the same established per-file convention rather than introducing a shared export).
+2. **GPU busy, no restart involved** — `code === 'GPU_BUSY'`, the `GpuBusyError` class (defined at
+   `server/src/gpu/gpu-load.ts:10-16`) thrown by `withGpuLoad` (`:28-44`) when the design call can't even
+   get GPU room because the local Ollama analyzer is resident and busy. Reusing `ensureSidecarEngineReady`
+   for this wait would not actually wait either, but not for the reason an earlier draft of this spec
+   assumed: it wraps its own poll in `withGpuLoad` too (`ensure-sidecar-loaded.ts:138`) — the exact same
+   contention check that just refused us — so it would immediately **re-throw another `GpuBusyError`**
+   rather than resolve "ready." That's not a real wait, just an instant same-condition bounce. This class
+   gets an explicit, bounded sleep instead — a plain timed pause outside any GPU-eligibility check, which
+   is what actually gives the analyzer time to free up (new, small, matches the existing abort-aware
+   `sleep(ms, signal)` idiom already duplicated in `ensure-sidecar-loaded.ts:217`, `retry.ts:103`,
+   `analyzer/gemini.ts:821` — one more local copy, following the same established per-file convention
+   rather than introducing a shared export).
 
 ```ts
 // SIDECAR_DOWN_RE (cast-design.ts:97) widens to also recognize the existing
@@ -254,7 +258,15 @@ if (isSidecarRestartClass(e, message)) {
 }
 /* Per-character failure — record it and move on. (unchanged) */
 job.failures.push({ characterId, name: character.name ?? characterId, error: message });
+broadcast(job, { type: 'character_failed', characterId, name: character.name ?? characterId, errorReason: message });
+break; // exits the for(;;) retry loop — load-bearing, must be preserved (cast-design.ts:435 today)
 ```
+
+(Implementation note: the snippet above shows only the two new/changed branches plus the tail of the
+existing fallthrough for context — the `character_failed` broadcast and the trailing `break` out of the
+`for (;;)` retry loop are today's existing code, not new, but MUST survive the restructure. An
+implementer copying this snippet literally without them would leave the retry loop unable to exit on an
+ordinary per-character failure.)
 
 Two distinct `code`s are kept on the final `endJob` — `sidecar_unavailable` (unchanged name; now also
 covers the poison-restart case, which conceptually *is* "the sidecar is down/restarting") and
@@ -375,6 +387,19 @@ mint-variant's `base17-unavailable` 503 could have been misclassified as GPU con
 mint-variant OOM path (originally a stated non-goal) is now in scope for the same fix as design-voice,
 since the review confirmed it shares the identical gap and the real screenshot that motivated this spec
 involved a scope mixing both base and variant work.
+
+**A second, independent Opus pass** re-verified the revised text against the real code end-to-end
+(`SidecarDesignError.code` parsing, `GpuBusyError` propagation through the single-design route, the
+mint-variant `except` clause ordering, the widened `SIDECAR_DOWN_RE` for false positives, the
+persona-prepass/encode steps as a possible third OOM site) and reported the design as structurally
+correct, with three sub-critical write-up issues, all fixed in place: §4.2's GPU_BUSY rationale had the
+cause and effect backwards (fixed — `ensureSidecarEngineReady` would re-throw `GpuBusyError`, not
+resolve "ready," for that class), the restructured-loop snippet omitted the load-bearing
+`character_failed` broadcast and trailing `break` from the existing fallthrough (fixed — now shown
+explicitly with an implementer note), and a few line-number citations had drifted (fixed). The
+persona-prepass/encode question was confirmed genuinely out of scope: persona generation runs through
+the separate Ollama analyzer process (no sidecar CUDA involvement) and the encode step is CPU-only
+ffmpeg.
 
 ## 7. Ship notes
 

--- a/server/src/routes/cast-design.test.ts
+++ b/server/src/routes/cast-design.test.ts
@@ -386,6 +386,160 @@ describe('POST /api/books/:bookId/cast/design', () => {
     designSpy.mockRestore();
   });
 
+  it('rides out the recycling drain-fence message too (widened SIDECAR_DOWN_RE)', async () => {
+    /* Pre-existing gap found during spec review: "Voice engine is recycling to
+       free memory; retry shortly." never matched the old SIDECAR_DOWN_RE, so
+       this transient case was ALSO wrongly treated as an ordinary per-character
+       failure before this fix. */
+    const ensureSpy = vi
+      .spyOn(ensureMod, 'ensureSidecarEngineReady')
+      .mockResolvedValue(undefined);
+    const designSpy = vi
+      .spyOn(qwenVoiceMod, 'designQwenVoiceForCharacter')
+      .mockRejectedValueOnce(new Error('Voice engine is recycling to free memory; retry shortly.'))
+      .mockResolvedValue({ voiceId: 'qwen-v_aria' } as Awaited<
+        ReturnType<typeof qwenVoiceMod.designQwenVoiceForCharacter>
+      >);
+
+    const res = await request(app)
+      .post(`/api/books/${bookId}/cast/design`)
+      .send({ characterIds: ['aria'], modelKey: QWEN_KEY });
+
+    const events = parseSse(res.text);
+    expect(events.find((e) => e.type === 'error')).toBeUndefined();
+    expect(events.find((e) => e.type === 'idle')).toMatchObject({ done: 1, total: 1 });
+    expect(ensureSpy).toHaveBeenCalled();
+
+    ensureSpy.mockRestore();
+    designSpy.mockRestore();
+  });
+
+  it('rides out a gpu_poisoned sidecar response via the health-poll wait, then completes', async () => {
+    const ensureSpy = vi
+      .spyOn(ensureMod, 'ensureSidecarEngineReady')
+      .mockResolvedValue(undefined); // sidecar reports ready again
+    const designSpy = vi
+      .spyOn(qwenVoiceMod, 'designQwenVoiceForCharacter')
+      .mockRejectedValueOnce(
+        Object.assign(new Error('GPU is out of memory — likely another job is using it.'), {
+          code: 'gpu_poisoned',
+          status: 503,
+        }),
+      )
+      .mockResolvedValue({ voiceId: 'qwen-v_aria' } as Awaited<
+        ReturnType<typeof qwenVoiceMod.designQwenVoiceForCharacter>
+      >);
+
+    const res = await request(app)
+      .post(`/api/books/${bookId}/cast/design`)
+      .send({ characterIds: ['aria'], modelKey: QWEN_KEY });
+
+    const events = parseSse(res.text);
+    expect(events.find((e) => e.type === 'error')).toBeUndefined();
+    expect(events.find((e) => e.type === 'idle')).toMatchObject({ done: 1, total: 1 });
+    expect(ensureSpy).toHaveBeenCalled(); // used the health-poll wait, not a raw sleep
+    expect(designSpy).toHaveBeenCalledTimes(2);
+
+    ensureSpy.mockRestore();
+    designSpy.mockRestore();
+  });
+
+  it('halts with gpu_contention (not sidecar_unavailable) after a GPU_BUSY ride-out is exhausted', async () => {
+    const ensureSpy = vi.spyOn(ensureMod, 'ensureSidecarEngineReady');
+    const designSpy = vi
+      .spyOn(qwenVoiceMod, 'designQwenVoiceForCharacter')
+      .mockRejectedValue(
+        Object.assign(new Error('GPU busy with analysis — try again once it finishes.'), {
+          code: 'GPU_BUSY',
+        }),
+      );
+
+    const res = await request(app)
+      .post(`/api/books/${bookId}/cast/design`)
+      .send({ characterIds: ['aria', 'brann'], modelKey: QWEN_KEY });
+
+    const events = parseSse(res.text);
+    const errorEvent = events.find((e) => e.type === 'error');
+    expect(errorEvent?.code).toBe('gpu_contention');
+    expect(errorEvent?.message).toContain('0 of 2 designed');
+    expect(events.some((e) => e.type === 'character_designed')).toBe(false);
+    expect(designSpy).toHaveBeenCalledTimes(1 + MAX_RECYCLE_RIDEOUTS);
+    /* GPU_BUSY uses the new bounded sleep, NOT the sidecar health-poll wait —
+       ensureSidecarEngineReady must never be called for this class. */
+    expect(ensureSpy).not.toHaveBeenCalled();
+
+    ensureSpy.mockRestore();
+    designSpy.mockRestore();
+  }, 10_000);
+
+  it('base17-unavailable is NOT treated as systemic — records a per-character failure and continues', async () => {
+    const ensureSpy = vi.spyOn(ensureMod, 'ensureSidecarEngineReady');
+    const designSpy = vi
+      .spyOn(qwenVoiceMod, 'designQwenVoiceForCharacter')
+      .mockRejectedValueOnce(
+        Object.assign(new Error("Qwen 1.7B-Base unavailable (not-installed)."), {
+          code: 'base17-unavailable',
+          status: 503,
+        }),
+      )
+      .mockResolvedValue({ voiceId: 'qwen-v_brann' } as Awaited<
+        ReturnType<typeof qwenVoiceMod.designQwenVoiceForCharacter>
+      >);
+
+    const res = await request(app)
+      .post(`/api/books/${bookId}/cast/design`)
+      .send({ characterIds: ['aria', 'brann'], modelKey: QWEN_KEY });
+
+    const events = parseSse(res.text);
+    expect(events.find((e) => e.type === 'error')).toBeUndefined();
+    expect(events.some((e) => e.type === 'character_failed' && e.characterId === 'aria')).toBe(true);
+    expect(events.some((e) => e.type === 'character_designed' && e.characterId === 'brann')).toBe(true);
+    /* No ride-out attempted for a permanent condition. */
+    expect(designSpy).toHaveBeenCalledTimes(2); // one failed attempt (aria) + one success (brann)
+    expect(ensureSpy).not.toHaveBeenCalled();
+
+    ensureSpy.mockRestore();
+    designSpy.mockRestore();
+  });
+
+  it('regression: a non-abort error during the sidecar-restart wait retries instead of silently dropping the character', async () => {
+    /* Bug found during spec review: the OLD code's `catch { break }` around
+       ensureSidecarEngineReady treated ANY thrown error there as a clean
+       pause and silently exited without recording done/skipped/failures.
+       ensureSidecarEngineReady wraps withGpuLoad, which CAN throw
+       GpuBusyError (analysis contention) during the wait itself — that must
+       NOT be treated as a run-level abort. */
+    const ensureSpy = vi
+      .spyOn(ensureMod, 'ensureSidecarEngineReady')
+      .mockRejectedValueOnce(
+        Object.assign(new Error('GPU busy with analysis — try again once it finishes.'), {
+          code: 'GPU_BUSY',
+        }),
+      )
+      .mockResolvedValue(undefined); // second ride-out's wait succeeds
+    const designSpy = vi
+      .spyOn(qwenVoiceMod, 'designQwenVoiceForCharacter')
+      .mockRejectedValueOnce(new Error('TTS sidecar (http://localhost:9000) is unreachable'))
+      .mockResolvedValue({ voiceId: 'qwen-v_aria' } as Awaited<
+        ReturnType<typeof qwenVoiceMod.designQwenVoiceForCharacter>
+      >);
+
+    const res = await request(app)
+      .post(`/api/books/${bookId}/cast/design`)
+      .send({ characterIds: ['aria'], modelKey: QWEN_KEY });
+
+    const events = parseSse(res.text);
+    const idle = events.find((e) => e.type === 'idle');
+    /* The character must be accounted for — either designed here (this test's
+       retry path succeeds) or, at minimum, never silently vanish from
+       done+skipped+failures. */
+    expect(idle).toBeDefined();
+    expect((idle!.done as number) + (idle!.skipped as number) + (idle!.failures as unknown[]).length).toBe(1);
+
+    ensureSpy.mockRestore();
+    designSpy.mockRestore();
+  });
+
   it('mutual exclusion: refuses to start while analysis is busy (409)', async () => {
     designLock.markAnalysisBusy(bookDir);
     const res = await request(app)

--- a/server/src/routes/cast-design.ts
+++ b/server/src/routes/cast-design.ts
@@ -93,8 +93,57 @@ export const castDesignRouter = Router();
 export const MAX_RECYCLE_RIDEOUTS = 2;
 
 /* The error-message shapes that mean "the sidecar is down / recycling" (vs. a
-   per-character synthesis failure that should be recorded and skipped past). */
-const SIDECAR_DOWN_RE = /unreachable|did not complete within|stopped responding/i;
+   per-character synthesis failure that should be recorded and skipped past).
+   Widened to also recognize the existing drain-fence "recycling" 503
+   ("Voice engine is recycling to free memory; retry shortly.") — that
+   transient case never matched this regex before and was wrongly treated as
+   an ordinary per-character failure (found auditing every 503 shape this
+   route can return, see the design spec's review-findings section). */
+const SIDECAR_DOWN_RE = /unreachable|did not complete within|stopped responding|recycling/i;
+
+/* Bounded pause between GPU-busy ride-out retries. Deliberately short and
+   NOT test-configurable (kept simple per the spec's non-goals) — real
+   contention from another job almost always outlasts any reasonable
+   constant anyway, so this only meaningfully helps a brief, sub-second
+   blip; its main job is to not hammer the same busy resource in a tight
+   loop before giving up and halting with a clear message. */
+const GPU_BUSY_RIDEOUT_MS = 1_000;
+
+/* Abort-aware setTimeout — same idiom as ensure-sidecar-loaded.ts:217,
+   retry.ts:103, analyzer/gemini.ts:821 (each file keeps its own local copy
+   rather than a shared export, matching this codebase's existing
+   convention for this exact helper). */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new DOMException('cast-design GPU-busy ride-out sleep aborted', 'AbortError'));
+    };
+    if (signal) signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/* "Sidecar is down or restarting" — a connection-level failure OR the
+   sidecar's own CUDA-poison classification (which schedules a supervised
+   restart, see server/tts-sidecar/main.py's _mark_cuda_poisoned). The
+   existing ensureSidecarEngineReady health-poll is the right wait for both:
+   it already treats a `poisoned: true` /health response as "keep waiting". */
+function isSidecarRestartClass(e: unknown, message: string): boolean {
+  return SIDECAR_DOWN_RE.test(message) || (e as { code?: string } | null)?.code === 'gpu_poisoned';
+}
+
+/* "GPU busy, no sidecar restart involved" — the Node-side GpuBusyError
+   thrown by withGpuLoad when the local Ollama analyzer is resident and busy.
+   Reusing ensureSidecarEngineReady for this would immediately re-throw
+   ANOTHER GpuBusyError (it wraps the same withGpuLoad check), not resolve
+   "ready" — so this class gets its own short explicit sleep instead. */
+function isGpuBusyClass(e: unknown): boolean {
+  return (e as { code?: string } | null)?.code === 'GPU_BUSY';
+}
 
 interface CastFile {
   characters: CastCharacter[];
@@ -401,27 +450,59 @@ async function runDesignJob(
           break;
         } catch (e) {
           const message = (e as Error).message || 'Voice design failed.';
-          if (SIDECAR_DOWN_RE.test(message)) {
-            /* Sidecar down/recycling. Ride out the respawn and retry this
-               character — unless we've exhausted the budget (genuinely dead) or
-               the job was cancelled, in which case stop the run. */
+          if (isSidecarRestartClass(e, message)) {
+            /* Sidecar down/recycling/poison-restarting. Ride out the respawn
+               and retry this character — unless we've exhausted the budget
+               (genuinely dead) or the job was cancelled, in which case stop
+               the run. */
             if (!job.controller.signal.aborted && rideouts < MAX_RECYCLE_RIDEOUTS) {
               rideouts += 1;
               broadcast(job, { type: 'heartbeat', characterId }); // keep the pill alive through the respawn
               try {
                 await ensureSidecarEngineReady('qwen', job.controller.signal);
               } catch {
-                /* aborted (pause) during the wait — stop cleanly; the outer
-                   loop's abort-check ends the job. */
-                break;
+                /* Only a genuine run-level abort is a clean stop here — the
+                   outer loop's abort-check ends the job. Anything else (e.g.
+                   ensureSidecarEngineReady's own withGpuLoad wrap throwing a
+                   GpuBusyError mid-wait) falls through to retry instead of
+                   silently dropping this character's accounting (bug found
+                   during spec review — the old code broke unconditionally on
+                   ANY throw here). rideouts is already bounded above. */
+                if (job.controller.signal.aborted) break;
               }
-              continue; // sidecar should be back — retry this character
+              continue; // retry this character
             }
             /* Exhausted ride-outs (or aborted): a still-down sidecar would fail
                every remaining character identically — stop with a catastrophic
                error instead of grinding through N timeouts. */
             clearInterval(heartbeat);
-            endJob(job, { type: 'error', code: 'sidecar_unavailable', message });
+            endJob(job, {
+              type: 'error',
+              code: 'sidecar_unavailable',
+              message: `${message} (${job.done} of ${job.total} designed before this happened.)`,
+            });
+            return;
+          }
+          if (isGpuBusyClass(e)) {
+            /* GPU busy (no restart involved) — a short bounded pause, then
+               retry; NOT the sidecar health-poll (that would just re-throw
+               the same GpuBusyError immediately, not actually wait). */
+            if (!job.controller.signal.aborted && rideouts < MAX_RECYCLE_RIDEOUTS) {
+              rideouts += 1;
+              broadcast(job, { type: 'heartbeat', characterId });
+              try {
+                await sleep(GPU_BUSY_RIDEOUT_MS, job.controller.signal);
+              } catch {
+                break; // aborted during the wait — clean stop
+              }
+              continue; // retry this character
+            }
+            clearInterval(heartbeat);
+            endJob(job, {
+              type: 'error',
+              code: 'gpu_contention',
+              message: `${message} (${job.done} of ${job.total} designed before this happened.)`,
+            });
             return;
           }
           /* Per-character synthesis failure — record it and move on. */

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -5691,7 +5691,22 @@ async def qwen_mint_variant(req: Request) -> Response:
             },
             status_code=503,
         )
-    except Exception:
+    except Exception as e:
+        err_str = f"{e}"
+        if _CUDA_POISON_RE.search(err_str):
+            log.warning("/qwen/mint-variant CUDA poison (baseVoiceId=%s): %s", base_voice_id, e)
+            _mark_cuda_poisoned(err_str)
+            return JSONResponse(
+                {
+                    "detail": (
+                        "GPU is out of memory — likely another job (generation/analysis/design) "
+                        "is using it. Free up GPU memory and try again."
+                    ),
+                    "poisoned": True,
+                    "code": "gpu_poisoned",
+                },
+                status_code=503,
+            )
         log.exception("/qwen/mint-variant failed (baseVoiceId=%s)", base_voice_id)
         return JSONResponse({"detail": "Internal error."}, status_code=500)
     finally:

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -5584,7 +5584,22 @@ async def qwen_design_voice(req: Request) -> Response:
             mint_method,
             fallback_for,
         )
-    except Exception:
+    except Exception as e:
+        err_str = f"{e}"
+        if _CUDA_POISON_RE.search(err_str):
+            log.warning("/qwen/design-voice CUDA poison (voiceId=%s): %s", voice_id, e)
+            _mark_cuda_poisoned(err_str)
+            return JSONResponse(
+                {
+                    "detail": (
+                        "GPU is out of memory — likely another job (generation/analysis/design) "
+                        "is using it. Free up GPU memory and try again."
+                    ),
+                    "poisoned": True,
+                    "code": "gpu_poisoned",
+                },
+                status_code=503,
+            )
         log.exception("/qwen/design-voice failed (voiceId=%s)", voice_id)
         return JSONResponse({"detail": "Internal error."}, status_code=500)
     finally:

--- a/server/tts-sidecar/tests/test_qwen3.py
+++ b/server/tts-sidecar/tests/test_qwen3.py
@@ -1928,10 +1928,19 @@ def test_mint_variant_route_503_not_installed(fake_qwen_runtime, monkeypatch):
     assert body["detail"] == "Qwen 1.7B-Base unavailable (not-installed)."
 
 
-def test_mint_variant_route_500_on_oom(fake_qwen_runtime, monkeypatch):
-    """OOM during base17 load → generic 500, not a 503 fallback signal."""
+def test_mint_variant_route_503_poisoned_on_oom(fake_qwen_runtime, monkeypatch):
+    """OOM during base17 load → classified 503/gpu_poisoned (triggers the
+    sidecar's supervised restart), NOT the base17-unavailable 503 fallback
+    signal — an OOM must never be silently treated as 'model missing/
+    corrupt, fall back to design-voice'. Updated by the cast-design-job-
+    hardening fix (docs/superpowers/specs/2026-07-11-cast-design-job-
+    hardening-design.md §4.1): this route previously swallowed OOM into a
+    generic, unclassified 500 (this test used to assert exactly that); it
+    now participates in the same CUDA-poison-detection/restart mechanism
+    /transcribe, /embed, and /qwen/design-voice already use."""
     import main
     eng = fake_qwen_runtime["engine"]
+    monkeypatch.setattr(main, "_mark_cuda_poisoned", lambda reason: None)
     # Design the base voice so the 409 path isn't hit.
     eng.design_voice("v1", "A warm narrator.", "English", None)
     monkeypatch.setattr(main, "_qwen_base17_weights_present", lambda: True)
@@ -1943,8 +1952,10 @@ def test_mint_variant_route_500_on_oom(fake_qwen_runtime, monkeypatch):
         "variantVoiceId": "v1__angry",
         "emotionInstruct": "Delivered angrily.",
     })
-    assert r.status_code == 500
-    assert "code" not in r.json()  # NOT a fallback signal
+    assert r.status_code == 503
+    body = r.json()
+    assert body["code"] == "gpu_poisoned"
+    assert body["code"] != "base17-unavailable"  # NOT a fallback signal
 
 
 def test_mint_variant_route_500_on_postload_failure_not_corrupt(fake_qwen_runtime, monkeypatch):

--- a/server/tts-sidecar/tests/test_qwen_design_poison.py
+++ b/server/tts-sidecar/tests/test_qwen_design_poison.py
@@ -1,0 +1,65 @@
+"""CUDA-poison classification for /qwen/design-voice and /qwen/mint-variant
+(issue: the bulk 'Design full cast' job silently ground through every
+character on GPU contention because these two routes never checked
+_CUDA_POISON_RE like /transcribe and /embed already do — see
+docs/superpowers/specs/2026-07-11-cast-design-job-hardening-design.md)."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+import main
+
+
+def _reset_poison_guards(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mirrors test_speaker_embed.py's test_embed_load_poison_is_fenced: clear
+    both guard flags so the route reaches the design call, and stub
+    _mark_cuda_poisoned so the test process never schedules a real
+    threading.Timer-based os._exit."""
+    monkeypatch.setattr(main, "_process_poisoned", False, raising=False)
+    monkeypatch.setattr(main, "_restart_pending", False, raising=False)
+    monkeypatch.setattr(main, "_mark_cuda_poisoned", lambda reason: None)
+
+
+class _FakeQwenOom(main.QwenEngine):
+    def __init__(self):
+        pass  # skip the real heavy __init__; the route only calls design_voice
+
+    def design_voice(self, voice_id, instruct, language, calibration_text, voice_uuid=None, report_progress=None, mint_method=None, fallback_for=None):
+        raise RuntimeError(
+            "CUDA out of memory. Tried to allocate 20.00 MiB (GPU 0; 8.00 GiB total capacity; "
+            "7.90 GiB already allocated)"
+        )
+
+
+class _FakeQwenOther(main.QwenEngine):
+    def __init__(self):
+        pass
+
+    def design_voice(self, voice_id, instruct, language, calibration_text, voice_uuid=None, report_progress=None, mint_method=None, fallback_for=None):
+        raise RuntimeError("some unrelated, unclassified failure")
+
+
+def test_design_voice_oom_returns_classified_503(monkeypatch: pytest.MonkeyPatch):
+    _reset_poison_guards(monkeypatch)
+    monkeypatch.setitem(main.ENGINES, "qwen", _FakeQwenOom())
+
+    client = TestClient(main.app)
+    res = client.post("/qwen/design-voice", json={"voiceId": "qwen-x", "instruct": "warm"})
+
+    assert res.status_code == 503
+    body = res.json()
+    assert body["code"] == "gpu_poisoned"
+    assert body["poisoned"] is True
+    assert "GPU is out of memory" in body["detail"]
+    assert body["detail"] != "Internal error."
+
+
+def test_design_voice_non_poison_exception_stays_generic_500(monkeypatch: pytest.MonkeyPatch):
+    _reset_poison_guards(monkeypatch)
+    monkeypatch.setitem(main.ENGINES, "qwen", _FakeQwenOther())
+
+    client = TestClient(main.app)
+    res = client.post("/qwen/design-voice", json={"voiceId": "qwen-x", "instruct": "warm"})
+
+    assert res.status_code == 500
+    assert res.json() == {"detail": "Internal error."}

--- a/server/tts-sidecar/tests/test_qwen_design_poison.py
+++ b/server/tts-sidecar/tests/test_qwen_design_poison.py
@@ -63,3 +63,52 @@ def test_design_voice_non_poison_exception_stays_generic_500(monkeypatch: pytest
 
     assert res.status_code == 500
     assert res.json() == {"detail": "Internal error."}
+
+
+class _FakeQwenMintOom(main.QwenEngine):
+    def __init__(self):
+        pass
+
+    def mint_variant(self, base_voice_id, variant_voice_id, emotion_instruct, language=None, calibration_text=None, voice_uuid=None, report_progress=None):
+        raise RuntimeError("CUDA out of memory. Tried to allocate 20.00 MiB (GPU 0; 8.00 GiB total capacity)")
+
+
+class _FakeQwenMintOther(main.QwenEngine):
+    def __init__(self):
+        pass
+
+    def mint_variant(self, base_voice_id, variant_voice_id, emotion_instruct, language=None, calibration_text=None, voice_uuid=None, report_progress=None):
+        raise RuntimeError("some unrelated, unclassified failure")
+
+
+def _mint_body():
+    return {
+        "baseVoiceId": "qwen-base",
+        "variantVoiceId": "qwen-base__angry",
+        "emotionInstruct": "Delivered angrily, with raised intensity and edge.",
+    }
+
+
+def test_mint_variant_oom_returns_classified_503(monkeypatch: pytest.MonkeyPatch):
+    _reset_poison_guards(monkeypatch)
+    monkeypatch.setitem(main.ENGINES, "qwen", _FakeQwenMintOom())
+
+    client = TestClient(main.app)
+    res = client.post("/qwen/mint-variant", json=_mint_body())
+
+    assert res.status_code == 503
+    body = res.json()
+    assert body["code"] == "gpu_poisoned"
+    assert body["poisoned"] is True
+    assert "GPU is out of memory" in body["detail"]
+
+
+def test_mint_variant_non_poison_exception_stays_generic_500(monkeypatch: pytest.MonkeyPatch):
+    _reset_poison_guards(monkeypatch)
+    monkeypatch.setitem(main.ENGINES, "qwen", _FakeQwenMintOther())
+
+    client = TestClient(main.app)
+    res = client.post("/qwen/mint-variant", json=_mint_body())
+
+    assert res.status_code == 500
+    assert res.json() == {"detail": "Internal error."}

--- a/server/tts-sidecar/tests/test_qwen_design_poison.py
+++ b/server/tts-sidecar/tests/test_qwen_design_poison.py
@@ -10,14 +10,23 @@ from fastapi.testclient import TestClient
 import main
 
 
-def _reset_poison_guards(monkeypatch: pytest.MonkeyPatch) -> None:
+def _reset_poison_guards(monkeypatch: pytest.MonkeyPatch) -> list:
     """Mirrors test_speaker_embed.py's test_embed_load_poison_is_fenced: clear
     both guard flags so the route reaches the design call, and stub
     _mark_cuda_poisoned so the test process never schedules a real
-    threading.Timer-based os._exit."""
+    threading.Timer-based os._exit.
+
+    Returns a list that records calls to _mark_cuda_poisoned for assertion."""
     monkeypatch.setattr(main, "_process_poisoned", False, raising=False)
     monkeypatch.setattr(main, "_restart_pending", False, raising=False)
-    monkeypatch.setattr(main, "_mark_cuda_poisoned", lambda reason: None)
+
+    # Record calls to _mark_cuda_poisoned for assertion in tests
+    calls = []
+    def record_mark_cuda_poisoned(reason):
+        calls.append(reason)
+
+    monkeypatch.setattr(main, "_mark_cuda_poisoned", record_mark_cuda_poisoned)
+    return calls
 
 
 class _FakeQwenOom(main.QwenEngine):
@@ -40,7 +49,7 @@ class _FakeQwenOther(main.QwenEngine):
 
 
 def test_design_voice_oom_returns_classified_503(monkeypatch: pytest.MonkeyPatch):
-    _reset_poison_guards(monkeypatch)
+    calls = _reset_poison_guards(monkeypatch)
     monkeypatch.setitem(main.ENGINES, "qwen", _FakeQwenOom())
 
     client = TestClient(main.app)
@@ -53,9 +62,13 @@ def test_design_voice_oom_returns_classified_503(monkeypatch: pytest.MonkeyPatch
     assert "GPU is out of memory" in body["detail"]
     assert body["detail"] != "Internal error."
 
+    # Assert that _mark_cuda_poisoned was called exactly once with the right reason
+    assert len(calls) == 1
+    assert "CUDA out of memory" in calls[0]
+
 
 def test_design_voice_non_poison_exception_stays_generic_500(monkeypatch: pytest.MonkeyPatch):
-    _reset_poison_guards(monkeypatch)
+    calls = _reset_poison_guards(monkeypatch)
     monkeypatch.setitem(main.ENGINES, "qwen", _FakeQwenOther())
 
     client = TestClient(main.app)
@@ -63,6 +76,9 @@ def test_design_voice_non_poison_exception_stays_generic_500(monkeypatch: pytest
 
     assert res.status_code == 500
     assert res.json() == {"detail": "Internal error."}
+
+    # Assert that _mark_cuda_poisoned was never called (non-poison path)
+    assert len(calls) == 0
 
 
 class _FakeQwenMintOom(main.QwenEngine):
@@ -90,7 +106,7 @@ def _mint_body():
 
 
 def test_mint_variant_oom_returns_classified_503(monkeypatch: pytest.MonkeyPatch):
-    _reset_poison_guards(monkeypatch)
+    calls = _reset_poison_guards(monkeypatch)
     monkeypatch.setitem(main.ENGINES, "qwen", _FakeQwenMintOom())
 
     client = TestClient(main.app)
@@ -102,9 +118,13 @@ def test_mint_variant_oom_returns_classified_503(monkeypatch: pytest.MonkeyPatch
     assert body["poisoned"] is True
     assert "GPU is out of memory" in body["detail"]
 
+    # Assert that _mark_cuda_poisoned was called exactly once with the right reason
+    assert len(calls) == 1
+    assert "CUDA out of memory" in calls[0]
+
 
 def test_mint_variant_non_poison_exception_stays_generic_500(monkeypatch: pytest.MonkeyPatch):
-    _reset_poison_guards(monkeypatch)
+    calls = _reset_poison_guards(monkeypatch)
     monkeypatch.setitem(main.ENGINES, "qwen", _FakeQwenMintOther())
 
     client = TestClient(main.app)
@@ -112,3 +132,6 @@ def test_mint_variant_non_poison_exception_stays_generic_500(monkeypatch: pytest
 
     assert res.status_code == 500
     assert res.json() == {"detail": "Internal error."}
+
+    # Assert that _mark_cuda_poisoned was never called (non-poison path)
+    assert len(calls) == 0

--- a/src/components/layout.test.tsx
+++ b/src/components/layout.test.tsx
@@ -712,6 +712,50 @@ describe('Layout — Export status pill (fs-54)', () => {
   });
 });
 
+describe('Layout — Design status pill percent excludes failures (issue: "0/16 · 94%")', () => {
+  it('does not inflate percent when every processed character has failed', async () => {
+    const store = makeStore();
+    store.dispatch(
+      castDesignSlice.actions.begin({
+        bookId: 'b1',
+        total: 16,
+        currentName: 'Narrator',
+        lastTickAt: Date.parse('2026-01-01T00:00:00Z'),
+      }),
+    );
+    for (let i = 0; i < 15; i += 1) {
+      store.dispatch(
+        castDesignSlice.actions.charFailed({
+          bookId: 'b1',
+          characterId: `char_${i}`,
+          name: `Char ${i}`,
+          error: 'GPU is out of memory — likely another job is using it.',
+          lastTickAt: Date.parse('2026-01-01T00:00:00Z'),
+        }),
+      );
+    }
+
+    const { findByTestId } = render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/books']}>
+          <Routes>
+            <Route path="/books" element={<Layout />} />
+          </Routes>
+        </MemoryRouter>
+      </Provider>,
+    );
+
+    fireEvent.click(await findByTestId('status-pill'));
+    const pill = await findByTestId('design-pill');
+    expect(pill).toHaveTextContent('0/16');
+    expect(pill).toHaveTextContent('15 failed');
+    /* The bug: this used to read "94%" (15 failures / 16 counted as
+       "progress"). Failures no longer count toward percent. */
+    expect(pill).not.toHaveTextContent('94%');
+    expect(pill).toHaveTextContent('0%');
+  });
+});
+
 describe('Layout — default-engine TTS pill reachable without an open book', () => {
   /* The default/primary engine's Load/Stop pill must be reachable on book-less
      views (Books home) so the model can be pre-loaded right after launch. The

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1446,7 +1446,7 @@ export function Layout() {
   const designPill: DesignPillData | null = (() => {
     if (!designSnapshot) return null;
     const { bookId: dBookId, total, done, skipped, failures, currentName, state } = designSnapshot;
-    const completed = done + skipped + failures.length;
+    const completed = done + skipped;
     const percent = total > 0 ? Math.round((completed / total) * 100) : 0;
     const stalled =
       state === 'running' &&

--- a/src/components/top-bar.test.tsx
+++ b/src/components/top-bar.test.tsx
@@ -484,6 +484,41 @@ describe('DesignPill', () => {
     expect(screen.getByTestId('design-pill')).toHaveTextContent('Designing · 3/8 · 38%');
   });
 
+  it('surfaces the failure count inline while running (not just in the terminal summary)', () => {
+    render(
+      <DesignPill
+        data={{
+          state: 'running',
+          done: 2,
+          total: 6,
+          percent: 83,
+          skipped: 3,
+          failureCount: 1,
+          onClick: vi.fn(),
+        }}
+      />,
+    );
+    expect(screen.getByTestId('design-pill')).toHaveTextContent('2/6 · 1 failed · 83%');
+  });
+
+  it('omits the failed segment when nothing has failed', () => {
+    render(
+      <DesignPill
+        data={{
+          state: 'running',
+          done: 3,
+          total: 8,
+          percent: 38,
+          skipped: 0,
+          failureCount: 0,
+          onClick: vi.fn(),
+        }}
+      />,
+    );
+    expect(screen.getByTestId('design-pill')).toHaveTextContent('3/8 · 38%');
+    expect(screen.getByTestId('design-pill')).not.toHaveTextContent('failed');
+  });
+
   it('renders the terminal summary "Designed N · M failed · K skipped"', () => {
     render(
       <DesignPill

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -1050,7 +1050,7 @@ export function DesignPill({ data }: { data: DesignPillData }) {
         ]
           .filter(Boolean)
           .join(' · ')
-      : `${done}/${total}${total > 0 ? ` · ${percent}%` : ''}`;
+      : `${done}/${total}${failureCount > 0 ? ` · ${failureCount} failed` : ''}${total > 0 ? ` · ${percent}%` : ''}`;
   return (
     <button
       onClick={onClick}


### PR DESCRIPTION
## Summary

Fixes the "Design full cast" bulk voice-design job silently grinding through every remaining character with the same GPU-contention failure instead of failing clearly — and the misleading "Designing · 0/16 · 94%" progress display that made it hard to notice. Two compounding defects, three coordinated fixes:

1. **Sidecar** (`server/tts-sidecar/main.py`): `/qwen/design-voice` and `/qwen/mint-variant` now classify a CUDA-out-of-memory error as poison and trigger the sidecar's existing supervised-restart mechanism — matching four sibling routes (`/transcribe`, `/embed`, etc.) that already do this. Previously both routes swallowed *any* exception, poison included, into an opaque `{"detail": "Internal error."}` 500.
2. **Server** (`server/src/routes/cast-design.ts`): the bulk job's per-character retry loop now recognizes two systemic-error classes — sidecar restarting (reuses the existing health-poll ride-out) and GPU-busy-with-no-restart (a new short bounded sleep) — and rides each out briefly before halting the whole job with a clear, actionable message naming the cause and how far it got. Previously only connection-down failures got this treatment; a GPU-OOM/contention error was recorded as an ordinary per-character failure and the loop silently ground through the rest of the queue. Also fixes a latent bug where a non-abort error during the sidecar-restart wait silently dropped a character's accounting.
3. **Frontend** (`src/components/layout.tsx`, `src/components/top-bar.tsx`): the status pill's percent no longer counts failures as progress, and the running-state label now surfaces the failure count inline instead of hiding it until the terminal toast.

Design doc: `docs/superpowers/specs/2026-07-11-cast-design-job-hardening-design.md` (two rounds of adversarial `assumption-checker` review — the first round found the original design invented a "non-poisoning OOM" category that contradicted this codebase's own established poison-detection policy).
Plan: `docs/superpowers/plans/2026-07-11-cast-design-job-hardening.md` (also adversarially reviewed before execution).

Built via `subagent-driven-development`: 4 tasks, each with a fresh implementer + task-scoped reviewer, then a final whole-branch review. The final review caught one real cross-task gap (a pre-existing sidecar test asserting the old, now-intentionally-changed OOM→500 behavior — it wasn't mocking the restart call, so it triggered a **real** process exit that silently killed the sidecar test run mid-suite with no failure report; fixed and reverified: 515 passed, 8 skipped, 0 failed).

Closes #1532

## Test plan

- [x] `npm run verify:fast:branch` — green (lint, typecheck, test, test:server, build, test:sidecar)
- [x] Sidecar: 4 new/updated pytest cases (`test_qwen_design_poison.py`, `test_qwen3.py`) — CUDA-OOM → classified 503, non-poison exception → unchanged generic 500, restart call asserted directly
- [x] Server: 5 new Vitest cases (`cast-design.test.ts`) — widened recycling-message ride-out, gpu_poisoned ride-out-then-complete, gpu_contention halt after exhausted ride-out, `base17-unavailable` correctly NOT treated as systemic, regression test for the abort-handling accounting bug
- [x] Frontend: 3 new Vitest cases (`top-bar.test.tsx`, `layout.test.tsx`) — failure count surfaces inline while running, percent excludes failures (direct repro of the "0/16 · 94%" bug, now "0/16 · 0%")
- [ ] Reviewer: spot-check `cast-design.ts:412-517` (the restructured retry loop) against `docs/superpowers/specs/2026-07-11-cast-design-job-hardening-design.md` §4.2