### PR TITLE
docs(docs): design + plan app-10 stream-over-LAN loopback proxy

### DIFF
--- a/docs/features/188-android-companion-app.md
+++ b/docs/features/188-android-companion-app.md
@@ -49,13 +49,15 @@ per CLAUDE.md; this doc is what they hang off.
 | `app-14` | #582 (merge `e5b5da9`, closed #550) | home shelf + multi-book switching: pure `home_shelf` (`buildContinueListening` = in-progress books most-recently-played first; `buildRecentlyUpdated` newest-first capped) + presentational `HomeScreen` (Continue-listening rail + recently-updated rail; tap → `onOpenBook`, host wires to the player's `switchBook` for seamless per-book resume). 6 paired Dart tests. **Live device acceptance owed.** **MVP app block (app-1..8,13,14) complete.** |
 | `app-11` | #586 (merge `0563f05`, closed #554) | distribution: Gradle release signing via git-ignored `android/key.properties` (real upload keystore) with a **debug-signed fallback** so `flutter build apk --release` always produces an installable sideload APK; `key.properties.example` + `.gitignore` for the secrets; CI publishes a `companion-release-apk` artifact per build. Build-config (no Dart tests); release APK verified locally (65.6 MB). |
 | `app-9` | #588 (merge `e05753d`, closed #552) | in-car (Android Auto + CarPlay): pure `media_browse_tree` (root→books→chapters `MediaNode` + `bookMediaId`/`chapterMediaId` codec + `childrenOf`) wired into `CompanionAudioHandler.getChildren`/`playFromMediaId` (audio_service `MediaBrowser`); Android Auto descriptor (`automotive_app_desc.xml` + manifest meta-data). 6 paired Dart tests. **Live device/head-unit acceptance owed.** |
-| `app-10` | #589 (merge `c51f71e`, closed #553) | stream-over-LAN instant play: pure `resolvePlaybackSource` (downloaded → local file; else streaming-on + on-LAN → LAN stream; else needs-download — offline-first) + `AppSettings.streamOverLan` toggle (default off) + `AudioEngine.setStreamUrl` (just_audio `AudioSource.uri` with auth headers) + a settings switch. 4 paired Dart tests. **Live device acceptance owed.** |
+| `app-10` | #589 (merge `c51f71e`) — **scaffolding only; #553 REOPENED (blocked)** | stream-over-LAN instant play. **Shipped inert 2026-06:** the pure pieces exist and are unit-tested (`resolvePlaybackSource`, `AppSettings.streamOverLan` default-off toggle, `AudioEngine.setStreamUrl`, the settings switch — 4 tests) but **nothing in production consumes `lanStream`**, and the feature can't be wired under the companion's app-pinned-CA model: `just_audio` streams via the native platform player (OS trust store), which rejects the mkcert CA at `https://<lan>:8443`. **Unblock designed 2026-07-12** — an in-app **loopback proxy** re-serves CA-pinned HTTPS bytes as plaintext to the player over `127.0.0.1`: spec [`2026-07-12-app-10-lan-loopback-proxy-design.md`](../superpowers/specs/2026-07-12-app-10-lan-loopback-proxy-design.md), plan [`2026-07-12-app-10-lan-loopback-proxy.md`](../superpowers/plans/2026-07-12-app-10-lan-loopback-proxy.md). **Implementation pending; #553 closes on that PR.** |
 | `srv-33` | _this PR_ (closed #551) | per-device tokens + revoke, layered on srv-20 (server): `workspace/device-tokens.ts` (pure `findValidDevice`/`hashToken`/`redactDevice` + cache-backed mint/list/revoke, sha-256-only at rest) + `routes/devices.ts` (`GET`/`POST`/`DELETE /api/devices` behind the LAN guard) + `lan-auth.ts` now accepts the shared secret **OR** a non-revoked device token (still sync). Backward-compatible. 18 server tests; openapi `/api/devices` + `Device` schema. **App-side adoption (mint+use a per-device token at pairing) is an optional small follow-up — the shipped app keeps working on the shared token.** |
 
 ### Build track complete
 
-**Every `app-*` item through `app-10`, plus the `srv-33` server follow-up, is built, tested,
-and merged.** The only remaining work is the **batched live-device/head-unit acceptance pass**
+**Every `app-*` item through `app-9`, plus the `srv-33` server follow-up, is built, tested,
+and merged** — **`app-10` is the exception: its scaffolding merged but the feature is BLOCKED
+(#553 reopened), with an unblock now designed + planned (in-app loopback proxy — see the
+`app-10` row/section).** The other remaining work is the **batched live-device/head-unit acceptance pass**
 (per the user's directive — run the whole feature set on the Pixel 10 Pro / a physical device +
 a head unit against the real GPU server). Parked: **`app-12`** (iOS release — the codebase is
 iOS-ready: app-pinned TLS, dual-platform plugins, the unsigned-iOS CI compile is green on every
@@ -488,6 +490,22 @@ IDs are permanent. Priority = position. MVP block first, follow-ups after.
   on the home network. Deprioritized — the user emphasized offline.
 - **Benefit (user):** zero-wait preview before committing a download. **Depends on:**
   `app-2`, `app-5`.
+- **Status (2026-07-12): scaffolding merged but BLOCKED (#553 reopened).** The native
+  platform player (`just_audio` → ExoPlayer/AVPlayer) streams over the OS trust store, which
+  rejects the app-pinned mkcert CA, so `https://<lan>:8443` audio fails TLS and nothing
+  consumes `lanStream`. **Unblock designed + planned** via an in-app loopback proxy that
+  re-serves CA-pinned HTTPS bytes as plaintext to the player over `127.0.0.1` (no OS cert
+  install, token never leaves the app): spec
+  [`2026-07-12-app-10-lan-loopback-proxy-design.md`](../superpowers/specs/2026-07-12-app-10-lan-loopback-proxy-design.md),
+  plan [`2026-07-12-app-10-lan-loopback-proxy.md`](../superpowers/plans/2026-07-12-app-10-lan-loopback-proxy.md).
+  Implementation is a separate thread; #553 closes on that PR.
+- **On-device acceptance (owed post-implementation):** real Android phone on home Wi-Fi,
+  undownloaded chapter, "Stream over LAN" on → tap play → instant start; seek mid-chapter;
+  lock-screen transport controls; background survival via the media foreground service;
+  confirm NO OS cert-install prompt. Then toggle off / leave Wi-Fi → tap the same chapter →
+  "download to play" message (no stall). Also confirm just_audio surfaces initial-load
+  failure (rejected `setAudioSource`) and mid-stream failure (`playbackEventStream` error)
+  so the fallback fires, and the completion subscription isn't torn down by a stream error.
 
 #### `app-11` — Distribution: signed release APK + alpha channel
 
@@ -851,17 +869,20 @@ top for the running status):
   (audio_service `MediaBrowser`, Android Auto + CarPlay) + Android Auto descriptor
   (`automotive_app_desc.xml` + manifest meta-data). 6 paired Dart tests; clean + APK builds.
   **Live device/head-unit acceptance owed.**
-- `app-10` — stream-over-LAN instant play (closed #553): pure `resolvePlaybackSource`
-  (offline-first: downloaded → local; else streaming-on + on-LAN → stream; else download) +
-  `AppSettings.streamOverLan` toggle (default off) + `AudioEngine.setStreamUrl` (just_audio
-  `AudioSource.uri` + auth headers) + a settings switch. 4 paired Dart tests; clean + APK
-  builds. **Live device acceptance owed.**
+- `app-10` — stream-over-LAN instant play (**#553 REOPENED — blocked; scaffolding only**):
+  the pure pieces exist and are unit-tested (`resolvePlaybackSource`, `AppSettings.streamOverLan`
+  default-off toggle, `AudioEngine.setStreamUrl`, the settings switch — 4 tests) but nothing
+  consumes `lanStream` and it can't be wired under the app-pinned-CA model (the native player
+  uses the OS trust store, which rejects the mkcert CA). **Unblock designed 2026-07-12** via an
+  in-app loopback proxy (see the `app-10` section below for spec + plan links); implementation
+  pending, #553 closes on that PR.
 
-**The `app-*` build track (through `app-10`) is code-complete** — all items built, tested
-(167 Dart tests), and merged; `flutter analyze` clean and the debug + release APKs build, with
-CI (android + unsigned-iOS + verify) green on every PR. The remaining work is the **batched
-live-device/head-unit acceptance pass** on the user's real GPU server. Parked follow-ups:
-`srv-33`, `app-12` (iOS release).
+**The `app-*` build track (through `app-9`) is code-complete** — all items built, tested,
+and merged; `flutter analyze` clean and the debug + release APKs build, with CI (android +
+unsigned-iOS + verify) green on every PR. **`app-10` is the one exception: scaffolding merged
+but the feature is BLOCKED (#553 reopened); the unblock is designed + planned (loopback proxy)
+and awaits implementation.** The other remaining work is the **batched live-device/head-unit
+acceptance pass** on the user's real GPU server. Parked follow-ups: `srv-33`, `app-12` (iOS release).
 
 - 2026-06-13 — `app-15` (iOS `AppIcon` set rendered square + opaque from
   `brand/castwright-icon.svg`, replacing the default Flutter logo) + `app-16`

--- a/docs/superpowers/plans/2026-07-12-app-10-lan-loopback-proxy.md
+++ b/docs/superpowers/plans/2026-07-12-app-10-lan-loopback-proxy.md
@@ -124,7 +124,8 @@ void main() {
   });
 
   test('cancel aborts only this request; a sibling on the same client survives', () async {
-    // A slow server that streams a byte, waits, then finishes — so we can cancel mid-stream.
+    // A slow server that streams a byte, waits, then finishes — so we can cancel
+    // request `a` mid-stream (after it has actually started reading).
     final slow = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
     slow.listen((req) async {
       final res = req.response;
@@ -140,12 +141,23 @@ void main() {
     final a = await streamRange(client, slowUrl, bearer: 't');
     final b = await streamRange(client, slowUrl, bearer: 't');
 
-    // Start draining b fully; cancel a immediately.
+    // ACTIVELY read `a` up to its first chunk so a real socket read is in flight
+    // on the shared client — otherwise cancel() would be a no-op and prove nothing.
+    final aStarted = Completer<void>();
+    final aSub = a.body.listen((_) {
+      if (!aStarted.isCompleted) aStarted.complete();
+    });
+    await aStarted.future.timeout(const Duration(seconds: 2));
+
+    // Drain b fully in parallel, then cancel a mid-stream.
     final bDone = b.body.fold<List<int>>(<int>[], (acc, c) => acc..addAll(c));
     await a.cancel();
+    await aSub.cancel();
 
+    // The sibling completes despite a's mid-stream cancel — cancel tore down only
+    // a's socket, not the shared client's pool.
     final bBytes = await bDone.timeout(const Duration(seconds: 2));
-    expect(bBytes, [9, 9]); // sibling completed despite a's cancel
+    expect(bBytes, [9, 9]);
     client.close(force: true);
     await slow.close(force: true);
   });
@@ -215,23 +227,28 @@ Future<PinnedStreamResponse> streamRange(HttpClient client, Uri url,
   res.headers.forEach((name, values) => headers[name] = values.join(','));
 
   final out = StreamController<List<int>>();
-  StreamSubscription<List<int>>? sub;
-  out.onListen = () {
-    sub = res.listen(
-      out.add,
-      onError: out.addError,
-      onDone: () {
-        if (!out.isClosed) out.close();
-      },
-      cancelOnError: true,
-    );
-  };
-  out.onPause = () => sub?.pause();
-  out.onResume = () => sub?.resume();
-  out.onCancel = () async => sub?.cancel();
+  // Subscribe EAGERLY (then pause) — not lazily in onListen — so `cancel()` can
+  // always tear down the real socket, even on a HEAD / non-2xx path where the
+  // body is never drained (`addStream` never fires onListen). A lazy subscription
+  // would leave the HttpClientResponse dangling on every HEAD probe and every
+  // 401/404/5xx upstream. dart:io delivers events async, so the pause below can't
+  // race a synchronous first event.
+  final sub = res.listen(
+    out.add,
+    onError: out.addError,
+    onDone: () {
+      if (!out.isClosed) out.close();
+    },
+    cancelOnError: true,
+  );
+  sub.pause();
+  out.onListen = () => sub.resume();
+  out.onPause = () => sub.pause();
+  out.onResume = () => sub.resume();
+  out.onCancel = () => sub.cancel();
 
   Future<void> cancel() async {
-    await sub?.cancel();
+    await sub.cancel(); // abort THIS socket only — never client.close()
     if (!out.isClosed) await out.close();
   }
 
@@ -280,7 +297,6 @@ Create `apps/android/test/data/loopback_proxy_test.dart`:
 
 ```dart
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
 
@@ -696,10 +712,12 @@ In `apps/android/test/data/player_controller_test.dart`, extend `FakeAudioEngine
 
 Add `await _errorCtl.close();` inside `FakeAudioEngine.dispose()`.
 
-- [ ] **Step 2: Run the suite to verify it fails to compile**
+- [ ] **Step 2: Run analyze to verify it fails**
 
-Run: `cd apps/android && flutter test test/data/player_controller_test.dart`
-Expected: FAIL — the other `AudioEngine` fakes/impls don't yet implement `errorStream` (analyzer/compile error).
+Run `flutter analyze` (NOT a single-file `flutter test` — that compiles only that file's transitive imports, where the local `FakeAudioEngine` already has `errorStream`, so it would pass and hide the gap).
+
+Run: `cd apps/android && flutter analyze`
+Expected: FAIL — `just_audio_engine.dart`, `demo_audio_engine.dart`, and the other three test fakes are missing the `errorStream` override (`missing_concrete_implementation` / non-abstract-class errors).
 
 - [ ] **Step 3: Implement across every `AudioEngine`**
 
@@ -1011,17 +1029,16 @@ Then the tests:
 
 ```dart
   group('app-10 streaming', () {
-    StreamingConfig cfg(
+    Future<StreamingConfig> cfg(
       FakeProxy proxy, {
       required bool streamOn,
       required bool onLan,
       Set<String> downloaded = const {},
       void Function()? onRepair,
-    }) {
+    }) async {
       final fs = InMemoryFileStore();
       for (final p in downloaded) {
-        // seed as "exists"
-        fs.writeBytes(p, const [0]);
+        await fs.writeBytes(p, const [0]); // seed as "exists"
       }
       return StreamingConfig(
         fileStore: fs,
@@ -1045,7 +1062,7 @@ Then the tests:
         playbackStore: MemPlaybackStore(),
         playlistLoader: (_) async => list,
         clock: () => DateTime.utc(2026, 6, 6),
-        streaming: cfg(proxy, streamOn: true, onLan: true, downloaded: {'/b1/u1/audio.mp3'}),
+        streaming: await cfg(proxy, streamOn: true, onLan: true, downloaded: {'/b1/u1/audio.mp3'}),
       );
       await pc.openBook('b1');
       expect(engine.calls, contains('set:/b1/u1/audio.mp3'));
@@ -1060,7 +1077,7 @@ Then the tests:
         playbackStore: MemPlaybackStore(),
         playlistLoader: (_) async => list,
         clock: () => DateTime.utc(2026, 6, 6),
-        streaming: cfg(proxy, streamOn: true, onLan: true),
+        streaming: await cfg(proxy, streamOn: true, onLan: true),
       );
       await pc.openBook('b1');
       expect(proxy.starts, 1);
@@ -1071,8 +1088,8 @@ Then the tests:
 
     test('toggle off / off-Wi-Fi -> needs download, proxy never starts', () async {
       for (final c in [
-        cfg(FakeProxy(), streamOn: false, onLan: true),
-        cfg(FakeProxy(), streamOn: true, onLan: false),
+        await cfg(FakeProxy(), streamOn: false, onLan: true),
+        await cfg(FakeProxy(), streamOn: true, onLan: false),
       ]) {
         final engine = FakeAudioEngine();
         final pc = PlayerController(
@@ -1100,7 +1117,7 @@ Then the tests:
         playbackStore: MemPlaybackStore(),
         playlistLoader: (_) async => list,
         clock: () => DateTime.utc(2026, 6, 6),
-        streaming: cfg(proxy, streamOn: true, onLan: true, onRepair: () => repaired++),
+        streaming: await cfg(proxy, streamOn: true, onLan: true, onRepair: () => repaired++),
       );
       final emitted = <String>[];
       pc.needsDownloadStream.listen(emitted.add);
@@ -1121,7 +1138,7 @@ Then the tests:
         playbackStore: MemPlaybackStore(),
         playlistLoader: (_) async => list,
         clock: () => DateTime.utc(2026, 6, 6),
-        streaming: cfg(proxy, streamOn: true, onLan: true, onRepair: () => repaired++),
+        streaming: await cfg(proxy, streamOn: true, onLan: true, onRepair: () => repaired++),
       );
       final emitted = <String>[];
       pc.needsDownloadStream.listen(emitted.add);
@@ -1132,6 +1149,34 @@ Then the tests:
       expect(emitted, isEmpty);
     });
 
+    test('auto-advance into a needs-download chapter halts quietly (no play/stream)', () async {
+      // ch1 downloaded, ch2 not; streaming OFF so ch2 resolves to needsDownload.
+      final engine = FakeAudioEngine();
+      final proxy = FakeProxy();
+      const two = [
+        PlayableChapter(uuid: 'u1', path: '/b1/u1.mp3', audioUrl: '/api/books/b1/chapters/1/audio.mp3'),
+        PlayableChapter(uuid: 'u2', path: '/b1/u2.mp3', audioUrl: '/api/books/b1/chapters/2/audio.mp3'),
+      ];
+      final pc = PlayerController(
+        audioEngine: engine,
+        playbackStore: MemPlaybackStore(),
+        playlistLoader: (_) async => two,
+        clock: () => DateTime.utc(2026, 6, 6),
+        streaming: await cfg(proxy, streamOn: false, onLan: true, downloaded: {'/b1/u1.mp3'}),
+      );
+      await pc.openBook('b1'); // loads u1 (downloaded local file)
+      await pc.play();
+      engine.calls.clear();
+      engine.emitCompletion(); // end of u1 -> _advance into u2 (needsDownload)
+      await Future<void>.delayed(Duration.zero);
+      // No new source loaded and no play() on the quiet-halt path.
+      expect(
+        engine.calls.where((x) =>
+            x.startsWith('set:') || x.startsWith('stream:') || x == 'play'),
+        isEmpty,
+      );
+    });
+
     test('dispose disposes the proxy', () async {
       final proxy = FakeProxy();
       final pc = PlayerController(
@@ -1139,7 +1184,7 @@ Then the tests:
         playbackStore: MemPlaybackStore(),
         playlistLoader: (_) async => list,
         clock: () => DateTime.utc(2026, 6, 6),
-        streaming: cfg(proxy, streamOn: true, onLan: true),
+        streaming: await cfg(proxy, streamOn: true, onLan: true),
       );
       await pc.dispose();
       expect(proxy.disposed, isTrue);
@@ -1209,43 +1254,54 @@ In the constructor body (after `_playingSub = …`):
 
 ```dart
     if (_streaming != null) {
-      _errorSub = _engine.errorStream.listen((_) {
-        // Mid-stream failure channel (§6). Only route when the live source is a
-        // stream — a local-file playback error must not trigger download/re-pair.
-        if (_currentIsStream) _handleStreamFailure();
-      });
+      // Mid-stream failure channel (§6). `_handleStreamFailure` self-guards on
+      // `_currentIsStream`, so a local-file playback error no-ops and a single
+      // failure can't be routed twice (this errorStream event AND the initial-load
+      // `catch` in `_loadSource` can both fire — the guard makes it idempotent).
+      _errorSub = _engine.errorStream.listen((_) => _handleStreamFailure());
     }
 ```
 
-> Constructor-signature note: `_streaming` is a positional optional trailing field alongside `_statsDb/_sessionId/_localDate`. Because those are positional-optional (`this._statsDb,` etc. inside the `{ }`? — they are named-optional in the current constructor), add `StreamingConfig? streaming` as a **named** optional param and assign `_streaming = streaming` in the initializer list, mirroring how `_statsDb` is wired. Keep it named so call sites read `streaming: …`.
+> Constructor-signature note: add `this._streaming,` as an **initializing formal** inside the existing named-optional `{ }` block, exactly like the current `this._statsDb,` / `this._sessionId,` / `this._localDate,` (which ARE named-optional initializing formals — confirmed against the live `companion_runtime.dart:161-174` call site that passes `statsDb:` / `sessionId:` / `localDate:`). Do NOT also declare a separate `StreamingConfig? streaming` param or a manual `_streaming = streaming` initializer — an initializing formal and a manual initializer for the same field is a compile error. The underscore is auto-stripped, so call sites read `streaming: …`.
 
-Replace the single `await _engine.setFilePath(c.path);` line in `_loadIndex` (currently `player_controller.dart:280`) with a call to the new resolver, and thread `userInitiated`:
-
-```dart
-  Future<void> _loadIndex(int index, {int seekMs = 0, bool userInitiated = false}) async {
-```
-
-(inside, where `setFilePath` was:)
+Change `_loadIndex` to return whether a source actually loaded, thread `userInitiated`, and gate the post-load engine calls (speed/boost/seek) on a real load so a `needsDownload` resolution doesn't mutate the PREVIOUS still-loaded source. Signature + early return:
 
 ```dart
-    await _loadSource(c, userInitiated: userInitiated);
+  Future<bool> _loadIndex(int index, {int seekMs = 0, bool userInitiated = false}) async {
+    if (index < 0 || index >= _playlist.length) return false;
 ```
 
-Update the three callers to pass `userInitiated`:
-- `openBook` → `await _loadIndex(index, seekMs: saved?.positionMs ?? 0, userInitiated: true);`
-- `playChapter` → `await _loadIndex(i, userInitiated: true);`
-- `skip`'s `ChapterStep` branch → `await _loadIndex(next, userInitiated: true);`
-- `_advance` stays `await _loadIndex(_index + 1);` (default `userInitiated: false`).
+Replace the single `await _engine.setFilePath(c.path);` line (currently `player_controller.dart:280`) and the speed/boost/seek block that follows it with:
+
+```dart
+    final loaded = await _loadSource(c, userInitiated: userInitiated);
+    if (loaded) {
+      if (_speed != 1.0) await _engine.setSpeed(_speed); // persist across chapters
+      if (_boostDb > 0) await _engine.setVolumeBoost(_boostDb);
+      if (seekMs > 0) await _engine.seek(Duration(milliseconds: seekMs));
+    }
+```
+
+At the end of `_loadIndex` (after the `_bookReplayed` emit), `return loaded;`.
+
+Update the callers to pass `userInitiated` and gate `play()` on the load result (so an auto-advance or a user tap into a `needsDownload` chapter halts quietly instead of replaying the prior chapter):
+- `openBook` → `await _loadIndex(index, seekMs: saved?.positionMs ?? 0, userInitiated: true);` (openBook does not auto-play; return ignored).
+- `playChapter` → `final loaded = await _loadIndex(i, userInitiated: true); if (loaded) await play();`
+- `skip`'s `ChapterStep` branch → `await _loadIndex(next, userInitiated: true);` (skip never calls `play()`; return ignored).
+- `_advance` → `final loaded = await _loadIndex(_index + 1); if (loaded) await play();` (default `userInitiated: false`).
 
 Add the resolver + failure router:
 
 ```dart
-  Future<void> _loadSource(PlayableChapter c, {required bool userInitiated}) async {
+  /// Loads the chapter's playback source. Returns true iff a source was actually
+  /// set on the engine (local file or a live stream); false for `needsDownload`,
+  /// a null `audioUrl`, or a failed stream — callers skip `play()` on false.
+  Future<bool> _loadSource(PlayableChapter c, {required bool userInitiated}) async {
     final cfg = _streaming;
     if (cfg == null) {
       _currentIsStream = false;
       await _engine.setFilePath(c.path); // legacy: offline-first only
-      return;
+      return true;
     }
     final src = resolvePlaybackSource(
       localFileExists: await cfg.fileStore.exists(c.path),
@@ -1256,12 +1312,13 @@ Add the resolver + failure router:
       case PlaybackSource.localFile:
         _currentIsStream = false;
         await _engine.setFilePath(c.path);
+        return true;
       case PlaybackSource.lanStream:
         final audioUrl = c.audioUrl;
         if (audioUrl == null) {
           _currentIsStream = false;
           if (userInitiated) _notifyDownloadToPlay();
-          return;
+          return false;
         }
         await cfg.proxy.start(); // first bind, on demand
         final loopback = cfg.proxy.register(upstream: cfg.urlResolver(audioUrl));
@@ -1269,25 +1326,31 @@ Add the resolver + failure router:
         try {
           // The player only ever sees http://127.0.0.1/… and NO headers.
           await _engine.setStreamUrl(loopback.toString());
+          return true;
         } catch (_) {
           _handleStreamFailure(); // initial-load throw channel (§6/§7)
+          return false;
         }
       case PlaybackSource.needsDownload:
         _currentIsStream = false;
         if (userInitiated) _notifyDownloadToPlay(); // else auto-advance: halt quietly
+        return false;
     }
   }
 
   /// The single §7 failure router (shared by the initial-load throw and the
-  /// mid-stream errorStream event). Reads the proxy's upstream-status
-  /// side-channel, clears the mapping, and either re-pairs (fresh 401/403) or
-  /// surfaces "download to play" (everything else, incl. null). No auto-retry.
+  /// mid-stream errorStream event). Self-guards on `_currentIsStream` so it is
+  /// idempotent per stream load AND no-ops on a local-file error: reads the
+  /// proxy's upstream-status side-channel, clears the mapping, and either re-pairs
+  /// (fresh 401/403) or surfaces "download to play" (everything else, incl. null).
+  /// No auto-retry.
   void _handleStreamFailure() {
     final cfg = _streaming;
     if (cfg == null) return;
+    if (!_currentIsStream) return; // not streaming, or already handled
+    _currentIsStream = false;
     final status = cfg.proxy.lastUpstreamStatus;
     cfg.proxy.clearMapping();
-    _currentIsStream = false;
     if (status == 401 || status == 403) {
       cfg.onRepairNeeded();
     } else {
@@ -1494,3 +1557,14 @@ git commit -m "docs(docs): reconcile app-10 to the loopback proxy + release note
 **Type consistency** — `PinnedStreamResponse` (Task 1) is consumed by `UpstreamFetch`/`LoopbackProxy` (Task 2) and `ApiClient.pinnedRangeStream` (Tasks 1, 8). `LoopbackProxy` surface (`start`/`register({upstream})`/`lastUpstreamStatus`/`clearMapping`/`dispose`) is used identically by the `FakeProxy` (Task 7) and the runtime (Task 8). `StreamingConfig` fields (Task 7) are constructed with the same names in Task 8. `AudioEngine.errorStream` (Task 4) is subscribed in Task 7. `PlayableChapter.audioUrl` (Task 6) is read in Task 7's `_loadSource`. `Reachability.onHomeLan` (Task 5) is used in Task 8's config.
 
 **Placeholder scan** — no TBD/TODO; every code step carries full code. The one soft spot (Task 6 Step 1's "reuse the file's existing detail-seeding pattern") is called out explicitly with the exact assertion, because `sync_controller_test.dart`'s existing harness should drive the seeding rather than a fabricated helper.
+
+**Adversarial assumption-check (Premium/Opus) — folded 2026-07-12.** The mandatory plan-review gate ran and returned *ready-with-fixes*; all findings were folded before approval:
+- **[Major] Real-socket leak on HEAD / non-2xx** — `streamRange` created its response subscription lazily in `onListen`, so `cancel()` on a never-drained body was a no-op and leaked the `HttpClientResponse`. Fixed: subscribe eagerly then `pause()`; `cancel()` now always aborts the real socket (Task 1 Step 3).
+- **[Major] Placebo cancel test** — the concurrency test never listened to `a.body`, so `a.cancel()` proved nothing. Fixed: actively read `a` to its first chunk, cancel mid-stream, assert the sibling still completes (Task 1 Step 1, test 2) — this is the spec's core §2 trap, now genuinely verified.
+- **[Major] Contradictory constructor instructions** — the note told the engineer to add BOTH `this._streaming` (initializing formal) AND a manual `_streaming = streaming` initializer (a compile error). Fixed: keep only `this._streaming,`, matching the live `this._statsDb` pattern (Task 7 Step 3).
+- **[Minor] Task 4 "expected FAIL"** used a single-file `flutter test` that would pass; switched to `flutter analyze`.
+- **[Minor] Unused imports** (`dart:convert` in the proxy test) scrubbed to keep `flutter analyze` green.
+- **[Minor] Auto-advance quiet-halt** — `_advance` unconditionally called `play()` after a `needsDownload` load; `_loadSource`/`_loadIndex` now return whether a source loaded and callers gate `play()` on it (+ a new auto-advance-halts test).
+- **[Minor] Double-route guard** — `_handleStreamFailure` is now idempotent (`if (!_currentIsStream) return`), so the initial-load `catch` and the mid-stream `errorStream` event can't both emit.
+- **[Minor] Unawaited seed** — the test `cfg` builder now `await`s `fileStore.writeBytes`.
+- **On-device checklist (not plan defects):** the two load-bearing just_audio assumptions — `setAudioSource` rejecting on initial-load failure, and mid-stream errors arriving via `playbackEventStream.listen(onError:)` — plus the §6 `_completionSub`-not-torn-down check, are called out for the on-device acceptance pass (Task 9 walkthrough).

--- a/docs/superpowers/plans/2026-07-12-app-10-lan-loopback-proxy.md
+++ b/docs/superpowers/plans/2026-07-12-app-10-lan-loopback-proxy.md
@@ -1,0 +1,1496 @@
+# app-10 — Stream-over-LAN via an in-app loopback proxy — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make an undownloaded chapter play instantly over the home LAN in the Flutter companion by running a tiny in-app loopback HTTP proxy that re-serves CA-pinned HTTPS chapter bytes as plaintext `127.0.0.1` to the native platform player.
+
+**Architecture:** A `dart:io HttpServer` bound to `127.0.0.1:0` accepts the platform player's plaintext range requests and re-fetches each range over the app's already-pinned HTTPS client (`ApiClient`), streaming `206` bytes straight through. The mkcert CA never has to be trusted by the OS and the Bearer token never leaves the app. Playback-source selection, failure fallback (download-to-play vs. re-pair), and an engine error seam wire the proxy into the existing `PlayerController` without disturbing the offline-first download path.
+
+**Tech Stack:** Dart / Flutter, `dart:io` (`HttpServer`, `HttpClient`), `just_audio` (native ExoPlayer/AVPlayer), `flutter_test`. No new pubspec dependency. Android `network_security_config.xml`.
+
+**Spec:** [`docs/superpowers/specs/2026-07-12-app-10-lan-loopback-proxy-design.md`](../specs/2026-07-12-app-10-lan-loopback-proxy-design.md) (design approved 2026-07-12, converged after 3 adversarial rounds).
+
+**Issue:** [#553](https://github.com/dudarenok-maker/Castwright/issues/553) (`app-10`). PR closes it; on-device Android smoke test is owed to the owner post-merge (standard app-* "live device acceptance owed").
+
+## Global Constraints
+
+- **No new pubspec dependency.** Everything is `dart:io` / existing packages.
+- **Two invariants must both hold:** (a) **app-pinned CA only — no OS cert install**; (b) **HTTPS-on-LAN — no cleartext chapter bytes or token off-device.** The only permitted cleartext is the in-process `127.0.0.1` hop.
+- **Ephemeral preview only.** Streamed bytes are never persisted; no coupling to the downloader. Offline stays the existing explicit Download flow.
+- **Stream-through, never whole-file buffering** (instant play + no OOM on large chapters).
+- **Demand-scoped, never a background server.** No socket binds at app launch, on pairing, or while playing local files. The proxy `start()`s only on the first resolution to `PlaybackSource.lanStream` and is disposed with the `PlayerController`.
+- **No auto-retry on stream failure.** A single clean fallback (download-to-play, or re-pair on `401/403`) — no silent retry loop.
+- **Backward-compatible constructor.** `PlayerController` gains the streaming deps as ONE optional bundle; when absent, `_loadIndex` keeps its exact current behaviour (`setFilePath(c.path)`), so every existing `PlayerController` test stays green unchanged.
+- **Commit convention:** `<type>(<scope>): <subject>`; scope for companion code is `app`, for docs is `docs`. The commit-msg hook enforces this.
+- **The only automated gate for `apps/android/` is `app.yml`** (`flutter analyze` + `flutter test`). Every task below ships paired Dart tests; run `flutter test` from `apps/android/`.
+- **`network_security_config.xml` + manifest wiring is NOT unit-testable for effect** — a string-assertion test guards its presence; real behaviour is validated only on-device.
+
+## Deviations from the spec (deliberate, carry into the handover)
+
+1. **`LoopbackProxy.register` drops the `headers` parameter.** The spec's §1 `register({upstream, headers})` and §2 "`pinnedRangeStream` … Same `Authorization: Bearer` injection" would inject the Bearer twice. Resolution: **auth lives in exactly one place — `pinnedRangeStream` injects the Bearer** (consistent with `pinnedRangeFetch`). The proxy is constructed with the `pinnedRangeStream` tear-off as its upstream fetch and stays auth-agnostic; `register` needs only `upstream`. No token is ever handed to the proxy or duplicated.
+2. **`pinnedRangeStream` uses ONE shared streaming client and `cancel()` aborts via the held `StreamSubscription` only** (never `client.close(force: true)`) — exactly the spec §2 trap. A `@visibleForTesting` `streamRange(HttpClient, …)` helper isolates the socket logic so the cancel-only-this-request contract is tested against a real plaintext `HttpServer` without TLS.
+3. **The `PlayerController` streaming deps are bundled into one optional `StreamingConfig`** (rather than 6 separate required constructor params) to keep the change backward-compatible and bound test churn, per the Global Constraint above.
+
+---
+
+## File Structure
+
+**New files:**
+- `apps/android/lib/src/data/loopback_proxy.dart` — the `LoopbackProxy` (`HttpServer` on `127.0.0.1:0`, one active mapping, upstream relay, failure side-channel).
+- `apps/android/test/data/loopback_proxy_test.dart` — proxy tests against a fake upstream fetch.
+- `apps/android/android/app/src/main/res/xml/network_security_config.xml` — loopback-scoped cleartext exemption.
+- `apps/android/test/network_security_config_test.dart` — string-assertion guard for the config + manifest wiring.
+- `apps/android/test/data/api_client_stream_test.dart` — `pinnedRangeStream` / `streamRange` transport tests (real plaintext server).
+- `apps/android/test/data/loopback_reachability_test.dart` — `Reachability.onHomeLan` mapping.
+
+**Modified files:**
+- `apps/android/lib/src/data/api_client.dart` — add `PinnedStreamResponse`, `pinnedRangeStream`, `streamRange`.
+- `apps/android/lib/src/data/audio_engine.dart` — add `Stream<Object> get errorStream;`.
+- `apps/android/lib/src/data/just_audio_engine.dart` — map `playbackEventStream` errors onto `errorStream`.
+- `apps/android/lib/src/demo/demo_audio_engine.dart` — empty `errorStream`.
+- `apps/android/lib/src/data/network_info.dart` — add `Reachability` + `CurrentNetwork` typedef.
+- `apps/android/lib/src/data/player_controller.dart` — `PlayableChapter.audioUrl`; `StreamingConfig`; source-resolution + failure routing in `_loadIndex`.
+- `apps/android/lib/src/data/sync_controller.dart` — carry `audioUrl` through `playlistFor`.
+- `apps/android/lib/src/data/companion_runtime.dart` — build + inject the `StreamingConfig`; thread `onRepairNeeded`.
+- `apps/android/lib/main.dart` — expose the re-pair entry to the runtime.
+- `apps/android/android/app/src/main/AndroidManifest.xml` — `android:networkSecurityConfig` attribute.
+- Test fakes implementing `AudioEngine` (add `errorStream`): `test/data/player_controller_test.dart`, `test/data/player_controller_playing_stream_test.dart`, `test/data/companion_runtime_test.dart`, `test/data/companion_audio_handler_test.dart`.
+- `apps/android/test/domain/playback_source_test.dart` — add the `NetworkType → onHomeLan` cases.
+- `docs/features/188-android-companion-app.md` — reconcile the `app-10` row + acceptance walkthrough.
+- `docs/release-notes-next.md` + `RELEASE_NOTES.md` — one entry each (at ship time).
+
+---
+
+## Task 1: `pinnedRangeStream` — CA-pinned, cancellable range streaming
+
+**Files:**
+- Modify: `apps/android/lib/src/data/api_client.dart`
+- Test: `apps/android/test/data/api_client_stream_test.dart` (create)
+
+**Interfaces:**
+- Consumes: `_pinnedHttpClient(Connection)` (`api_client.dart:311`), `connection.server.token`.
+- Produces:
+  - `class PinnedStreamResponse { final int statusCode; final Map<String,String> headers; final Stream<List<int>> body; final Future<void> Function() cancel; }`
+  - `Future<PinnedStreamResponse> ApiClient.pinnedRangeStream(Uri url, {String? range})`
+  - `@visibleForTesting Future<PinnedStreamResponse> streamRange(HttpClient client, Uri url, {required String bearer, String? range})`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/android/test/data/api_client_stream_test.dart`:
+
+```dart
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:castwright/src/data/api_client.dart';
+
+void main() {
+  late HttpServer server;
+  final received = <HttpRequest>[];
+
+  setUp(() async {
+    received.clear();
+    server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    server.listen((req) async {
+      received.add(req);
+      final res = req.response;
+      res.statusCode = req.headers.value(HttpHeaders.rangeHeader) != null ? 206 : 200;
+      res.headers.set(HttpHeaders.contentTypeHeader, 'audio/mpeg');
+      res.headers.set('x-echo-range', req.headers.value(HttpHeaders.rangeHeader) ?? '');
+      res.headers.set('x-echo-auth', req.headers.value(HttpHeaders.authorizationHeader) ?? '');
+      res.add([1, 2, 3, 4]);
+      await res.close();
+    });
+  });
+
+  tearDown(() async => server.close(force: true));
+
+  Uri url() => Uri.parse('http://127.0.0.1:${server.port}/audio.mp3');
+
+  test('streamRange passes status, headers, body; injects Bearer; forwards Range', () async {
+    final client = HttpClient();
+    final r = await streamRange(client, url(), bearer: 'TKN', range: 'bytes=0-3');
+    expect(r.statusCode, 206);
+    expect(r.headers['content-type'], 'audio/mpeg');
+    expect(r.headers['x-echo-range'], 'bytes=0-3');
+    expect(r.headers['x-echo-auth'], 'Bearer TKN');
+    final bytes = <int>[];
+    await for (final chunk in r.body) {
+      bytes.addAll(chunk);
+    }
+    expect(bytes, [1, 2, 3, 4]);
+    client.close(force: true);
+  });
+
+  test('cancel aborts only this request; a sibling on the same client survives', () async {
+    // A slow server that streams a byte, waits, then finishes — so we can cancel mid-stream.
+    final slow = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    slow.listen((req) async {
+      final res = req.response;
+      res.add([9]);
+      await res.flush();
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+      res.add([9]);
+      await res.close();
+    });
+    final slowUrl = Uri.parse('http://127.0.0.1:${slow.port}/x');
+    final client = HttpClient(); // ONE shared client for both requests
+
+    final a = await streamRange(client, slowUrl, bearer: 't');
+    final b = await streamRange(client, slowUrl, bearer: 't');
+
+    // Start draining b fully; cancel a immediately.
+    final bDone = b.body.fold<List<int>>(<int>[], (acc, c) => acc..addAll(c));
+    await a.cancel();
+
+    final bBytes = await bDone.timeout(const Duration(seconds: 2));
+    expect(bBytes, [9, 9]); // sibling completed despite a's cancel
+    client.close(force: true);
+    await slow.close(force: true);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/android && flutter test test/data/api_client_stream_test.dart`
+Expected: FAIL — `streamRange`/`PinnedStreamResponse` not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `apps/android/lib/src/data/api_client.dart`, add the `visibleForTesting` import usage is already present (`import 'package:flutter/foundation.dart' show visibleForTesting;`). Add this class near the top-level types and the two functions (method on `ApiClient`, helper at file scope):
+
+```dart
+/// A streamed, CA-pinned range response for the loopback proxy (`app-10`). The
+/// [body] is a single-subscription stream that preserves backpressure; [cancel]
+/// aborts THIS request's socket via the held subscription — it never closes the
+/// shared streaming client, so sibling concurrent range fetches keep running.
+class PinnedStreamResponse {
+  const PinnedStreamResponse({
+    required this.statusCode,
+    required this.headers,
+    required this.body,
+    required this.cancel,
+  });
+  final int statusCode;
+  final Map<String, String> headers; // lower-cased header names
+  final Stream<List<int>> body;
+  final Future<void> Function() cancel;
+}
+```
+
+Add a lazily-created shared streaming client field + method on `ApiClient` (after `pinnedRangeFetch()`):
+
+```dart
+  HttpClient? _streamClient;
+
+  /// A range-capable, CA-pinned, streamed byte fetcher for `app-10` LAN preview.
+  /// Reuses ONE pinned client across concurrent range fetches in a playback
+  /// session (connection reuse); each response's [PinnedStreamResponse.cancel]
+  /// aborts only its own socket. The Bearer is injected here, so the loopback
+  /// proxy never sees the token.
+  Future<PinnedStreamResponse> pinnedRangeStream(Uri url, {String? range}) {
+    final client = _streamClient ??= _pinnedHttpClient(connection);
+    return streamRange(client, url, bearer: connection.server.token, range: range);
+  }
+```
+
+Add the file-scope helper (after `_pinnedSend`):
+
+```dart
+/// Transport core for [ApiClient.pinnedRangeStream], split out so the streaming +
+/// cancel behaviour is unit-testable against a real plaintext `HttpServer`
+/// (production passes the CA-pinned client). Holds the response subscription so
+/// [PinnedStreamResponse.cancel] tears down ONLY this socket.
+@visibleForTesting
+Future<PinnedStreamResponse> streamRange(HttpClient client, Uri url,
+    {required String bearer, String? range}) async {
+  final req = await client.getUrl(url);
+  req.headers.set(HttpHeaders.authorizationHeader, 'Bearer $bearer');
+  if (range != null) req.headers.set(HttpHeaders.rangeHeader, range);
+  final res = await req.close();
+
+  final headers = <String, String>{};
+  res.headers.forEach((name, values) => headers[name] = values.join(','));
+
+  final out = StreamController<List<int>>();
+  StreamSubscription<List<int>>? sub;
+  out.onListen = () {
+    sub = res.listen(
+      out.add,
+      onError: out.addError,
+      onDone: () {
+        if (!out.isClosed) out.close();
+      },
+      cancelOnError: true,
+    );
+  };
+  out.onPause = () => sub?.pause();
+  out.onResume = () => sub?.resume();
+  out.onCancel = () async => sub?.cancel();
+
+  Future<void> cancel() async {
+    await sub?.cancel();
+    if (!out.isClosed) await out.close();
+  }
+
+  return PinnedStreamResponse(
+    statusCode: res.statusCode,
+    headers: headers,
+    body: out.stream,
+    cancel: cancel,
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/android && flutter test test/data/api_client_stream_test.dart`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/android/lib/src/data/api_client.dart apps/android/test/data/api_client_stream_test.dart
+git commit -m "feat(app): add CA-pinned cancellable range streaming for LAN preview"
+```
+
+---
+
+## Task 2: `LoopbackProxy` — the in-app loopback server
+
+**Files:**
+- Create: `apps/android/lib/src/data/loopback_proxy.dart`
+- Test: `apps/android/test/data/loopback_proxy_test.dart` (create)
+
+**Interfaces:**
+- Consumes: `PinnedStreamResponse` (Task 1). The upstream fetch is injected as `typedef UpstreamFetch = Future<PinnedStreamResponse> Function(Uri url, {String? range})` — production passes `apiClient.pinnedRangeStream`.
+- Produces:
+  - `LoopbackProxy(UpstreamFetch fetch, {Random? random})`
+  - `Future<void> start()` — idempotent; binds `127.0.0.1:0`.
+  - `Uri register({required Uri upstream})` — mints a 128-bit id, resets `lastUpstreamStatus`, returns `http://127.0.0.1:<port>/s/<id>`.
+  - `int? get lastUpstreamStatus`
+  - `void clearMapping()`
+  - `Future<void> dispose()`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/android/test/data/loopback_proxy_test.dart`:
+
+```dart
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:castwright/src/data/api_client.dart';
+import 'package:castwright/src/data/loopback_proxy.dart';
+
+/// A programmable fake upstream. Records the URL/range it was asked for and
+/// returns a canned PinnedStreamResponse.
+class _FakeUpstream {
+  int status = 206;
+  Map<String, String> headers = {
+    'content-type': 'audio/mpeg',
+    'content-length': '4',
+    'content-range': 'bytes 0-3/4',
+    'accept-ranges': 'bytes',
+  };
+  List<int> bytes = [1, 2, 3, 4];
+  final List<String?> ranges = [];
+  int cancelled = 0;
+  bool throwOnFetch = false;
+
+  Future<PinnedStreamResponse> fetch(Uri url, {String? range}) async {
+    ranges.add(range);
+    if (throwOnFetch) throw const SocketException('unreachable');
+    final ctl = StreamController<List<int>>();
+    ctl.onListen = () {
+      ctl.add(bytes);
+      ctl.close();
+    };
+    return PinnedStreamResponse(
+      statusCode: status,
+      headers: headers,
+      body: ctl.stream,
+      cancel: () async {
+        cancelled++;
+        if (!ctl.isClosed) await ctl.close();
+      },
+    );
+  }
+}
+
+Future<HttpClientResponse> _get(Uri url, {String method = 'GET', String? range}) async {
+  final client = HttpClient();
+  final req = await client.openUrl(method, url);
+  if (range != null) req.headers.set(HttpHeaders.rangeHeader, range);
+  final res = await req.close();
+  return res;
+}
+
+void main() {
+  late _FakeUpstream up;
+  late LoopbackProxy proxy;
+
+  setUp(() async {
+    up = _FakeUpstream();
+    // Seeded Random so ids are deterministic in tests.
+    proxy = LoopbackProxy(up.fetch, random: Random(1));
+    await proxy.start();
+  });
+
+  tearDown(() async => proxy.dispose());
+
+  test('register returns a loopback URL that streams upstream bytes', () async {
+    final loopback = proxy.register(upstream: Uri.parse('https://lan:8443/a.mp3'));
+    expect(loopback.host, '127.0.0.1');
+    expect(loopback.path, startsWith('/s/'));
+    final res = await _get(loopback, range: 'bytes=0-3');
+    expect(res.statusCode, 206);
+    expect(res.headers.value('content-range'), 'bytes 0-3/4');
+    expect(res.headers.value(HttpHeaders.acceptRangesHeader), 'bytes');
+    final body = await res.fold<List<int>>(<int>[], (a, c) => a..addAll(c));
+    expect(body, [1, 2, 3, 4]);
+    expect(up.ranges.last, 'bytes=0-3'); // Range forwarded
+  });
+
+  test('unknown / stale id -> 404; non-GET/HEAD -> 405', () async {
+    final loopback = proxy.register(upstream: Uri.parse('https://lan/a.mp3'));
+    final bad = loopback.replace(path: '/s/deadbeef');
+    expect((await _get(bad)).statusCode, 404);
+    expect((await _get(loopback, method: 'POST')).statusCode, 405);
+  });
+
+  test('HEAD relays headers only (no body); cancels upstream', () async {
+    final loopback = proxy.register(upstream: Uri.parse('https://lan/a.mp3'));
+    final res = await _get(loopback, method: 'HEAD');
+    expect(res.statusCode, 206);
+    expect(res.headers.value(HttpHeaders.contentTypeHeader), 'audio/mpeg');
+    final body = await res.fold<List<int>>(<int>[], (a, c) => a..addAll(c));
+    expect(body, isEmpty);
+    expect(up.cancelled, greaterThanOrEqualTo(1));
+  });
+
+  test('registering a new chapter evicts the prior id (old URL 404s)', () async {
+    final first = proxy.register(upstream: Uri.parse('https://lan/a.mp3'));
+    final second = proxy.register(upstream: Uri.parse('https://lan/b.mp3'));
+    expect((await _get(first)).statusCode, 404);
+    expect((await _get(second)).statusCode, 206);
+  });
+
+  test('non-2xx upstream sets lastUpstreamStatus and relays the code', () async {
+    up.status = 401;
+    final loopback = proxy.register(upstream: Uri.parse('https://lan/a.mp3'));
+    final res = await _get(loopback);
+    expect(res.statusCode, 401);
+    expect(proxy.lastUpstreamStatus, 401);
+  });
+
+  test('fetch throw -> 502 and lastUpstreamStatus 0', () async {
+    up.throwOnFetch = true;
+    final loopback = proxy.register(upstream: Uri.parse('https://lan/a.mp3'));
+    final res = await _get(loopback);
+    expect(res.statusCode, 502);
+    expect(proxy.lastUpstreamStatus, 0);
+  });
+
+  test('register() resets lastUpstreamStatus to null', () async {
+    up.status = 500;
+    await _get(proxy.register(upstream: Uri.parse('https://lan/a.mp3')));
+    expect(proxy.lastUpstreamStatus, 500);
+    proxy.register(upstream: Uri.parse('https://lan/b.mp3'));
+    expect(proxy.lastUpstreamStatus, isNull);
+  });
+
+  test('start() is idempotent (same port on a second call)', () async {
+    final before = proxy.register(upstream: Uri.parse('https://lan/a.mp3')).port;
+    await proxy.start();
+    final after = proxy.register(upstream: Uri.parse('https://lan/b.mp3')).port;
+    expect(after, before);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/android && flutter test test/data/loopback_proxy_test.dart`
+Expected: FAIL — `loopback_proxy.dart` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/android/lib/src/data/loopback_proxy.dart`:
+
+```dart
+import 'dart:async';
+import 'dart:io';
+import 'dart:math';
+
+import 'api_client.dart' show PinnedStreamResponse;
+
+/// Fetches one upstream range over the CA-pinned HTTPS client. Production passes
+/// `ApiClient.pinnedRangeStream` (which injects the Bearer), so the proxy stays
+/// auth-agnostic and the token never reaches the platform player.
+typedef UpstreamFetch = Future<PinnedStreamResponse> Function(Uri url, {String? range});
+
+/// An in-app loopback TLS-terminating proxy (`app-10`). Binds `127.0.0.1:0` on
+/// demand and re-serves CA-pinned HTTPS chapter bytes as plaintext to the native
+/// platform player, honouring `Range`/`206`. One active mapping at a time
+/// (single-player app); a stale loopback id cleanly `404`s. Loopback-only bind +
+/// an unguessable 128-bit path id keep it unreachable off-device and unguessable
+/// to other local apps.
+class LoopbackProxy {
+  LoopbackProxy(this._fetch, {Random? random}) : _random = random ?? Random.secure();
+
+  final UpstreamFetch _fetch;
+  final Random _random;
+
+  HttpServer? _server;
+  String? _activeId;
+  Uri? _activeUpstream;
+  int? _lastUpstreamStatus;
+
+  /// The last non-2xx upstream code (or `0` for a connection/timeout failure),
+  /// scoped to the current registration — [register] resets it to null.
+  int? get lastUpstreamStatus => _lastUpstreamStatus;
+
+  /// Bind the loopback socket. Idempotent — a second call is a no-op.
+  Future<void> start() async {
+    if (_server != null) return;
+    _server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    _server!.listen(_handle);
+  }
+
+  /// Point the proxy at [upstream] under a fresh 128-bit id and return the
+  /// loopback URL to hand to the player. Evicts any prior mapping and resets
+  /// [lastUpstreamStatus].
+  Uri register({required Uri upstream}) {
+    final server = _server;
+    if (server == null) {
+      throw StateError('LoopbackProxy.register called before start()');
+    }
+    _lastUpstreamStatus = null;
+    final id = _mintId();
+    _activeId = id;
+    _activeUpstream = upstream;
+    return Uri.parse('http://127.0.0.1:${server.port}/s/$id');
+  }
+
+  /// Drop the active mapping so any live loopback URL `404`s (called on failure).
+  void clearMapping() {
+    _activeId = null;
+    _activeUpstream = null;
+  }
+
+  Future<void> dispose() async {
+    clearMapping();
+    await _server?.close(force: true);
+    _server = null;
+  }
+
+  String _mintId() {
+    final b = List<int>.generate(16, (_) => _random.nextInt(256));
+    return b.map((x) => x.toRadixString(16).padLeft(2, '0')).join();
+  }
+
+  Future<void> _handle(HttpRequest req) async {
+    final res = req.response;
+    if (req.method != 'GET' && req.method != 'HEAD') {
+      res.statusCode = HttpStatus.methodNotAllowed; // 405
+      await res.close();
+      return;
+    }
+    final path = req.uri.path;
+    final id = path.startsWith('/s/') ? path.substring(3) : '';
+    final upstreamUrl = _activeUpstream;
+    if (id.isEmpty || id != _activeId || upstreamUrl == null) {
+      res.statusCode = HttpStatus.notFound; // 404
+      await res.close();
+      return;
+    }
+
+    final range = req.headers.value(HttpHeaders.rangeHeader);
+    PinnedStreamResponse upstream;
+    try {
+      upstream = await _fetch(upstreamUrl, range: range);
+    } catch (_) {
+      _lastUpstreamStatus = 0;
+      res.statusCode = HttpStatus.badGateway; // 502
+      await res.close();
+      return;
+    }
+
+    if (upstream.statusCode < 200 || upstream.statusCode >= 300) {
+      _lastUpstreamStatus = upstream.statusCode;
+      res.statusCode = upstream.statusCode;
+      await upstream.cancel();
+      await res.close();
+      return;
+    }
+
+    res.statusCode = upstream.statusCode; // 200 | 206
+    for (final h in const [
+      HttpHeaders.contentTypeHeader,
+      HttpHeaders.contentLengthHeader,
+      'content-range',
+      HttpHeaders.acceptRangesHeader,
+    ]) {
+      final v = upstream.headers[h];
+      if (v != null) res.headers.set(h, v);
+    }
+
+    if (req.method == 'HEAD') {
+      await upstream.cancel();
+      await res.close();
+      return;
+    }
+
+    try {
+      await res.addStream(upstream.body); // backpressure-preserving
+      await res.close();
+    } catch (_) {
+      // Client disconnect (seek/stop) → abort the upstream socket so it can't leak.
+      await upstream.cancel();
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/android && flutter test test/data/loopback_proxy_test.dart`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/android/lib/src/data/loopback_proxy.dart apps/android/test/data/loopback_proxy_test.dart
+git commit -m "feat(app): add in-app loopback proxy for LAN chapter streaming"
+```
+
+---
+
+## Task 3: Android cleartext-to-loopback config
+
+**Files:**
+- Create: `apps/android/android/app/src/main/res/xml/network_security_config.xml`
+- Modify: `apps/android/android/app/src/main/AndroidManifest.xml:15-18` (the `<application>` open tag)
+- Test: `apps/android/test/network_security_config_test.dart` (create)
+
+**Interfaces:** None (declarative). Without this, ExoPlayer's `DefaultHttpDataSource` throws on a cleartext `http://127.0.0.1` load and the feature serves zero bytes on release builds.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/android/test/network_security_config_test.dart`:
+
+```dart
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('network security config permits cleartext ONLY for 127.0.0.1 loopback', () {
+    final xml = File('android/app/src/main/res/xml/network_security_config.xml')
+        .readAsStringSync();
+    // Base default stays secure (no global cleartext).
+    expect(xml.contains('<base-config cleartextTrafficPermitted="false"'), isTrue);
+    // A domain-config opens cleartext for loopback only.
+    expect(xml.contains('cleartextTrafficPermitted="true"'), isTrue);
+    expect(xml.contains('<domain includeSubdomains="false">127.0.0.1</domain>'), isTrue);
+    // The LAN-HTTPS invariant: no other host is granted cleartext.
+    expect(xml.contains('0.0.0.0'), isFalse);
+  });
+
+  test('manifest wires the network security config on <application>', () {
+    final manifest =
+        File('android/app/src/main/AndroidManifest.xml').readAsStringSync();
+    expect(
+      manifest.contains(
+          'android:networkSecurityConfig="@xml/network_security_config"'),
+      isTrue,
+    );
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/android && flutter test test/network_security_config_test.dart`
+Expected: FAIL — file missing / manifest attribute absent.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/android/android/app/src/main/res/xml/network_security_config.xml`:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<!-- app-10: permit cleartext ONLY for the in-app loopback proxy (127.0.0.1).
+     Everything else stays HTTPS-only, preserving the LAN-HTTPS invariant. The
+     proxy re-serves CA-pinned HTTPS chapter bytes as plaintext to the native
+     player over loopback; ExoPlayer's NetworkSecurityPolicy would otherwise
+     throw on the http://127.0.0.1 load. -->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false" />
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">127.0.0.1</domain>
+    </domain-config>
+</network-security-config>
+```
+
+In `apps/android/android/app/src/main/AndroidManifest.xml`, add the attribute to the `<application>` open tag (currently lines 15-18):
+
+```xml
+    <application
+        android:label="Castwright"
+        android:name="${applicationName}"
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:icon="@mipmap/ic_launcher">
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/android && flutter test test/network_security_config_test.dart`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/android/android/app/src/main/res/xml/network_security_config.xml apps/android/android/app/src/main/AndroidManifest.xml apps/android/test/network_security_config_test.dart
+git commit -m "feat(app): scope Android cleartext to 127.0.0.1 for the loopback proxy"
+```
+
+---
+
+## Task 4: Engine error seam (`AudioEngine.errorStream`)
+
+**Files:**
+- Modify: `apps/android/lib/src/data/audio_engine.dart`
+- Modify: `apps/android/lib/src/data/just_audio_engine.dart`
+- Modify: `apps/android/lib/src/demo/demo_audio_engine.dart`
+- Modify (add `errorStream` to fakes): `apps/android/test/data/player_controller_test.dart`, `test/data/player_controller_playing_stream_test.dart`, `test/data/companion_runtime_test.dart`, `test/data/companion_audio_handler_test.dart`
+- Test: `apps/android/test/data/player_controller_test.dart` (the fake gains `emitError`, used by Task 7)
+
+**Interfaces:**
+- Produces: `Stream<Object> get errorStream;` on `AudioEngine`. `JustAudioEngine` maps `just_audio`'s `playbackEventStream` error events onto it; demo/fake engines emit nothing but expose a hook for controller tests.
+
+- [ ] **Step 1: Add the interface method + a failing fake hook**
+
+In `apps/android/lib/src/data/audio_engine.dart`, add to the abstract class (after `completionStream`):
+
+```dart
+  /// Fires when the underlying player reports a load/playback error (e.g. a
+  /// failed loopback fetch mid-stream — `app-10`). Drives the streaming
+  /// fallback in [PlayerController]. Empty on engines that never error.
+  Stream<Object> get errorStream;
+```
+
+In `apps/android/test/data/player_controller_test.dart`, extend `FakeAudioEngine` with an error controller + emitter (add fields near the other controllers, the getter, and dispose):
+
+```dart
+  final _errorCtl = StreamController<Object>.broadcast();
+  @override
+  Stream<Object> get errorStream => _errorCtl.stream;
+  void emitError(Object e) => _errorCtl.add(e);
+```
+
+Add `await _errorCtl.close();` inside `FakeAudioEngine.dispose()`.
+
+- [ ] **Step 2: Run the suite to verify it fails to compile**
+
+Run: `cd apps/android && flutter test test/data/player_controller_test.dart`
+Expected: FAIL — the other `AudioEngine` fakes/impls don't yet implement `errorStream` (analyzer/compile error).
+
+- [ ] **Step 3: Implement across every `AudioEngine`**
+
+`apps/android/lib/src/data/just_audio_engine.dart` — add an error controller fed from `playbackEventStream`'s error channel, the getter, and close on dispose. Change the private constructor body and add fields:
+
+```dart
+  final _errors = StreamController<Object>.broadcast();
+
+  JustAudioEngine._(this._loudness)
+      : _player = AudioPlayer(
+          audioPipeline: AudioPipeline(androidAudioEffects: [_loudness]),
+        ) {
+    // just_audio surfaces load/playback failures on playbackEventStream's error
+    // channel (a PlayerException). Route them to errorStream for the app-10
+    // streaming fallback. The listener never cancels — it lives with the engine.
+    _player.playbackEventStream.listen(
+      (_) {},
+      onError: (Object e, StackTrace _) {
+        if (!_errors.isClosed) _errors.add(e);
+      },
+    );
+  }
+```
+
+Add the getter:
+
+```dart
+  @override
+  Stream<Object> get errorStream => _errors.stream;
+```
+
+Change `dispose`:
+
+```dart
+  @override
+  Future<void> dispose() async {
+    await _errors.close();
+    await _player.dispose();
+  }
+```
+
+`apps/android/lib/src/demo/demo_audio_engine.dart` — add an empty broadcast getter:
+
+```dart
+  @override
+  Stream<Object> get errorStream => const Stream<Object>.empty();
+```
+
+Add the same `errorStream` getter (empty stream, or a controller with an `emitError` hook if the test drives errors) to the remaining fakes: `DrivableEngine` (`test/data/player_controller_playing_stream_test.dart`), `_FakeAudioEngine` (`test/data/companion_runtime_test.dart`), `FakeAudioEngine` (`test/data/companion_audio_handler_test.dart`). For fakes that don't drive errors, `Stream<Object> get errorStream => const Stream<Object>.empty();` suffices. Confirm completeness with:
+
+```bash
+cd apps/android && grep -rln "implements AudioEngine" lib test
+```
+
+Every hit must now declare `errorStream`.
+
+- [ ] **Step 4: Run the suites to verify green**
+
+Run: `cd apps/android && flutter test test/data/player_controller_test.dart test/data/player_controller_playing_stream_test.dart test/data/companion_runtime_test.dart test/data/companion_audio_handler_test.dart`
+Expected: PASS (behaviour unchanged; the seam compiles everywhere).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/android/lib/src/data/audio_engine.dart apps/android/lib/src/data/just_audio_engine.dart apps/android/lib/src/demo/demo_audio_engine.dart apps/android/test/data/player_controller_test.dart apps/android/test/data/player_controller_playing_stream_test.dart apps/android/test/data/companion_runtime_test.dart apps/android/test/data/companion_audio_handler_test.dart
+git commit -m "feat(app): add an error stream seam to AudioEngine for streaming fallback"
+```
+
+---
+
+## Task 5: Reachability (`onHomeLan`)
+
+**Files:**
+- Modify: `apps/android/lib/src/data/network_info.dart`
+- Test: `apps/android/test/data/loopback_reachability_test.dart` (create) + extend `apps/android/test/domain/playback_source_test.dart`
+
+**Interfaces:**
+- Consumes: `NetworkType` (`sync_gate.dart:7`), `currentNetwork` (`network_info.dart:22`).
+- Produces:
+  - `typedef CurrentNetwork = Future<NetworkType> Function();`
+  - `class Reachability { const Reachability(CurrentNetwork); Future<bool> onHomeLan(); }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/android/test/data/loopback_reachability_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:castwright/src/data/network_info.dart';
+import 'package:castwright/src/domain/sync_gate.dart';
+
+void main() {
+  Reachability r(NetworkType n) => Reachability(() async => n);
+
+  test('onHomeLan true on unmetered + metered Wi-Fi', () async {
+    expect(await r(NetworkType.wifiUnmetered).onHomeLan(), isTrue);
+    expect(await r(NetworkType.wifiMetered).onHomeLan(), isTrue);
+  });
+
+  test('onHomeLan false on mobile AND offline (NOT `!= mobile`)', () async {
+    expect(await r(NetworkType.mobile).onHomeLan(), isFalse);
+    expect(await r(NetworkType.offline).onHomeLan(), isFalse);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/android && flutter test test/data/loopback_reachability_test.dart`
+Expected: FAIL — `Reachability` not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `apps/android/lib/src/data/network_info.dart`, add (after `currentNetwork`):
+
+```dart
+/// The current-network resolver seam (injectable for tests).
+typedef CurrentNetwork = Future<NetworkType> Function();
+
+/// Answers "is the paired server plausibly reachable on THIS network?" for the
+/// `app-10` streaming decision. True on any Wi-Fi/Ethernet (metered or not),
+/// false on mobile AND offline. Deliberately NOT `network != mobile` — that is
+/// true when offline, which would route an offline tap to a doomed LAN stream.
+class Reachability {
+  const Reachability(this._currentNetwork);
+  final CurrentNetwork _currentNetwork;
+
+  Future<bool> onHomeLan() async {
+    final n = await _currentNetwork();
+    return n == NetworkType.wifiUnmetered || n == NetworkType.wifiMetered;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes; extend the source truth-table**
+
+Run: `cd apps/android && flutter test test/data/loopback_reachability_test.dart`
+Expected: PASS.
+
+Then add a group to `apps/android/test/domain/playback_source_test.dart` documenting the `onHomeLan → resolvePlaybackSource` composition (offline ⇒ `onHomeLan false` ⇒ needs-download):
+
+```dart
+  group('onHomeLan feeds resolvePlaybackSource', () {
+    test('offline (onHomeLan false) + streaming on -> needs download', () {
+      expect(
+        resolvePlaybackSource(
+            localFileExists: false, onHomeLan: false, streamingEnabled: true),
+        PlaybackSource.needsDownload,
+      );
+    });
+  });
+```
+
+Run: `cd apps/android && flutter test test/domain/playback_source_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/android/lib/src/data/network_info.dart apps/android/test/data/loopback_reachability_test.dart apps/android/test/domain/playback_source_test.dart
+git commit -m "feat(app): add onHomeLan reachability for the streaming decision"
+```
+
+---
+
+## Task 6: Data plumbing — carry `audioUrl` through the playlist
+
+**Files:**
+- Modify: `apps/android/lib/src/data/player_controller.dart:16-27` (`PlayableChapter`)
+- Modify: `apps/android/lib/src/data/sync_controller.dart:186-199` (`playlistFor`)
+- Test: `apps/android/test/data/sync_controller_test.dart` (extend)
+
+**Interfaces:**
+- Produces: `PlayableChapter.audioUrl` (`String?`) — the full server path for streaming. `playlistFor` copies `c.audioUrl` from the manifest chapter onto each `PlayableChapter`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `apps/android/test/data/sync_controller_test.dart` (a test that `playlistFor` carries `audioUrl`). Locate the existing detail-building helper in that file and add:
+
+```dart
+  test('playlistFor carries audioUrl through the projection', () async {
+    // Arrange a SyncController whose in-session detail has a rendered chapter
+    // with a known audioUrl, then assert the PlayableChapter carries it.
+    // (Mirror the existing test setup in this file for building `detail`.)
+    final detail = SyncManifestBookDetail(
+      schemaVersion: 1,
+      bookId: 'bk',
+      updatedAt: '',
+      chapters: const [
+        SyncManifestChapter(
+          uuid: 'u1',
+          id: 1,
+          title: 'One',
+          fingerprint: 'abc|123',
+          urlSuffix: 'audio.mp3',
+          audioUrl: '/api/books/bk/chapters/1/audio.mp3',
+          durationSec: 42,
+        ),
+      ],
+      activeChapterUuids: const ['u1'],
+    );
+    final sync = makeSyncControllerWithDetail('bk', detail); // existing helper or inline construct
+    final list = sync.playlistFor('bk');
+    expect(list.single.audioUrl, '/api/books/bk/chapters/1/audio.mp3');
+  });
+```
+
+> Implementation note for the engineer: `sync_controller_test.dart` already constructs `SyncController` and seeds `_details` via a fetched `bookDetail`. Reuse whatever seeding pattern that file uses (e.g. `downloadBook`/`ensureDetail` against a fake `ManifestApi`) rather than a new helper if one isn't present — the assertion (`list.single.audioUrl == …`) is the point.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/android && flutter test test/data/sync_controller_test.dart`
+Expected: FAIL — `PlayableChapter` has no `audioUrl` getter.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `apps/android/lib/src/data/player_controller.dart`, widen `PlayableChapter`:
+
+```dart
+class PlayableChapter {
+  const PlayableChapter({
+    required this.uuid,
+    required this.path,
+    this.title = '',
+    this.durationSec,
+    this.audioUrl,
+  });
+  final String uuid;
+  final String path;
+  final String title;
+  final double? durationSec;
+
+  /// Full server path for LAN streaming (`app-10`), e.g.
+  /// `/api/books/<id>/chapters/<n>/audio.mp3`. Null when the chapter has no
+  /// rendered audio (never added to a playlist in that case).
+  final String? audioUrl;
+}
+```
+
+In `apps/android/lib/src/data/sync_controller.dart`, carry it in `playlistFor`:
+
+```dart
+        if (c.hasAudio)
+          PlayableChapter(
+            uuid: c.uuid,
+            path: _library.audioPath(bookId, c.uuid, c.urlSuffix!),
+            title: c.title,
+            durationSec: c.durationSec,
+            audioUrl: c.audioUrl,
+          ),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/android && flutter test test/data/sync_controller_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/android/lib/src/data/player_controller.dart apps/android/lib/src/data/sync_controller.dart apps/android/test/data/sync_controller_test.dart
+git commit -m "feat(app): carry chapter audioUrl through the player playlist"
+```
+
+---
+
+## Task 7: `PlayerController` streaming wiring + failure routing
+
+**Files:**
+- Modify: `apps/android/lib/src/data/player_controller.dart` (constructor, `_loadIndex`, new `_loadSource`/`_handleStreamFailure`, `StreamingConfig`)
+- Test: `apps/android/test/data/player_controller_test.dart` (add a streaming group)
+
+**Interfaces:**
+- Consumes: `LoopbackProxy` (Task 2), `Reachability`/closures (Task 5), `PlayableChapter.audioUrl` (Task 6), `AudioEngine.errorStream` + `FakeAudioEngine.emitError` (Task 4), `resolvePlaybackSource` (`playback_source.dart`).
+- Produces:
+  - `class StreamingConfig { fileStore, streamOverLan, onHomeLan, urlResolver, proxy, onRepairNeeded }`
+  - `PlayerController({ …, StreamingConfig? streaming })`
+  - `Stream<String> get needsDownloadStream` (emits the chapter uuid that couldn't stream / needs downloading).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a group to `apps/android/test/data/player_controller_test.dart`. First, a tiny fake proxy + config builder near the top of the file:
+
+```dart
+class FakeProxy implements LoopbackProxy {
+  int starts = 0;
+  final List<Uri> registered = [];
+  int? lastUpstreamStatus;
+  int clears = 0;
+  bool disposed = false;
+
+  @override
+  Future<void> start() async => starts++;
+  @override
+  Uri register({required Uri upstream}) {
+    registered.add(upstream);
+    return Uri.parse('http://127.0.0.1:9/s/id');
+  }
+  @override
+  void clearMapping() => clears++;
+  @override
+  Future<void> dispose() async => disposed = true;
+}
+```
+
+(Import `package:castwright/src/data/loopback_proxy.dart`, `.../network_info.dart`, `.../file_store.dart`, `.../domain/playback_source.dart` at the top.)
+
+Then the tests:
+
+```dart
+  group('app-10 streaming', () {
+    StreamingConfig cfg(
+      FakeProxy proxy, {
+      required bool streamOn,
+      required bool onLan,
+      Set<String> downloaded = const {},
+      void Function()? onRepair,
+    }) {
+      final fs = InMemoryFileStore();
+      for (final p in downloaded) {
+        // seed as "exists"
+        fs.writeBytes(p, const [0]);
+      }
+      return StreamingConfig(
+        fileStore: fs,
+        streamOverLan: () => streamOn,
+        onHomeLan: () async => onLan,
+        urlResolver: (path) => Uri.parse('https://lan:8443$path'),
+        proxy: proxy,
+        onRepairNeeded: onRepair ?? () {},
+      );
+    }
+
+    List<PlayableChapter> list = const [
+      PlayableChapter(uuid: 'u1', path: '/b1/u1/audio.mp3', audioUrl: '/api/books/b1/chapters/1/audio.mp3'),
+    ];
+
+    test('downloaded chapter plays the local file (proxy never starts)', () async {
+      final engine = FakeAudioEngine();
+      final proxy = FakeProxy();
+      final pc = PlayerController(
+        audioEngine: engine,
+        playbackStore: MemPlaybackStore(),
+        playlistLoader: (_) async => list,
+        clock: () => DateTime.utc(2026, 6, 6),
+        streaming: cfg(proxy, streamOn: true, onLan: true, downloaded: {'/b1/u1/audio.mp3'}),
+      );
+      await pc.openBook('b1');
+      expect(engine.calls, contains('set:/b1/u1/audio.mp3'));
+      expect(proxy.starts, 0);
+    });
+
+    test('undownloaded + streaming + on Wi-Fi -> proxy start + register + stream (no headers)', () async {
+      final engine = FakeAudioEngine();
+      final proxy = FakeProxy();
+      final pc = PlayerController(
+        audioEngine: engine,
+        playbackStore: MemPlaybackStore(),
+        playlistLoader: (_) async => list,
+        clock: () => DateTime.utc(2026, 6, 6),
+        streaming: cfg(proxy, streamOn: true, onLan: true),
+      );
+      await pc.openBook('b1');
+      expect(proxy.starts, 1);
+      expect(proxy.registered.single.toString(),
+          'https://lan:8443/api/books/b1/chapters/1/audio.mp3');
+      expect(engine.calls, contains('stream:http://127.0.0.1:9/s/id'));
+    });
+
+    test('toggle off / off-Wi-Fi -> needs download, proxy never starts', () async {
+      for (final c in [
+        cfg(FakeProxy(), streamOn: false, onLan: true),
+        cfg(FakeProxy(), streamOn: true, onLan: false),
+      ]) {
+        final engine = FakeAudioEngine();
+        final pc = PlayerController(
+          audioEngine: engine,
+          playbackStore: MemPlaybackStore(),
+          playlistLoader: (_) async => list,
+          clock: () => DateTime.utc(2026, 6, 6),
+          streaming: c,
+        );
+        final emitted = <String>[];
+        pc.needsDownloadStream.listen(emitted.add);
+        await pc.playChapter('u1'); // user-initiated
+        await Future<void>.delayed(Duration.zero);
+        expect(engine.calls.where((x) => x.startsWith('stream:')), isEmpty);
+        expect(emitted, ['u1']); // user-initiated prompt
+      }
+    });
+
+    test('errorStream with lastUpstreamStatus 404 -> needs-download, clears mapping, no re-pair', () async {
+      final engine = FakeAudioEngine();
+      final proxy = FakeProxy()..lastUpstreamStatus = 404;
+      var repaired = 0;
+      final pc = PlayerController(
+        audioEngine: engine,
+        playbackStore: MemPlaybackStore(),
+        playlistLoader: (_) async => list,
+        clock: () => DateTime.utc(2026, 6, 6),
+        streaming: cfg(proxy, streamOn: true, onLan: true, onRepair: () => repaired++),
+      );
+      final emitted = <String>[];
+      pc.needsDownloadStream.listen(emitted.add);
+      await pc.playChapter('u1'); // streams
+      engine.emitError('boom');
+      await Future<void>.delayed(Duration.zero);
+      expect(emitted, ['u1']);
+      expect(proxy.clears, greaterThanOrEqualTo(1));
+      expect(repaired, 0);
+    });
+
+    test('errorStream with lastUpstreamStatus 401 -> onRepairNeeded, no download prompt', () async {
+      final engine = FakeAudioEngine();
+      final proxy = FakeProxy()..lastUpstreamStatus = 401;
+      var repaired = 0;
+      final pc = PlayerController(
+        audioEngine: engine,
+        playbackStore: MemPlaybackStore(),
+        playlistLoader: (_) async => list,
+        clock: () => DateTime.utc(2026, 6, 6),
+        streaming: cfg(proxy, streamOn: true, onLan: true, onRepair: () => repaired++),
+      );
+      final emitted = <String>[];
+      pc.needsDownloadStream.listen(emitted.add);
+      await pc.playChapter('u1');
+      engine.emitError('boom');
+      await Future<void>.delayed(Duration.zero);
+      expect(repaired, 1);
+      expect(emitted, isEmpty);
+    });
+
+    test('dispose disposes the proxy', () async {
+      final proxy = FakeProxy();
+      final pc = PlayerController(
+        audioEngine: FakeAudioEngine(),
+        playbackStore: MemPlaybackStore(),
+        playlistLoader: (_) async => list,
+        clock: () => DateTime.utc(2026, 6, 6),
+        streaming: cfg(proxy, streamOn: true, onLan: true),
+      );
+      await pc.dispose();
+      expect(proxy.disposed, isTrue);
+    });
+  });
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/android && flutter test test/data/player_controller_test.dart`
+Expected: FAIL — `StreamingConfig` / `streaming:` / `needsDownloadStream` undefined.
+
+- [ ] **Step 3: Implement**
+
+In `apps/android/lib/src/data/player_controller.dart`:
+
+Add imports at the top:
+
+```dart
+import '../domain/playback_source.dart';
+import 'file_store.dart';
+import 'loopback_proxy.dart';
+```
+
+Add the config type (near `PlayableChapter`):
+
+```dart
+/// The `app-10` streaming dependencies, bundled so [PlayerController]'s
+/// constructor stays backward-compatible: when this is null the controller keeps
+/// its exact offline-first behaviour (always `setFilePath`). All-or-nothing —
+/// the runtime always supplies every field together.
+class StreamingConfig {
+  const StreamingConfig({
+    required this.fileStore,
+    required this.streamOverLan,
+    required this.onHomeLan,
+    required this.urlResolver,
+    required this.proxy,
+    required this.onRepairNeeded,
+  });
+
+  final FileStore fileStore;
+  final bool Function() streamOverLan; // live toggle (re-read per load)
+  final Future<bool> Function() onHomeLan;
+  final Uri Function(String path) urlResolver;
+  final LoopbackProxy proxy;
+  final void Function() onRepairNeeded;
+}
+```
+
+Add the constructor param + field + error subscription. In the constructor parameter list add `this._streaming,` (after `this._localDate,`), add the field, and subscribe to `errorStream`:
+
+```dart
+  final StreamingConfig? _streaming;
+  StreamSubscription<Object>? _errorSub;
+  bool _currentIsStream = false;
+
+  final StreamController<String> _downloadToPlay =
+      StreamController<String>.broadcast();
+  /// Emits the chapter uuid the user tried to play that must be downloaded first
+  /// (or whose LAN stream failed for a non-auth reason). The UI shows the
+  /// one-line "download to play" message.
+  Stream<String> get needsDownloadStream => _downloadToPlay.stream;
+```
+
+In the constructor body (after `_playingSub = …`):
+
+```dart
+    if (_streaming != null) {
+      _errorSub = _engine.errorStream.listen((_) {
+        // Mid-stream failure channel (§6). Only route when the live source is a
+        // stream — a local-file playback error must not trigger download/re-pair.
+        if (_currentIsStream) _handleStreamFailure();
+      });
+    }
+```
+
+> Constructor-signature note: `_streaming` is a positional optional trailing field alongside `_statsDb/_sessionId/_localDate`. Because those are positional-optional (`this._statsDb,` etc. inside the `{ }`? — they are named-optional in the current constructor), add `StreamingConfig? streaming` as a **named** optional param and assign `_streaming = streaming` in the initializer list, mirroring how `_statsDb` is wired. Keep it named so call sites read `streaming: …`.
+
+Replace the single `await _engine.setFilePath(c.path);` line in `_loadIndex` (currently `player_controller.dart:280`) with a call to the new resolver, and thread `userInitiated`:
+
+```dart
+  Future<void> _loadIndex(int index, {int seekMs = 0, bool userInitiated = false}) async {
+```
+
+(inside, where `setFilePath` was:)
+
+```dart
+    await _loadSource(c, userInitiated: userInitiated);
+```
+
+Update the three callers to pass `userInitiated`:
+- `openBook` → `await _loadIndex(index, seekMs: saved?.positionMs ?? 0, userInitiated: true);`
+- `playChapter` → `await _loadIndex(i, userInitiated: true);`
+- `skip`'s `ChapterStep` branch → `await _loadIndex(next, userInitiated: true);`
+- `_advance` stays `await _loadIndex(_index + 1);` (default `userInitiated: false`).
+
+Add the resolver + failure router:
+
+```dart
+  Future<void> _loadSource(PlayableChapter c, {required bool userInitiated}) async {
+    final cfg = _streaming;
+    if (cfg == null) {
+      _currentIsStream = false;
+      await _engine.setFilePath(c.path); // legacy: offline-first only
+      return;
+    }
+    final src = resolvePlaybackSource(
+      localFileExists: await cfg.fileStore.exists(c.path),
+      onHomeLan: await cfg.onHomeLan(),
+      streamingEnabled: cfg.streamOverLan(),
+    );
+    switch (src) {
+      case PlaybackSource.localFile:
+        _currentIsStream = false;
+        await _engine.setFilePath(c.path);
+      case PlaybackSource.lanStream:
+        final audioUrl = c.audioUrl;
+        if (audioUrl == null) {
+          _currentIsStream = false;
+          if (userInitiated) _notifyDownloadToPlay();
+          return;
+        }
+        await cfg.proxy.start(); // first bind, on demand
+        final loopback = cfg.proxy.register(upstream: cfg.urlResolver(audioUrl));
+        _currentIsStream = true;
+        try {
+          // The player only ever sees http://127.0.0.1/… and NO headers.
+          await _engine.setStreamUrl(loopback.toString());
+        } catch (_) {
+          _handleStreamFailure(); // initial-load throw channel (§6/§7)
+        }
+      case PlaybackSource.needsDownload:
+        _currentIsStream = false;
+        if (userInitiated) _notifyDownloadToPlay(); // else auto-advance: halt quietly
+    }
+  }
+
+  /// The single §7 failure router (shared by the initial-load throw and the
+  /// mid-stream errorStream event). Reads the proxy's upstream-status
+  /// side-channel, clears the mapping, and either re-pairs (fresh 401/403) or
+  /// surfaces "download to play" (everything else, incl. null). No auto-retry.
+  void _handleStreamFailure() {
+    final cfg = _streaming;
+    if (cfg == null) return;
+    final status = cfg.proxy.lastUpstreamStatus;
+    cfg.proxy.clearMapping();
+    _currentIsStream = false;
+    if (status == 401 || status == 403) {
+      cfg.onRepairNeeded();
+    } else {
+      _notifyDownloadToPlay();
+    }
+  }
+
+  void _notifyDownloadToPlay() {
+    final uuid = currentChapterUuid;
+    if (uuid != null && !_downloadToPlay.isClosed) _downloadToPlay.add(uuid);
+  }
+```
+
+In `dispose()`, cancel the error sub, close the stream, and dispose the proxy (add before `await _engine.dispose();`):
+
+```dart
+    await _errorSub?.cancel();
+    await _downloadToPlay.close();
+    await _streaming?.proxy.dispose();
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/android && flutter test test/data/player_controller_test.dart`
+Expected: PASS (existing tests unchanged + the new streaming group green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/android/lib/src/data/player_controller.dart apps/android/test/data/player_controller_test.dart
+git commit -m "feat(app): wire LAN streaming + failure fallback into PlayerController"
+```
+
+---
+
+## Task 8: Runtime + app-shell wiring (`onRepairNeeded` → pairing)
+
+**Files:**
+- Modify: `apps/android/lib/src/data/companion_runtime.dart` (build + inject `StreamingConfig`; accept an `onRepairNeeded`)
+- Modify: `apps/android/lib/main.dart` (pass the re-pair entry into the runtime)
+- Test: `apps/android/test/data/companion_runtime_test.dart` (the forDemo path stays green; add a smoke test that a runtime built with a StreamingConfig still wires finished-tracking)
+
+**Interfaces:**
+- Consumes: `PlayerController.streaming`, `LoopbackProxy`, `Reachability`, `ApiClient.pinnedRangeStream`.
+- Produces: `CompanionRuntime.forConnection(connection, {handler, onRepairNeeded})` — the `onRepairNeeded` reaches `main.dart`'s `_openPairing`.
+
+> This task is **device glue** (`CompanionRuntime.forConnection` is explicitly "exercised on a device, not in unit tests"). Keep the testable surface minimal: the wiring compiles + the existing runtime tests stay green; behaviour is validated on-device.
+
+- [ ] **Step 1: Add the `onRepairNeeded` parameter (failing compile at call site)**
+
+In `apps/android/lib/src/data/companion_runtime.dart`, change the `forConnection` signature:
+
+```dart
+  static Future<CompanionRuntime> forConnection(
+    Connection connection, {
+    CompanionAudioHandler? handler,
+    void Function()? onRepairNeeded,
+  }) async {
+```
+
+- [ ] **Step 2: Build the `StreamingConfig` and inject it into the player**
+
+In `forConnection`, after `final fs = const DiskFileStore();` is available and the `resolve` closure is defined, construct the proxy + config and pass it to the `PlayerController`:
+
+```dart
+    final proxy = LoopbackProxy(api.pinnedRangeStream);
+    // Settings are loaded below; read the live toggle via a closure so a runtime
+    // settings change takes effect on the next chapter load.
+    late final CompanionRuntime runtimeRef; // for the live settings read
+```
+
+Because `settings` is loaded *after* the player is currently constructed, reorder so `settingsStore.load()` runs before building the `PlayerController`, then pass:
+
+```dart
+    final settingsStore = SettingsStore(fs, path: '$root/settings.json');
+    final settings = await settingsStore.load();
+
+    final proxy = LoopbackProxy(api.pinnedRangeStream);
+    final player = PlayerController(
+      audioEngine: JustAudioEngine(),
+      playbackStore: library,
+      playlistLoader: (bookId) async => sync.playlistFor(bookId),
+      clock: DateTime.now,
+      statsDb: db,
+      sessionId: sessionId,
+      localDate: () { /* unchanged */ },
+      streaming: StreamingConfig(
+        fileStore: fs,
+        streamOverLan: () => runtimeRef.settings.streamOverLan,
+        onHomeLan: const Reachability(currentNetwork).onHomeLan,
+        urlResolver: resolve,
+        proxy: proxy,
+        onRepairNeeded: onRepairNeeded ?? () {},
+      ),
+    );
+```
+
+Then assign `runtimeRef` when the runtime is constructed at the end (so the `streamOverLan` closure reads the live, mutable `settings` field). The simplest robust form: capture the runtime in a local after `CompanionRuntime._(...)` is built and before returning:
+
+```dart
+    final runtime = CompanionRuntime._(api, library, sync, player, thumbnails,
+        settingsStore, settings, resumeSync, sleepTimer, handler,
+        [connectivitySub, ...finishedSubs]);
+    runtimeRef = runtime;
+    return runtime;
+```
+
+> Note: `settingsStore`/`settings` currently sit *below* the player build (`companion_runtime.dart:183-184`); this task moves those two lines above the player construction. The subsequent `await player.setSpeed(settings.defaultSpeed)` etc. block stays where it is. Verify the file still reads top-to-bottom with `settings` defined before first use.
+
+Add the imports at the top of `companion_runtime.dart`:
+
+```dart
+import 'loopback_proxy.dart';
+// network_info.dart is already imported (currentNetwork); add Reachability use.
+```
+
+(`network_info.dart` is already imported at `companion_runtime.dart:17`, so `Reachability` is in scope.)
+
+- [ ] **Step 3: Thread `onRepairNeeded` from `main.dart`**
+
+In `apps/android/lib/main.dart`, the widget already has `_openPairing`. Pass it into the runtime build (`main.dart:245-246`):
+
+```dart
+      final runtime = await CompanionRuntime.forConnection(
+        conn,
+        handler: widget.audioHandler,
+        onRepairNeeded: () => _openPairing(),
+      );
+```
+
+`_openPairing` is idempotent (`if (_pairingOpen) return;`), so a burst of stream errors can't stack pairing screens.
+
+- [ ] **Step 4: Run the runtime + shell suites**
+
+Run: `cd apps/android && flutter test test/data/companion_runtime_test.dart test/ui/runtime_override_test.dart test/main_deep_link_test.dart`
+Expected: PASS — `forDemo` path is unchanged (no `onRepairNeeded`), and the new named param is optional.
+
+Then the full app suite:
+
+Run: `cd apps/android && flutter test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/android/lib/src/data/companion_runtime.dart apps/android/lib/main.dart apps/android/test/data/companion_runtime_test.dart
+git commit -m "feat(app): wire the loopback proxy + re-pair callback into the runtime"
+```
+
+---
+
+## Task 9: Docs reconciliation + release notes
+
+**Files:**
+- Modify: `docs/features/188-android-companion-app.md:52` + its `app-10` narrative
+- Modify: `docs/release-notes-next.md`, `RELEASE_NOTES.md`
+
+**Interfaces:** None (docs). Do this at ship time (in the same PR as the code).
+
+- [ ] **Step 1: Reconcile plan 188**
+
+The `app-10` row (`docs/features/188-android-companion-app.md:52`) currently reads as `closed #553 … 4 paired Dart tests` — factually wrong (the feature shipped as inert scaffolding and #553 was reopened as BLOCKED). Update the row to state that `app-10` was blocked by the companion's app-pinned-CA-vs-platform-player TLS gap and is now delivered via the in-app loopback proxy (link the spec + this plan), with the new component set (`LoopbackProxy`, `pinnedRangeStream`, `network_security_config.xml`, engine error seam) and the paired Dart tests from Tasks 1-8. Add the on-device acceptance walkthrough (below) to its `app-10` section.
+
+- [ ] **Step 2: Add the on-device acceptance walkthrough**
+
+Under the `app-10` narrative, add: real Android phone on home Wi-Fi, undownloaded chapter, "Stream over LAN" on → tap play → instant start; seek mid-chapter; lock-screen transport controls; background survival via the media foreground service; confirm NO OS cert install prompt; then toggle off / leave Wi-Fi → tap the same chapter → "download to play" message (no stall).
+
+- [ ] **Step 3: Release notes**
+
+Append to `docs/release-notes-next.md` (technical register, ref this PR):
+
+```markdown
+- **app-10 — Stream-over-LAN instant play (companion).** An undownloaded chapter now plays instantly over the home LAN via an in-app loopback proxy that re-serves CA-pinned HTTPS audio as plaintext to the native player — no OS cert install, token never leaves the app. Failure degrades cleanly to download-to-play (or a re-pair prompt on an expired device token). (#553)
+```
+
+Append to the in-progress version section at the top of `RELEASE_NOTES.md` (brand voice):
+
+```markdown
+- **Play instantly at home.** Start any chapter you haven't downloaded yet the moment you tap it — as long as you're on your home Wi-Fi with your library server running. Off the home network, we'll nudge you to download it first.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/features/188-android-companion-app.md docs/release-notes-next.md RELEASE_NOTES.md
+git commit -m "docs(docs): reconcile app-10 to the loopback proxy + release notes"
+```
+
+---
+
+## Definition of done
+
+- All of Tasks 1-8 green under `cd apps/android && flutter test` and `flutter analyze` clean (the `app.yml` gate).
+- Docs reconciled (Task 9); the `app-10` row no longer claims a false "closed."
+- PR body carries `Closes #553`; mandatory `code-review` pass (single-scope `feat(app)` → `medium` effort per model-routing) triaged before merge.
+- **On-device Android smoke test is owed to the owner post-merge** (standard app-* "live device acceptance owed"). Reopen #553 only if it fails on a real phone.
+
+## Self-review (writing-plans)
+
+**Spec coverage** — every spec component maps to a task:
+- §1 `LoopbackProxy` → Task 2. §2 `pinnedRangeStream` → Task 1. §3 Android config → Task 3. §4 wiring + data plumbing → Tasks 6 (data) + 7 (controller) + 8 (runtime/shell). §5 reachability → Task 5. §6 engine error seam → Task 4. §7 failure/fallback table + re-pair wiring → Task 7 (`_handleStreamFailure`) + Task 8 (`onRepairNeeded` → `_openPairing`). Testing strategy items 1-6 → the per-task tests. Docs reconciliation → Task 9.
+- Two spec/impl inconsistencies were resolved and recorded under **Deviations** (register headers → single-point Bearer injection; shared streaming client + subscription-cancel).
+
+**Type consistency** — `PinnedStreamResponse` (Task 1) is consumed by `UpstreamFetch`/`LoopbackProxy` (Task 2) and `ApiClient.pinnedRangeStream` (Tasks 1, 8). `LoopbackProxy` surface (`start`/`register({upstream})`/`lastUpstreamStatus`/`clearMapping`/`dispose`) is used identically by the `FakeProxy` (Task 7) and the runtime (Task 8). `StreamingConfig` fields (Task 7) are constructed with the same names in Task 8. `AudioEngine.errorStream` (Task 4) is subscribed in Task 7. `PlayableChapter.audioUrl` (Task 6) is read in Task 7's `_loadSource`. `Reachability.onHomeLan` (Task 5) is used in Task 8's config.
+
+**Placeholder scan** — no TBD/TODO; every code step carries full code. The one soft spot (Task 6 Step 1's "reuse the file's existing detail-seeding pattern") is called out explicitly with the exact assertion, because `sync_controller_test.dart`'s existing harness should drive the seeding rather than a fabricated helper.

--- a/docs/superpowers/specs/2026-07-12-app-10-lan-loopback-proxy-design.md
+++ b/docs/superpowers/specs/2026-07-12-app-10-lan-loopback-proxy-design.md
@@ -1,6 +1,6 @@
 # app-10 — Stream-over-LAN instant play via an in-app loopback proxy
 
-**Status:** design approved (2026-07-12)
+**Status:** design approved (2026-07-12), revised after adversarial assumption-check
 **Issue:** [#553](https://github.com/dudarenok-maker/Castwright/issues/553) (`app-10`, reopened twice as BLOCKED)
 **Umbrella:** [plan 188 — Android companion app](../../features/188-android-companion-app.md)
 **Scope:** `apps/android/` (Flutter companion) + a docs reconciliation. No server changes.
@@ -28,21 +28,21 @@ Server auth is **not** the blocker: the audio endpoint
 (`GET /api/books/:bookId/chapters/:chapterId/audio.mp3`,
 `server/src/routes/chapter-audio.ts:352`) already supports `Accept-Ranges`/`206`
 and sits behind the LAN guard, which accepts the `Authorization: Bearer` device
-token the app already holds. The recent LAN-HTTPS-default work (plans 225/250)
-changed the *server + browser* story (`castwright.local`, `__Host-cw_lan`
-cookie, browser trusts the CA at OS level) but did **not** touch the companion's
-app-pinned model — so the blocker stands.
+token the app already holds (`lan-auth.ts:171-183`; a bare Bearer GET with no
+cookie is exempt from the CSRF `requireSameOrigin` guard). The recent
+LAN-HTTPS-default work (plans 225/250) changed the *server + browser* story
+(`castwright.local`, `__Host-cw_lan` cookie, browser trusts the CA at OS level)
+but did **not** touch the companion's app-pinned model — so the blocker stands.
 
 ## Goal
 
 Make an undownloaded chapter play **instantly over the home LAN** while preserving
 both invariants the companion depends on: **app-pinned CA (no OS cert install)**
-and **HTTPS-on-LAN (no cleartext audio/token on the wire)**. Offline-first is
+and **HTTPS-on-LAN (no cleartext audio/token off-device)**. Offline-first is
 unchanged — a downloaded chapter always plays its local file.
 
 **Non-goals (YAGNI):** persistence of the streamed bytes, background-download
-coupling, auto-download-after-preview, mDNS discovery, iOS-specific work beyond
-what the cross-platform `dart:io` path gives for free, and any server change.
+coupling, auto-download-after-preview, mDNS discovery, and any server change.
 
 ## Chosen approach: in-app loopback TLS-terminating proxy
 
@@ -77,6 +77,10 @@ Rejected alternatives:
   `PlayerController`.
 - **No auto-retry on stream failure.** A single clean fallback to "download to
   play" beats a silent retry loop.
+- **Cross-platform (Android + iOS), iOS unverified.** The `dart:io` path is
+  platform-neutral and we ship it unconditionally. Android is validated on-device;
+  the iOS backgrounding path is a **known unverified risk** (see Risks) to confirm
+  under app-12, not a v1 blocker.
 
 ## Components
 
@@ -106,7 +110,10 @@ class LoopbackProxy {
   4. **Client disconnect (seek/stop) → cancel the upstream fetch** so sockets
      don't leak.
 - **One active mapping at a time** (single-player app): registering a new chapter
-  evicts the prior id, so any stale loopback URL cleanly `404`s.
+  evicts the prior id, so any stale loopback URL cleanly `404`s. This is safe
+  against ExoPlayer's *within-chapter* concurrent range connections — they all
+  target the same live id and are served independently per-request; a chapter
+  switch tears down the old `AudioSource`, so a stale-id `404` is harmless.
 - **Security:** loopback-only bind + unguessable 128-bit path id + single active
   mapping. Unreachable off-device; unguessable to other local apps; upstream stays
   HTTPS+pinned.
@@ -120,7 +127,7 @@ class PinnedStreamResponse {
   final int statusCode;                  // 200 | 206 | 4xx | 5xx
   final Map<String, String> headers;     // Content-Type/Length/Range, Accept-Ranges
   final Stream<List<int>> body;          // the live HttpClientResponse — NOT drained
-  final Future<void> Function() cancel;  // aborts the upstream request
+  final Future<void> Function() cancel;  // aborts THIS request only (see trap below)
 }
 ```
 
@@ -131,59 +138,121 @@ class PinnedStreamResponse {
   is native — the proxy receives the undrained response and pipes it. No new
   buffering, no new dependency.
 - `4xx/5xx` propagate as status codes for the proxy/controller to act on.
-- The buffered `pinnedRangeFetch` (downloader hot path) is **untouched** — we add a
-  seam, not a refactor. The two share only the private factory.
+- **Implementation trap (must honor):** `pinnedRangeFetch` reuses **one pooled
+  `HttpClient`**. `cancel()` MUST abort only *this* request — cancel the
+  `HttpClientResponse` stream subscription / detach the socket — and MUST NOT call
+  `client.close(force: true)`, which would kill every concurrent range fetch and
+  the shared pool. The buffered `pinnedRangeFetch` (downloader hot path) is
+  otherwise **untouched**; the two share only the private factory.
 
-### 3. Player-flow wiring (`apps/android/lib/src/data/player_controller.dart`)
+### 3. Android cleartext-to-loopback (new — `apps/android/android/app/src/main/res/xml/network_security_config.xml` + manifest wiring)
 
-`_loadIndex` (currently an unconditional `_engine.setFilePath(c.path)` at
-`player_controller.dart:280`) gains the single decision point that consumes the
-existing-but-dead `resolvePlaybackSource`:
+**Without this the feature serves zero bytes on Android release builds.** Android
+(target SDK ≥ 28, Flutter's default) sets `cleartextTrafficPermitted=false` for
+all hosts with no loopback exemption; ExoPlayer's `DefaultHttpDataSource` consults
+`NetworkSecurityPolicy` and throws on a cleartext `http://127.0.0.1` load. There is
+currently **no** `network_security_config.xml` and **no**
+`usesCleartextTraffic`/`networkSecurityConfig` attribute in the manifest.
+
+Fix — a **narrowly loopback-scoped** config (the LAN-HTTPS invariant is preserved
+because only `127.0.0.1` is permitted cleartext, nothing else):
+
+```xml
+<!-- network_security_config.xml -->
+<network-security-config>
+  <base-config cleartextTrafficPermitted="false" />
+  <domain-config cleartextTrafficPermitted="true">
+    <domain includeSubdomains="false">127.0.0.1</domain>
+  </domain-config>
+</network-security-config>
+```
+
+Wire `android:networkSecurityConfig="@xml/network_security_config"` on
+`<application>` in `AndroidManifest.xml`.
+
+iOS needs no equivalent: ATS is **not enforced for raw IP-literal hosts** like
+`127.0.0.1`, so AVPlayer loads `http://127.0.0.1:<port>` without an `Info.plist`
+exception.
+
+### 4. Player-flow wiring + data plumbing (`player_controller.dart`, `sync_controller.dart`, `sync_manifest.dart`/`PlayableChapter`)
+
+This is **more than a single seam** — the current types don't carry what the
+streaming branch needs, so three things move together:
+
+**(a) Widen `PlayableChapter` to carry upstream identity.** Today
+`PlayableChapter` (`player_controller.dart:16-27`) has only
+`uuid/path/title/durationSec` — no `bookId`/`chapterId`/`urlSuffix` to build
+`/api/books/:bookId/chapters/:chapterId/audio.mp3`, and no `isDownloaded`. Add the
+upstream-identity fields (source: `SyncManifestChapter`, `sync_manifest.dart:104-117`),
+and stop dropping them in the `playlistFor` projection
+(`sync_controller.dart:186-199`), which already emits undownloaded-but-rendered
+chapters (`c.hasAudio`) with a *local* `path` that may not exist on disk.
+
+**(b) "Downloaded?" is a file-existence check on `c.path`**, not a non-existent
+`isDownloaded` flag.
+
+**(c) Expand the `PlayerController` constructor.** It currently injects none of
+the streaming deps; add `settings` (for `streamOverLan`), a reachability source
+(component 5), the connection/token (`ApiClient` or the paired-server token), and
+the `LoopbackProxy`. Every existing `PlayerController` test gains fakes for these.
+
+The decision point in `_loadIndex` (`player_controller.dart:280`) then becomes:
 
 ```dart
 final src = resolvePlaybackSource(
-  localFileExists:  c.isDownloaded,
-  onHomeLan:        _reachability.onHomeLan,
+  localFileExists:  await _fileStore.exists(c.path),
+  onHomeLan:        _reachability.onHomeLan,        // component 5
   streamingEnabled: _settings.streamOverLan,
 );
 switch (src) {
   case PlaybackSource.localFile:
     await _engine.setFilePath(c.path);
   case PlaybackSource.lanStream:
-    await _proxy.start();                                   // FIRST bind, on demand
+    await _proxy.start();                            // FIRST bind, on demand
     final loopback = _proxy.register(
-      upstream: _resolveUpstream(c),
+      upstream: _resolveUpstream(c),                 // needs bookId+chapterId+urlSuffix from (a)
       headers: {'Authorization': 'Bearer ${_conn.token}'},
     );
-    await _engine.setStreamUrl(loopback.toString());         // player sees only 127.0.0.1
+    await _engine.setStreamUrl(loopback.toString()); // player sees only 127.0.0.1, no headers
   case PlaybackSource.needsDownload:
-    _notifyDownloadToPlay();                                 // no silent no-op
+    _notifyDownloadToPlay();                         // no silent no-op
 }
 ```
 
 Consequences:
 
-- `PlaybackSource.lanStream` gets its **first and only production consumer**.
-- The `settings_screen.dart` "Stream over LAN" toggle **stops being inert** — it now
-  gates this branch.
-- The accrual caveat at `player_controller.dart:352-355` is honored: while
-  streaming, stats accrual is additionally gated on `processingState == ready`, so
-  buffering stalls don't inflate listen-time.
+- `PlaybackSource.lanStream` gets its **first and only production consumer**; the
+  `settings_screen.dart` "Stream over LAN" toggle **stops being inert**.
+- `_loadIndex` is also reached via `openBook`, `playChapter`, `_advance`
+  (auto-advance) and `skip`'s `ChapterStep` — so **auto-advancing into an
+  undownloaded chapter streams it too**. That is the desired behavior (seamless
+  LAN listening), not a bug; tests cover the auto-advance path.
+- `setStreamUrl` is called with the loopback URL and **no `headers`** (confirmed:
+  `just_audio_engine.dart:47` passes `headers: null` → `AudioSource.uri`), so the
+  Bearer never reaches the player.
 - Controller `dispose()` also disposes the proxy — no lingering socket.
+- **Dropped from v1:** gating stats-accrual on `processingState == ready` (the
+  `player_controller.dart:352-355` caveat) — `AudioEngine` doesn't expose
+  `processingState`, and adding that seam isn't worth it for an ephemeral preview.
+  See Risks.
 
-### 4. Reachability signal (`onHomeLan`)
+### 5. Reachability signal (`onHomeLan`)
 
-Reuse the existing app-8 `NetworkType` probe (`network_info.dart`, currently
-unconnected): `onHomeLan = networkType != cellular` (on Wi-Fi/wired). This is a
-cheap **attempt gate** — no mandatory network round-trip on the happy path, no
-background polling. Whether the paired server is actually on *this* Wi-Fi is settled
-by the streaming attempt itself, via the failure path below.
+Reuse the existing app-8 network probe (`network_info.dart`, currently
+unconnected). Its enum is `{offline, mobile, wifiMetered, wifiUnmetered}`
+(`sync_gate.dart:7`). The correct attempt-gate is:
 
-A mandatory pinned reachability pre-probe was considered and rejected: it adds up to
-2 s before every stream and duplicates what the first upstream request already
-proves.
+```dart
+onHomeLan = network == NetworkType.wifiUnmetered || network == NetworkType.wifiMetered;
+```
 
-### 5. Failure / fallback behavior — no silent stalls
+**Not** `network != mobile` — that is *true when `offline`*, which would route an
+offline tap to `lanStream` and only discover the failure via a doomed upstream
+fetch. Being on Wi-Fi is a cheap gate; whether the paired server is actually on
+*this* Wi-Fi is settled by the streaming attempt itself (the failure path below).
+No mandatory pre-probe (adds ~2 s and duplicates what the first request proves).
+
+### 6. Failure / fallback behavior — no silent stalls
 
 The proxy's first upstream request **is** the real reachability test. The engine
 error stream drives fallback (no infinite buffer spinner):
@@ -193,7 +262,7 @@ error stream drives fallback (no infinite buffer spinner):
 | Server unreachable / timeout (wrong Wi-Fi, server off) | proxy → `502/504` → engine error | Stop; message *"Couldn't stream over LAN — download to play"*; chapter stays needs-download |
 | `401/403` (device token expired/revoked) | proxy relays status → controller | Reuse ApiClient's existing **re-pair** path (`api_client.dart:55`) |
 | `404/5xx` from server | proxy relays status → engine error | Same "couldn't stream — download" message |
-| Toggle off / off-Wi-Fi / downloaded-but-missing file | `resolvePlaybackSource → needsDownload` | *"Download this chapter to play"* — never a silent no-op |
+| Toggle off / off-Wi-Fi / offline / local file missing | `resolvePlaybackSource → needsDownload` | *"Download this chapter to play"* — never a silent no-op |
 
 Streaming is best-effort; any failure degrades gracefully to the offline-first
 download flow with a clear one-line message. **No auto-retry.**
@@ -212,23 +281,44 @@ automated gate for `apps/android/`.
    match; `HEAD` = headers only; client disconnect → `cancel()`; new registration
    evicts prior id (old URL → `404`); single active mapping.
 2. **`pinnedRangeStream`** — status/headers/stream passthrough, `Bearer` injected,
-   `Range` forwarded, `cancel` aborts. (CA-pinning stays covered by the existing
-   `cert_pinning`/`api_client` tests — same factory reused.)
-3. **`PlayerController` wiring** (fake engine/proxy/reachability/settings):
-   downloaded → `setFilePath` (unchanged); undownloaded+on+Wi-Fi →
-   `start()`+`register`+`setStreamUrl(loopback)` with **Bearer never passed to the
-   engine**; **lazy invariant** — `proxy.start()` never called in
-   `localFile`/`needsDownload` branches; toggle off / off-Wi-Fi → `needsDownload`
-   message + no proxy start; stream engine-error → fallback message + mapping
-   cleared + **no auto-retry**; accrual gated on `processingState == ready`;
-   `dispose()` disposes the proxy.
-4. **`resolvePlaybackSource`** — extend the existing truth-table test for the
-   `networkType → onHomeLan` mapping.
+   `Range` forwarded, and the **cancel-aborts-only-this-request** contract (a
+   second concurrent fetch on the shared pool keeps working after one is
+   cancelled). CA-pinning stays covered by the existing `cert_pinning`/`api_client`
+   tests — same factory reused.
+3. **Data plumbing** — `PlayableChapter`/`playlistFor` carry `bookId`/`chapterId`/
+   `urlSuffix` through the projection; `_resolveUpstream` builds the correct
+   `/api/books/…/audio.mp3` URL.
+4. **`PlayerController` wiring** (fake engine/proxy/reachability/settings/fileStore):
+   downloaded (file exists) → `setFilePath`; undownloaded+on+Wi-Fi →
+   `start()`+`register`+`setStreamUrl(loopback)` with **no headers to the engine**;
+   **lazy invariant** — `proxy.start()` never called in `localFile`/`needsDownload`
+   branches; toggle off / off-Wi-Fi / offline → `needsDownload` + no proxy start;
+   auto-advance into an undownloaded chapter streams; stream engine-error →
+   fallback message + mapping cleared + **no auto-retry**; `dispose()` disposes the
+   proxy.
+5. **`resolvePlaybackSource`** — extend the existing truth-table test; add the
+   `NetworkType → onHomeLan` mapping (offline ⇒ false).
 
-**On-device (the "live device acceptance owed" step — owner):** real phone on home
-Wi-Fi, undownloaded chapter, toggle on → instant play, seek, lock-screen controls,
-**no OS cert install**; off-LAN → download prompt. This cannot run from a dev box
-and is why #553 closes on merge with acceptance owed.
+**Not unit-testable (on-device / declarative):** the `network_security_config.xml`
++ manifest wiring (Android cleartext-to-loopback) — validated only by the on-device
+run; `flutter analyze` won't catch a missing config.
+
+**On-device (the "live device acceptance owed" step — owner):** real Android phone
+on home Wi-Fi, undownloaded chapter, toggle on → instant play, seek, lock-screen
+controls (background survival via the media foreground service), **no OS cert
+install**; off-LAN → download prompt. This cannot run from a dev box and is why
+#553 closes on merge with acceptance owed.
+
+## Risks / known limitations
+
+- **iOS backgrounding unverified.** `ios/Runner/Info.plist` has no
+  `UIBackgroundModes: audio`, so the loopback server (and AVPlayer buffering) may
+  stall when the app is backgrounded on iOS. Accepted for v1 (iOS is app-12
+  territory); flagged to validate + add the background mode when iOS is enabled.
+- **Stats over-count on buffer stalls.** With the `processingState == ready` gate
+  dropped, a LAN preview that stalls mid-buffer while "playing" may slightly
+  over-count listen-time. Acceptable for an ephemeral preview; revisit only if it
+  proves material.
 
 ## Docs reconciliation
 
@@ -241,6 +331,6 @@ and is why #553 closes on merge with acceptance owed.
 ## Acceptance / definition of done
 
 Code-complete + the automated tests above green + docs updated + PR merged (which
-closes #553). On-device smoke test is **owed to the owner** post-merge (standard
-app-* "live device acceptance owed" pattern); reopen only if it fails on a real
-phone.
+closes #553). On-device Android smoke test is **owed to the owner** post-merge
+(standard app-* "live device acceptance owed" pattern); reopen only if it fails on
+a real phone.

--- a/docs/superpowers/specs/2026-07-12-app-10-lan-loopback-proxy-design.md
+++ b/docs/superpowers/specs/2026-07-12-app-10-lan-loopback-proxy-design.md
@@ -116,6 +116,11 @@ class LoopbackProxy {
      can only come from the proxy, not the engine.
   5. **Client disconnect (seek/stop) → cancel the upstream fetch** so sockets
      don't leak.
+- **`register()` resets `lastUpstreamStatus` to `null`** so the side-channel is
+  scoped to the *current* registration and can never carry a prior chapter's code.
+  The controller re-pairs (the high-blast-radius action) **only** on a freshly
+  recorded `401/403` for the live id; a `null` status (or any non-HTTP engine
+  error) routes to the generic "download to play" path, never re-pair.
 - **One active mapping at a time** (single-player app): registering a new chapter
   evicts the prior id, so any stale loopback URL cleanly `404`s. This is safe
   against ExoPlayer's *within-chapter* concurrent range connections — they all
@@ -204,10 +209,14 @@ may not exist on disk. `_resolveUpstream(c)` is then `_resolveUrl(c.audioUrl)` �
 `isDownloaded` flag.
 
 **(c) Expand the `PlayerController` constructor.** It currently injects none of
-the streaming deps; add `fileStore` (for the `exists()` check — `file_store.dart`,
-not currently injected), `settings` (for `streamOverLan`), a reachability source
-(component 5), the connection/token (`ApiClient` or the paired-server token), and
-the `LoopbackProxy`. Every existing `PlayerController` test gains fakes for these.
+the streaming deps; add: `fileStore` (for the `exists()` check — `file_store.dart`,
+not currently injected); `settings` (for `streamOverLan`); a reachability source
+(component 5); a **`urlResolver` closure** (`Uri Function(String)`) — reuse the
+same `Uri resolve(String path) => Uri.parse('${connection.server.url}$path')`
+already built at `companion_runtime.dart:146` and handed to `SyncController`, so
+the token (`connection.server.token`) and base URL live in one place, not a raw
+`Connection`; the `LoopbackProxy`; and an **`onRepairNeeded` callback** (see below).
+Every existing `PlayerController` test gains fakes/closures for these.
 
 The decision point in `_loadIndex` (`player_controller.dart:280`) then becomes
 (note: `_loadIndex` is already `async`, so awaiting the file-existence and
@@ -224,16 +233,25 @@ switch (src) {
     await _engine.setFilePath(c.path);
   case PlaybackSource.lanStream:
     await _proxy.start();                            // FIRST bind, on demand
-    final loopback = _proxy.register(
-      upstream: _resolveUrl(c.audioUrl),             // audioUrl carried through (a)
-      headers: {'Authorization': 'Bearer ${_conn.token}'},
+    final loopback = _proxy.register(               // resets lastUpstreamStatus
+      upstream: _urlResolver(c.audioUrl),           // audioUrl carried through (a)
+      headers: {'Authorization': 'Bearer ${_connection.server.token}'},
     );
-    await _engine.setStreamUrl(loopback.toString()); // player sees only 127.0.0.1, no headers
+    try {
+      await _engine.setStreamUrl(loopback.toString()); // player sees only 127.0.0.1, no headers
+    } catch (_) {
+      _handleStreamFailure();                        // initial-load throw → §7 routing
+    }
   case PlaybackSource.needsDownload:
     if (userInitiated) _notifyDownloadToPlay();      // prompt only on explicit play
     // else (auto-advance): halt the run quietly — no unprompted download nag
 }
 ```
+
+`_handleStreamFailure()` is the single §7 router: it reads `_proxy.lastUpstreamStatus`,
+clears the mapping, and either invokes `onRepairNeeded()` (fresh `401/403`) or
+surfaces "download to play" (everything else, incl. `null`). It is shared by the
+`catch` above **and** the mid-stream `errorStream` subscription (§6).
 
 Consequences:
 
@@ -291,30 +309,47 @@ just_audio as a player error that today goes nowhere. Add a minimal seam:
 Stream<Object> get errorStream;   // AudioEngine interface
 ```
 
-`JustAudioEngine` maps `_player.playbackEventStream`'s error events (and/or
-`processingStateStream` idle-after-load) onto it; the demo/fake engines emit
-nothing. The `PlayerController` subscribes and drives §7. This is the seam the
-dropped `processingState==ready` idea would also have needed — we add the smaller
-error-only version, not the full processing-state surface.
+`JustAudioEngine` maps `_player.playbackEventStream`'s **error events** (via
+`listen(onError:)` — a `PlayerException`) onto it; the demo/fake engines emit
+nothing (and the fake can push a synthetic error for controller tests).
+
+**Two failure channels, one router.** just_audio reports a failed load in *two*
+ways: an **initial-load failure throws** — the `setStreamUrl` `Future` rejects —
+caught by the `try/catch` in §4; a **mid-stream failure** (post-load
+codec/EOF/network drop) arrives as an **`errorStream` event**. Both call the same
+`_handleStreamFailure()` router (§7). `errorStream` is *not* the sole trigger — it
+covers only the mid-stream case. (Don't rely on a `processingState` idle-after-load
+transition; a failed load doesn't reliably reach `idle`.) Implementation note: the
+existing `_completionSub` (`player_controller.dart:76`) derives from the same
+broadcast stream and has no `onError` — confirm loopback errors are isolated to the
+new `errorStream` and don't tear it down.
 
 ### 7. Failure / fallback behavior — no silent stalls
 
-The proxy's first upstream request **is** the real reachability test. Fallback is
-driven by the **engine error seam (§6)** — the platform player collapses upstream
-HTTP codes into one opaque error, so on an engine error the controller reads the
-proxy's **`lastUpstreamStatus` side-channel (§1)** to recover the real code and
-route accordingly (no infinite buffer spinner):
+The proxy's first upstream request **is** the real reachability test. Both failure
+channels (§6: the `setStreamUrl` throw and the mid-stream `errorStream` event) call
+one router, `_handleStreamFailure()`, which reads the proxy's **`lastUpstreamStatus`
+side-channel (§1)** — the platform player collapses upstream HTTP codes into one
+opaque error, so the real code can only come from the proxy — clears the mapping,
+and routes (no infinite buffer spinner):
 
-| Failure | How the controller learns it | User-visible result |
+| Upstream reality | `lastUpstreamStatus` | User-visible result |
 |---|---|---|
-| Server unreachable / timeout (wrong Wi-Fi, server off) | engine error + `lastUpstreamStatus == 0` | Stop; *"Couldn't stream over LAN — download to play"*; chapter stays needs-download |
-| `401/403` (device token expired/revoked) | engine error + `lastUpstreamStatus ∈ {401,403}` | Trigger the existing **re-pair** flow (same UX as `api_client.dart:55`) |
-| `404/5xx` from server | engine error + `lastUpstreamStatus ∈ {404,5xx}` | Same "couldn't stream — download" message |
-| Toggle off / off-Wi-Fi / offline / local file missing | `resolvePlaybackSource → needsDownload` | user-initiated: *"Download this chapter to play"*; auto-advance: halt quietly |
+| Server unreachable / timeout (wrong Wi-Fi, server off) | `0` | Stop; *"Couldn't stream over LAN — download to play"*; chapter stays needs-download |
+| Device token expired/revoked | `401` / `403` (fresh, this id) | Invoke `onRepairNeeded()` → the app-shell re-pair flow (see wiring) |
+| Server `404/5xx` | `404` / `5xx` | Same "couldn't stream — download" message |
+| Non-HTTP engine error / stale / none recorded | `null` | Generic "download to play" — **never** re-pair |
+| Toggle off / off-Wi-Fi / offline / local file missing | (pre-flight `needsDownload`) | user-initiated: *"Download this chapter to play"*; auto-advance: halt quietly |
 
-On any stream error the controller also **clears the proxy mapping** (so the stale
-loopback id `404`s) and stops. Streaming is best-effort; every failure degrades to
-the offline-first download flow with a clear one-line message. **No auto-retry.**
+**Re-pair wiring (new plumbing, Critical to budget).** There is no runtime
+401→pairing path today — `_openPairing` (`main.dart:263-280`) is reachable only by
+a user tap or deep-link. So the `onRepairNeeded` callback is threaded
+`PlayerController` (constructor) → `CompanionRuntime.forConnection`
+(`companion_runtime.dart:161`) → `main.dart`'s `_openPairing`. This is the one new
+seam that reaches the app-shell navigator; it must be built, not assumed.
+
+Streaming is best-effort; every failure degrades to the offline-first download flow
+with a clear one-line message. **No auto-retry.**
 
 ## Testing strategy
 
@@ -328,7 +363,8 @@ automated gate for `apps/android/`.
    → loopback URL; unknown id → `404`; non-GET/HEAD → `405`; `Range` forwarded;
    `206` + `Content-Range`/`Length`/`Type`/`Accept-Ranges` relayed; body bytes
    match; `HEAD` = headers only; client disconnect → `cancel()`; new registration
-   evicts prior id (old URL → `404`); single active mapping.
+   evicts prior id (old URL → `404`); single active mapping; a non-2xx upstream
+   sets `lastUpstreamStatus`, and **`register()` resets it to `null`**.
 2. **`pinnedRangeStream`** — status/headers/stream passthrough, `Bearer` injected,
    `Range` forwarded, and the **cancel-aborts-only-this-request** contract (a
    second concurrent fetch on the shared pool keeps working after one is
@@ -339,16 +375,18 @@ automated gate for `apps/android/`.
 4. **Engine error seam** — `JustAudioEngine` maps a just_audio player-error event
    onto `errorStream`; the fake engine can emit a synthetic error for controller
    tests.
-5. **`PlayerController` wiring** (fake engine/proxy/reachability/settings/fileStore):
-   downloaded (file exists) → `setFilePath`; undownloaded+on+Wi-Fi →
-   `start()`+`register`+`setStreamUrl(loopback)` with **no headers to the engine**;
-   **lazy invariant** — `proxy.start()` never called in `localFile`/`needsDownload`
-   branches; toggle off / off-Wi-Fi / offline → `needsDownload` (user-initiated
-   prompts, auto-advance halts quietly) + no proxy start; auto-advance into an
-   undownloaded chapter streams; **failure routing** — engine error with
-   `lastUpstreamStatus` of `0`/`404`/`5xx` → download message, `401/403` → re-pair
-   flow, each clearing the mapping with **no auto-retry**; `dispose()` disposes the
-   proxy.
+5. **`PlayerController` wiring** (fake engine/proxy/reachability/settings/fileStore/
+   urlResolver/onRepairNeeded): downloaded (file exists) → `setFilePath`;
+   undownloaded+on+Wi-Fi → `start()`+`register`+`setStreamUrl(loopback)` with **no
+   headers to the engine**; **lazy invariant** — `proxy.start()` never called in
+   `localFile`/`needsDownload` branches; toggle off / off-Wi-Fi / offline →
+   `needsDownload` (user-initiated prompts, auto-advance halts quietly) + no proxy
+   start; auto-advance into an undownloaded chapter streams. **Failure routing via
+   `_handleStreamFailure`** — both an initial-load `setStreamUrl` **throw** and a
+   mid-stream **`errorStream` event** route identically: `lastUpstreamStatus` of
+   `0`/`404`/`5xx`/`null` → download message (and `null`/stale **never** re-pairs),
+   fresh `401/403` → `onRepairNeeded()` invoked, each clearing the mapping with **no
+   auto-retry**; `dispose()` disposes the proxy.
 6. **`resolvePlaybackSource`** — extend the existing truth-table test; add the
    `NetworkType → onHomeLan` mapping (offline ⇒ false).
 

--- a/docs/superpowers/specs/2026-07-12-app-10-lan-loopback-proxy-design.md
+++ b/docs/superpowers/specs/2026-07-12-app-10-lan-loopback-proxy-design.md
@@ -1,0 +1,246 @@
+# app-10 — Stream-over-LAN instant play via an in-app loopback proxy
+
+**Status:** design approved (2026-07-12)
+**Issue:** [#553](https://github.com/dudarenok-maker/Castwright/issues/553) (`app-10`, reopened twice as BLOCKED)
+**Umbrella:** [plan 188 — Android companion app](../../features/188-android-companion-app.md)
+**Scope:** `apps/android/` (Flutter companion) + a docs reconciliation. No server changes.
+
+## Problem
+
+`app-10` ("play an undownloaded chapter instantly over the home LAN") shipped as
+scaffolding in June 2026 but has been **blocked and inert** ever since — reopened
+twice on #553. The pure pieces exist and are unit-tested
+(`resolvePlaybackSource`, `AppSettings.streamOverLan`, the settings toggle,
+`AudioEngine.setStreamUrl`), but **nothing in production consumes them**, and the
+feature cannot be wired under the companion's TLS model:
+
+- The companion trusts the server by **app-level pinning only**: `ApiClient`
+  builds a `SecurityContext(withTrustedRoots: false)` and pins the mkcert root CA
+  (`api_client.dart:311`). There is deliberately **no OS-level cert install**
+  (`README.md:141`).
+- `just_audio`'s `AudioSource.uri` streams via the **native OS platform player**
+  (ExoPlayer on Android / AVPlayer on iOS), which uses the **OS trust store** —
+  not the app's pinned Dart `HttpClient`. Streaming `https://<lan>:8443/…` from
+  the platform player therefore **fails TLS validation** (mkcert CA untrusted at
+  OS level).
+
+Server auth is **not** the blocker: the audio endpoint
+(`GET /api/books/:bookId/chapters/:chapterId/audio.mp3`,
+`server/src/routes/chapter-audio.ts:352`) already supports `Accept-Ranges`/`206`
+and sits behind the LAN guard, which accepts the `Authorization: Bearer` device
+token the app already holds. The recent LAN-HTTPS-default work (plans 225/250)
+changed the *server + browser* story (`castwright.local`, `__Host-cw_lan`
+cookie, browser trusts the CA at OS level) but did **not** touch the companion's
+app-pinned model — so the blocker stands.
+
+## Goal
+
+Make an undownloaded chapter play **instantly over the home LAN** while preserving
+both invariants the companion depends on: **app-pinned CA (no OS cert install)**
+and **HTTPS-on-LAN (no cleartext audio/token on the wire)**. Offline-first is
+unchanged — a downloaded chapter always plays its local file.
+
+**Non-goals (YAGNI):** persistence of the streamed bytes, background-download
+coupling, auto-download-after-preview, mDNS discovery, iOS-specific work beyond
+what the cross-platform `dart:io` path gives for free, and any server change.
+
+## Chosen approach: in-app loopback TLS-terminating proxy
+
+A tiny `dart:io HttpServer` runs **inside the app**, bound to `127.0.0.1:0`
+(OS-assigned ephemeral port, loopback interface only). The platform player streams
+**plaintext from loopback**; the proxy re-fetches over HTTPS via the
+**already-pinned** client, streaming `Range`/`206` bytes straight through. The
+mkcert CA never has to be trusted by the OS, the Bearer token never leaves the
+app (the player only ever sees `http://127.0.0.1:<port>/…`), and the plaintext hop
+is `127.0.0.1` in-process only.
+
+Rejected alternatives:
+
+- **OS-level cert trust** (install mkcert root in the OS store): least code, but
+  breaks the explicit "no OS cert install" design goal, forces a profile-install
+  step per device (awkward/limited on iOS), and widens the trust surface. Already
+  rejected on #553.
+- **Plaintext LAN HTTP for audio**: violates the HTTPS-on-LAN requirement and puts
+  chapter bytes + Bearer token on the wire in cleartext. Out of scope.
+
+## Product decisions (locked during brainstorming)
+
+- **Ephemeral preview only.** Streaming plays live from the LAN; nothing is
+  persisted. Offline = the existing explicit Download flow (a separate tap). No
+  coupling to the downloader.
+- **Stream-through, not buffered.** For "instant play" the proxy pipes upstream
+  bytes incrementally, honoring the platform player's `Range` requests. Whole-file
+  buffering would defeat "instant" and risk OOM on large chapters.
+- **Demand-scoped, never a background server.** Nothing binds a socket at app
+  launch, on pairing, or while playing downloaded files. The proxy `start()`s only
+  on the first resolution to `PlaybackSource.lanStream`, and is disposed with the
+  `PlayerController`.
+- **No auto-retry on stream failure.** A single clean fallback to "download to
+  play" beats a silent retry loop.
+
+## Components
+
+### 1. `LoopbackProxy` (new — `apps/android/lib/src/data/loopback_proxy.dart`)
+
+```dart
+class LoopbackProxy {
+  Future<void> start();                     // idempotent; binds 127.0.0.1:0
+  Uri register({required Uri upstream,      // https://<lan>:8443/api/books/…/audio.mp3
+                required Map<String, String> headers});  // {Authorization: Bearer …}
+  Future<void> dispose();                   // closes server, clears mappings
+}
+```
+
+- `register` mints a **128-bit random opaque id** and returns
+  `http://127.0.0.1:<port>/s/<id>`. That loopback URL is what we hand to
+  `setStreamUrl` — the Bearer token and the real HTTPS URL **never reach the
+  platform player**; the proxy injects them on the upstream side.
+- **Per-request** (each GET/HEAD on `/s/<id>`):
+  1. Unknown/stale id → `404`. Non-GET/HEAD → `405`.
+  2. Forward the incoming `Range` header to `ApiClient.pinnedRangeStream`
+     (component 2) with the registered Bearer header.
+  3. Relay upstream status (`200`/`206`) and pass through `Content-Type`,
+     `Content-Length`, `Content-Range`, `Accept-Ranges`; then **pipe the upstream
+     body straight through** (no full-file buffering), flushing as bytes arrive.
+     `HEAD` relays headers only.
+  4. **Client disconnect (seek/stop) → cancel the upstream fetch** so sockets
+     don't leak.
+- **One active mapping at a time** (single-player app): registering a new chapter
+  evicts the prior id, so any stale loopback URL cleanly `404`s.
+- **Security:** loopback-only bind + unguessable 128-bit path id + single active
+  mapping. Unreachable off-device; unguessable to other local apps; upstream stays
+  HTTPS+pinned.
+
+### 2. `ApiClient.pinnedRangeStream` (new sibling — `apps/android/lib/src/data/api_client.dart`)
+
+```dart
+Future<PinnedStreamResponse> pinnedRangeStream(Uri url, {String? range});
+
+class PinnedStreamResponse {
+  final int statusCode;                  // 200 | 206 | 4xx | 5xx
+  final Map<String, String> headers;     // Content-Type/Length/Range, Accept-Ranges
+  final Stream<List<int>> body;          // the live HttpClientResponse — NOT drained
+  final Future<void> Function() cancel;  // aborts the upstream request
+}
+```
+
+- Reuses the **same** private pinned-client factory (`_pinnedHttpClient()`,
+  `api_client.dart:311`) as every other pinned call — one CA-pinning code path, not
+  two. Same `Authorization: Bearer` injection and 2 s `connectionTimeout`.
+- `dart:io`'s `HttpClientResponse` **is** a `Stream<List<int>>`, so stream-through
+  is native — the proxy receives the undrained response and pipes it. No new
+  buffering, no new dependency.
+- `4xx/5xx` propagate as status codes for the proxy/controller to act on.
+- The buffered `pinnedRangeFetch` (downloader hot path) is **untouched** — we add a
+  seam, not a refactor. The two share only the private factory.
+
+### 3. Player-flow wiring (`apps/android/lib/src/data/player_controller.dart`)
+
+`_loadIndex` (currently an unconditional `_engine.setFilePath(c.path)` at
+`player_controller.dart:280`) gains the single decision point that consumes the
+existing-but-dead `resolvePlaybackSource`:
+
+```dart
+final src = resolvePlaybackSource(
+  localFileExists:  c.isDownloaded,
+  onHomeLan:        _reachability.onHomeLan,
+  streamingEnabled: _settings.streamOverLan,
+);
+switch (src) {
+  case PlaybackSource.localFile:
+    await _engine.setFilePath(c.path);
+  case PlaybackSource.lanStream:
+    await _proxy.start();                                   // FIRST bind, on demand
+    final loopback = _proxy.register(
+      upstream: _resolveUpstream(c),
+      headers: {'Authorization': 'Bearer ${_conn.token}'},
+    );
+    await _engine.setStreamUrl(loopback.toString());         // player sees only 127.0.0.1
+  case PlaybackSource.needsDownload:
+    _notifyDownloadToPlay();                                 // no silent no-op
+}
+```
+
+Consequences:
+
+- `PlaybackSource.lanStream` gets its **first and only production consumer**.
+- The `settings_screen.dart` "Stream over LAN" toggle **stops being inert** — it now
+  gates this branch.
+- The accrual caveat at `player_controller.dart:352-355` is honored: while
+  streaming, stats accrual is additionally gated on `processingState == ready`, so
+  buffering stalls don't inflate listen-time.
+- Controller `dispose()` also disposes the proxy — no lingering socket.
+
+### 4. Reachability signal (`onHomeLan`)
+
+Reuse the existing app-8 `NetworkType` probe (`network_info.dart`, currently
+unconnected): `onHomeLan = networkType != cellular` (on Wi-Fi/wired). This is a
+cheap **attempt gate** — no mandatory network round-trip on the happy path, no
+background polling. Whether the paired server is actually on *this* Wi-Fi is settled
+by the streaming attempt itself, via the failure path below.
+
+A mandatory pinned reachability pre-probe was considered and rejected: it adds up to
+2 s before every stream and duplicates what the first upstream request already
+proves.
+
+### 5. Failure / fallback behavior — no silent stalls
+
+The proxy's first upstream request **is** the real reachability test. The engine
+error stream drives fallback (no infinite buffer spinner):
+
+| Failure | Where caught | User-visible result |
+|---|---|---|
+| Server unreachable / timeout (wrong Wi-Fi, server off) | proxy → `502/504` → engine error | Stop; message *"Couldn't stream over LAN — download to play"*; chapter stays needs-download |
+| `401/403` (device token expired/revoked) | proxy relays status → controller | Reuse ApiClient's existing **re-pair** path (`api_client.dart:55`) |
+| `404/5xx` from server | proxy relays status → engine error | Same "couldn't stream — download" message |
+| Toggle off / off-Wi-Fi / downloaded-but-missing file | `resolvePlaybackSource → needsDownload` | *"Download this chapter to play"* — never a silent no-op |
+
+Streaming is best-effort; any failure degrades gracefully to the offline-first
+download flow with a clear one-line message. **No auto-retry.**
+
+## Testing strategy
+
+Automated tests run in `app.yml` (`flutter analyze` + `flutter test`) — the only
+automated gate for `apps/android/`.
+
+**Automatable (ship in this PR):**
+
+1. **`LoopbackProxy`** — real `dart:io` server on `127.0.0.1:0` against a **fake
+   upstream** (injected `pinnedRangeStream` stub; no real TLS needed): `register`
+   → loopback URL; unknown id → `404`; non-GET/HEAD → `405`; `Range` forwarded;
+   `206` + `Content-Range`/`Length`/`Type`/`Accept-Ranges` relayed; body bytes
+   match; `HEAD` = headers only; client disconnect → `cancel()`; new registration
+   evicts prior id (old URL → `404`); single active mapping.
+2. **`pinnedRangeStream`** — status/headers/stream passthrough, `Bearer` injected,
+   `Range` forwarded, `cancel` aborts. (CA-pinning stays covered by the existing
+   `cert_pinning`/`api_client` tests — same factory reused.)
+3. **`PlayerController` wiring** (fake engine/proxy/reachability/settings):
+   downloaded → `setFilePath` (unchanged); undownloaded+on+Wi-Fi →
+   `start()`+`register`+`setStreamUrl(loopback)` with **Bearer never passed to the
+   engine**; **lazy invariant** — `proxy.start()` never called in
+   `localFile`/`needsDownload` branches; toggle off / off-Wi-Fi → `needsDownload`
+   message + no proxy start; stream engine-error → fallback message + mapping
+   cleared + **no auto-retry**; accrual gated on `processingState == ready`;
+   `dispose()` disposes the proxy.
+4. **`resolvePlaybackSource`** — extend the existing truth-table test for the
+   `networkType → onHomeLan` mapping.
+
+**On-device (the "live device acceptance owed" step — owner):** real phone on home
+Wi-Fi, undownloaded chapter, toggle on → instant play, seek, lock-screen controls,
+**no OS cert install**; off-LAN → download prompt. This cannot run from a dev box
+and is why #553 closes on merge with acceptance owed.
+
+## Docs reconciliation
+
+- **Plan 188** currently mis-states `app-10` as "closed #553" (line 52) — reconcile
+  to "wired via in-app loopback proxy," and add the on-device acceptance walkthrough
+  to its `app-10` section.
+- Two release-notes entries (`docs/release-notes-next.md` technical +
+  `RELEASE_NOTES.md` brand-voice) for the in-progress version.
+
+## Acceptance / definition of done
+
+Code-complete + the automated tests above green + docs updated + PR merged (which
+closes #553). On-device smoke test is **owed to the owner** post-merge (standard
+app-* "live device acceptance owed" pattern); reopen only if it fails on a real
+phone.

--- a/docs/superpowers/specs/2026-07-12-app-10-lan-loopback-proxy-design.md
+++ b/docs/superpowers/specs/2026-07-12-app-10-lan-loopback-proxy-design.md
@@ -91,7 +91,8 @@ class LoopbackProxy {
   Future<void> start();                     // idempotent; binds 127.0.0.1:0
   Uri register({required Uri upstream,      // https://<lan>:8443/api/books/…/audio.mp3
                 required Map<String, String> headers});  // {Authorization: Bearer …}
-  Future<void> dispose();                   // closes server, clears mappings
+  int? get lastUpstreamStatus;              // side-channel: the last non-2xx upstream code
+  Future<void> dispose();                   // close(force: true), clears mappings
 }
 ```
 
@@ -107,7 +108,13 @@ class LoopbackProxy {
      `Content-Length`, `Content-Range`, `Accept-Ranges`; then **pipe the upstream
      body straight through** (no full-file buffering), flushing as bytes arrive.
      `HEAD` relays headers only.
-  4. **Client disconnect (seek/stop) → cancel the upstream fetch** so sockets
+  4. On a **non-2xx upstream** (or fetch throw), record it in `lastUpstreamStatus`
+     (`0` for a connection/timeout failure) and return an error status to the
+     player. This is the **failure side-channel** the controller reads when the
+     engine reports an error (component 6) — the platform player collapses upstream
+     codes into one opaque error, so the real `401/403` vs `404/5xx` distinction
+     can only come from the proxy, not the engine.
+  5. **Client disconnect (seek/stop) → cancel the upstream fetch** so sockets
      don't leak.
 - **One active mapping at a time** (single-player app): registering a new chapter
   evicts the prior id, so any stale loopback URL cleanly `404`s. This is safe
@@ -138,12 +145,15 @@ class PinnedStreamResponse {
   is native — the proxy receives the undrained response and pipes it. No new
   buffering, no new dependency.
 - `4xx/5xx` propagate as status codes for the proxy/controller to act on.
-- **Implementation trap (must honor):** `pinnedRangeFetch` reuses **one pooled
-  `HttpClient`**. `cancel()` MUST abort only *this* request — cancel the
-  `HttpClientResponse` stream subscription / detach the socket — and MUST NOT call
-  `client.close(force: true)`, which would kill every concurrent range fetch and
-  the shared pool. The buffered `pinnedRangeFetch` (downloader hot path) is
-  otherwise **untouched**; the two share only the private factory.
+- **Implementation trap (must honor):** `cancel()` MUST abort only *this* request
+  by holding the `StreamSubscription` from `response.listen(...)` and calling
+  `subscription.cancel()` (dart:io tears down that one socket). It MUST NOT call
+  `client.close(force: true)` — a `pinnedRangeStream` client is per-call, so
+  closing it wouldn't hurt the downloader, but it **would** kill sibling concurrent
+  range fetches within the same playback session. Corollary: the proxy must
+  manually `.listen()`-and-forward, **not** `response.pipe(httpResponse)` (which
+  gives no subscription handle to cancel). The buffered `pinnedRangeFetch`
+  (downloader hot path) is **untouched**; the two share only the private factory.
 
 ### 3. Android cleartext-to-loopback (new — `apps/android/android/app/src/main/res/xml/network_security_config.xml` + manifest wiring)
 
@@ -179,29 +189,34 @@ exception.
 This is **more than a single seam** — the current types don't carry what the
 streaming branch needs, so three things move together:
 
-**(a) Widen `PlayableChapter` to carry upstream identity.** Today
-`PlayableChapter` (`player_controller.dart:16-27`) has only
-`uuid/path/title/durationSec` — no `bookId`/`chapterId`/`urlSuffix` to build
-`/api/books/:bookId/chapters/:chapterId/audio.mp3`, and no `isDownloaded`. Add the
-upstream-identity fields (source: `SyncManifestChapter`, `sync_manifest.dart:104-117`),
-and stop dropping them in the `playlistFor` projection
-(`sync_controller.dart:186-199`), which already emits undownloaded-but-rendered
-chapters (`c.hasAudio`) with a *local* `path` that may not exist on disk.
+**(a) Widen `PlayableChapter` to carry `audioUrl`.** Today `PlayableChapter`
+(`player_controller.dart:16-27`) has only `uuid/path/title/durationSec` and no
+`isDownloaded`. `SyncManifestChapter` (`lib/src/domain/sync_manifest.dart:90-131`)
+already holds `audioUrl` — the **full server path** (`/api/books/$bookId/chapters/
+$id/$urlSuffix`, built server-side, used verbatim at `sync_controller.dart:105`).
+So the widening is just: carry `audioUrl` on `PlayableChapter` and stop dropping it
+in the `playlistFor` projection (`sync_controller.dart:186-199`), which already
+emits undownloaded-but-rendered chapters (`c.hasAudio`) with a *local* `path` that
+may not exist on disk. `_resolveUpstream(c)` is then `_resolveUrl(c.audioUrl)` — no
+`bookId`+`chapterId`+`urlSuffix` re-assembly needed.
 
 **(b) "Downloaded?" is a file-existence check on `c.path`**, not a non-existent
 `isDownloaded` flag.
 
 **(c) Expand the `PlayerController` constructor.** It currently injects none of
-the streaming deps; add `settings` (for `streamOverLan`), a reachability source
+the streaming deps; add `fileStore` (for the `exists()` check — `file_store.dart`,
+not currently injected), `settings` (for `streamOverLan`), a reachability source
 (component 5), the connection/token (`ApiClient` or the paired-server token), and
 the `LoopbackProxy`. Every existing `PlayerController` test gains fakes for these.
 
-The decision point in `_loadIndex` (`player_controller.dart:280`) then becomes:
+The decision point in `_loadIndex` (`player_controller.dart:280`) then becomes
+(note: `_loadIndex` is already `async`, so awaiting the file-existence and
+reachability checks is free):
 
 ```dart
 final src = resolvePlaybackSource(
   localFileExists:  await _fileStore.exists(c.path),
-  onHomeLan:        _reachability.onHomeLan,        // component 5
+  onHomeLan:        await _reachability.onHomeLan(),  // component 5 (async, cheap)
   streamingEnabled: _settings.streamOverLan,
 );
 switch (src) {
@@ -210,12 +225,13 @@ switch (src) {
   case PlaybackSource.lanStream:
     await _proxy.start();                            // FIRST bind, on demand
     final loopback = _proxy.register(
-      upstream: _resolveUpstream(c),                 // needs bookId+chapterId+urlSuffix from (a)
+      upstream: _resolveUrl(c.audioUrl),             // audioUrl carried through (a)
       headers: {'Authorization': 'Bearer ${_conn.token}'},
     );
     await _engine.setStreamUrl(loopback.toString()); // player sees only 127.0.0.1, no headers
   case PlaybackSource.needsDownload:
-    _notifyDownloadToPlay();                         // no silent no-op
+    if (userInitiated) _notifyDownloadToPlay();      // prompt only on explicit play
+    // else (auto-advance): halt the run quietly — no unprompted download nag
 }
 ```
 
@@ -224,48 +240,81 @@ Consequences:
 - `PlaybackSource.lanStream` gets its **first and only production consumer**; the
   `settings_screen.dart` "Stream over LAN" toggle **stops being inert**.
 - `_loadIndex` is also reached via `openBook`, `playChapter`, `_advance`
-  (auto-advance) and `skip`'s `ChapterStep` — so **auto-advancing into an
-  undownloaded chapter streams it too**. That is the desired behavior (seamless
-  LAN listening), not a bug; tests cover the auto-advance path.
+  (auto-advance) and `skip`'s `ChapterStep`. **Auto-advancing into an
+  undownloaded chapter over LAN streams it** (desired — seamless listening); but an
+  auto-advance into `needsDownload` (off-LAN / toggle off) must **halt quietly**,
+  not pop a download prompt mid-listen. The `needsDownload` prompt fires only for a
+  **user-initiated** load; tests cover both the auto-advance-streams and
+  auto-advance-halts-quietly paths.
 - `setStreamUrl` is called with the loopback URL and **no `headers`** (confirmed:
   `just_audio_engine.dart:47` passes `headers: null` → `AudioSource.uri`), so the
   Bearer never reaches the player.
 - Controller `dispose()` also disposes the proxy — no lingering socket.
 - **Dropped from v1:** gating stats-accrual on `processingState == ready` (the
-  `player_controller.dart:352-355` caveat) — `AudioEngine` doesn't expose
-  `processingState`, and adding that seam isn't worth it for an ephemeral preview.
+  `player_controller.dart:352-355` caveat). We add a minimal *error-only* engine
+  seam (§6) for fallback, but **not** the full `processingState` surface — the
+  accrual over-count on a buffer stall isn't worth that for an ephemeral preview.
   See Risks.
 
 ### 5. Reachability signal (`onHomeLan`)
 
 Reuse the existing app-8 network probe (`network_info.dart`, currently
 unconnected). Its enum is `{offline, mobile, wifiMetered, wifiUnmetered}`
-(`sync_gate.dart:7`). The correct attempt-gate is:
+(`sync_gate.dart:7`); `currentNetwork()` returns a `Future<NetworkType>` (a cheap
+`connectivity_plus.checkConnectivity()` — **not** the ~2 s server probe). The
+reachability source exposes:
 
 ```dart
-onHomeLan = network == NetworkType.wifiUnmetered || network == NetworkType.wifiMetered;
+Future<bool> onHomeLan() async {
+  final n = await _networkInfo.currentNetwork();
+  return n == NetworkType.wifiUnmetered || n == NetworkType.wifiMetered;
+}
 ```
 
 **Not** `network != mobile` — that is *true when `offline`*, which would route an
 offline tap to `lanStream` and only discover the failure via a doomed upstream
-fetch. Being on Wi-Fi is a cheap gate; whether the paired server is actually on
-*this* Wi-Fi is settled by the streaming attempt itself (the failure path below).
-No mandatory pre-probe (adds ~2 s and duplicates what the first request proves).
+fetch. (`network_info.dart` today only ever returns `wifiUnmetered`/`mobile`/
+`offline`, so the `wifiMetered` disjunct is presently dead but harmless.) It is
+`await`-ed per load inside the already-async `_loadIndex`; no cached subscription,
+no mandatory pre-probe. Whether the paired server is actually on *this* Wi-Fi is
+settled by the streaming attempt itself (the failure path below).
 
-### 6. Failure / fallback behavior — no silent stalls
+### 6. Engine error seam (`AudioEngine` + `JustAudioEngine`)
 
-The proxy's first upstream request **is** the real reachability test. The engine
-error stream drives fallback (no infinite buffer spinner):
+**New — the fallback in §7 cannot be built without this.** `AudioEngine`
+(`audio_engine.dart:4-38`) exposes `position`/`playing`/`duration`/`completion`
+but **no error stream**, and `JustAudioEngine` doesn't surface just_audio's
+`playbackEventStream`/`processingStateStream`. A failed loopback fetch surfaces in
+just_audio as a player error that today goes nowhere. Add a minimal seam:
 
-| Failure | Where caught | User-visible result |
+```dart
+Stream<Object> get errorStream;   // AudioEngine interface
+```
+
+`JustAudioEngine` maps `_player.playbackEventStream`'s error events (and/or
+`processingStateStream` idle-after-load) onto it; the demo/fake engines emit
+nothing. The `PlayerController` subscribes and drives §7. This is the seam the
+dropped `processingState==ready` idea would also have needed — we add the smaller
+error-only version, not the full processing-state surface.
+
+### 7. Failure / fallback behavior — no silent stalls
+
+The proxy's first upstream request **is** the real reachability test. Fallback is
+driven by the **engine error seam (§6)** — the platform player collapses upstream
+HTTP codes into one opaque error, so on an engine error the controller reads the
+proxy's **`lastUpstreamStatus` side-channel (§1)** to recover the real code and
+route accordingly (no infinite buffer spinner):
+
+| Failure | How the controller learns it | User-visible result |
 |---|---|---|
-| Server unreachable / timeout (wrong Wi-Fi, server off) | proxy → `502/504` → engine error | Stop; message *"Couldn't stream over LAN — download to play"*; chapter stays needs-download |
-| `401/403` (device token expired/revoked) | proxy relays status → controller | Reuse ApiClient's existing **re-pair** path (`api_client.dart:55`) |
-| `404/5xx` from server | proxy relays status → engine error | Same "couldn't stream — download" message |
-| Toggle off / off-Wi-Fi / offline / local file missing | `resolvePlaybackSource → needsDownload` | *"Download this chapter to play"* — never a silent no-op |
+| Server unreachable / timeout (wrong Wi-Fi, server off) | engine error + `lastUpstreamStatus == 0` | Stop; *"Couldn't stream over LAN — download to play"*; chapter stays needs-download |
+| `401/403` (device token expired/revoked) | engine error + `lastUpstreamStatus ∈ {401,403}` | Trigger the existing **re-pair** flow (same UX as `api_client.dart:55`) |
+| `404/5xx` from server | engine error + `lastUpstreamStatus ∈ {404,5xx}` | Same "couldn't stream — download" message |
+| Toggle off / off-Wi-Fi / offline / local file missing | `resolvePlaybackSource → needsDownload` | user-initiated: *"Download this chapter to play"*; auto-advance: halt quietly |
 
-Streaming is best-effort; any failure degrades gracefully to the offline-first
-download flow with a clear one-line message. **No auto-retry.**
+On any stream error the controller also **clears the proxy mapping** (so the stale
+loopback id `404`s) and stops. Streaming is best-effort; every failure degrades to
+the offline-first download flow with a clear one-line message. **No auto-retry.**
 
 ## Testing strategy
 
@@ -285,18 +334,22 @@ automated gate for `apps/android/`.
    second concurrent fetch on the shared pool keeps working after one is
    cancelled). CA-pinning stays covered by the existing `cert_pinning`/`api_client`
    tests — same factory reused.
-3. **Data plumbing** — `PlayableChapter`/`playlistFor` carry `bookId`/`chapterId`/
-   `urlSuffix` through the projection; `_resolveUpstream` builds the correct
-   `/api/books/…/audio.mp3` URL.
-4. **`PlayerController` wiring** (fake engine/proxy/reachability/settings/fileStore):
+3. **Data plumbing** — `PlayableChapter`/`playlistFor` carry `audioUrl` through the
+   projection; `_resolveUrl(c.audioUrl)` yields the correct absolute upstream URL.
+4. **Engine error seam** — `JustAudioEngine` maps a just_audio player-error event
+   onto `errorStream`; the fake engine can emit a synthetic error for controller
+   tests.
+5. **`PlayerController` wiring** (fake engine/proxy/reachability/settings/fileStore):
    downloaded (file exists) → `setFilePath`; undownloaded+on+Wi-Fi →
    `start()`+`register`+`setStreamUrl(loopback)` with **no headers to the engine**;
    **lazy invariant** — `proxy.start()` never called in `localFile`/`needsDownload`
-   branches; toggle off / off-Wi-Fi / offline → `needsDownload` + no proxy start;
-   auto-advance into an undownloaded chapter streams; stream engine-error →
-   fallback message + mapping cleared + **no auto-retry**; `dispose()` disposes the
+   branches; toggle off / off-Wi-Fi / offline → `needsDownload` (user-initiated
+   prompts, auto-advance halts quietly) + no proxy start; auto-advance into an
+   undownloaded chapter streams; **failure routing** — engine error with
+   `lastUpstreamStatus` of `0`/`404`/`5xx` → download message, `401/403` → re-pair
+   flow, each clearing the mapping with **no auto-retry**; `dispose()` disposes the
    proxy.
-5. **`resolvePlaybackSource`** — extend the existing truth-table test; add the
+6. **`resolvePlaybackSource`** — extend the existing truth-table test; add the
    `NetworkType → onHomeLan` mapping (offline ⇒ false).
 
 **Not unit-testable (on-device / declarative):** the `network_security_config.xml`


### PR DESCRIPTION
## Summary

Design-thread deliverables for **app-10 — Stream-over-LAN instant play** (`#553`), which shipped as inert scaffolding in June 2026 and has been **blocked/reopened** ever since: `just_audio` streams via the native platform player (OS trust store), which rejects the companion's app-pinned mkcert CA, so `https://<lan>:8443` audio fails TLS and nothing consumes `lanStream`.

This PR is **docs-only** — no runtime code. It lands:

- **Spec** (`docs/superpowers/specs/2026-07-12-app-10-lan-loopback-proxy-design.md`) — the in-app **loopback TLS-terminating proxy** approach: a `dart:io HttpServer` on `127.0.0.1:0` re-serves CA-pinned HTTPS chapter bytes as plaintext to the native player over loopback. Both invariants preserved (app-pinned CA / no OS cert install; HTTPS-on-LAN / token never off-device). Converged after **3 adversarial assumption-check rounds**.
- **Implementation plan** (`docs/superpowers/plans/2026-07-12-app-10-lan-loopback-proxy.md`) — 9 TDD tasks with full no-placeholder code (`pinnedRangeStream`, `LoopbackProxy`, Android `network_security_config.xml`, `AudioEngine.errorStream` seam, `Reachability`, `PlayableChapter.audioUrl` plumbing, `PlayerController` streaming + failure routing, runtime/app-shell re-pair wiring, docs). Passed the mandatory **Premium/Opus plan-review gate** (*ready-with-fixes* → all 3 must-fix + 5 cleanups folded).
- **Plan 188 reconciliation** — the `app-10` row wrongly claimed "closed #553 / code-complete"; corrected to *blocked-then-designed*, linking the spec + plan.

**Implementation is a separate thread** (the design→implementation handover per the Execution model). `#553` closes on that PR, not this one.

## Test plan

Docs-only — no automated surface. Per CONTRIBUTING.md's doc-only fast-path, `verify.yml` reports green on env-setup alone and the mandatory code-review gate is exempt. The plan's own tests (per-task `flutter test` + `flutter analyze`) run when the implementation thread executes it.

Refs #553
