### PR TITLE
docs(docs): unwrap hard-wrapped release-notes prose (wiki)

### DIFF
--- a/docs/wiki/Release-Notes-v1.11.0.md
+++ b/docs/wiki/Release-Notes-v1.11.0.md
@@ -37,66 +37,25 @@ flat, unthemed accretion) — see CONTRIBUTING.md "Release notes".
 ### 🎭 Cast-first landing + a pre-flight voice-readiness gate (new) — fe-46
 Confirming a cast now takes you straight to your characters, and starting a render checks every one of them has a voice before committing to a generic stand-in.
 
-- **`confirmCast` now lands on the Cast view, not Manuscript** — the flow
-  becomes confirm → Cast → Manuscript → Generate, with a new "Continue to
-  manuscript" CTA on the Cast view's header action row (#1278).
-- **A pre-flight voice-readiness gate** opens instead of the tier prompt when
-  `startGenerationFlow` finds a speaking Qwen character with no designed
-  voice: lists them in talk-time order, offers "Design full cast" as the
-  primary action and "Proceed anyway — generic Kokoro fallback voices" for
-  English books, and hard-blocks with no proceed affordance for non-English
-  books (#1278).
-- **New reusable selectors** — `src/store/voice-readiness-selectors.ts`
-  (`selectUndesignedQwenCharacters`, sharing the cast view's exact
-  `needsVoiceIds` semantics via `resolveVoiceStatus`) and `src/lib/cast-sort.ts`
-  (`compareCastRows`, extracted out of `views/cast.tsx`).
-  `EnqueueInput`/`QueueEntry` gain an optional per-entry `fallbackConfirmed`
-  flag, stamped at enqueue by the proceed-anyway path so the per-chapter
-  `awaiting_fallback_confirm` gate doesn't re-prompt for that run's fresh
-  chapters — later enqueues still get the per-chapter backstop (#1278).
+- **`confirmCast` now lands on the Cast view, not Manuscript** — the flow becomes confirm → Cast → Manuscript → Generate, with a new "Continue to manuscript" CTA on the Cast view's header action row (#1278).
+- **A pre-flight voice-readiness gate** opens instead of the tier prompt when `startGenerationFlow` finds a speaking Qwen character with no designed voice: lists them in talk-time order, offers "Design full cast" as the primary action and "Proceed anyway — generic Kokoro fallback voices" for English books, and hard-blocks with no proceed affordance for non-English books (#1278).
+- **New reusable selectors** — `src/store/voice-readiness-selectors.ts` (`selectUndesignedQwenCharacters`, sharing the cast view's exact `needsVoiceIds` semantics via `resolveVoiceStatus`) and `src/lib/cast-sort.ts` (`compareCastRows`, extracted out of `views/cast.tsx`). `EnqueueInput`/`QueueEntry` gain an optional per-entry `fallbackConfirmed` flag, stamped at enqueue by the proceed-anyway path so the per-chapter `awaiting_fallback_confirm` gate doesn't re-prompt for that run's fresh chapters — later enqueues still get the per-chapter backstop (#1278).
 
 ### 🛡️ Per-book quality gate report (new) — fs-51
 Every book now ships a visible, exportable "quality gate" receipt — the acoustic, transcript, voice-match, and cast-continuity checks the pipeline already runs, aggregated into one honest card instead of buried in per-chapter detail.
 
-- **New `GET /api/books/{bookId}/qa-report`** composes the existing signal-QA,
-  ASR content-QA, srv-36 voice-drift, and cast-config-drift signals into one
-  `BookQaReport`, computed fresh on every call (nothing new persisted) —
-  display and the text/JSON export can never diverge from each other, since
-  both read the same endpoint (#1433, Closes #973).
-- **A new `QaReportCard`** on both the Listen view (post-generation) and the
-  Generation view (live, refetching on chapter/run completion) — built around
-  a "never show a false pass" rule: a check that never ran, had nothing to
-  check, or was checked incompletely never renders as clean.
-  `chaptersEligible`/`chaptersScored`/`chaptersEmbedFailed` distinguish "gate
-  off" from "nothing to check" from "an isolated embed failure," computed
-  independently of `scoreBook`'s own control flow so the three states can
-  never be confused (#1433).
-- **Fixed a real, pre-existing correctness gap surfaced while building
-  this**: a chapter re-recorded via manual splice or QA-repair was spreading
-  its stale pre-re-record `qa`/`suspect`/`asr` verdict forward instead of
-  writing the fresh one — a repair that genuinely failed to fix a bad
-  sentence could have its `suspect: true` silently cleared to `undefined`.
-  Both `chapter-splice.ts` and `chapter-qa-repair.ts` now write a fresh
-  verdict from the actual re-recorded audio (#1433).
-- **Text and JSON export**, reusing the same aggregated data the card shows —
-  a clean book reads `"Every line held."`, a partial-coverage book states its
-  coverage fractions plainly rather than hiding them.
+- **New `GET /api/books/{bookId}/qa-report`** composes the existing signal-QA, ASR content-QA, srv-36 voice-drift, and cast-config-drift signals into one `BookQaReport`, computed fresh on every call (nothing new persisted) — display and the text/JSON export can never diverge from each other, since both read the same endpoint (#1433, Closes #973).
+- **A new `QaReportCard`** on both the Listen view (post-generation) and the Generation view (live, refetching on chapter/run completion) — built around a "never show a false pass" rule: a check that never ran, had nothing to check, or was checked incompletely never renders as clean. `chaptersEligible`/`chaptersScored`/`chaptersEmbedFailed` distinguish "gate off" from "nothing to check" from "an isolated embed failure," computed independently of `scoreBook`'s own control flow so the three states can never be confused (#1433).
+- **Fixed a real, pre-existing correctness gap surfaced while building this**: a chapter re-recorded via manual splice or QA-repair was spreading its stale pre-re-record `qa`/`suspect`/`asr` verdict forward instead of writing the fresh one — a repair that genuinely failed to fix a bad sentence could have its `suspect: true` silently cleared to `undefined`. Both `chapter-splice.ts` and `chapter-qa-repair.ts` now write a fresh verdict from the actual re-recorded audio (#1433).
+- **Text and JSON export**, reusing the same aggregated data the card shows — a clean book reads `"Every line held."`, a partial-coverage book states its coverage fractions plainly rather than hiding them.
 
 ### 🩺 Live voice-match progress + a manual resume for a stuck check (new) — fs-72
 The voice-match check used to batch every character's result until the whole book's cast was done — a book with many minor characters could sit at "0 of N scored" for the entire generation with zero indication it was actually working, and a killed check on an already-rendered book had no way to pick back up.
 
-- **Each character's voice-match result now saves the moment it's ready**,
-  cheapest characters first — no more waiting on your book's rarest voices
-  before you see anything at all (Closes #1449).
-- **A live "Checking character voices — X of Y done" readout** on the
-  Quality Gate card, plus a matching Activity feed entry, while the check
-  runs in the background during generation.
-- **A "Resume scoring" button** appears if a check gets interrupted (e.g. a
-  restart) on a book that's already finished rendering, with nothing left to
-  automatically pick it back up.
-- **A transient hiccup checking a character's voice now genuinely retries**
-  (up to 3 times) instead of being permanently marked "can't be checked" —
-  only a character whose voice truly can't be built settles into that state.
+- **Each character's voice-match result now saves the moment it's ready**, cheapest characters first — no more waiting on your book's rarest voices before you see anything at all (Closes #1449).
+- **A live "Checking character voices — X of Y done" readout** on the Quality Gate card, plus a matching Activity feed entry, while the check runs in the background during generation.
+- **A "Resume scoring" button** appears if a check gets interrupted (e.g. a restart) on a book that's already finished rendering, with nothing left to automatically pick it back up.
+- **A transient hiccup checking a character's voice now genuinely retries** (up to 3 times) instead of being permanently marked "can't be checked" — only a character whose voice truly can't be built settles into that state.
 
 ---
 

--- a/docs/wiki/Release-Notes-v1.12.md
+++ b/docs/wiki/Release-Notes-v1.12.md
@@ -1,7 +1,4 @@
-Covers the whole v1.12.x line: the v1.12.0 minor release plus its three follow-on patches. [v1.12.0 on GitHub](https://github.com/dudarenok-maker/Castwright/releases/tag/v1.12.0) ·
-[v1.12.1 on GitHub](https://github.com/dudarenok-maker/Castwright/releases/tag/v1.12.1) ·
-[v1.12.2 on GitHub](https://github.com/dudarenok-maker/Castwright/releases/tag/v1.12.2) ·
-[v1.12.3 on GitHub](https://github.com/dudarenok-maker/Castwright/releases/tag/v1.12.3).
+Covers the whole v1.12.x line: the v1.12.0 minor release plus its three follow-on patches. [v1.12.0 on GitHub](https://github.com/dudarenok-maker/Castwright/releases/tag/v1.12.0) · [v1.12.1 on GitHub](https://github.com/dudarenok-maker/Castwright/releases/tag/v1.12.1) · [v1.12.2 on GitHub](https://github.com/dudarenok-maker/Castwright/releases/tag/v1.12.2) · [v1.12.3 on GitHub](https://github.com/dudarenok-maker/Castwright/releases/tag/v1.12.3).
 
 ---
 
@@ -186,54 +183,17 @@ is resolved.
 ### 🗣️ Deterministic dialogue-structure attribution (new) — srv-59
 A structure-evidence pass now corrects tag-proven speaker mistakes before you ever see them, and replaces the model's own inflated self-reported confidence with an honest, derived value.
 
-- **A new pure-code `server/src/analyzer/dialogue-structure/` module family**
-  (per-language convention tables for en/es/fr/de/ru) slots into
-  `attributeChapterStage2`: a structure parser derives
-  `tag-name`/`tag-pronoun`/`alternation`/`unanchored` speaker evidence per
-  paragraph, an aligner matches it against the stage-2 model output (tolerant
-  of glyph/whitespace drift), and a cross-examiner replays every sentence
-  against that evidence with confidence values drawn from one `CONFIDENCE`
-  constants block instead of the model's own — measured on a 14,065-sentence
-  Russian book, every sentence self-reported confidence ≥ 0.8, so the
-  existing `< 0.75` low-confidence triage view never fired despite heaps of
-  real ambiguity.
-- **Two hard invariants:** a `tag-name` attribution is never overridden by
-  anything, including the new default-on `'local'` escalation pass over
-  unresolved conversation windows (`analyzer.structure.escalation`); a
-  dash-continuation sentence inside a speech span is exempt from the
-  narrator-default demotion, closing a bug in the shipped plan-221 Wave A
-  heuristic this engine absorbs.
-- **Engine-off (`analyzer.structure.enabled`, default on), an unsupported
-  book language, or a chapter's alignment rate falling below its floor** all
-  degrade to byte-identical pre-engine output. Two new additive `state.json`
-  fields (`analysisProvenance`: engine/model/timestamp; a per-run
-  structure-engine report: aligned%/confirmed/corrected/flagged/escalated)
-  close a forensics gap — nothing previously recorded which analyzer produced
-  a given analysis.
-- New Castwright-owned dash-dialogue Russian fixture plus full
-  unit/integration coverage across parser/aligner/cross-examiner/escalation/
-  windows. On-box acceptance against the full _Ночной дозор_ book is owed
-  post-merge. See [plan 247](features/247-dialogue-structure-attribution.md)
-  (#1482, srv-59, Closes #1471).
+- **A new pure-code `server/src/analyzer/dialogue-structure/` module family** (per-language convention tables for en/es/fr/de/ru) slots into `attributeChapterStage2`: a structure parser derives `tag-name`/`tag-pronoun`/`alternation`/`unanchored` speaker evidence per paragraph, an aligner matches it against the stage-2 model output (tolerant of glyph/whitespace drift), and a cross-examiner replays every sentence against that evidence with confidence values drawn from one `CONFIDENCE` constants block instead of the model's own — measured on a 14,065-sentence Russian book, every sentence self-reported confidence ≥ 0.8, so the existing `< 0.75` low-confidence triage view never fired despite heaps of real ambiguity.
+- **Two hard invariants:** a `tag-name` attribution is never overridden by anything, including the new default-on `'local'` escalation pass over unresolved conversation windows (`analyzer.structure.escalation`); a dash-continuation sentence inside a speech span is exempt from the narrator-default demotion, closing a bug in the shipped plan-221 Wave A heuristic this engine absorbs.
+- **Engine-off (`analyzer.structure.enabled`, default on), an unsupported book language, or a chapter's alignment rate falling below its floor** all degrade to byte-identical pre-engine output. Two new additive `state.json` fields (`analysisProvenance`: engine/model/timestamp; a per-run structure-engine report: aligned%/confirmed/corrected/flagged/escalated) close a forensics gap — nothing previously recorded which analyzer produced a given analysis.
+- New Castwright-owned dash-dialogue Russian fixture plus full unit/integration coverage across parser/aligner/cross-examiner/escalation/ windows. On-box acceptance against the full _Ночной дозор_ book is owed post-merge. See [plan 247](features/247-dialogue-structure-attribution.md) (#1482, srv-59, Closes #1471).
 
 ### 💾 Script Review results now persist (new) — fs-58
 Findings from a script review used to live only in the moment — reload the page, close the tab, or click away, and they were gone, whether you'd acted on them or not. They now survive across a reload, and closing the results modal can never silently discard them.
 
-- **The server checkpoints each chapter's findings into a per-book on-disk
-  ledger** as a review runs — a mid-review reload reattaches to the same
-  server-side job instead of losing it.
-- **The modal's close paths now dispatch a non-destructive hide**; only an
-  explicit, confirmation-gated "Dismiss all" discards findings. A badge +
-  re-run confirm gate also stop a fresh review from starting blind over a
-  chapter with unresolved findings already sitting untouched.
-- **Fixed a data-loss bug found while shipping this:** a single-chapter (or
-  partial) review run could silently wipe OTHER chapters' still-unresolved
-  findings out of the in-memory bucket, and mount-time hydration could
-  force-reopen a modal the user had explicitly hidden. `setReview` now merges
-  by chapter instead of a whole-bucket replace; `hydrateBucket` preserves an
-  existing bucket's `visible` flag. See
-  [`docs/features/INDEX.md`'s fs-58 entry](features/INDEX.md) for the full
-  design (#1479).
+- **The server checkpoints each chapter's findings into a per-book on-disk ledger** as a review runs — a mid-review reload reattaches to the same server-side job instead of losing it.
+- **The modal's close paths now dispatch a non-destructive hide**; only an explicit, confirmation-gated "Dismiss all" discards findings. A badge + re-run confirm gate also stop a fresh review from starting blind over a chapter with unresolved findings already sitting untouched.
+- **Fixed a data-loss bug found while shipping this:** a single-chapter (or partial) review run could silently wipe OTHER chapters' still-unresolved findings out of the in-memory bucket, and mount-time hydration could force-reopen a modal the user had explicitly hidden. `setReview` now merges by chapter instead of a whole-bucket replace; `hydrateBucket` preserves an existing bucket's `visible` flag. See [`docs/features/INDEX.md`'s fs-58 entry](features/INDEX.md) for the full design (#1479).
 
 ### 🎬 Caption/SRT export (new) — fs-52
 Any finished book can now export `.srt`/`.vtt` captions — line, sentence, or word granularity, whole-book or per-chapter — as a new `captions` `BookExportJob` format (fs-52, #PR).
@@ -255,21 +215,8 @@ Any finished book can now export `.srt`/`.vtt` captions — line, sentence, or w
 - **Script Review's in-flight jobs can now be cancelled, and a reload can no longer silently start a duplicate re-review.** Two narrow, deliberately-accepted gaps in the persistence work above (#1479) are closed. A new book-level `POST .../script-review/cancel` reuses each running job's existing `AbortController`; a mid-chapter cancel now skips the checkpoint for the in-flight chapter entirely rather than persisting a partial result the ledger couldn't distinguish from a fully-reviewed one, and the SSE stream now ends with a terminal `cancelled` event instead of hanging with no terminal event at all. A new join-only `POST .../script-review/attach` closes a TOCTOU race in the reattach-on-reload path: if the job finished in the gap between the client's `GET /state` and its join, the route now 404s instead of falling through to create a fresh job, and the client falls back to a plain ledger re-read instead of silently re-running the whole review. `attachToRunningReview` deliberately still never dispatches the shared `clear` action itself, preserving the persistence work's own concurrent-reattach fix (#1481).
 - **The off-roster reattribute confirm form could leak a field across a multi-op batch.** `CreateCharacterForm`'s name/gender/ageRange fields are seeded via `useState(initial ...)`, which only runs on first mount; `ScriptReviewDiff`'s confirm-queue overlay (`src/components/script-review-diff.tsx`) rendered the same JSX element across every `confirm.index` advance with no `key`, so React reused the instance and a field typed for op N could survive into op N+1's own form — and, if unedited, reach op N+1's create/reassign call. The form is now keyed on the op's own identity (`opKey`) so it remounts, and its state resets, on every confirm-queue advance (#1480).
 - **The Pinokio one-click installer's menu was fundamentally broken, across two attempts to fix it.** First surfaced during on-box acceptance (#822): root `pinokio.js` used CommonJS syntax (`require`/`__dirname`/`module.exports`) under the root `package.json`'s `"type": "module"`, throwing a `ReferenceError` (bug #1458) — "fixed" by rewriting it as genuine ESM (`import`/`export default`), on the assumption that Pinokio's runtime dynamically `import()`s app scripts. That assumption was itself wrong (bug #1484): Pinokio's kernel (`pinokiocomputer/pinokiod`, `kernel/loader.js`, `requireJS()`) actually loads scripts with a plain synchronous `require(filepath)`, which cannot load an ES module at all — so the install screen still never loaded, for a different reason. Root `pinokio.js` is now genuine CommonJS again, matching every other `pinokio/**` script, and the root `package.json` is `"type": "commonjs"` (was `"module"`) to make that load correctly; `eslint.config.js` — the only other bare `.js` file at the repo root relying on ESM syntax — is renamed to `eslint.config.mjs` to keep working under the new default. The regression test now `require()`s the entry via `createRequire` instead of dynamically `import()`ing it, so it actually reproduces Pinokio's real loading path (#1458, #1484, #1485).
-- **FlashAttention-2 detection is no longer Windows-only, and the stale
-  Windows pin is no longer the only path.** `install-qwen3.mjs --flash-attn`
-  now checks whether `flash_attn` is already importable in the sidecar venv
-  on ANY platform/accelerator profile first — if so, it just reports how to
-  activate it (`QWEN_ATTN_IMPL=flash_attention_2`) rather than attempting a
-  reinstall. On Linux, when it isn't already present and the standalone
-  NVIDIA CUDA Toolkit (`nvcc`) is on PATH, the installer now attempts an
-  unpinned `pip install flash-attn --no-build-isolation` build; without the
-  toolkit it skips cleanly instead of burning a doomed compile. The Windows
-  pinned-wheel path (still cp311-only; the cp312/torch2.11/cu128 real-stack
-  fix is tracked on side-22, #1001) is unchanged. (side-21, #1000)
-- **The library welcome subhead no longer hardcodes "book seven."** `LibraryChrome`
-  (`src/components/library/library-chrome.tsx`) claimed a character "carries through
-  to book seven" regardless of how many books are actually in the library — now
-  reads "book after book," which holds true at any count (#1493, Closes #1461).
+- **FlashAttention-2 detection is no longer Windows-only, and the stale Windows pin is no longer the only path.** `install-qwen3.mjs --flash-attn` now checks whether `flash_attn` is already importable in the sidecar venv on ANY platform/accelerator profile first — if so, it just reports how to activate it (`QWEN_ATTN_IMPL=flash_attention_2`) rather than attempting a reinstall. On Linux, when it isn't already present and the standalone NVIDIA CUDA Toolkit (`nvcc`) is on PATH, the installer now attempts an unpinned `pip install flash-attn --no-build-isolation` build; without the toolkit it skips cleanly instead of burning a doomed compile. The Windows pinned-wheel path (still cp311-only; the cp312/torch2.11/cu128 real-stack fix is tracked on side-22, #1001) is unchanged. (side-21, #1000)
+- **The library welcome subhead no longer hardcodes "book seven."** `LibraryChrome` (`src/components/library/library-chrome.tsx`) claimed a character "carries through to book seven" regardless of how many books are actually in the library — now reads "book after book," which holds true at any count (#1493, Closes #1461).
 
 ---
 

--- a/docs/wiki/Release-Notes.md
+++ b/docs/wiki/Release-Notes.md
@@ -1,8 +1,6 @@
 # Release Notes
 
-Full, unabridged release notes for every shipped version — copied verbatim
-from each version's GitHub Release. For the shorter, user-facing summary
-surfaced in the app, see [RELEASE_NOTES.md](https://github.com/dudarenok-maker/Castwright/blob/main/RELEASE_NOTES.md).
+Full, unabridged release notes for every shipped version — copied verbatim from each version's GitHub Release. For the shorter, user-facing summary surfaced in the app, see [RELEASE_NOTES.md](https://github.com/dudarenok-maker/Castwright/blob/main/RELEASE_NOTES.md).
 
 - [v1.13.0](Release-Notes-v1.13.0) — 2026-07-12
 - [v1.12](Release-Notes-v1.12) — 2026-07-10 (v1.12.0, v1.12.1, v1.12.2, v1.12.3)


### PR DESCRIPTION
## Summary

GitHub renders release/wiki bodies with hard line breaks, so historical release notes hard-wrapped at ~72–80 cols displayed with mid-sentence breaks. This un-wraps the affected **wiki** pages so each bullet/paragraph is one physical line: the `Release-Notes.md` index header paragraph, `Release-Notes-v1.11.0.md`, and the v1.12.0 section of the `Release-Notes-v1.12.md` bundle. (The historical standalone wiki pages v1.0.0–v1.7.0 were already unwrapped.)

The matching **GitHub Release bodies** — v1.0.0, v1.1.0, v1.2.2, v1.3.1, v1.4.0, v1.5.0, v1.5.1, v1.6.0, v1.7.0, v1.11.0, v1.12.0 — were reflowed the same way via `gh release edit` (already applied).

Content-preserving: only soft-wrap newlines were joined (blockquote continuations drop the redundant `>` marker). Every file was verified **prose-identical** before applying.

## Test plan

Docs-only. Re-scanned all 11 GitHub bodies post-edit → 0 wrapped lines; wiki changes verified prose-identical against the pre-reflow source. Published to the wiki remote via `wiki:sync`.

Closes #1553