### PR TITLE
refactor(frontend): extract shared QA report classification logic

### DIFF
--- a/src/components/qa-report-card.tsx
+++ b/src/components/qa-report-card.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type { BookQaReport } from '../lib/types';
 import { downloadFile } from '../lib/download-file';
 import { formatQaReportJson, formatQaReportText } from '../lib/qa-report-export';
+import { classifyHeadline, classifyVoiceMatch } from '../lib/qa-report-classify';
 import { api } from '../lib/api';
 import { Pill } from './primitives';
 
@@ -18,17 +19,20 @@ function slugify(title: string): string {
   return title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
 }
 
-/* fs-51 round-2 review fix — see the matching comment in qa-report-export.ts;
-   the bold span must be a genuine line count (linesRerecorded), never a sum
-   of unlike units mislabeled "lines." `before`/`after` sandwich the bold
-   span so every case (bold-first or bold-last) still ends with a period. */
+/* the bold span must be a genuine line count (linesRerecorded), never a sum
+   of unlike units mislabeled "lines" — see qa-report-classify.ts. `before`/
+   `after` sandwich the bold span so every case (bold-first or bold-last)
+   still ends with a period. */
 function headline(report: BookQaReport): { before: string; bold: string; after: string } {
-  const hasOtherIssues = report.asr.linesFlaggedDrift > 0 || report.voiceDrift.mismatches.length > 0;
-  if (report.acoustic.linesRerecorded > 0) {
-    return { before: '', bold: String(report.acoustic.linesRerecorded), after: ' lines needed a second take.' };
+  const c = classifyHeadline(report);
+  switch (c.kind) {
+    case 'rerecorded':
+      return { before: '', bold: String(c.linesRerecorded), after: ' lines needed a second take.' };
+    case 'otherIssues':
+      return { before: 'Some lines need a ', bold: 'second look', after: '.' };
+    case 'clean':
+      return { before: 'Every line ', bold: 'held', after: '.' };
   }
-  if (hasOtherIssues) return { before: 'Some lines need a ', bold: 'second look', after: '.' };
-  return { before: 'Every line ', bold: 'held', after: '.' };
 }
 
 function AcousticRow({ report }: { report: BookQaReport }) {
@@ -71,8 +75,9 @@ function VoiceMatchRow({
   const vd = report.voiceDrift;
   const [resuming, setResuming] = useState(false);
   const [resumed, setResumed] = useState(false);
+  const classification = classifyVoiceMatch(report);
 
-  if (vd.chaptersEligible === 0) {
+  if (classification.kind === 'noEligible') {
     return (
       <div className="flex items-center justify-between py-2">
         <span className="text-sm text-ink/70">Voice match</span>
@@ -144,15 +149,10 @@ function VoiceMatchRow({
       </div>
     );
   }
-  /* fs-51 correctness fix: chaptersScored === 0 alone no longer means "the
-     gate never ran" — a fleet-wide embedding failure (the gate attempted
-     every eligible chapter, but embeddings failed for literally all of
-     them) ALSO produces chaptersScored === 0, while chaptersEmbedFailed is
-     now correctly nonzero for that case. Only show the "never ran"
-     invitation copy when chaptersEmbedFailed is ALSO 0 — otherwise fall
-     through to the eligible-chapters-scored branch below, which already
-     renders the honest "0 of N eligible chapters scored" fraction. */
-  if (vd.chaptersScored === 0 && vd.chaptersEmbedFailed === 0) {
+  /* the notRun/embedShortfall/scored classification (including the
+     fs-51 fleet-wide-embed-failure and isolated-embed-shortfall correctness
+     fixes) lives in qa-report-classify.ts, shared with qa-report-export.ts. */
+  if (classification.kind === 'notRun') {
     return (
       <div className="flex items-center justify-between py-2">
         <span className="text-sm text-ink/70">Voice match</span>
@@ -160,21 +160,13 @@ function VoiceMatchRow({
       </div>
     );
   }
-  /* fs-51 round-2 review fix: chaptersScored < chaptersEligible (an isolated
-     embed failure) must lead the row, exactly like the character-shortfall
-     case below — otherwise a full-roster book with a failed embed still
-     reads as a clean "N of N characters checked", the false-clean the
-     chaptersEmbedFailed field exists to prevent.
-     fs-51 round-3 review fix: also surface inconclusiveCount (short quotes
-     below the minimum-duration gate) on this row per the spec — it was
-     computed but only ever reached the JSON export. */
-  const inconclusiveNote = vd.inconclusiveCount > 0 ? ` · ${vd.inconclusiveCount} chapters inconclusive` : '';
-  if (vd.chaptersScored < vd.chaptersEligible) {
+  const inconclusiveNote = classification.inconclusiveCount > 0 ? ` · ${classification.inconclusiveCount} chapters inconclusive` : '';
+  if (classification.kind === 'embedShortfall') {
     return (
       <div className="flex items-center justify-between py-2">
         <span className="text-sm text-ink/70">Voice match</span>
         <span className="text-sm text-ink">
-          {vd.chaptersScored} of {vd.chaptersEligible} eligible chapters scored ({vd.chaptersEmbedFailed} couldn't be embedded), {vd.mismatches.length} mismatches{inconclusiveNote}
+          {classification.chaptersScored} of {classification.chaptersEligible} eligible chapters scored ({classification.chaptersEmbedFailed} couldn't be embedded), {classification.mismatchCount} mismatches{inconclusiveNote}
         </span>
       </div>
     );
@@ -183,7 +175,7 @@ function VoiceMatchRow({
     <div className="flex items-center justify-between py-2">
       <span className="text-sm text-ink/70">Voice match</span>
       <span className="text-sm text-ink">
-        {vd.charactersChecked} of {vd.charactersOnRoster} characters checked, {vd.mismatches.length} mismatches{inconclusiveNote}
+        {classification.charactersChecked} of {classification.charactersOnRoster} characters checked, {classification.mismatchCount} mismatches{inconclusiveNote}
       </span>
     </div>
   );

--- a/src/lib/qa-report-classify.test.ts
+++ b/src/lib/qa-report-classify.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { classifyHeadline, classifyVoiceMatch } from './qa-report-classify';
+import { MOCK_QA_REPORT } from '../data/qa-report';
+
+describe('classifyHeadline', () => {
+  it('classifies rerecorded when linesRerecorded > 0, regardless of other signals', () => {
+    const report = { ...MOCK_QA_REPORT, acoustic: { ...MOCK_QA_REPORT.acoustic, linesRerecorded: 3 } };
+    expect(classifyHeadline(report)).toEqual({ kind: 'rerecorded', linesRerecorded: 3 });
+  });
+
+  it('classifies otherIssues when ASR drift was flagged but no lines were rerecorded', () => {
+    const report = { ...MOCK_QA_REPORT, asr: { ...MOCK_QA_REPORT.asr, linesFlaggedDrift: 2 } };
+    expect(classifyHeadline(report)).toEqual({ kind: 'otherIssues' });
+  });
+
+  it('classifies otherIssues when a voice mismatch exists but no lines were rerecorded', () => {
+    const report = {
+      ...MOCK_QA_REPORT,
+      voiceDrift: { ...MOCK_QA_REPORT.voiceDrift, mismatches: [{ characterId: 'ren', fixable: true }] },
+    };
+    expect(classifyHeadline(report)).toEqual({ kind: 'otherIssues' });
+  });
+
+  it('classifies clean when nothing was rerecorded or flagged', () => {
+    expect(classifyHeadline(MOCK_QA_REPORT)).toEqual({ kind: 'clean' });
+  });
+});
+
+describe('classifyVoiceMatch', () => {
+  it('classifies noEligible when there are no stochastic-voiced characters', () => {
+    const report = { ...MOCK_QA_REPORT, voiceDrift: { ...MOCK_QA_REPORT.voiceDrift, chaptersEligible: 0 } };
+    expect(classifyVoiceMatch(report)).toEqual({ kind: 'noEligible' });
+  });
+
+  it('classifies notRun when chaptersScored and chaptersEmbedFailed are both 0', () => {
+    const report = {
+      ...MOCK_QA_REPORT,
+      voiceDrift: { ...MOCK_QA_REPORT.voiceDrift, chaptersEligible: 12, chaptersScored: 0, chaptersEmbedFailed: 0 },
+    };
+    expect(classifyVoiceMatch(report)).toEqual({ kind: 'notRun' });
+  });
+
+  it('classifies embedShortfall for a fleet-wide embed failure (chaptersScored 0 but chaptersEmbedFailed nonzero)', () => {
+    const report = {
+      ...MOCK_QA_REPORT,
+      voiceDrift: { ...MOCK_QA_REPORT.voiceDrift, chaptersEligible: 12, chaptersScored: 0, chaptersEmbedFailed: 12 },
+    };
+    expect(classifyVoiceMatch(report)).toEqual({
+      kind: 'embedShortfall',
+      chaptersScored: 0,
+      chaptersEligible: 12,
+      chaptersEmbedFailed: 12,
+      mismatchCount: 0,
+      inconclusiveCount: 0,
+    });
+  });
+
+  it('classifies embedShortfall for an isolated embed failure even when every character was checked', () => {
+    const report = {
+      ...MOCK_QA_REPORT,
+      voiceDrift: { ...MOCK_QA_REPORT.voiceDrift, chaptersEligible: 12, chaptersScored: 11, chaptersEmbedFailed: 1 },
+    };
+    expect(classifyVoiceMatch(report)).toEqual({
+      kind: 'embedShortfall',
+      chaptersScored: 11,
+      chaptersEligible: 12,
+      chaptersEmbedFailed: 1,
+      mismatchCount: 0,
+      inconclusiveCount: 0,
+    });
+  });
+
+  it('classifies scored with the character-checked fraction once every eligible chapter was scored', () => {
+    expect(classifyVoiceMatch(MOCK_QA_REPORT)).toEqual({
+      kind: 'scored',
+      charactersChecked: 18,
+      charactersOnRoster: 18,
+      mismatchCount: 0,
+      inconclusiveCount: 0,
+    });
+  });
+
+  it('surfaces inconclusiveCount on the scored branch', () => {
+    const report = { ...MOCK_QA_REPORT, voiceDrift: { ...MOCK_QA_REPORT.voiceDrift, inconclusiveCount: 2 } };
+    const result = classifyVoiceMatch(report);
+    expect(result.kind).toBe('scored');
+    expect(result).toMatchObject({ inconclusiveCount: 2 });
+  });
+
+  it('surfaces inconclusiveCount on the embedShortfall branch', () => {
+    const report = {
+      ...MOCK_QA_REPORT,
+      voiceDrift: {
+        ...MOCK_QA_REPORT.voiceDrift,
+        chaptersEligible: 12,
+        chaptersScored: 11,
+        chaptersEmbedFailed: 1,
+        inconclusiveCount: 2,
+      },
+    };
+    const result = classifyVoiceMatch(report);
+    expect(result.kind).toBe('embedShortfall');
+    expect(result).toMatchObject({ inconclusiveCount: 2 });
+  });
+});

--- a/src/lib/qa-report-classify.ts
+++ b/src/lib/qa-report-classify.ts
@@ -1,0 +1,77 @@
+import type { BookQaReport } from './types';
+
+/* fs-51 round-2 review fix: the headline number must be a genuine line
+   count, not a sum of unlike units (a chapter count + a line count + a
+   mismatch count, mislabeled "lines" — the bug an earlier draft shipped).
+   `acoustic.linesRerecorded` is the one field that's actually a line count;
+   when it's zero but other signals still found something, fall back to
+   non-numeric copy rather than mislabel a different unit as "lines." */
+export type HeadlineClassification =
+  | { kind: 'rerecorded'; linesRerecorded: number }
+  | { kind: 'otherIssues' }
+  | { kind: 'clean' };
+
+export function classifyHeadline(report: BookQaReport): HeadlineClassification {
+  const hasOtherIssues = report.asr.linesFlaggedDrift > 0 || report.voiceDrift.mismatches.length > 0;
+  if (report.acoustic.linesRerecorded > 0) {
+    return { kind: 'rerecorded', linesRerecorded: report.acoustic.linesRerecorded };
+  }
+  if (hasOtherIssues) return { kind: 'otherIssues' };
+  return { kind: 'clean' };
+}
+
+export type VoiceMatchClassification =
+  | { kind: 'noEligible' }
+  | { kind: 'notRun' }
+  | {
+      kind: 'embedShortfall';
+      chaptersScored: number;
+      chaptersEligible: number;
+      chaptersEmbedFailed: number;
+      mismatchCount: number;
+      inconclusiveCount: number;
+    }
+  | {
+      kind: 'scored';
+      charactersChecked: number;
+      charactersOnRoster: number;
+      mismatchCount: number;
+      inconclusiveCount: number;
+    };
+
+export function classifyVoiceMatch(report: BookQaReport): VoiceMatchClassification {
+  const vd = report.voiceDrift;
+  if (vd.chaptersEligible === 0) return { kind: 'noEligible' };
+  /* fs-51 correctness fix: chaptersScored === 0 alone no longer means "the
+     gate never ran" — a fleet-wide embedding failure (the gate attempted
+     every eligible chapter, but embeddings failed for literally all of
+     them) ALSO produces chaptersScored === 0, while chaptersEmbedFailed is
+     now correctly nonzero for that case. Only classify as "never ran" when
+     chaptersEmbedFailed is ALSO 0 — otherwise fall through to the
+     embed-shortfall branch below, which reports the honest fraction. */
+  if (vd.chaptersScored === 0 && vd.chaptersEmbedFailed === 0) return { kind: 'notRun' };
+  /* fs-51 round-2 review fix: chaptersScored < chaptersEligible (an isolated
+     embed failure) must lead, exactly like the character-shortfall case
+     below — otherwise a full-roster book with a failed embed still reads as
+     a clean "N of N characters checked", the false-clean the
+     chaptersEmbedFailed field exists to prevent.
+     fs-51 round-3 review fix: also surface inconclusiveCount (short quotes
+     below the minimum-duration gate) per the spec. */
+  if (vd.chaptersScored < vd.chaptersEligible) {
+    return {
+      kind: 'embedShortfall',
+      chaptersScored: vd.chaptersScored,
+      chaptersEligible: vd.chaptersEligible,
+      chaptersEmbedFailed: vd.chaptersEmbedFailed,
+      mismatchCount: vd.mismatches.length,
+      inconclusiveCount: vd.inconclusiveCount,
+    };
+  }
+  return {
+    kind: 'scored',
+    charactersChecked: vd.charactersChecked,
+    charactersOnRoster: vd.charactersOnRoster,
+    mismatchCount: vd.mismatches.length,
+    inconclusiveCount: vd.inconclusiveCount,
+  };
+}

--- a/src/lib/qa-report-export.ts
+++ b/src/lib/qa-report-export.ts
@@ -1,4 +1,5 @@
 import type { BookQaReport } from './types';
+import { classifyHeadline, classifyVoiceMatch } from './qa-report-classify';
 
 function acousticLine(r: BookQaReport): string {
   return `Acoustic — ${r.acoustic.linesChecked} lines checked, ${r.acoustic.linesRerecorded} needed a second take`;
@@ -10,26 +11,14 @@ function asrLine(r: BookQaReport): string {
 }
 
 function voiceMatchLine(r: BookQaReport): string {
-  const vd = r.voiceDrift;
-  if (vd.chaptersEligible === 0) return 'Voice match — no stochastic-voiced characters in this book';
-  /* fs-51 correctness fix: chaptersScored === 0 alone no longer means "the
-     gate never ran" — a fleet-wide embedding failure (every eligible
-     chapter attempted, all of them failed) also produces chaptersScored
-     === 0, but chaptersEmbedFailed is now correctly nonzero for that case.
-     Only report "not run" when chaptersEmbedFailed is ALSO 0; otherwise
-     fall through to the embedShortfall branch below. */
-  if (vd.chaptersScored === 0 && vd.chaptersEmbedFailed === 0) return 'Voice match — not run for this book';
-  /* fs-51 round-3 review fix — the spec requires the inconclusive-chapter
-     count to be surfaced on this row (usually short quotes below the
-     minimum-duration gate), not silently dropped to the JSON export only.
-     Appended to every non-empty branch below rather than duplicated per
-     branch. */
-  const inconclusiveSuffix = vd.inconclusiveCount > 0 ? `, ${vd.inconclusiveCount} chapters inconclusive` : '';
-  const embedShortfall = vd.chaptersScored < vd.chaptersEligible;
-  if (embedShortfall) {
-    return `Voice match — ${vd.chaptersScored} of ${vd.chaptersEligible} eligible chapters scored (${vd.chaptersEmbedFailed} couldn't be embedded), ${vd.mismatches.length} mismatches${inconclusiveSuffix}`;
+  const c = classifyVoiceMatch(r);
+  if (c.kind === 'noEligible') return 'Voice match — no stochastic-voiced characters in this book';
+  if (c.kind === 'notRun') return 'Voice match — not run for this book';
+  const inconclusiveSuffix = c.inconclusiveCount > 0 ? `, ${c.inconclusiveCount} chapters inconclusive` : '';
+  if (c.kind === 'embedShortfall') {
+    return `Voice match — ${c.chaptersScored} of ${c.chaptersEligible} eligible chapters scored (${c.chaptersEmbedFailed} couldn't be embedded), ${c.mismatchCount} mismatches${inconclusiveSuffix}`;
   }
-  return `Voice match — ${vd.charactersChecked} of ${vd.charactersOnRoster} characters checked, ${vd.mismatches.length} mismatches${inconclusiveSuffix}`;
+  return `Voice match — ${c.charactersChecked} of ${c.charactersOnRoster} characters checked, ${c.mismatchCount} mismatches${inconclusiveSuffix}`;
 }
 
 function castContinuityLine(r: BookQaReport): string {
@@ -37,17 +26,16 @@ function castContinuityLine(r: BookQaReport): string {
   return `Cast continuity — ${total} changes since render`;
 }
 
-/* fs-51 round-2 review fix: the headline number must be a genuine line
-   count, not a sum of unlike units (a chapter count + a line count + a
-   mismatch count, mislabeled "lines" — the bug an earlier draft shipped).
-   `acoustic.linesRerecorded` is the one field that's actually a line count;
-   when it's zero but other signals still found something, fall back to
-   non-numeric copy rather than mislabel a different unit as "lines." */
 function headline(r: BookQaReport): string {
-  const hasOtherIssues = r.asr.linesFlaggedDrift > 0 || r.voiceDrift.mismatches.length > 0;
-  if (r.acoustic.linesRerecorded > 0) return `${r.acoustic.linesRerecorded} lines needed a second take.`;
-  if (hasOtherIssues) return 'Some lines need a second look.';
-  return 'Every line held.';
+  const c = classifyHeadline(r);
+  switch (c.kind) {
+    case 'rerecorded':
+      return `${c.linesRerecorded} lines needed a second take.`;
+    case 'otherIssues':
+      return 'Some lines need a second look.';
+    case 'clean':
+      return 'Every line held.';
+  }
 }
 
 export function formatQaReportText(report: BookQaReport, bookTitle: string): string {


### PR DESCRIPTION
## Summary

`QaReportCard`'s `headline()`/`VoiceMatchRow` and `qa-report-export.ts`'s `headline()`/`voiceMatchLine()` independently re-implemented the same classification logic — the headline three-way branch and the voice-match-line four-way branch — including duplicated comments describing the fs-51 round-2/round-3 correctness fixes. A future fix applied to only one copy would produce a downloaded report whose text disagrees with the on-screen card.

- Extracted the shared logic into `src/lib/qa-report-classify.ts`: `classifyHeadline()` (rerecorded / otherIssues / clean) and `classifyVoiceMatch()` (noEligible / notRun / embedShortfall / scored, each carrying only the fields that branch needs).
- `qa-report-card.tsx` renders from the classifier's output via JSX (its card-only `scoringProgress`/`charactersPending` interactive states are unchanged and still take priority, matching the original ordering).
- `qa-report-export.ts` renders from the same classifier via string templates.
- Pure refactor — no behavior change.

## Test plan

- [x] New `src/lib/qa-report-classify.test.ts` — 11 cases covering every branch of both classifiers, including inconclusiveCount presence per branch.
- [x] Existing `qa-report-card.test.tsx` and `qa-report-export.test.ts` pass unchanged (29 tests across the three files).
- [x] `npm run verify:fast:branch` green (lint, typecheck, test, build).

Release notes skipped — pure internal refactor, no user- or operator-visible effect.

Closes #1437

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Kw2otunUemywTTvRd5AVb