### PR TITLE
chore: bump version to 1.13.0

### DIFF
--- a/apps/android/pubspec.yaml
+++ b/apps/android/pubspec.yaml
@@ -21,7 +21,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # 3-digit build-iteration band so successive Play uploads of the same marketing
 # version take base+1, base+2, … via `flutter build … --build-number=<N>`).
 # Plan 188.
-version: 1.12.3+11203000
+version: 1.13.0+11300000
 
 environment:
   sdk: ^3.12.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "castwright",
-  "version": "1.12.3",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "castwright",
-      "version": "1.12.3",
+      "version": "1.13.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "castwright",
-  "version": "1.12.3",
+  "version": "1.13.0",
   "private": true,
   "type": "commonjs",
   "engines": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "castwright-server",
-  "version": "1.12.3",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "castwright-server",
-      "version": "1.12.3",
+      "version": "1.13.0",
       "dependencies": {
         "@google/genai": "^2.7.0",
         "@lingo-reader/mobi-parser": "^0.4.6",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "castwright-server",
-  "version": "1.12.3",
+  "version": "1.13.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/tts-sidecar/version.py
+++ b/server/tts-sidecar/version.py
@@ -7,4 +7,4 @@ SIDECAR_PROTOCOL_VERSION in main.py: the protocol version gates adopt/replace of
 a running sidecar, while __version__ is purely informational.
 """
 
-__version__ = "1.12.3"
+__version__ = "1.13.0"


### PR DESCRIPTION
## Summary

Cuts the **v1.13.0** minor release (from v1.12.3). Bumps the version in lockstep across root + server `package.json` (+ both lockfiles), `server/tts-sidecar/version.py`, and `apps/android/pubspec.yaml` (marketing `1.13.0` + monotonic build `11300000`).

Produced by `scripts/bump-version.mjs --level minor`. The cross-OS gate (`cross-os.yml` run 29179627842 — macOS + Windows verify/build + mobile e2e) passed **before** the tag was created. Routed through this PR because `main` blocks direct pushes; the annotated `v1.13.0` tag (body from `docs/release-notes-next.md`) is pushed after merge to trigger `release.yml`.

## Test plan

- Cross-OS gate green (run 29179627842) on the exact origin/main base.
- Pre-push `verify:fast:branch` green on this branch.
- `release.yml` re-verifies the tagged commit (full verify + cross-OS on Ubuntu/macOS/Windows) before publishing.

Closes #1549