### PR TITLE
docs(server): mark third-party front-matter guard spec stable (#1447)

### DIFF
--- a/docs/superpowers/specs/2026-07-11-third-party-front-matter-guard-design.md
+++ b/docs/superpowers/specs/2026-07-11-third-party-front-matter-guard-design.md
@@ -1,11 +1,22 @@
 ---
-status: draft
+status: stable
 issue: 1447
 refs: [1446, 938, 537]
 area: srv
+shipped: 2026-07-11
+pr: 1538
 ---
 
 # Third-party front-matter roster guard (#1447)
+
+> **Ship notes (2026-07-11):** Shipped via PR #1538 (merge commit `6b784771`),
+> `Closes #1447`. Both signals landed. Implementation plan:
+> `docs/superpowers/plans/2026-07-11-third-party-front-matter-guard.md`. One
+> accepted conscious choice: the essay-title regex is intentionally unanchored
+> (anchoring would miss valid prefixed essay titles); the narrow substring case
+> is gated by conditions (b)+(c). **Owed:** live-GPU acceptance of the Signal-2
+> `runNonStoryClassification` path on a real front-matter-essay book (the
+> unit/integration tests stub the analyzer).
 
 ## Problem
 


### PR DESCRIPTION
## Summary

Post-ship doc hygiene for #1447 (shipped in #1538, merge `6b784771`): flip the design spec's `status:` from `draft` to `stable` and add ship notes (PR + merge SHA, the accepted unanchored-regex choice, and the owed live-GPU acceptance of the Signal-2 path).

Docs-only; no runtime surface.

## Test plan

N/A — docs-only. `verify.yml` legs scope out to green.

Refs #1447