### PR TITLE
docs(server): fs-59 CJK (zh/ja) support — design spec + implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-07-13-fs59-cjk-support.md
+++ b/docs/superpowers/plans/2026-07-13-fs59-cjk-support.md
@@ -1,0 +1,468 @@
+# fs-59 CJK (Chinese / Japanese) Support — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add end-to-end Chinese (`zh`) and Japanese (`ja`) support — analysis + synthesis on both Qwen and Coqui XTTS — reusing the shipped fs-50 language framework.
+
+**Architecture:** CJK is a follow-on to fs-50 (registry + server-side detection + dual-gate rollout). Detection already routes Han→`zh` / Kana→`ja`; adding registry rows flips it on. The CJK-specific work is: a per-paragraph CJK sentence-split (`Intl.Segmenter`), a CJK-aware dup-key floor in the coverage guard, `dialogue-structure/lang/{zh,ja}` convention tables, per-language prompt examples, Qwen CJK calibration ref-text, and a Coqui `ENGINE_LANGUAGE_SUPPORT` extension + `zh`→`zh-cn` code map. A **language-agnostic attribution eval harness** lands first (Wave 1) as the gate every language needs. `supported` flips per language only after an on-box dual gate (Wave 5).
+
+**Tech Stack:** TypeScript (server, Vitest + node env), Python (tts-sidecar, pytest), `Intl.Segmenter` (Node/ICU built-in, no new dep), Qwen + Coqui XTTS v2 sidecar engines.
+
+**Design spec:** `docs/superpowers/specs/2026-07-13-fs59-cjk-support-design.md` — read §2.1 (empirical validation) before touching the coverage guard.
+
+## Global Constraints
+
+- **No new runtime dependency.** Segmentation uses `Intl.Segmenter` (Node/ICU built-in). Never add jieba/fugashi/nodejieba. (Confirmed: `node >=20.19.0`, `.nvmrc` 24, full-ICU default.)
+- **Ship `supported:false` through W1–W4.** Only Wave 5 flips `zh`/`ja` to `supported:true`, per-language (independent — a JA miss does not hold ZH), and only after the on-box dual gate.
+- **Every task lands paired automated tests** (project rule). New behaviour → new test; bug fix → a test that fails before / passes after.
+- **Registry knob rule:** any `registry.ts` config knob added needs `npm run config:sync` in the same commit.
+- **Scope: Chinese + Japanese only.** Korean (`ko`) is explicitly OUT (spaced Hangul, no shared foundations) → fs-70. Do not add `ko`.
+- **Self-detecting, not language-threaded:** the coverage-guard and `isNarrativeLine` fixes key off per-text Han/Kana presence, NOT a threaded book-language param (those seams have none).
+- **Reconcile, don't absorb:** Wave 5 reconciles fs-70 (#1303) by reference (marks its zh-cn/ja slice done-by-fs-59, narrows its charter). Do not silently delete fs-70.
+
+---
+
+## Wave 1 — Attribution eval harness (language-agnostic · own PR)
+
+Net-new infra. Lives under a new `server/src/analyzer/attribution-eval/`. Proven on an English fixture so it needs no fluent CJK labeler. Consumed by the Wave-5 gate for every language.
+
+### Task 1.1: Labelled-sample schema + loader
+
+**Files:**
+- Create: `server/src/analyzer/attribution-eval/schema.ts`
+- Test: `server/src/analyzer/attribution-eval/schema.test.ts`
+
+**Interfaces:**
+- Produces: `interface LabelledChapter { chapterText: string; lines: Array<{ text: string; speakerId: string }> }`; `function parseLabelledChapter(json: unknown): LabelledChapter` (zod-validated; throws on malformed input).
+
+- [ ] **Step 1: Write the failing test** — a valid object parses; a missing `speakerId` throws.
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { parseLabelledChapter } from './schema.js';
+
+describe('parseLabelledChapter', () => {
+  it('accepts a well-formed labelled chapter', () => {
+    const ok = { chapterText: 'Hello. World.', lines: [{ text: 'Hello.', speakerId: 'narrator' }] };
+    expect(parseLabelledChapter(ok).lines).toHaveLength(1);
+  });
+  it('rejects a line missing speakerId', () => {
+    const bad = { chapterText: 'x', lines: [{ text: 'x' }] };
+    expect(() => parseLabelledChapter(bad)).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails** — `cd server && npx vitest run src/analyzer/attribution-eval/schema.test.ts` → FAIL (module not found).
+- [ ] **Step 3: Implement** — a zod schema (`zod` is already a dep; see `gemini.ts`) with `chapterText: z.string()`, `lines: z.array(z.object({ text: z.string(), speakerId: z.string() }))`, and `parseLabelledChapter = (j) => LabelledChapterSchema.parse(j)`.
+- [ ] **Step 4: Run test to verify it passes.**
+- [ ] **Step 5: Commit** — `feat(server): attribution-eval labelled-chapter schema (fs-59 W1)`.
+
+### Task 1.2: Scorer (id-alignment → FP/FN)
+
+**Files:**
+- Create: `server/src/analyzer/attribution-eval/scorer.ts`
+- Test: `server/src/analyzer/attribution-eval/scorer.test.ts`
+
+**Interfaces:**
+- Consumes: `LabelledChapter` (Task 1.1); analyzer output shaped as `Array<{ text: string; characterId: string }>` (the stage-2 sentence shape).
+- Produces: `interface AttributionScore { truePositive: number; falsePositive: number; falseNegative: number; precision: number; recall: number; perLine: Array<{ text: string; truth: string; predicted: string | null; correct: boolean }> }`; `function scoreAttribution(truth: LabelledChapter, predicted: Array<{ text: string; characterId: string }>, aliasMap?: Map<string,string>): AttributionScore`.
+
+**Design notes (from spec §3.4):** align by `text` after the same normalisation `stage2-coverage.ts` `words()` uses (so smart quotes / spacing don't misalign). `aliasMap` collapses truth↔predicted id differences (alias-merge / id-stability): apply it to BOTH ids before comparing. A predicted line whose normalised text isn't in truth is an FP; a truth line with no matching prediction is an FN; a match with the wrong (alias-resolved) id is both an FP and an FN for that line.
+
+- [ ] **Step 1: Write the failing test** — perfect match scores precision=recall=1.0; a single mis-attribution produces FP=FN=1; an alias map rescues an id rename.
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { scoreAttribution } from './scorer.js';
+
+const truth = { chapterText: '', lines: [
+  { text: '"Careful."', speakerId: 'mairin' },
+  { text: 'She said.', speakerId: 'narrator' },
+] };
+
+describe('scoreAttribution', () => {
+  it('perfect match → precision/recall 1.0', () => {
+    const pred = [{ text: '"Careful."', characterId: 'mairin' }, { text: 'She said.', characterId: 'narrator' }];
+    const s = scoreAttribution(truth, pred);
+    expect(s.precision).toBe(1); expect(s.recall).toBe(1); expect(s.falsePositive).toBe(0);
+  });
+  it('one mis-attribution → FP and FN each 1', () => {
+    const pred = [{ text: '"Careful."', characterId: 'narrator' }, { text: 'She said.', characterId: 'narrator' }];
+    const s = scoreAttribution(truth, pred);
+    expect(s.falsePositive).toBe(1); expect(s.falseNegative).toBe(1);
+  });
+  it('alias map rescues an id rename', () => {
+    const pred = [{ text: '"Careful."', characterId: 'char_7' }, { text: 'She said.', characterId: 'narrator' }];
+    const s = scoreAttribution(truth, pred, new Map([['char_7', 'mairin']]));
+    expect(s.precision).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails.**
+- [ ] **Step 3: Implement** the scorer per the design notes. Reuse a local copy of `words()`-normalisation (or import a shared normaliser if one exists) to key lines.
+- [ ] **Step 4: Run test to verify it passes.**
+- [ ] **Step 5: Commit** — `feat(server): attribution-eval scorer with FP/FN + alias map (fs-59 W1)`.
+
+### Task 1.3: English proving fixture + end-to-end harness test
+
+**Files:**
+- Create: `server/src/analyzer/attribution-eval/__fixtures__/coalfall-ch1.en.labelled.json`
+- Create: `server/src/analyzer/attribution-eval/harness.test.ts`
+
+**Interfaces:**
+- Consumes: `parseLabelledChapter` (1.1), `scoreAttribution` (1.2).
+
+- [ ] **Step 1: Hand-label** ~30 lines of `server/src/__fixtures__/the-coalfall-commission.md` Chapter One into the schema (spoken lines → character ids matching the canned roster; narration/beats → `narrator`). Include at least one interrupted-quote turn (spoken—tag—spoken) so the harness exercises the hard case (mirrors the W5 CJK requirement).
+- [ ] **Step 2: Write the test** — load the fixture, feed it a **deliberately-wrong** predicted set (mis-attribute 3 lines), assert the scorer reports exactly those 3 as FP/FN; feed the correct set, assert precision=recall=1.0.
+- [ ] **Step 3: Run** `cd server && npx vitest run src/analyzer/attribution-eval/harness.test.ts` → PASS.
+- [ ] **Step 4: Commit** — `test(server): attribution-eval English proving fixture (fs-59 W1)`.
+- [ ] **Step 5: Ship notes** — this PR closes W1; note in the PR body that the harness is language-agnostic and reusable for es/fr/de.
+
+---
+
+## Wave 2 — CJK analyze foundations (server · synthetic fixtures · `supported:false`)
+
+### Task 2.1: Registry rows for zh + ja
+
+**Files:**
+- Modify: `server/src/tts/language-registry.ts` (`LanguageEntry` interface + `ENTRIES` array)
+- Test: `server/src/tts/language-registry.test.ts`, `server/src/tts/detect-language.test.ts`
+
+**Interfaces:**
+- Modify `LanguageEntry`: widen `detect.script` to `'latin' | 'cyrillic' | 'cjk'`; add optional `promptExamples?: { roster: string; attribution: string }` (used in W3).
+- Produces: `getLanguageEntry('zh')` / `('ja')` return entries with `supported: false`.
+
+- [ ] **Step 1: Write the failing test** — zh/ja resolve, are `supported:false`, and detection now returns them with `supported:false` from the registry (not a hardcode).
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { getLanguageEntry, isSupportedLanguage } from './language-registry.js';
+
+it('zh/ja are registered but not yet supported', () => {
+  expect(getLanguageEntry('zh')?.sidecarName).toBe('Chinese');
+  expect(getLanguageEntry('ja')?.sidecarName).toBe('Japanese');
+  expect(isSupportedLanguage('zh')).toBe(false);
+  expect(isSupportedLanguage('ja')).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails.**
+- [ ] **Step 3: Implement** — widen the `detect.script` union; add:
+  ```ts
+  { code: 'zh', sidecarName: 'Chinese',  supported: false, detect: { script: 'cjk', iso6393: 'cmn' },
+    headingLexicon: { keywords: ['章', '部', '巻', '節', '幕'], numberWords: [], standalone: ['序章', '終章', '序', '跋', 'プロローグ', 'エピローグ'] },
+    frontMatterKeywords: ['目录', '版权', '致谢', '序言', '后记', '附录', '关于作者'] },
+  { code: 'ja', sidecarName: 'Japanese', supported: false, detect: { script: 'cjk', iso6393: 'jpn' },
+    headingLexicon: { keywords: ['章', '部', '巻', '節', '話', '幕'], numberWords: [], standalone: ['序章', '終章', 'プロローグ', 'エピローグ', 'あとがき', '前書き'] },
+    frontMatterKeywords: ['目次', '著作権', '献辞', '謝辞', 'まえがき', 'あとがき', '付録', '著者について'] },
+  ```
+  (Adjust the exact heading/front-matter terms with a native reviewer at W5 — these are the starting set.)
+- [ ] **Step 4: Run to verify it passes.** Also confirm `detect-language.test.ts` still green (detection already routed zh/ja; now `supported` reads through).
+- [ ] **Step 5: Commit** — `feat(server): register zh/ja (supported:false) (fs-59 W2)`.
+
+### Task 2.2: CJK sentence split in `stage2-chunk`
+
+**Files:**
+- Modify: `server/src/analyzer/stage2-chunk.ts` (`splitParagraphIntoSentences`, `:122`)
+- Test: `server/src/analyzer/stage2-chunk.test.ts`
+
+**Interfaces:**
+- `splitParagraphIntoSentences(para, charBudget)` signature unchanged; behaviour gains a CJK branch (self-detecting).
+
+**Design note:** keep the existing Latin path. Add: if the paragraph contains Han/Kana (`/[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u`) and the Latin split yields ≤1 unit, split via `Intl.Segmenter(lang, { granularity: 'sentence' })` where `lang` is `'ja'` if any Kana present else `'zh'`. Reassemble under `charBudget` exactly as the Latin path does.
+
+- [ ] **Step 1: Write the failing test** — a spaceless CJK paragraph with three `。` sentences splits into ≥3 chunks under a small budget (today it returns `[para]`).
+
+```ts
+it('splits a spaceless CJK paragraph on 。 boundaries', () => {
+  const para = '彼は歩いた。彼女は走った。二人は止まった。';
+  const chunks = splitParagraphIntoSentences(para, 6); // tiny budget forces splitting
+  expect(chunks.length).toBeGreaterThan(1);
+  expect(chunks.join('')).toBe(para); // lossless
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** (current split returns `[para]`).
+- [ ] **Step 3: Implement** the CJK branch with `Intl.Segmenter` sentence granularity, self-detecting the language.
+- [ ] **Step 4: Run to verify it passes;** confirm existing Latin tests stay green.
+- [ ] **Step 5: Commit** — `fix(server): CJK sentence-split fallback in stage2-chunk (fs-59 W2)`.
+
+### Task 2.3: CJK-aware dup-key floor in coverage guard
+
+**Files:**
+- Modify: `server/src/analyzer/stage2-coverage.ts` (`findDuplicatedBlock`, the `key.length < 8` skip, `:117`)
+- Test: `server/src/analyzer/stage2-coverage.test.ts`
+
+**Design note (spec §2.1 — the ONE real CJK coverage bug):** the `<8`-char key skip blinds the dup-detector to short CJK dialogue lines (~80% of CJK dialogue keys are shorter), so a CJK repeat-loop of short quotes passes (measured ratio 1.15, dup=false). Fix: make the floor script-aware — for a key containing Han/Kana, use a **character-count floor of 2** (a 2-char CJK clause is meaningful) instead of 8. Do NOT change `words()` or the ratio band (verified irrelevant — ratio is scale-invariant; mild truncation passing at 0.70 is by-design and language-agnostic).
+
+- [ ] **Step 1: Write the failing test** — a chapter of short CJK dialogue lines with a 4-run repeat is flagged as a duplicated block (today it isn't).
+
+```ts
+it('flags a CJK short-dialogue repeat-loop the <8 key floor used to miss', () => {
+  const line = (t: string) => ({ text: t });
+  const base = ['「そうだ」', '「本当に」', '「行こう」', '「まだだ」'].map(line);
+  const sentences = [...base, ...base]; // a 4-run repeat at constant offset
+  const v = validateStage2Coverage('', sentences, DEFAULT_STAGE2_COVERAGE_THRESHOLDS);
+  expect(v.duplicatedBlock).not.toBeNull();
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** (short keys skipped → no dup).
+- [ ] **Step 3: Implement** — in `findDuplicatedBlock`, replace `if (key.length < 8) return;` with a script-aware floor: compute `const hasCjk = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u.test(key);` and `if (key.length < (hasCjk ? 2 : 8)) return;`.
+- [ ] **Step 4: Run to verify it passes;** add a guard test that a *faithful* CJK attribution still scores `ok: true` (no new false positive).
+- [ ] **Step 5: Commit** — `fix(server): CJK-aware dup-key floor in stage2 coverage guard (fs-59 W2)`.
+
+### Task 2.4: `isNarrativeLine` CJK fix
+
+**Files:**
+- Modify: `server/src/analyzer/strip-front-matter.ts` (`isNarrativeLine`, `:32`)
+- Test: `server/src/analyzer/strip-front-matter.test.ts`
+
+**Design note:** two Latin assumptions break for CJK — `line.length < 60` (CJK is denser) and `/\p{Ll}/u` (never matches caseless Han/Kana). Self-detecting fix: if the line contains Han/Kana, treat it as narrative when it has a CJK sentence ender (`[。！？…]`) and length ≥ a lower CJK threshold (e.g. 15), bypassing the lowercase test.
+
+- [ ] **Step 1: Write the failing test** — a real CJK narrative sentence is recognised as narrative (ends the front-matter region); a short CJK heading is not.
+
+```ts
+it('treats a CJK narrative line as narrative (not front-matter)', () => {
+  const body = '献辞\n\n彼は古い石段の上で足を止め、霧に沈んだ谷を見下ろした。';
+  const out = stripFrontMatterBoilerplate(body, {});
+  expect(out).toContain('彼は古い石段'); // narrative kept
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** (`\p{Ll}` never matches → line treated as front-matter, potentially stripped).
+- [ ] **Step 3: Implement** the self-detecting CJK branch in `isNarrativeLine`.
+- [ ] **Step 4: Run to verify it passes;** English/Russian tests stay green.
+- [ ] **Step 5: Commit** — `fix(server): CJK-aware isNarrativeLine (fs-59 W2)`.
+
+### Task 2.5: CJK token-estimate divisor
+
+**Files:**
+- Modify: `server/src/analyzer/gemini.ts` (`estimateInputTokens`, `:862-899`)
+- Test: `server/src/analyzer/gemini.test.ts`
+
+**Design note:** add `HAN_KANA_CHARS_PER_TOKEN = 1.2` and a CJK-fraction measurement mirroring the existing `countCyrillic`; blend so a CJK-dense prompt uses ≈1.2 (vs Latin 4, Cyrillic 2.5).
+
+- [ ] **Step 1: Write the failing test** — a CJK-dense string estimates ~2× the tokens the current Cyrillic/Latin interpolation gives it.
+
+```ts
+it('estimateInputTokens: CJK uses ~1.2 chars/token', async () => {
+  const { estimateInputTokens } = await import('./gemini.js');
+  const cjk = '彼は歩いた'.repeat(200); // 1000 CJK chars ≈ ~830 tokens at 1.2
+  const est = estimateInputTokens('', wrap(cjk));
+  expect(est).toBeGreaterThan(600); // far above the Latin /4 = 250
+});
+```
+
+- [ ] **Step 2: Run to verify it fails.**
+- [ ] **Step 3: Implement** the CJK constant + fraction measurement.
+- [ ] **Step 4: Run to verify it passes;** existing Latin/Cyrillic assertions stay green.
+- [ ] **Step 5: Commit** — `feat(server): CJK token-estimate divisor (fs-59 W2)`.
+
+---
+
+## Wave 3 — CJK dialogue conventions + prompts (server)
+
+### Task 3.1: `lang/zh.ts` + `lang/ja.ts` convention tables
+
+**Files:**
+- Create: `server/src/analyzer/dialogue-structure/lang/zh.ts`, `.../ja.ts`
+- Modify: `server/src/analyzer/dialogue-structure/lang/index.ts` (`TABLES` map)
+- Test: `server/src/analyzer/dialogue-structure/lang/index.test.ts` + `parser.test.ts`
+
+**Interfaces:** each file exports a `LanguageConventions` (see `../types.ts`) named `zh` / `ja`, registered in `TABLES`.
+
+**Design note:** `dialogueOpen: null` (no dash-dialogue); `quotePairs` — `ja`: `[['「','」'],['『','』']]`; `zh`: `[['「','」'],['『','』'],['“','”']]` (Simplified uses fullwidth `“”`). `nameStemmer: (t) => t` (identity, no inflection); `minStemLength: 1`. `speechVerbStems` (substring-matched): zh `['说','道','问','答','喊','叫','回答','说道','问道','喃喃','低语']`; ja `['言','話','答','尋','叫','呟','囁','続け','応え']`. `beatVerbStems`: zh `['点头','笑','皱眉','叹']`; ja `['頷','笑','頬','息']`. `pronouns`: zh `{ firstPerson: /我/u, male: /他/u, female: /她/u }`; ja `{ firstPerson: /(私|僕|俺)/u, male: /彼(?!女)/u, female: /彼女/u }`.
+
+- [ ] **Step 1: Write the failing test** (`index.test.ts`) — `conventionsFor('zh')` and `('ja')` are non-null with the expected quote pairs.
+
+```ts
+it('registers zh/ja conventions', () => {
+  expect(conventionsFor('ja')?.quotePairs).toContainEqual(['「', '」']);
+  expect(conventionsFor('zh')?.quotePairs).toContainEqual(['“', '”']);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails.**
+- [ ] **Step 3: Implement** both files + register in `TABLES`.
+- [ ] **Step 4: Add a `parser.test.ts` case** — a JA line `「気をつけて」と彼女は言った。` attributes the spoken span to the speaker and the tag to narrator (the §2.1 interrupted-quote defect target). Run; PASS.
+- [ ] **Step 5: Commit** — `feat(server): CJK dialogue-structure conventions zh/ja (fs-59 W3)`.
+
+### Task 3.2: CJK quote glyphs in audio-tags + roster-coverage
+
+**Files:**
+- Modify: `server/src/parsers/audio-tags.ts` (`QUOTE_OPENS`/`QUOTE_CLOSES`, `:22`)
+- Modify: `server/src/analyzer/roster-coverage.ts` (`QUOTE_CHARS_WIDE`, `:171`)
+- Test: the colocated `*.test.ts` for each
+
+- [ ] **Step 1: Write failing tests** — an audio-tag inside `「…」` is detected; a roster tag scan recognises a `「」`-quoted line.
+- [ ] **Step 2: Run to verify they fail.**
+- [ ] **Step 3: Implement** — add `「『` to opens, `」』` to closes; add the same to `QUOTE_CHARS_WIDE`.
+- [ ] **Step 4: Run to verify they pass.**
+- [ ] **Step 5: Commit** — `feat(server): CJK quote glyphs in audio-tags + roster guard (fs-59 W3)`.
+
+### Task 3.3: CJK prompt hints + in-language few-shot examples
+
+**Files:**
+- Modify: `server/src/analyzer/gemini.ts` (`languagePreamble`, `:207-234`; the `LATIN_CONVENTIONS` map / conventions string)
+- Modify: `server/src/tts/language-registry.ts` (populate `promptExamples` on zh/ja — field added in 2.1)
+- Test: `server/src/analyzer/language-preamble.test.ts`
+
+**Design note:** add a CJK conventions clause (「」/`“”` quote marking, no dash-dialogue, tag-is-narrator note) and inject the registry's in-language `promptExamples` (a short roster + an attribution example written in ZH/JA) into the preamble. Target the §2.1 interrupted-quote error with an in-language few-shot showing the second spoken half attributed to the speaker.
+
+- [ ] **Step 1: Write the failing test** — `languagePreamble('zh')` / `('ja')` contain the CJK convention text and the in-language example.
+
+```ts
+it('languagePreamble carries CJK conventions + in-language examples', () => {
+  expect(languagePreamble('ja')).toMatch(/「」|Japanese/);
+  expect(languagePreamble('zh')).toMatch(/“”|「」|Chinese/);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails.**
+- [ ] **Step 3: Implement** — add the zh/ja conventions strings + wire `promptExamples`.
+- [ ] **Step 4: Run to verify it passes.**
+- [ ] **Step 5: Commit** — `feat(server): CJK prompt conventions + in-language few-shot (fs-59 W3)`.
+
+### Task 3.4: tag-grammar gate-OFF for CJK (documented)
+
+**Files:**
+- Modify: `server/src/analyzer/tag-grammar.ts` (add an explanatory comment; leave `zh`/`ja` OUT of `TAG_GRAMMARS`)
+- Test: `server/src/analyzer/tag-grammar.test.ts`
+
+**Design note:** `grammarFor('zh'|'ja')` must return `null` (caller stays gated — a no-op). Its `nameCapture` is `[A-Z]`/`\p{Lu}`; CJK has no case, so the roster-false-positive guard is structurally inapplicable. Document the lost-net in the comment.
+
+- [ ] **Step 1: Write the test** — `grammarFor('zh')` and `('ja')` return `null`.
+- [ ] **Step 2: Run** — likely already passes (they're unmapped); this locks the invariant against a future accidental mapping.
+- [ ] **Step 3: Add the explanatory comment** naming the lost-net (dialogue-structure conventions + the W1 eval harness carry CJK attribution instead).
+- [ ] **Step 4: Run to verify green.**
+- [ ] **Step 5: Commit** — `docs(server): document tag-grammar gate-off for CJK (fs-59 W3)`.
+
+---
+
+## Wave 4 — CJK synthesis, both engines (sidecar + server)
+
+### Task 4a.1: Qwen CJK calibration ref-text
+
+**Files:**
+- Modify: `server/tts-sidecar/main.py` (`CALIBRATION_TEXTS` dict, `~:1888-1905`)
+- Test: `server/tts-sidecar/tests/test_calibration_text.py` (create if absent)
+
+**Design note:** add phonetically-rich `"Chinese"` and `"Japanese"` rows keyed by the sidecar language word (matching `sidecarName`). Today `_calibration_text()` falls back silently to the English pangram for any unmapped language — a CJK designed voice would fix the wrong phoneme set.
+
+- [ ] **Step 1: Write the failing pytest** — `_calibration_text('Chinese')` and `('Japanese')` return CJK text (contain Han/Kana), not the English pangram.
+- [ ] **Step 2: Run** `npm run test:sidecar` → FAIL (falls back to English).
+- [ ] **Step 3: Implement** — add the two rows (a native reviewer refines the exact ref sentences at W5).
+- [ ] **Step 4: Run to verify it passes.**
+- [ ] **Step 5: Commit** — `feat(sidecar): Qwen CJK calibration ref-text (fs-59 W4a)`.
+
+### Task 4a.2: EMOTION_INSTRUCT / fill-tone for CJK (or documented deferral)
+
+**Files:**
+- Modify: `server/src/routes/qwen-voice.ts` (`EMOTION_INSTRUCT`, `~:119`), `server/src/analyzer/fill-tone.ts` (`NUDGES`, `:8`)
+- Test: colocated `*.test.ts`
+
+- [ ] **Step 1:** Decide per the spec — either add ZH/JA emotion/nudge phrases OR document deferral (VoiceDesign persona-stays-English is a known won't-fix). If deferring, add a code comment + a test asserting the fallback is safe (no crash, neutral behaviour). If implementing, TDD a zh/ja emotion phrase lookup.
+- [ ] **Step 2–5:** test-first, implement/decide, run, commit `feat(server): CJK emotion-instruct (or documented deferral) (fs-59 W4a)`.
+
+### Task 4b.0: XTTS language-code pre-check (BLOCKS the rest of 4b)
+
+**Files:**
+- Investigate only (no code): the installed `TTS` package's accepted language set.
+
+- [ ] **Step 1:** In the sidecar venv, confirm XTTS v2's exact Chinese code — `zh-cn` vs `zh` vs `zh_cn` — e.g. `python -c "from TTS.tts.models.xtts import Xtts; print(...)"` or inspect the model config's `languages` list. Record the verified string.
+- [ ] **Step 2:** If it is not `zh-cn`, update Task 4b.2's map accordingly before writing it. **Do not proceed to 4b.1–4b.3 until this string is verified.**
+
+### Task 4b.1: Coqui eligibility for zh/ja
+
+**Files:**
+- Modify: `server/src/tts/voice-mapping.ts` (`ENGINE_LANGUAGE_SUPPORT.coqui`, `:41`)
+- Test: `server/src/tts/language.test.ts`
+
+- [ ] **Step 1: Write the failing test** — `resolveEligibleEngines('zh', ALL_TTS_ENGINES)` returns `['qwen','coqui']` (today `['qwen']`).
+
+```ts
+it('zh/ja are eligible on qwen + coqui', () => {
+  expect(resolveEligibleEngines('zh', ALL_TTS_ENGINES).sort()).toEqual(['coqui', 'qwen']);
+  expect(resolveEligibleEngines('ja', ALL_TTS_ENGINES).sort()).toEqual(['coqui', 'qwen']);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails.**
+- [ ] **Step 3: Implement** — add `'zh','ja'` to the `coqui` array.
+- [ ] **Step 4: Run to verify it passes;** confirm the fs-60 eligibility tests stay green.
+- [ ] **Step 5: Commit** — `feat(server): Coqui XTTS eligible for zh/ja (fs-59 W4b)`.
+
+### Task 4b.2: `zh`→`zh-cn` Coqui language-code map
+
+**Files:**
+- Create: a small helper `coquiLanguageCode(bcp47: string): string` (in `server/src/tts/voice-mapping.ts` or `language.ts`)
+- Modify: `server/src/tts/synthesise-chapter.ts` — apply the map at the **Coqui provider call only** (NOT at the shared `langCode` resolution `:884`, which feeds `expandForSpeech` and must keep the registry code `zh`)
+- Test: `server/src/tts/synthesise-chapter-coqui-fallback.test.ts`
+
+- [ ] **Step 1: Write the failing test** — a Coqui zh synth call carries `language: 'zh-cn'` (use the verified 4b.0 string); `ja` stays `ja`; a non-CJK language is unchanged.
+- [ ] **Step 2: Run to verify it fails.**
+- [ ] **Step 3: Implement** `coquiLanguageCode` (identity except `zh`→`zh-cn`) and apply it only where the Coqui provider receives its `language`.
+- [ ] **Step 4: Run to verify it passes;** assert the Qwen/ASR paths still see `zh` (no leak).
+- [ ] **Step 5: Commit** — `feat(server): zh→zh-cn Coqui language-code map (fs-59 W4b)`.
+
+### Task 4b.3: Coqui CJK output validation (on-box, procedure)
+
+- [ ] Render a short ZH and JA line through Coqui XTTS with an existing `COQUI_PROFILE_VOICES` speaker. Confirm audio is intelligible CJK (cross-lingual voice cloning). Only if quality is unacceptable, curate a CJK speaker subset — otherwise no code. Record the result for the W5 gate.
+
+---
+
+## Wave 5 — Validation + flip (operator tail · own PR)
+
+Not desk-verifiable — needs the GPU box, real weights, the operator's ears, and a fluent ZH/JA labeler.
+
+### Task 5.1: ZH + JA Coalfall fixtures
+
+- [ ] Obtain ZH and JA translations of *The Coalfall Commission* Chapter One (dep: **fs-61** / fluent translator), added alongside `the-coalfall-commission-{es,fr,de,ru}` samples. These feed both the labelled eval chapter and the operator audio gate.
+
+### Task 5.2: Labelled ZH + JA chapters (harness input)
+
+- [ ] Hand-label (fluent speaker) a ZH and a JA chapter into the W1 schema. **Requirement:** each MUST include (a) interrupted-quote turns (spoken—tag—spoken across a fullwidth comma — the §2.1 defect) and (b) roster-false-positive constructions (a name-like token that is not a speaker tag — the case tag-grammar gate-off no longer guards). A clean easy-case chapter hides exactly the errors this validates.
+
+### Task 5.3: Run the W1 harness → record attribution FP/FN
+
+- [ ] Analyse the labelled chapters (Gemini or local), run `scoreAttribution`, record ZH and JA FP/FN/precision/recall. Attribution is engine-independent — one pass covers both engines. Gate: FP/FN within the operator's accepted bound.
+
+### Task 5.4: Operator audio gate — both engines × both languages
+
+- [ ] Design + render ZH and JA Coalfall samples on **Qwen** and on **Coqui XTTS**. Operator listens; confirm Qwen honours a CJK persona and XTTS `zh-cn`/`ja` quality. Record per (engine × language) verdict.
+
+### Task 5.5: Flip `supported` (per language) + reconcile fs-70
+
+**Files:**
+- Modify: `server/src/tts/language-registry.ts` (`zh.supported` / `ja.supported` → `true`, per language that passed)
+- Test: an e2e detect→confirm→cast path for a CJK book once `supported`.
+
+- [ ] **Step 1:** Flip `zh.supported` and/or `ja.supported` to `true` — **independently** (D2: a JA miss does not hold ZH). Add a regression test asserting a CJK book forces Qwen-or-Coqui (never Kokoro) and the never-cross-language invariant holds.
+- [ ] **Step 2:** Update **fs-70 (#1303)**: mark its `zh-cn`/`ja` bullets done-by-fs-59; narrow its charter to the remaining XTTS languages (ko/ar/hi/nl/pl/tr/cs/hu/it/pt). Note the reconciliation on #1004 and #1303.
+- [ ] **Step 3:** Fill the spec's **Ship notes** (shipped date, per-wave SHAs, W5 operator verdict, ZH/JA FP/FN, audio-gate result per engine×language, fs-70 link). Create/finalise the `docs/features/NN-fs59-cjk-support.md` regression plan and move the spec if stable.
+- [ ] **Step 4: Commit** — `feat(server): flip zh/ja supported after CJK dual gate (fs-59 W5)`.
+
+---
+
+## Self-Review — spec coverage
+
+- Registry rows / detection flip → 2.1 ✓
+- Coverage guard (dup-key floor only; word-count ruled out) → 2.3 ✓
+- Sentence split → 2.2 ✓; isNarrativeLine → 2.4 ✓; token divisor → 2.5 ✓
+- Dialogue conventions zh/ja → 3.1 ✓; quote glyphs → 3.2 ✓; prompt few-shot + `promptExamples` field → 3.3 (field added 2.1) ✓; tag-grammar gate-off → 3.4 ✓
+- Qwen calibration → 4a.1 ✓; emotion/nudge → 4a.2 ✓
+- Coqui: zh-cn pre-check → 4b.0 ✓; eligibility → 4b.1 ✓; code map → 4b.2 ✓; output validation → 4b.3 ✓
+- Attribution eval harness (W1, own PR) → 1.1–1.3 ✓
+- Fixtures / labelling / harness run / audio gate / flip / fs-70 reconcile → 5.1–5.5 ✓
+- Korean explicitly excluded (Global Constraints) ✓
+- Independent per-language flip (D2) → 5.5 Step 1 ✓
+
+## Notes for the implementer
+
+- Read spec §2.1 before Task 2.3 — the coverage fix is the dup-key floor ONLY; do not add word-level counting (verified irrelevant: ratio is scale-invariant).
+- The heading/front-matter/speech-verb/calibration term lists in W2–W4 are starting sets; a native ZH/JA reviewer refines them at W5.
+- W4b.0 is a hard gate: verify XTTS's Chinese code before writing the map.
+- W1 is a standalone PR; W2/W3 are server-only and can each be 1–2 PRs; W4/W5 are the operator-gated tail.

--- a/docs/superpowers/plans/2026-07-13-fs59-cjk-support.md
+++ b/docs/superpowers/plans/2026-07-13-fs59-cjk-support.md
@@ -66,11 +66,11 @@ describe('parseLabelledChapter', () => {
 
 **Interfaces:**
 - Consumes: `LabelledChapter` (Task 1.1); analyzer output shaped as `Array<{ text: string; characterId: string }>` (the stage-2 sentence shape).
-- Produces: `interface AttributionScore { truePositive: number; falsePositive: number; falseNegative: number; precision: number; recall: number; perLine: Array<{ text: string; truth: string; predicted: string | null; correct: boolean }> }`; `function scoreAttribution(truth: LabelledChapter, predicted: Array<{ text: string; characterId: string }>, aliasMap?: Map<string,string>): AttributionScore`.
+- Produces: `interface AttributionScore { truePositive: number; falsePositive: number; falseNegative: number; segMismatch: number; precision: number; recall: number; perLine: Array<{ text: string; truth: string | null; predicted: string | null; correct: boolean }> }`; `function scoreAttribution(truth: LabelledChapter, predicted: Array<{ text: string; characterId: string }>, aliasMap?: Map<string,string>): AttributionScore`. (`segMismatch` = predicted lines whose normalised text has no truth match — a segmentation-drift signal, kept separate from attribution FP.)
 
-**Design notes (from spec §3.4):** align by `text` after the same normalisation `stage2-coverage.ts` `words()` uses (so smart quotes / spacing don't misalign). `aliasMap` collapses truth↔predicted id differences (alias-merge / id-stability): apply it to BOTH ids before comparing. A predicted line whose normalised text isn't in truth is an FP; a truth line with no matching prediction is an FN; a match with the wrong (alias-resolved) id is both an FP and an FN for that line.
+**Design notes (from spec §3.4):** align by `text` after the same normalisation `stage2-coverage.ts` `words()` uses (so smart quotes / spacing don't misalign). `aliasMap` collapses truth↔predicted id differences (alias-merge / id-stability): apply it to BOTH ids before comparing. A predicted line whose normalised text isn't in truth is a **`segMismatch`** (segmentation drift — a separate metric, NOT an attribution FP); a truth line with no matching prediction is an FN; a match with the wrong (alias-resolved) id is both an FP and an FN for that line.
 
-**Load-bearing alignment assumption (must hold):** the scorer aligns lines by text, so it REQUIRES that truth and predicted share the same sentence segmentation. If the analyzer splits `「気をつけて」と彼女は言った。` into two lines and the labeller kept it as one (or vice-versa), text-alignment cascades into garbage FP/FN. **Therefore labelled chapters are built ON the analyzer's own segmentation** (Task 1.3 / 5.2): run the analyzer once, then a human corrects only the `speakerId` on its emitted lines — text is never re-segmented by hand. The scorer additionally asserts `predicted.length === truth.length` and flags a segmentation-mismatch error loudly rather than scoring a misaligned pair (so a granularity drift surfaces as an explicit failure, not a silent bad number).
+**Alignment must tolerate segmentation drift (stage-2 is stochastic).** Do NOT align by index or assert `predicted.length === truth.length` — a fresh analyzer run can segment differently than when the fixture was labelled, so a hard length check would flake on exactly the non-determinism the coverage guard exists for. Instead **align by a normalised-text map**: build `Map<normalisedText, speakerId>` from truth; for each predicted line, look up its normalised text — matched+right id = TP, matched+wrong id = FP&FN, **predicted text not in truth = segmentation-mismatch (report as a separate `segMismatch` count, not silently an FP)**, truth line never matched = FN. Emit `segMismatch` as its own metric so drift is visible without hard-failing. Best practice to keep drift low (Task 1.3 / 5.2): build labelled chapters ON the analyzer's own segmentation — run it once, correct only `speakerId`, never re-segment by hand — so `segMismatch` stays near zero and FP/FN reflects attribution, not segmentation.
 
 - [ ] **Step 1: Write the failing test** — perfect match scores precision=recall=1.0; a single mis-attribution produces FP=FN=1; an alias map rescues an id rename.
 
@@ -276,22 +276,24 @@ it('estimateInputTokens: CJK uses ~1.2 chars/token', async () => {
 
 **Why this is its own task (adversarial finding):** "a CJK book splits into chapters" is a #1004 acceptance criterion. The existing `CHAPTER_HEADING_RE` is `^(?:…|(KEYWORD)\s+(NUMBER)\b|(STANDALONE)\b)` — it requires `keyword → whitespace → number` (verified `parsers/text.ts:48-52`). CJK headings are the **circumfix** `第<number>章` — keyword *after* the number, **no whitespace**, and **kanji numerals** (一二三…十百) that `NUMBER_PART` (`[ivxlcdm\d]+`) doesn't match. So the heading lexicon (Task 2.1) cannot split CJK chapters; a dedicated pattern is required, or CJK books collapse to one chapter.
 
-**Design note:** add a CJK alternative to the heading regex: `第[0-9〇一二三四五六七八九十百千]+[章話回節部幕]` (Arabic OR kanji numerals; the common circumfix enders). Also make the STANDALONE match `\p{Script=Han}`/Katakana-aware for `序章`/`終章`/`プロローグ` (the trailing `\b` is unreliable after CJK — anchor on line end / punctuation instead). Self-detecting (the pattern only fires on CJK glyphs); no book-language threading.
+**Entry point (verified):** the splitter is `parseText(text, { format })` (`parsers/text.ts:231`), which tests `normaliseHeading(line)` against `CHAPTER_HEADING_RE` (`:51`, applied `:271`) and flushes a chapter per match. `normaliseHeading` (`:127`) only strips edge non-`\p{L}\p{N}` chars, so `第一章`/`第2章` survive intact (all Han/digit); `MAX_HEADING_LEN` (120) is fine for short CJK headings. **So the ONLY change is `CHAPTER_HEADING_RE` — no `normaliseHeading` change needed.**
 
-- [ ] **Step 1: Write the failing test** — a body with `第一章`, `第2章`, `第十二話` headings splits into the right number of chapters; a mid-paragraph `章` does not misfire.
+**Design note:** add a CJK alternative to `CHAPTER_HEADING_RE`: `第[0-9〇一二三四五六七八九十百千]+[章話回節部幕]` (Arabic OR kanji numerals; the common circumfix enders). Also make the STANDALONE match `\p{Script=Han}`/Katakana-aware for `序章`/`終章`/`プロローグ` (the trailing `\b` is unreliable after CJK — anchor on line end / punctuation instead). Self-detecting (the pattern only fires on CJK glyphs); no book-language threading.
+
+- [ ] **Step 1: Write the failing test** — a body with `第一章`, `第2章`, `第十二話` headings splits into 3 chapters; a mid-paragraph `章` does not misfire.
 
 ```ts
+import { parseText } from './text.js';
+
 it('splits a CJK book on 第N章 / 第N話 circumfix headings', () => {
   const body = '第一章\n\n彼は歩いた。\n\n第2章\n\n彼女は走った。\n\n第十二話\n\n終わり。';
-  const chapters = splitIntoChapters(body); // the parser's chapter splitter
+  const { chapters } = parseText(body, { format: 'plaintext' });
   expect(chapters.length).toBe(3);
 });
 ```
 
-(Use the actual chapter-split entry point in `parsers/text.ts` — confirm its exported name when implementing.)
-
-- [ ] **Step 2: Run to verify it fails** (today: 1 chapter — the circumfix never matches).
-- [ ] **Step 3: Implement** the CJK heading alternative + kanji-numeral class + CJK-aware standalone anchoring.
+- [ ] **Step 2: Run to verify it fails** (`cd server && npx vitest run src/parsers/text.test.ts` — today: 1 chapter, the circumfix never matches).
+- [ ] **Step 3: Implement** the CJK alternative in `CHAPTER_HEADING_RE` + kanji-numeral class + CJK-aware standalone anchoring.
 - [ ] **Step 4: Run to verify it passes;** confirm English/ES/RU heading tests stay green (the new alternative only fires on CJK glyphs).
 - [ ] **Step 5: Commit** — `fix(server): CJK 第N章 chapter-heading split (fs-59 W2)`.
 

--- a/docs/superpowers/plans/2026-07-13-fs59-cjk-support.md
+++ b/docs/superpowers/plans/2026-07-13-fs59-cjk-support.md
@@ -70,6 +70,8 @@ describe('parseLabelledChapter', () => {
 
 **Design notes (from spec §3.4):** align by `text` after the same normalisation `stage2-coverage.ts` `words()` uses (so smart quotes / spacing don't misalign). `aliasMap` collapses truth↔predicted id differences (alias-merge / id-stability): apply it to BOTH ids before comparing. A predicted line whose normalised text isn't in truth is an FP; a truth line with no matching prediction is an FN; a match with the wrong (alias-resolved) id is both an FP and an FN for that line.
 
+**Load-bearing alignment assumption (must hold):** the scorer aligns lines by text, so it REQUIRES that truth and predicted share the same sentence segmentation. If the analyzer splits `「気をつけて」と彼女は言った。` into two lines and the labeller kept it as one (or vice-versa), text-alignment cascades into garbage FP/FN. **Therefore labelled chapters are built ON the analyzer's own segmentation** (Task 1.3 / 5.2): run the analyzer once, then a human corrects only the `speakerId` on its emitted lines — text is never re-segmented by hand. The scorer additionally asserts `predicted.length === truth.length` and flags a segmentation-mismatch error loudly rather than scoring a misaligned pair (so a granularity drift surfaces as an explicit failure, not a silent bad number).
+
 - [ ] **Step 1: Write the failing test** — perfect match scores precision=recall=1.0; a single mis-attribution produces FP=FN=1; an alias map rescues an id rename.
 
 ```ts
@@ -114,7 +116,7 @@ describe('scoreAttribution', () => {
 **Interfaces:**
 - Consumes: `parseLabelledChapter` (1.1), `scoreAttribution` (1.2).
 
-- [ ] **Step 1: Hand-label** ~30 lines of `server/src/__fixtures__/the-coalfall-commission.md` Chapter One into the schema (spoken lines → character ids matching the canned roster; narration/beats → `narrator`). Include at least one interrupted-quote turn (spoken—tag—spoken) so the harness exercises the hard case (mirrors the W5 CJK requirement).
+- [ ] **Step 1: Build the labelled fixture ON the analyzer's segmentation** — run stage-2 attribution over `server/src/__fixtures__/the-coalfall-commission.md` Chapter One, take its emitted `{text, characterId}` lines, and hand-correct ONLY the `speakerId` (never re-split the text) so truth and future predictions share segmentation (see Task 1.2 alignment assumption). Ensure the chapter contains ≥1 interrupted-quote turn (spoken—tag—spoken) so the harness exercises the hard case (mirrors the W5 CJK requirement).
 - [ ] **Step 2: Write the test** — load the fixture, feed it a **deliberately-wrong** predicted set (mis-attribute 3 lines), assert the scorer reports exactly those 3 as FP/FN; feed the correct set, assert precision=recall=1.0.
 - [ ] **Step 3: Run** `cd server && npx vitest run src/analyzer/attribution-eval/harness.test.ts` → PASS.
 - [ ] **Step 4: Commit** — `test(server): attribution-eval English proving fixture (fs-59 W1)`.
@@ -159,6 +161,11 @@ it('zh/ja are registered but not yet supported', () => {
     frontMatterKeywords: ['目次', '著作権', '献辞', '謝辞', 'まえがき', 'あとがき', '付録', '著者について'] },
   ```
   (Adjust the exact heading/front-matter terms with a native reviewer at W5 — these are the starting set.)
+  **NOTE:** the `headingLexicon.keywords` alone do NOT split CJK chapters — the
+  `parsers/text.ts` regex expects `keyword → whitespace → number` (Latin shape),
+  but CJK is the circumfix `第<number>章` with no whitespace and kanji numerals.
+  Chapter splitting is handled by **Task 2.6**, not by this lexicon. Keep the
+  `frontMatterKeywords` here (those DO feed `FRONT_MATTER_RX` as substrings).
 - [ ] **Step 4: Run to verify it passes.** Also confirm `detect-language.test.ts` still green (detection already routed zh/ja; now `supported` reads through).
 - [ ] **Step 5: Commit** — `feat(server): register zh/ja (supported:false) (fs-59 W2)`.
 
@@ -261,6 +268,33 @@ it('estimateInputTokens: CJK uses ~1.2 chars/token', async () => {
 - [ ] **Step 4: Run to verify it passes;** existing Latin/Cyrillic assertions stay green.
 - [ ] **Step 5: Commit** — `feat(server): CJK token-estimate divisor (fs-59 W2)`.
 
+### Task 2.6: CJK chapter-heading split (acceptance-critical)
+
+**Files:**
+- Modify: `server/src/parsers/text.ts` (chapter-heading regex construction, `:20-52`)
+- Test: `server/src/parsers/text.test.ts`
+
+**Why this is its own task (adversarial finding):** "a CJK book splits into chapters" is a #1004 acceptance criterion. The existing `CHAPTER_HEADING_RE` is `^(?:…|(KEYWORD)\s+(NUMBER)\b|(STANDALONE)\b)` — it requires `keyword → whitespace → number` (verified `parsers/text.ts:48-52`). CJK headings are the **circumfix** `第<number>章` — keyword *after* the number, **no whitespace**, and **kanji numerals** (一二三…十百) that `NUMBER_PART` (`[ivxlcdm\d]+`) doesn't match. So the heading lexicon (Task 2.1) cannot split CJK chapters; a dedicated pattern is required, or CJK books collapse to one chapter.
+
+**Design note:** add a CJK alternative to the heading regex: `第[0-9〇一二三四五六七八九十百千]+[章話回節部幕]` (Arabic OR kanji numerals; the common circumfix enders). Also make the STANDALONE match `\p{Script=Han}`/Katakana-aware for `序章`/`終章`/`プロローグ` (the trailing `\b` is unreliable after CJK — anchor on line end / punctuation instead). Self-detecting (the pattern only fires on CJK glyphs); no book-language threading.
+
+- [ ] **Step 1: Write the failing test** — a body with `第一章`, `第2章`, `第十二話` headings splits into the right number of chapters; a mid-paragraph `章` does not misfire.
+
+```ts
+it('splits a CJK book on 第N章 / 第N話 circumfix headings', () => {
+  const body = '第一章\n\n彼は歩いた。\n\n第2章\n\n彼女は走った。\n\n第十二話\n\n終わり。';
+  const chapters = splitIntoChapters(body); // the parser's chapter splitter
+  expect(chapters.length).toBe(3);
+});
+```
+
+(Use the actual chapter-split entry point in `parsers/text.ts` — confirm its exported name when implementing.)
+
+- [ ] **Step 2: Run to verify it fails** (today: 1 chapter — the circumfix never matches).
+- [ ] **Step 3: Implement** the CJK heading alternative + kanji-numeral class + CJK-aware standalone anchoring.
+- [ ] **Step 4: Run to verify it passes;** confirm English/ES/RU heading tests stay green (the new alternative only fires on CJK glyphs).
+- [ ] **Step 5: Commit** — `fix(server): CJK 第N章 chapter-heading split (fs-59 W2)`.
+
 ---
 
 ## Wave 3 — CJK dialogue conventions + prompts (server)
@@ -310,7 +344,7 @@ it('registers zh/ja conventions', () => {
 - Modify: `server/src/tts/language-registry.ts` (populate `promptExamples` on zh/ja — field added in 2.1)
 - Test: `server/src/analyzer/language-preamble.test.ts`
 
-**Design note:** add a CJK conventions clause (「」/`“”` quote marking, no dash-dialogue, tag-is-narrator note) and inject the registry's in-language `promptExamples` (a short roster + an attribution example written in ZH/JA) into the preamble. Target the §2.1 interrupted-quote error with an in-language few-shot showing the second spoken half attributed to the speaker.
+**Design note:** add a CJK conventions clause (「」/`“”` quote marking, no dash-dialogue, tag-is-narrator note) and inject the registry's in-language `promptExamples` (a short roster + an attribution example written in ZH/JA) into the preamble. Target the §2.1 interrupted-quote error with an in-language few-shot showing the second spoken half attributed to the speaker. Also extend the script-annotation at `gemini.ts:213` (`… === 'cyrillic' ? ' (Cyrillic script)' : ''`) to name the CJK script (e.g. `' (Chinese/Japanese script)'`) so the model is told the writing system, mirroring the Cyrillic branch.
 
 - [ ] **Step 1: Write the failing test** — `languagePreamble('zh')` / `('ja')` contain the CJK convention text and the in-language example.
 
@@ -424,7 +458,7 @@ Not desk-verifiable — needs the GPU box, real weights, the operator's ears, an
 
 ### Task 5.2: Labelled ZH + JA chapters (harness input)
 
-- [ ] Hand-label (fluent speaker) a ZH and a JA chapter into the W1 schema. **Requirement:** each MUST include (a) interrupted-quote turns (spoken—tag—spoken across a fullwidth comma — the §2.1 defect) and (b) roster-false-positive constructions (a name-like token that is not a speaker tag — the case tag-grammar gate-off no longer guards). A clean easy-case chapter hides exactly the errors this validates.
+- [ ] Hand-label (fluent speaker) a ZH and a JA chapter into the W1 schema, **built on the analyzer's own segmentation** (Task 1.2 assumption: run the analyzer, correct only `speakerId`, never re-split text). **Requirement:** each MUST include (a) interrupted-quote turns (spoken—tag—spoken across a fullwidth comma — the §2.1 defect) and (b) roster-false-positive constructions (a name-like token that is not a speaker tag — the case tag-grammar gate-off no longer guards). A clean easy-case chapter hides exactly the errors this validates.
 
 ### Task 5.3: Run the W1 harness → record attribution FP/FN
 
@@ -450,6 +484,7 @@ Not desk-verifiable — needs the GPU box, real weights, the operator's ears, an
 ## Self-Review — spec coverage
 
 - Registry rows / detection flip → 2.1 ✓
+- **CJK chapter splitting (第N章 circumfix) → 2.6 ✓ (acceptance-critical; NOT the heading lexicon)**
 - Coverage guard (dup-key floor only; word-count ruled out) → 2.3 ✓
 - Sentence split → 2.2 ✓; isNarrativeLine → 2.4 ✓; token divisor → 2.5 ✓
 - Dialogue conventions zh/ja → 3.1 ✓; quote glyphs → 3.2 ✓; prompt few-shot + `promptExamples` field → 3.3 (field added 2.1) ✓; tag-grammar gate-off → 3.4 ✓
@@ -463,6 +498,9 @@ Not desk-verifiable — needs the GPU box, real weights, the operator's ears, an
 ## Notes for the implementer
 
 - Read spec §2.1 before Task 2.3 — the coverage fix is the dup-key floor ONLY; do not add word-level counting (verified irrelevant: ratio is scale-invariant).
-- The heading/front-matter/speech-verb/calibration term lists in W2–W4 are starting sets; a native ZH/JA reviewer refines them at W5.
+- **Task 2.6 is acceptance-critical** — CJK chapter splitting is a #1004 requirement and does NOT come from the heading lexicon (wrong regex shape). Verify the `parsers/text.ts` chapter-split entry-point name when implementing.
+- **The eval-harness scorer (1.2) assumes truth and predictions share segmentation** — always build labelled chapters on the analyzer's own output and correct only ids; the scorer flags a length/segmentation mismatch loudly rather than scoring misaligned pairs.
+- The heading/front-matter/speech-verb/calibration term lists in W2–W4 are starting sets; a native ZH/JA reviewer refines them at W5. Include **kanji numerals** (一二三…十百) in the 2.6 heading number class, not just Arabic digits.
+- Known-accepted v1 limits (do not over-engineer): the `ja` male-pronoun `/彼(?!女)/` still matches 彼ら/彼氏; a 1-char CJK dup key (`「え」`) is below the floor-2 dup-detector and can evade a pure 1-char-line loop. Both pathological; leave them.
 - W4b.0 is a hard gate: verify XTTS's Chinese code before writing the map.
 - W1 is a standalone PR; W2/W3 are server-only and can each be 1–2 PRs; W4/W5 are the operator-gated tail.

--- a/docs/superpowers/plans/2026-07-13-fs59-cjk-support.md
+++ b/docs/superpowers/plans/2026-07-13-fs59-cjk-support.md
@@ -70,7 +70,7 @@ describe('parseLabelledChapter', () => {
 
 **Design notes (from spec §3.4):** align by `text` after the same normalisation `stage2-coverage.ts` `words()` uses (so smart quotes / spacing don't misalign). `aliasMap` collapses truth↔predicted id differences (alias-merge / id-stability): apply it to BOTH ids before comparing. A predicted line whose normalised text isn't in truth is a **`segMismatch`** (segmentation drift — a separate metric, NOT an attribution FP); a truth line with no matching prediction is an FN; a match with the wrong (alias-resolved) id is both an FP and an FN for that line.
 
-**Alignment must tolerate segmentation drift (stage-2 is stochastic).** Do NOT align by index or assert `predicted.length === truth.length` — a fresh analyzer run can segment differently than when the fixture was labelled, so a hard length check would flake on exactly the non-determinism the coverage guard exists for. Instead **align by a normalised-text map**: build `Map<normalisedText, speakerId>` from truth; for each predicted line, look up its normalised text — matched+right id = TP, matched+wrong id = FP&FN, **predicted text not in truth = segmentation-mismatch (report as a separate `segMismatch` count, not silently an FP)**, truth line never matched = FN. Emit `segMismatch` as its own metric so drift is visible without hard-failing. Best practice to keep drift low (Task 1.3 / 5.2): build labelled chapters ON the analyzer's own segmentation — run it once, correct only `speakerId`, never re-segment by hand — so `segMismatch` stays near zero and FP/FN reflects attribution, not segmentation.
+**Alignment must tolerate segmentation drift (stage-2 is stochastic) AND duplicate lines.** Do NOT align by index or assert `predicted.length === truth.length` — a fresh analyzer run can segment differently than when the fixture was labelled, so a hard length check would flake on exactly the non-determinism the coverage guard exists for. **Do NOT use a plain `Map<normalisedText, speakerId>` either** (independent-review finding): repeated dialogue with different speakers — `「はい」` by A then by B, common in the dialogue-heavy CJK chapters W5 mandates — collapses last-write-wins and mis-counts. Instead **align order-aware over occurrences**: group truth lines by normalised text into a queue per key (preserving order), and walk predicted lines in order, consuming the next unused truth occurrence of that text. For each predicted line — matched+right id = TP, matched+wrong id = FP&FN, **normalised text with no remaining truth occurrence = `segMismatch`** (a separate metric, not silently an FP); any truth occurrence never consumed = FN. Emit `segMismatch` so drift is visible without hard-failing. Best practice to keep drift low (Task 1.3 / 5.2): build labelled chapters ON the analyzer's own segmentation — run it once, correct only `speakerId`, never re-segment by hand — so segmentation matches and `segMismatch` stays near zero.
 
 - [ ] **Step 1: Write the failing test** — perfect match scores precision=recall=1.0; a single mis-attribution produces FP=FN=1; an alias map rescues an id rename.
 
@@ -98,6 +98,15 @@ describe('scoreAttribution', () => {
     const pred = [{ text: '"Careful."', characterId: 'char_7' }, { text: 'She said.', characterId: 'narrator' }];
     const s = scoreAttribution(truth, pred, new Map([['char_7', 'mairin']]));
     expect(s.precision).toBe(1);
+  });
+  it('repeated identical text with different speakers is not collapsed', () => {
+    const dup = { chapterText: '', lines: [
+      { text: '「はい」', speakerId: 'a' }, { text: '「はい」', speakerId: 'b' },
+    ] };
+    const pred = [{ text: '「はい」', characterId: 'a' }, { text: '「はい」', characterId: 'b' }];
+    const s = scoreAttribution(dup, pred);
+    expect(s.truePositive).toBe(2); // order-aware: each occurrence matched to its own truth
+    expect(s.falsePositive).toBe(0);
   });
 });
 ```
@@ -130,28 +139,38 @@ describe('scoreAttribution', () => {
 
 **Files:**
 - Modify: `server/src/tts/language-registry.ts` (`LanguageEntry` interface + `ENTRIES` array)
+- Modify: `server/src/tts/detect-language.ts` (`:49-52` — the CJK branch **hardcodes** `supported: false`)
 - Test: `server/src/tts/language-registry.test.ts`, `server/src/tts/detect-language.test.ts`
 
 **Interfaces:**
 - Modify `LanguageEntry`: widen `detect.script` to `'latin' | 'cyrillic' | 'cjk'`; add optional `promptExamples?: { roster: string; attribution: string }` (used in W3).
-- Produces: `getLanguageEntry('zh')` / `('ja')` return entries with `supported: false`.
+- Produces: `getLanguageEntry('zh')` / `('ja')` return entries; `detectManuscriptLanguage` reports `supported` **read through from the registry**, so the W5 flip actually propagates.
 
-- [ ] **Step 1: Write the failing test** — zh/ja resolve, are `supported:false`, and detection now returns them with `supported:false` from the registry (not a hardcode).
+> **CRITICAL (independent-review finding):** the spec's "adding registry rows flips detection automatically" is FALSE as written. `detect-language.ts:49-52` returns a **literal** `{ language, supported: false }` for CJK, bypassing the `result(code)` helper the ru/latin branches use. If left as-is, flipping `zh.supported = true` at W5 does nothing — `POST /api/import` keeps reporting `languageSupported: false`, the confirm gate keeps blocking, and the whole feature is a dead end despite every wave landing green. This task MUST change that branch to `return result(kana > han ? 'ja' : 'zh')`.
+
+- [ ] **Step 1: Write the failing test** — zh/ja resolve in the registry, and (the load-bearing one) a **temporary** registry stub with `zh.supported = true` makes `detectManuscriptLanguage(cjkText)` report `supported: true` — proving detection reads through, not hardcodes. (Since zh ships `supported:false`, assert the read-through via the helper path: e.g. a unit test that spies the registry, or assert the CJK branch calls `result()`; do NOT rely on the false==false coincidence.)
 
 ```ts
 import { describe, it, expect } from 'vitest';
 import { getLanguageEntry, isSupportedLanguage } from './language-registry.js';
+import { detectManuscriptLanguage } from './detect-language.js';
 
 it('zh/ja are registered but not yet supported', () => {
   expect(getLanguageEntry('zh')?.sidecarName).toBe('Chinese');
   expect(getLanguageEntry('ja')?.sidecarName).toBe('Japanese');
   expect(isSupportedLanguage('zh')).toBe(false);
-  expect(isSupportedLanguage('ja')).toBe(false);
+});
+it('detection reads supported THROUGH the registry for CJK (not a hardcode)', () => {
+  // a Japanese sample → ja, and supported mirrors the registry entry (false today)
+  const r = detectManuscriptLanguage('彼は歩いた。彼女は走った。'.repeat(50));
+  expect(r.language).toBe('ja');
+  expect(r.supported).toBe(getLanguageEntry('ja')?.supported ?? false); // read-through, not literal
 });
 ```
 
-- [ ] **Step 2: Run to verify it fails.**
-- [ ] **Step 3: Implement** — widen the `detect.script` union; add:
+- [ ] **Step 2: Run to verify it fails** (the registry entries don't exist yet).
+- [ ] **Step 3a: Fix the detection read-through** — in `detect-language.ts:49-52`, replace `return { language: kana > han ? 'ja' : 'zh', supported: false };` with `return result(kana > han ? 'ja' : 'zh');` (the `result` helper reads registry `supported`). Update `detect-language.test.ts:52-56` (which pins CJK→`supported:false`) to assert read-through instead of a literal — and note it will need to accept `true` once W5 flips the rows.
+- [ ] **Step 3b: Implement the registry rows** — widen the `detect.script` union; add:
   ```ts
   { code: 'zh', sidecarName: 'Chinese',  supported: false, detect: { script: 'cjk', iso6393: 'cmn' },
     headingLexicon: { keywords: ['章', '部', '巻', '節', '幕'], numberWords: [], standalone: ['序章', '終章', '序', '跋', 'プロローグ', 'エピローグ'] },
@@ -178,16 +197,17 @@ it('zh/ja are registered but not yet supported', () => {
 **Interfaces:**
 - `splitParagraphIntoSentences(para, charBudget)` signature unchanged; behaviour gains a CJK branch (self-detecting).
 
-**Design note:** keep the existing Latin path. Add: if the paragraph contains Han/Kana (`/[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u`) and the Latin split yields ≤1 unit, split via `Intl.Segmenter(lang, { granularity: 'sentence' })` where `lang` is `'ja'` if any Kana present else `'zh'`. Reassemble under `charBudget` exactly as the Latin path does.
+**Design note:** keep the existing Latin path. Add: if the paragraph contains Han/Kana (`/[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u`) and the Latin split yields ≤1 unit, split via `Intl.Segmenter(lang, { granularity: 'sentence' })` where `lang` is `'ja'` if any Kana present else `'zh'`. Reassemble under `charBudget` — but **join CJK segments with NO separator** (independent-review finding: the Latin reassembly joins packed sentences with a space at `stage2-chunk.ts:133`, `` `${cur} ${s}` ``; injecting ASCII spaces into CJK prose is lossy — `chunks.join('')` would no longer equal `para`). Use an empty joiner on the CJK branch.
 
 - [ ] **Step 1: Write the failing test** — a spaceless CJK paragraph with three `。` sentences splits into ≥3 chunks under a small budget (today it returns `[para]`).
 
 ```ts
-it('splits a spaceless CJK paragraph on 。 boundaries', () => {
+it('splits a spaceless CJK paragraph on 。 boundaries, lossless with no injected spaces', () => {
   const para = '彼は歩いた。彼女は走った。二人は止まった。';
-  const chunks = splitParagraphIntoSentences(para, 6); // tiny budget forces splitting
+  const chunks = splitParagraphIntoSentences(para, 14); // packs ~2 segments/chunk → exercises the joiner
   expect(chunks.length).toBeGreaterThan(1);
-  expect(chunks.join('')).toBe(para); // lossless
+  expect(chunks.join('')).toBe(para);        // no ASCII space injected (would fail with the Latin space-join)
+  expect(chunks.join('')).not.toContain(' '); // belt-and-suspenders
 });
 ```
 
@@ -229,17 +249,19 @@ it('flags a CJK short-dialogue repeat-loop the <8 key floor used to miss', () =>
 
 **Design note:** two Latin assumptions break for CJK — `line.length < 60` (CJK is denser) and `/\p{Ll}/u` (never matches caseless Han/Kana). Self-detecting fix: if the line contains Han/Kana, treat it as narrative when it has a CJK sentence ender (`[。！？…]`) and length ≥ a lower CJK threshold (e.g. 15), bypassing the lowercase test.
 
-- [ ] **Step 1: Write the failing test** — a real CJK narrative sentence is recognised as narrative (ends the front-matter region); a short CJK heading is not.
+- [ ] **Step 1: Write the failing test.** **NOTE (independent-review finding):** `isNarrativeLine` only controls WHEN the author/title-echo strip region ends; with `opts = {}` nothing is ever stripped, so a test with no author/title echo passes trivially and guards nothing. The failing test needs an author/title echo line placed AFTER a CJK narrative line — today the narrative line is mis-classified (never narrative → region stays open → the later echo is wrongly stripped); after the fix the narrative line closes the region and the echo survives.
 
 ```ts
-it('treats a CJK narrative line as narrative (not front-matter)', () => {
-  const body = '献辞\n\n彼は古い石段の上で足を止め、霧に沈んだ谷を見下ろした。';
-  const out = stripFrontMatterBoilerplate(body, {});
-  expect(out).toContain('彼は古い石段'); // narrative kept
+it('a CJK narrative line closes the front-matter region so a later author echo is NOT stripped', () => {
+  // 献辞 (dedication) → narrative line → then a line equal to the author name
+  const body = '献辞\n\n彼は古い石段の上で足を止め、霧に沈んだ谷を見下ろした。\n\n田中太郎';
+  const out = stripFrontMatterBoilerplate(body, { author: '田中太郎' });
+  expect(out).toContain('彼は古い石段');   // narrative kept
+  expect(out).toContain('田中太郎');        // author echo AFTER a real narrative line is NOT front-matter
 });
 ```
 
-- [ ] **Step 2: Run to verify it fails** (`\p{Ll}` never matches → line treated as front-matter, potentially stripped).
+- [ ] **Step 2: Run to verify it fails** (`\p{Ll}` never matches Han/Kana → the narrative line never closes the region → the trailing `田中太郎` is stripped as a byline echo).
 - [ ] **Step 3: Implement** the self-detecting CJK branch in `isNarrativeLine`.
 - [ ] **Step 4: Run to verify it passes;** English/Russian tests stay green.
 - [ ] **Step 5: Commit** — `fix(server): CJK-aware isNarrativeLine (fs-59 W2)`.
@@ -257,13 +279,15 @@ it('treats a CJK narrative line as narrative (not front-matter)', () => {
 ```ts
 it('estimateInputTokens: CJK uses ~1.2 chars/token', async () => {
   const { estimateInputTokens } = await import('./gemini.js');
-  const cjk = '彼は歩いた'.repeat(200); // 1000 CJK chars ≈ ~830 tokens at 1.2
+  const cjk = '彼は歩いた'.repeat(200); // 1000 CJK chars ≈ ~833 tokens at 1.2
   const est = estimateInputTokens('', wrap(cjk));
-  expect(est).toBeGreaterThan(600); // far above the Latin /4 = 250
+  // NOTE (independent-review): current code = ceil(1000/4) + 1000 flat margin (gemini.ts:898) = 1250,
+  // so the bound MUST exceed 1250 to actually fail before the fix (post-fix ≈ 833 + 1000 = 1833).
+  expect(est).toBeGreaterThan(1500);
 });
 ```
 
-- [ ] **Step 2: Run to verify it fails.**
+- [ ] **Step 2: Run to verify it fails** (current: 1250 < 1500).
 - [ ] **Step 3: Implement** the CJK constant + fraction measurement.
 - [ ] **Step 4: Run to verify it passes;** existing Latin/Cyrillic assertions stay green.
 - [ ] **Step 5: Commit** — `feat(server): CJK token-estimate divisor (fs-59 W2)`.
@@ -278,24 +302,51 @@ it('estimateInputTokens: CJK uses ~1.2 chars/token', async () => {
 
 **Entry point (verified):** the splitter is `parseText(text, { format })` (`parsers/text.ts:231`), which tests `normaliseHeading(line)` against `CHAPTER_HEADING_RE` (`:51`, applied `:271`) and flushes a chapter per match. `normaliseHeading` (`:127`) only strips edge non-`\p{L}\p{N}` chars, so `第一章`/`第2章` survive intact (all Han/digit); `MAX_HEADING_LEN` (120) is fine for short CJK headings. **So the ONLY change is `CHAPTER_HEADING_RE` — no `normaliseHeading` change needed.**
 
-**Design note:** add a CJK alternative to `CHAPTER_HEADING_RE`: `第[0-9〇一二三四五六七八九十百千]+[章話回節部幕]` (Arabic OR kanji numerals; the common circumfix enders). Also make the STANDALONE match `\p{Script=Han}`/Katakana-aware for `序章`/`終章`/`プロローグ` (the trailing `\b` is unreliable after CJK — anchor on line end / punctuation instead). Self-detecting (the pattern only fires on CJK glyphs); no book-language threading.
+**Design note — must be WHOLE-LINE anchored (independent-review finding: a naive prefix regex deletes prose).** A prefix-only `^第[…]+[章話…]` misfires on line-initial body sentences — verified with `node`: `第三章で述べたように、…` ("As stated in chapter 3, …") and `第二部隊が丘を越えて進軍した。` (`第N部隊` compound) both MATCH, and in `parseText` a matched line is **consumed as the chapter title and removed from the body** → silent data loss per misfire. Requirements for the CJK alternative:
+- **Anchor the whole line** (or allow only a trailing separator/subtitle): the number+ender must be followed by end-of-normalised-line or a separator (`：:—-　` / whitespace), NOT arbitrary prose. e.g. `^第[0-9０-９〇一二三四五六七八九十百千]+[章話回節部幕巻](?:\s|[：:—-]|$)` and reject if the line continues with kana/particles (`で`, `が`, `の`, `は`…).
+- **Include fullwidth digits** `０-９` (U+FF10–FF19) — common in JA headings; verified the kanji-only class misses `第１章`.
+- **CJK-appropriate length cap** — `MAX_HEADING_LEN` (120) is ~2 CJK sentences; a real CJK heading is short, so gate the CJK branch on a tighter length (e.g. ≤ 20 chars) to refuse `第三章で述べた…`.
+- Make the STANDALONE match `\p{Script=Han}`/Katakana-aware for `序章`/`終章`/`プロローグ` (trailing `\b` unreliable after CJK — anchor on line end).
+Self-detecting (fires only on CJK glyphs); no book-language threading.
 
-- [ ] **Step 1: Write the failing test** — a body with `第一章`, `第2章`, `第十二話` headings splits into 3 chapters; a mid-paragraph `章` does not misfire.
+- [ ] **Step 1: Write the failing test** — headings split; **the misfire cases do NOT** (this is the load-bearing guard).
 
 ```ts
 import { parseText } from './text.js';
 
-it('splits a CJK book on 第N章 / 第N話 circumfix headings', () => {
-  const body = '第一章\n\n彼は歩いた。\n\n第2章\n\n彼女は走った。\n\n第十二話\n\n終わり。';
+it('splits CJK headings but does not eat 第N-prefixed prose', () => {
+  const body = [
+    '第一章', '', '彼は歩いた。第三章で述べたように、彼は振り返らなかった。', '',
+    '第２章', '', '第二部隊が丘を越えて進軍した。二人は止まった。', '',
+    '第十二話', '', '終わり。',
+  ].join('\n');
   const { chapters } = parseText(body, { format: 'plaintext' });
-  expect(chapters.length).toBe(3);
+  expect(chapters.length).toBe(3);                       // 第一章 / 第２章 / 第十二話
+  expect(chapters.map((c) => c.body).join('')).toContain('第三章で述べた'); // prose NOT deleted
+  expect(chapters.map((c) => c.body).join('')).toContain('第二部隊が丘');   // compound NOT a title
 });
 ```
 
-- [ ] **Step 2: Run to verify it fails** (`cd server && npx vitest run src/parsers/text.test.ts` — today: 1 chapter, the circumfix never matches).
-- [ ] **Step 3: Implement** the CJK alternative in `CHAPTER_HEADING_RE` + kanji-numeral class + CJK-aware standalone anchoring.
-- [ ] **Step 4: Run to verify it passes;** confirm English/ES/RU heading tests stay green (the new alternative only fires on CJK glyphs).
+- [ ] **Step 2: Run to verify it fails** (`cd server && npx vitest run src/parsers/text.test.ts` — today: 1 chapter; a naive regex would instead delete the two prose lines).
+- [ ] **Step 3: Implement** the whole-line-anchored CJK alternative in `CHAPTER_HEADING_RE` + fullwidth+kanji numerals + the tighter CJK length gate + CJK-aware standalone.
+- [ ] **Step 4: Run to verify it passes;** confirm English/ES/RU heading tests stay green (the new alternative only fires on CJK glyphs, whole-line anchored).
 - [ ] **Step 5: Commit** — `fix(server): CJK 第N章 chapter-heading split (fs-59 W2)`.
+
+### Task 2.7: CJK word-count / front-matter miscount at import (independent-review finding)
+
+**Files:**
+- Modify: `server/src/routes/import.ts` (`countWords` `:73`; `isLikelyFrontMatter` `:161-163`)
+- Test: `server/src/routes/import.test.ts`
+
+**Why:** `countWords` (`:73`) splits on `\s+`; a spaceless CJK chapter yields ~1 "word" per paragraph, so a full CJK novel chapter counts ~30–60 "words" and trips `isLikelyFrontMatter: … || (wordCount > 0 && wordCount <= FRONT_MATTER_WORD_THRESHOLD /*150*/)` (`:161-163`). Result: **every chapter of a CJK book is pre-ticked for exclusion** on the confirm screen, and the book-level `wordCount` is nonsense — so "a CJK book splits into chapters" (issue acceptance) is hollow because the chapters are then auto-excluded.
+
+**Design note:** make the word count script-aware — for CJK text, count Han/Kana characters as word-equivalents (or divide char-count by ~1.7) rather than whitespace tokens. Self-detecting on Han/Kana presence; keep the Latin path byte-identical.
+
+- [ ] **Step 1: Write the failing test** — a spaceless CJK chapter of ~2000 characters is NOT flagged `isLikelyFrontMatter` and reports a plausible word count (hundreds, not ~40).
+- [ ] **Step 2: Run to verify it fails** (CJK chapter counts ~40 "words" → flagged front-matter).
+- [ ] **Step 3: Implement** the script-aware count.
+- [ ] **Step 4: Run to verify it passes;** English/Latin import tests stay green.
+- [ ] **Step 5: Commit** — `fix(server): CJK-aware import word count / front-matter flag (fs-59 W2)`.
 
 ---
 
@@ -323,21 +374,22 @@ it('registers zh/ja conventions', () => {
 
 - [ ] **Step 2: Run to verify it fails.**
 - [ ] **Step 3: Implement** both files + register in `TABLES`.
-- [ ] **Step 4: Add a `parser.test.ts` case** — a JA line `「気をつけて」と彼女は言った。` attributes the spoken span to the speaker and the tag to narrator (the §2.1 interrupted-quote defect target). Run; PASS.
+- [ ] **Step 4: Add a `parser.test.ts` case** — a JA line `「気をつけて」と彼女は言った。` attributes the spoken span to the speaker and the tag to narrator (the §2.1 interrupted-quote defect target). Run; PASS. **NOTE (independent-review):** `彼女` is a *pronoun* — it passes via the pronoun regex and masks the fact that NAME-tag anchoring is broken for CJK (Task 3.5). Add a SECOND case using a roster NAME tag (`「わかった」と田中は言った。` → 田中) which will FAIL until Task 3.5 lands — keep it (skipped/xfail) as the driver for 3.5, so this task doesn't falsely imply name-attribution works.
 - [ ] **Step 5: Commit** — `feat(server): CJK dialogue-structure conventions zh/ja (fs-59 W3)`.
 
-### Task 3.2: CJK quote glyphs in audio-tags + roster-coverage
+### Task 3.2: CJK quote glyphs in audio-tags (roster-coverage half is moot for CJK)
 
 **Files:**
-- Modify: `server/src/parsers/audio-tags.ts` (`QUOTE_OPENS`/`QUOTE_CLOSES`, `:22`)
-- Modify: `server/src/analyzer/roster-coverage.ts` (`QUOTE_CHARS_WIDE`, `:171`)
-- Test: the colocated `*.test.ts` for each
+- Modify: `server/src/parsers/audio-tags.ts` (`QUOTE_OPENS`/`QUOTE_CLOSES`, `:22-23`)
+- Test: `server/src/parsers/audio-tags.test.ts`
 
-- [ ] **Step 1: Write failing tests** — an audio-tag inside `「…」` is detected; a roster tag scan recognises a `「」`-quoted line.
-- [ ] **Step 2: Run to verify they fail.**
-- [ ] **Step 3: Implement** — add `「『` to opens, `」』` to closes; add the same to `QUOTE_CHARS_WIDE`.
-- [ ] **Step 4: Run to verify they pass.**
-- [ ] **Step 5: Commit** — `feat(server): CJK quote glyphs in audio-tags + roster guard (fs-59 W3)`.
+**Scope correction (independent-review finding):** do NOT add `「」` to `roster-coverage.ts` `QUOTE_CHARS_WIDE` — `validateRosterCoverage` early-returns `{ ok: true }` when `grammarFor(language)` is null (`roster-coverage.ts:189-190`), and Task 3.4 deliberately leaves zh/ja unmapped, so that half is **unreachable dead code** for CJK. Only the audio-tags half is real. Also: the audio-tag detectors trigger on ASCII cues (e.g. `!` at `audio-tags.ts:98`, `…`); adding corner-bracket *quote* glyphs alone does NOT make `[excited]` fire on a fullwidth `！`. Scope this task to: (a) add `「『` to `QUOTE_OPENS` / `」』` to `QUOTE_CLOSES` so a tag INSIDE corner brackets is found, and (b) decide per-detector whether to add fullwidth `！？。…` triggers or document the deferral (fullwidth-punctuation audio-tag detection is a nice-to-have, not an acceptance item).
+
+- [ ] **Step 1: Write the failing test** — a bracketed audio tag like `「[whisper] 静かに」` (or the detector's real trigger form) is recognised inside `「…」` (name the concrete detector under test).
+- [ ] **Step 2: Run to verify it fails.**
+- [ ] **Step 3: Implement** — add `「『`/`」』` to the quote sets; add fullwidth punctuation triggers only where a paired detector genuinely needs it.
+- [ ] **Step 4: Run to verify it passes.**
+- [ ] **Step 5: Commit** — `feat(server): CJK quote glyphs in audio-tag detectors (fs-59 W3)`.
 
 ### Task 3.3: CJK prompt hints + in-language few-shot examples
 
@@ -352,12 +404,18 @@ it('registers zh/ja conventions', () => {
 
 ```ts
 it('languagePreamble carries CJK conventions + in-language examples', () => {
-  expect(languagePreamble('ja')).toMatch(/「」|Japanese/);
-  expect(languagePreamble('zh')).toMatch(/“”|「」|Chinese/);
+  // NOTE (independent-review): do NOT assert on the language NAME — after Task 2.1
+  // registers the rows, `where` already contains "Japanese"/"Chinese" (gemini.ts:233),
+  // so /Japanese/ passes before any W3 change. Assert on the CJK-specific convention
+  // text + the in-language few-shot marker instead.
+  const ja = languagePreamble('ja');
+  expect(ja).toContain('「');                 // corner-bracket convention hint (new in W3)
+  expect(ja).toMatch(/tag[^]*narrator|話者ではない/); // interrupted-quote/tag-is-narrator few-shot
+  expect(languagePreamble('zh')).toContain('“'); // zh fullwidth-quote hint
 });
 ```
 
-- [ ] **Step 2: Run to verify it fails.**
+- [ ] **Step 2: Run to verify it fails** (the registered `where` string has the language name but none of the CJK convention text yet).
 - [ ] **Step 3: Implement** — add the zh/ja conventions strings + wire `promptExamples`.
 - [ ] **Step 4: Run to verify it passes.**
 - [ ] **Step 5: Commit** — `feat(server): CJK prompt conventions + in-language few-shot (fs-59 W3)`.
@@ -376,6 +434,22 @@ it('languagePreamble carries CJK conventions + in-language examples', () => {
 - [ ] **Step 4: Run to verify green.**
 - [ ] **Step 5: Commit** — `docs(server): document tag-grammar gate-off for CJK (fs-59 W3)`.
 
+### Task 3.5: CJK-aware roster-name tag anchoring (independent-review finding)
+
+**Files:**
+- Modify: `server/src/analyzer/dialogue-structure/name-matcher.ts` (`findRosterName`, `:27-35`)
+- Test: `server/src/analyzer/dialogue-structure/name-matcher.test.ts` + the 3.1 name-tag `parser.test.ts` case
+
+**Why:** `findRosterName` tokenises the tag clause with `text.toLowerCase().split(/[^\p{L}]+/u)` (`:27`). A CJK tag clause like `と田中は言った` has **no non-letter separators → one token**; with the identity `nameStemmer` (Task 3.1) the "stem" is the whole clause, so the roster lookup keyed by `田中` never hits. Result: `tag-name` evidence — the **highest-precedence** attribution anchor (`parser.ts:53-55`) — **never fires for CJK**; only the pronoun regexes work. This substantially weakens CJK attribution (and the §2.1 interrupted-quote fix leans on it).
+
+**Design note:** add a CJK branch to `findRosterName`: when the clause contains Han/Kana, match roster name stems by **substring containment** (does the clause contain any indexed Han name stem?) instead of whitespace tokenisation. Prefer the longest match; guard against 1-char stems causing false hits (require ≥2 Han chars, or the roster name's own length). Keep the Latin/Cyrillic tokenised path unchanged.
+
+- [ ] **Step 1: Write the failing test** — `findRosterName('と田中は言った', index)` returns the `田中` roster id (today: null). Also un-skip the 3.1 name-tag `parser.test.ts` case (`「わかった」と田中は言った。` → 田中).
+- [ ] **Step 2: Run to verify it fails.**
+- [ ] **Step 3: Implement** the substring-containment CJK branch.
+- [ ] **Step 4: Run to verify it passes;** Latin/Russian name-matching tests stay green.
+- [ ] **Step 5: Commit** — `fix(server): CJK substring roster-name tag anchoring (fs-59 W3)`.
+
 ---
 
 ## Wave 4 — CJK synthesis, both engines (sidecar + server)
@@ -387,6 +461,8 @@ it('languagePreamble carries CJK conventions + in-language examples', () => {
 - Test: `server/tts-sidecar/tests/test_calibration_text.py` (create if absent)
 
 **Design note:** add phonetically-rich `"Chinese"` and `"Japanese"` rows keyed by the sidecar language word (matching `sidecarName`). Today `_calibration_text()` falls back silently to the English pangram for any unmapped language — a CJK designed voice would fix the wrong phoneme set.
+
+**Wave-ordering note (independent-review finding — F9):** registering zh/ja in Task 2.1 makes `sidecarLanguageName('zh')` return `'Chinese'` instead of throwing, so the spec's "CJK can't reach the sidecar" fail-loud net is gone from W2 on, while calibration lands only here (W4a). The practical guard in the W2–W4a window is that zh/ja are `supported:false`, so the confirm gate blocks the book before design/synth — but to remove the latent wrong-phoneme-bake risk entirely, **land this task (4a.1) in the same PR wave as the registry rows (or immediately after), and do NOT attempt any on-box CJK voice design until it is merged.** If W2 and W4a must ship far apart, keep zh/ja out of the registry until calibration exists.
 
 - [ ] **Step 1: Write the failing pytest** — `_calibration_text('Chinese')` and `('Japanese')` return CJK text (contain Han/Kana), not the English pangram.
 - [ ] **Step 2: Run** `npm run test:sidecar` → FAIL (falls back to English).
@@ -428,25 +504,28 @@ it('zh/ja are eligible on qwen + coqui', () => {
 
 - [ ] **Step 2: Run to verify it fails.**
 - [ ] **Step 3: Implement** — add `'zh','ja'` to the `coqui` array.
-- [ ] **Step 4: Run to verify it passes;** confirm the fs-60 eligibility tests stay green.
+- [ ] **Step 4: Run to verify it passes.** **NOTE (independent-review):** this BREAKS a pinned fs-60 test — `language.test.ts:93-95` asserts `resolveEligibleEngines('zh', ALL_TTS_ENGINES)` `.toEqual(['qwen'])`. Update it in THIS commit to `['coqui','qwen']` (it exists precisely to pin zh as Qwen-only; that invariant is what this task changes). Confirm the OTHER fs-60 eligibility tests stay green.
 - [ ] **Step 5: Commit** — `feat(server): Coqui XTTS eligible for zh/ja (fs-59 W4b)`.
 
 ### Task 4b.2: `zh`→`zh-cn` Coqui language-code map
 
 **Files:**
 - Create: a small helper `coquiLanguageCode(bcp47: string): string` (in `server/src/tts/voice-mapping.ts` or `language.ts`)
-- Modify: `server/src/tts/synthesise-chapter.ts` — apply the map at the **Coqui provider call only** (NOT at the shared `langCode` resolution `:884`, which feeds `expandForSpeech` and must keep the registry code `zh`)
-- Test: `server/src/tts/synthesise-chapter-coqui-fallback.test.ts`
+- Modify: `server/src/tts/sidecar.ts` — apply the map inside `SidecarTtsProvider.synthesize` (`:100-105`), which already knows `this.engine === 'coqui'`. **This is the single clean seam** (independent-review finding) — cleaner than branching on `route.engine` at the two generic `provider.synthesize` call sites in `synthesise-chapter.ts` (`:1068`, `:1273`), and it does NOT touch the shared `langCode` (which feeds `expandForSpeech` and must keep the registry code `zh`).
+- Modify: `server/src/routes/voice-sample.ts` (`:145`) — **also thread `language` here** (see below).
+- Test: `server/src/tts/sidecar.test.ts` + `server/src/routes/voice-sample.test.ts`
 
-- [ ] **Step 1: Write the failing test** — a Coqui zh synth call carries `language: 'zh-cn'` (use the verified 4b.0 string); `ja` stays `ja`; a non-CJK language is unchanged.
-- [ ] **Step 2: Run to verify it fails.**
-- [ ] **Step 3: Implement** `coquiLanguageCode` (identity except `zh`→`zh-cn`) and apply it only where the Coqui provider receives its `language`.
-- [ ] **Step 4: Run to verify it passes;** assert the Qwen/ASR paths still see `zh` (no leak).
-- [ ] **Step 5: Commit** — `feat(server): zh→zh-cn Coqui language-code map (fs-59 W4b)`.
+**Second gap (independent-review finding):** `voice-sample.ts:145` calls `provider.synthesize({ text, voiceName, modelKey })` with **no `language`**, so a CJK Coqui voice sample renders through the English phonemiser (`COQUI_LANGUAGE='en'` default, `main.py:915,1105`) even after the map lands — and the Task 4b.3 listen-gate would false-fail if driven through the sample button. Thread the book/character language into this call too.
+
+- [ ] **Step 1: Write the failing tests** — (a) `SidecarTtsProvider('coqui').synthesize({..., language: 'zh'})` sends `zh-cn` (the verified 4b.0 string) in the request body; `ja` stays `ja`; Qwen/other engines pass language through unchanged. (b) `voice-sample.ts` forwards the language to `provider.synthesize`.
+- [ ] **Step 2: Run to verify they fail.**
+- [ ] **Step 3: Implement** `coquiLanguageCode` (identity except `zh`→`zh-cn`), apply it in `SidecarTtsProvider.synthesize` for the coqui engine, and thread language through `voice-sample.ts`.
+- [ ] **Step 4: Run to verify they pass;** assert the Qwen/ASR paths still see `zh` (no leak).
+- [ ] **Step 5: Commit** — `feat(server): zh→zh-cn Coqui language-code map + voice-sample language (fs-59 W4b)`.
 
 ### Task 4b.3: Coqui CJK output validation (on-box, procedure)
 
-- [ ] Render a short ZH and JA line through Coqui XTTS with an existing `COQUI_PROFILE_VOICES` speaker. Confirm audio is intelligible CJK (cross-lingual voice cloning). Only if quality is unacceptable, curate a CJK speaker subset — otherwise no code. Record the result for the W5 gate.
+- [ ] Render a short ZH and JA line through Coqui XTTS with an existing `COQUI_PROFILE_VOICES` speaker, **via a path that carries language** (a chapter render, or the sample button AFTER Task 4b.2 threads language — not before, or it renders English). Confirm audio is intelligible CJK (cross-lingual voice cloning). Only if quality is unacceptable, curate a CJK speaker subset — otherwise no code. Record the result for the W5 gate.
 
 ---
 
@@ -485,24 +564,30 @@ Not desk-verifiable — needs the GPU box, real weights, the operator's ears, an
 
 ## Self-Review — spec coverage
 
-- Registry rows / detection flip → 2.1 ✓
-- **CJK chapter splitting (第N章 circumfix) → 2.6 ✓ (acceptance-critical; NOT the heading lexicon)**
+- Registry rows + **detection read-through fix** (`detect-language.ts:51` hardcode) → 2.1 ✓
+- **CJK chapter splitting (第N章 circumfix, whole-line anchored) → 2.6 ✓ (acceptance-critical; NOT the heading lexicon)**
+- **CJK import word-count / front-matter miscount → 2.7 ✓ (else every CJK chapter auto-excluded)**
 - Coverage guard (dup-key floor only; word-count ruled out) → 2.3 ✓
-- Sentence split → 2.2 ✓; isNarrativeLine → 2.4 ✓; token divisor → 2.5 ✓
-- Dialogue conventions zh/ja → 3.1 ✓; quote glyphs → 3.2 ✓; prompt few-shot + `promptExamples` field → 3.3 (field added 2.1) ✓; tag-grammar gate-off → 3.4 ✓
-- Qwen calibration → 4a.1 ✓; emotion/nudge → 4a.2 ✓
-- Coqui: zh-cn pre-check → 4b.0 ✓; eligibility → 4b.1 ✓; code map → 4b.2 ✓; output validation → 4b.3 ✓
-- Attribution eval harness (W1, own PR) → 1.1–1.3 ✓
+- Sentence split (no-space CJK join) → 2.2 ✓; isNarrativeLine → 2.4 ✓; token divisor → 2.5 ✓
+- Dialogue conventions zh/ja → 3.1 ✓; **CJK roster-name tag anchoring → 3.5 ✓ (else only pronouns attribute)**; quote glyphs (audio-tags only; roster half moot) → 3.2 ✓; prompt few-shot + `promptExamples` field → 3.3 (field added 2.1) ✓; tag-grammar gate-off → 3.4 ✓
+- Qwen calibration (land with/near W2 registry rows — F9) → 4a.1 ✓; emotion/nudge → 4a.2 ✓
+- Coqui: zh-cn pre-check → 4b.0 ✓; eligibility (+ update pinned test) → 4b.1 ✓; code map (SidecarTtsProvider seam + voice-sample) → 4b.2 ✓; output validation → 4b.3 ✓
+- Attribution eval harness (W1, own PR; order-aware scorer) → 1.1–1.3 ✓
 - Fixtures / labelling / harness run / audio gate / flip / fs-70 reconcile → 5.1–5.5 ✓
-- Korean explicitly excluded (Global Constraints) ✓
-- Independent per-language flip (D2) → 5.5 Step 1 ✓
+- Korean explicitly excluded (Global Constraints) ✓; independent per-language flip (D2) → 5.5 Step 1 ✓
+- Spec Risk 5 (messy real-world fixture): a W2 fixture MUST include a chapter with mixed ASCII/fullwidth punctuation, U+3000 ideographic spaces, and a `第N章`-headed multi-chapter body — add it to the 2.2/2.6/2.7 fixtures.
 
 ## Notes for the implementer
 
-- Read spec §2.1 before Task 2.3 — the coverage fix is the dup-key floor ONLY; do not add word-level counting (verified irrelevant: ratio is scale-invariant).
-- **Task 2.6 is acceptance-critical** — CJK chapter splitting is a #1004 requirement and does NOT come from the heading lexicon (wrong regex shape). Verify the `parsers/text.ts` chapter-split entry-point name when implementing.
-- **The eval-harness scorer (1.2) assumes truth and predictions share segmentation** — always build labelled chapters on the analyzer's own output and correct only ids; the scorer flags a length/segmentation mismatch loudly rather than scoring misaligned pairs.
-- The heading/front-matter/speech-verb/calibration term lists in W2–W4 are starting sets; a native ZH/JA reviewer refines them at W5. Include **kanji numerals** (一二三…十百) in the 2.6 heading number class, not just Arabic digits.
-- Known-accepted v1 limits (do not over-engineer): the `ja` male-pronoun `/彼(?!女)/` still matches 彼ら/彼氏; a 1-char CJK dup key (`「え」`) is below the floor-2 dup-detector and can evade a pure 1-char-line loop. Both pathological; leave them.
+_Findings from an independent adversarial review are folded into the tasks above. The highest-consequence ones:_
+- **`detect-language.ts:49-52` hardcodes `supported:false` for CJK** — Task 2.1 MUST change it to read through the registry, or the W5 flip is a no-op and the whole feature is a dead end (Task 2.1 CRITICAL note).
+- **Task 2.6 regex must be whole-line anchored** — a naive prefix `^第[…]+[章…]` matches `第三章で述べた…` and `第N部隊…` and `parseText` then DELETES that prose as a title. Include fullwidth `０-９` + kanji numerals; cap CJK heading length.
+- **Task 2.7** — a spaceless CJK chapter counts ~40 whitespace "words" → pre-ticked front-matter → auto-excluded; the chapter-split win is hollow without this.
+- **Task 3.5** — `findRosterName` splits on `[^\p{L}]+`, so a CJK name tag is one token and never matches the roster; without the substring fix, CJK attribution rides on pronouns + prompt only.
+- **Three placebo tests fixed** (2.4 needs an author echo; 2.5 must exceed the +1000 flat margin, bound > 1500; 3.3 must not assert on the language name — it's already in `where`). Honour "verify it fails."
+- Read spec §2.1 before Task 2.3 — the coverage fix is the dup-key floor ONLY; word-level counting is verified irrelevant (ratio scale-invariant).
+- Scorer (1.2): order-aware occurrence matching, NOT a `Map` (duplicate lines with different speakers must not collapse); tolerate segmentation drift via `segMismatch`, never a hard length assertion.
+- Term lists in W2–W4 are starting sets; a native ZH/JA reviewer refines them at W5.
+- Known-accepted v1 limits (do not over-engineer): `ja` `/彼(?!女)/` still matches 彼ら/彼氏; a 1-char CJK dup key evades the floor-2 dup-detector. Pathological; leave them.
 - W4b.0 is a hard gate: verify XTTS's Chinese code before writing the map.
 - W1 is a standalone PR; W2/W3 are server-only and can each be 1–2 PRs; W4/W5 are the operator-gated tail.

--- a/docs/superpowers/specs/2026-07-13-fs59-cjk-support-design.md
+++ b/docs/superpowers/specs/2026-07-13-fs59-cjk-support-design.md
@@ -1,0 +1,327 @@
+---
+title: fs-59 — CJK (Chinese / Japanese) language support
+status: draft
+issue: 1004
+supersedes-section: docs/superpowers/specs/2026-06-22-fs41-fs50-language-aware-ingest-and-breadth-design.md §11.1
+date: 2026-07-13
+---
+
+# fs-59 — CJK (ZH / JA) language support: analysis + synthesis
+
+## 0. One-paragraph summary
+
+Extend the shipped fs-50 language framework (registry + server-side detection +
+dual-gate rollout) to **Chinese (`zh`) and Japanese (`ja`)**, end-to-end. CJK is
+the §11.1 follow-on that fs-50 deferred because CJK *analysis* is materially
+harder than Latin: a spaceless script breaks every whitespace-word heuristic, and
+the dialogue/quote/token/length primitives all assume Latin character density.
+This spec reuses the fs-50 framework unchanged and adds only the CJK-specific
+pieces. CJK renders on **both Qwen and Coqui XTTS** — uniquely among the wider
+non-English roadmap, because Qwen (an Alibaba model) natively supports zh/ja, so
+CJK is the one slice of fs-70's "XTTS languages beyond Qwen's five" that also has
+a Qwen path. Both `supported` flags flip together, only after an on-box dual gate
+(operator audio × both engines + attribution FP/FN from a new eval harness).
+
+## 1. Context — what already exists (do not rebuild)
+
+The fs-50 tranche (es/fr/de) **shipped** and left CJK a small delta on top of a
+proven framework. Verified against the current tree:
+
+- **Detection is done.** `server/src/tts/detect-language.ts` already runs an
+  authoritative script pre-pass: Cyrillic→`ru`, then `(han + kana)/letters ≥ 0.3`
+  → `{ language: kana > han ? 'ja' : 'zh', supported: false }` (front-matter
+  stripped first, 20 k-char sample). The Han-vs-Kana disambiguation and the
+  `detected-but-unsupported` return are already in place. **Adding registry rows
+  flips detection to `supported` automatically — no detection code changes.**
+- **Fail-loud block is in place.** `sidecarLanguageName()`
+  (`server/src/tts/language.ts:34`) throws for any code not in the registry, so
+  CJK cannot bake an English manifest today. This stays as the safety net.
+- **The engine-eligibility model exists (fs-60, #1005).**
+  `resolveEligibleEngines(bookLanguage, installedEngines)`
+  (`language.ts:59`) is a pure filter over
+  `ENGINE_LANGUAGE_SUPPORT` (`voice-mapping.ts:39`):
+  `qwen: '*'`, `coqui: ['en','ru','es','fr','de']`, others `['en']`. Coqui
+  already renders non-English (ru/es/fr/de) with per-request language threading,
+  a Qwen→Coqui fallback branch (`applyQwenFallback`,
+  `synthesise-chapter.ts:922`), mixed-engine serialization, cast banners, the
+  `eligibleTtsEngines` API field, and a "Fallback (Coqui)" pill — **all shipped**.
+- **The dialogue-structure subsystem replaced `isSpokenLine`.** Per-language
+  `LanguageConventions` tables live in
+  `server/src/analyzer/dialogue-structure/lang/{en,ru,es,fr,de}.ts`, registered in
+  `lang/index.ts`, dispatched by `conventionsFor(language)`. CJK adds `zh.ts` +
+  `ja.ts` here.
+- **The per-engine cast data model already supports CJK.**
+  `overrideTtsVoices?: Partial<Record<TtsEngine, { name }>>`
+  (`voice-mapping.ts`) is per-engine and not language-gated — a Coqui voice slot
+  for a zh/ja character is already representable.
+
+**Divergence note:** the fs-50 *implementation* did not build the monolithic
+`text{}` registry block the fs-50 spec §2 sketched. This spec targets the
+**actual** shipped seams (below), not that idealized shape.
+
+## 2. Decisions (locked with the requester)
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | **Segmenter = `Intl.Segmenter`** (zero-dep, Node/ICU built-in) | Pays off twice: `granularity:'word'` gives real CJK word counts for the coverage guard; `granularity:'sentence'` gives native CJK sentence boundaries for the chunker. No new dependency (matches the "one dep = franc" Latin precedent). |
+| D2 | **ZH + JA validated together**, one combined go/no-go; both `supported` flip in the same tail PR | Shared foundations land once; both languages exercise them; a single operator/labeler session covers both. |
+| D3 | **Build the full §4.8 attribution eval harness**, as **Wave 1 / its own PR**, language-agnostic | The Latin tranche skipped it and flipped `supported` on operator-audio alone. It is infrastructure every future language needs; building it first, proven on an existing language, de-risks the CJK waves and retro-enables an es/fr/de gate. |
+| D4 | **CJK renders on both Qwen and Coqui XTTS** | Qwen natively supports zh/ja; XTTS v2 natively supports `zh-cn`/`ja`; the sidecar has no language allowlist; fs-60's machinery is generic. Honors "it should also work for Coqui." |
+| D5 | **fs-59 owns the CJK slice; fs-70 (#1303) keeps the rest** | CJK is uniquely dual-engine (Qwen + Coqui); fs-70's other languages (ko/ar/hi/…) are XTTS-only. Reconcile by reference on both issues; do not silently absorb. |
+
+## 3. Architecture — the CJK seams (actual code)
+
+Each item names the real file:symbol and the CJK gap. Grouped by the delivery
+wave that owns it (§5).
+
+### 3.1 Analysis foundations (Wave 2 — engine-independent)
+
+- **Coverage guard** — `server/src/analyzer/stage2-coverage.ts`, `words()`
+  (`~:88-97`, `.split(/\s+/)`). A spaceless CJK sentence collapses to one "word",
+  so the attributed÷source coverage ratio is meaningless and
+  `runStage2WithCoverageGuard()` (`~:236`) burns every retry (the "infinite
+  retry" in the issue). **Fix:** when the book is CJK, count words via
+  `Intl.Segmenter(lang, { granularity: 'word' })` filtered to `isWordLike`
+  segments. The ratio stays self-consistent (both sides counted identically);
+  `endingTailWords` becomes ending-tail *segments*. The letter-class Unicode
+  work (`\p{L}\p{N}`) already done for Russian is preserved.
+- **Sentence splitting** — `server/src/analyzer/stage2-chunk.ts`,
+  `splitParagraphIntoSentences()` (`:122`, split on `/(?<=[.!?]["')\]]?)\s+/`).
+  CJK has no whitespace and ends sentences with `。！？`. **Fix:** CJK path uses
+  `Intl.Segmenter(lang, { granularity: 'sentence' })` (handles `。！？` + closing
+  `」』` natively). The pre-emptive `splitBodyIntoChunks` paragraph split
+  (`\n\n`) is script-independent and stays.
+- **`isNarrativeLine`** — `server/src/analyzer/strip-front-matter.ts:32`.
+  Two CJK gaps: (a) `line.length < 60` assumes Latin density — a CJK line reaches
+  equivalent information at far fewer chars; (b) `/\p{Ll}/u` (lowercase test)
+  never matches Han/Kana (no case), so a real CJK narrative line can never pass.
+  **Fix:** a CJK branch with a lower char threshold and a Han/Kana +
+  `。！？…` test replacing the lowercase check.
+- **Token estimator** — `server/src/analyzer/gemini.ts`, `estimateInputTokens()`
+  (`~:862-899`). Today interpolates between `LATIN_CHARS_PER_TOKEN = 4` and
+  `CYRILLIC_CHARS_PER_TOKEN = 2.5` by measuring the Cyrillic fraction. **Fix:**
+  add `HAN_KANA_CHARS_PER_TOKEN ≈ 1.2` and a CJK-fraction measurement mirroring
+  `countCyrillic`; a CJK-dense prompt uses the ~1.2 divisor. (The flat
+  `prompt.length/4` in `rate-limit.ts:209` is a secondary estimator — extend or
+  leave, noted as low-risk.)
+- **Registry rows** — `server/src/tts/language-registry.ts`. Add `zh` and `ja`
+  entries, `supported: false`, `detect.script: 'cjk'` (a single new tag for both;
+  the registry's `detect.script` only gates the *franc Latin* filter in
+  detect-language.ts — any non-`latin` value excludes CJK from it — while the
+  han-vs-kana `zh`/`ja` tiebreak stays the hardcoded script pre-pass, so one
+  `'cjk'` value suffices for both rows); `sidecarName: 'Chinese' | 'Japanese'`;
+  CJK `headingLexicon`
+  (第一章 / 第1話 / 序章 / 終章 …) and `frontMatterKeywords` (目次 / 著作権 /
+  献辞 · 目录 / 版权 / 致谢). Number-word lexicons are largely N/A for CJK
+  (digits are used directly) — document, don't force.
+
+### 3.2 Dialogue conventions + prompts (Wave 3 — engine-independent)
+
+- **`LanguageConventions` for CJK** — new
+  `server/src/analyzer/dialogue-structure/lang/zh.ts` + `ja.ts`, registered in
+  `lang/index.ts`. Shape (per `types.ts`):
+  - `quotePairs`: `ja` = `[['「','」'], ['『','』']]`; `zh` =
+    `[['「','」'], ['『','』'], ['“','”']]` (Simplified Chinese commonly uses
+    fullwidth `“”`; Traditional/JA use corner brackets — include both for `zh`).
+  - `dialogueOpen`: `null` (CJK does not use dash-dialogue).
+  - `speechVerbStems`: substring-matched (no inflection). `zh`: 说 / 道 / 问 /
+    答 / 喊 / 叫 / 问道 / 说道 / 回答 / 喃喃 …; `ja`: 言 / 話 / 答 / 尋 / 叫 /
+    呟 / 囁 / 続け … (kanji stems tolerate okurigana variation).
+  - `beatVerbStems`: `zh` 点头 / 笑 / 皱眉 …; `ja` 頷 / 笑 / 頬 …
+  - `nameStemmer`: identity (no case endings); `minStemLength`: 1 (CJK names run
+    1–3 Han chars).
+  - `pronouns`: `zh` 我 / 你 / 他 / 她; `ja` 私 / 僕 / 俺 / 彼 / 彼女 / あなた.
+- **Audio-tag + roster quote sets** — add corner-bracket pairs to
+  `server/src/parsers/audio-tags.ts` (`QUOTE_OPENS`/`QUOTE_CLOSES`, `~:22`) and to
+  `roster-coverage.ts` `QUOTE_CHARS_WIDE` (`~:171`). The all-caps shout heuristic
+  is inert on caseless CJK — leave as-is (no CJK shout signal in v1).
+- **Prompt few-shot** — `server/src/analyzer/gemini.ts` `languagePreamble()`
+  (`~:207-234`). Add CJK convention hints (「」quote marking, no dash-dialogue,
+  name-order note) to the `conventions` string, and inject **in-language
+  few-shot examples** (few-shot dominates small-model behaviour). This requires a
+  new `promptExamples` field on `LanguageEntry` (roster + attribution snippets in
+  ZH/JA) — the field the fs-50 spec named but never added. `sidecarName`
+  ('Chinese'/'Japanese') already flows into the preamble `where` string.
+- **tag-grammar: gate-OFF for CJK.** `server/src/analyzer/tag-grammar.ts`
+  `TAG_GRAMMARS` — leave `zh`/`ja` unmapped so `grammarFor()` returns `null`
+  (caller stays gated, a no-op). Rationale: its `nameCapture` is `[A-Z]` /
+  `\p{Lu}` — CJK has no case, so the `<Name> <verb>` roster-false-positive guard
+  is structurally inapplicable. Primary attribution comes from the
+  dialogue-structure conventions + the Wave-1 eval harness; document the
+  lost-net (same "gate-on vs gate-off + document" discipline fs-50 §4.3 used).
+
+### 3.3 Synthesis (Wave 4 — both engines)
+
+- **Qwen (4a).** `server/tts-sidecar/main.py`, `CALIBRATION_TEXTS` dict
+  (`~:1888-1905`) has es/fr/de/ru but **no Chinese/Japanese** — a CJK designed
+  voice silently falls back to the English pangram (wrong phoneme set). **Fix:**
+  add phonetically-rich `Chinese` + `Japanese` calibration/ref-text rows keyed by
+  sidecar language word. Qwen's synth path already ignores the request-level
+  `language` and reads the manifest baked at `design_voice` time — so the ref-text
+  is the load-bearing input. Thread CJK into `EMOTION_INSTRUCT`
+  (`qwen-voice.ts`) + `fill-tone` NUDGES or explicitly document deferral.
+- **Coqui XTTS (4b).** Net-new is small:
+  1. Add `'zh','ja'` to `ENGINE_LANGUAGE_SUPPORT.coqui` (`voice-mapping.ts:41`).
+  2. A `zh` → `zh-cn` language-code map at the Coqui synth call
+     (`normaliseBookLanguage` collapses `zh-CN`→`zh`; XTTS wants `zh-cn`; `ja` is
+     `ja`). A small per-engine `coquiLanguageCode()` helper; identity for all
+     other languages.
+  3. Confirm the existing `COQUI_PROFILE_VOICES` (engine-generic XTTS speakers)
+     produce acceptable CJK output via XTTS cross-lingual voice cloning — no new
+     catalog unless quality demands it; this is a validation item, not
+     necessarily code.
+  4. No new UI: fs-60's fallback / serialization / banner / pill / readiness-gate
+     machinery is generic and already keys off `eligibleTtsEngines`.
+  - The `cast.tsx:165` `!qwenOnly ⇒ Coqui-eligible` assumption **holds for CJK**
+    (both engines eligible, so `!qwenOnly` is correctly true); the fragility it
+    was flagged for bites only XTTS-only languages, which are fs-70's, not here.
+
+### 3.4 Attribution eval harness (Wave 1 — language-agnostic)
+
+No speaker→line labelling/eval exists today (the golden gate is audio-only).
+Build, in its own PR, independent of CJK:
+
+- **Schema** — a labelled sample `{ chapterText, lines: [{ text, speakerId }] }`.
+- **Scorer** — aligns analyzer-output character ids to truth (handling
+  alias-merge and id-stability across re-analysis) and emits attribution
+  **FP / FN** (and precision/recall).
+- **Proving fixture** — one labelled **English** Coalfall chapter + unit tests,
+  so the harness is validated without a fluent CJK labeler.
+- The §7 dual gate consumes this for every language going forward; ZH/JA labelled
+  chapters are added in Wave 5.
+
+## 4. Data / control flow (unchanged framework)
+
+Import → `detectManuscriptLanguage` (already returns zh/ja) → registry lookup →
+`languageSupported` on the import response → confirm screen (selector already
+built from `supportedLanguages()`; once zh/ja flip, they appear) → analysis
+(stage-1/2 with CJK conventions + preamble + segmenter-based guards) →
+cast/design (Qwen manifest baked with CJK ref-text; Coqui slot per-engine) →
+generation (`resolveEligibleEngines('zh'|'ja', …)` now returns `['qwen','coqui']`;
+force-to-Qwen honours an eligible Coqui manual choice; Coqui call maps `zh`→
+`zh-cn`) → export. The never-cross-language invariant
+(`verify-designed-voice-language.ts`) and `sidecarLanguageName`-throw are reused
+unchanged.
+
+## 5. Delivery — 5 waves
+
+W1 and W5 are their own PRs; W2–W4 are server/sidecar and land `supported:false`,
+desk/synthetic-verifiable.
+
+1. **Wave 1 — Attribution eval harness** (language-agnostic, own PR). §3.4.
+   *Benefit (architectural): the supported-flip gate every future language needs.*
+2. **Wave 2 — CJK analyze foundations** (server). §3.1. Synthetic ZH/JA fixtures.
+   Registry rows land here (`supported:false`).
+   *Benefit (technical): kills the coverage-guard infinite-retry; CJK chapters
+   split + segment correctly.*
+3. **Wave 3 — CJK conventions + prompts** (server). §3.2.
+   *Benefit (user): CJK dialogue (「」) is recognised as spoken, not demoted to
+   narrator; attribution is CJK-aware.*
+4. **Wave 4 — CJK synthesis, both engines** (sidecar + server). §3.3.
+   *Benefit (user): CJK voices render on Qwen and Coqui XTTS.*
+5. **Wave 5 — Validation + flip** (operator tail, own PR).
+   - ZH + JA Coalfall fixtures (**dep: fs-61 / fluent translator**).
+   - Label a ZH + JA chapter → run the W1 harness → attribution FP/FN recorded
+     (attribution is engine-independent — one pass covers both engines).
+   - Operator **audio** gate: Qwen×{zh,ja} **and** Coqui×{zh,ja}.
+   - On-box confirm Qwen honours a CJK persona and XTTS `zh-cn`/`ja` quality.
+   - Flip `zh.supported` + `ja.supported` together (tiny PR).
+   - **Reconcile fs-70 (#1303):** mark its zh-cn/ja bullets done-by-fs-59; narrow
+     its charter to the remaining XTTS-only languages (ko/ar/hi/nl/pl/tr/cs/hu/
+     it/pt). Note the reconciliation on #1004 and #1303.
+   *Benefit (strategic): zh + ja reach `supported`, the two highest-population
+   CJK languages.*
+
+**Why gated:** W5 needs the GPU box, real Qwen/XTTS weights, the operator's ears,
+AND a fluent-labelled ZH/JA sample — it cannot be desk-verified. W1–W4 are not
+held hostage to that.
+
+## 6. Testing
+
+Per-wave, paired with the change (project rule: every PR improves automated
+coverage):
+
+- **W1:** scorer unit tests (FP/FN math, alias-merge, id-stability) against the
+  labelled English fixture; a deliberately-wrong analyzer output asserts non-zero
+  FP/FN.
+- **W2:** synthetic ZH + JA fixtures — coverage-guard ratio in-band on healthy CJK
+  text and the retry loop terminates (regression for the infinite-retry);
+  `splitParagraphIntoSentences` splits a CJK paragraph on `。！？`;
+  `isNarrativeLine` accepts a real CJK narrative line and rejects a short heading;
+  `estimateInputTokens` uses ~1.2 for CJK-dense input; registry lookups for zh/ja.
+- **W3:** `dialogue-structure` recognises 「」 dialogue as spoken and attributes a
+  tagged CJK line to its speaker, not the narrator (the issue's core acceptance);
+  audio-tag + roster quote-set coverage; `languagePreamble('zh'|'ja')` contains
+  CJK hints + examples; `grammarFor('zh')` is `null` (gate-off asserted).
+- **W4:** sidecar `CALIBRATION_TEXTS` has Chinese/Japanese rows (no English-pangram
+  fallback for CJK); `resolveEligibleEngines('zh', ALL)` → `['qwen','coqui']`;
+  the `zh`→`zh-cn` map round-trips; a Coqui zh synth call carries `language:'zh-cn'`.
+- **W5:** on-box audio + attribution FP/FN recorded in Ship notes (manual gate);
+  an e2e detect→confirm→cast path for a CJK book once `supported`.
+
+Canonical fixture: ZH + JA translations of *The Coalfall Commission* (produced
+under fs-61), mirroring the existing en/de/es/fr/ru samples.
+
+## 7. Acceptance (from #1004, mapped to waves)
+
+- [ ] ZH and JA each: detection routes correctly (already true; flips to
+      `supported` on registry rows — W2) and a CJK book splits into chapters,
+      segments into sentences, and **does not trip the coverage-guard infinite
+      retry** (W2).
+- [ ] CJK dialogue (「」) is recognised as spoken, not demoted to narrator (W3).
+- [ ] Qwen **and** Coqui XTTS render ZH/JA at acceptable quality (operator audio
+      gate, both engines) AND attribution is validated against a fluent-labelled
+      sample with FP/FN recorded (W1 harness + W5 labelled chapters).
+- [ ] `supported` flips per language only after the dual gate; both flip together;
+      the never-cross-language invariant holds (W5).
+- [ ] fs-70 (#1303) reconciled by reference (W5).
+
+## 8. Scope boundaries
+
+**In:** CJK analysis (benefits all engines), CJK synthesis on **Qwen + Coqui
+XTTS**, the attribution eval harness, zh + ja → `supported`.
+
+**Out:**
+- **Kokoro-CJK** — Kokoro is English-only with no CJK G2P (misaki[ja,zh]); that is
+  fs-69 (#1302) / §11.2, not here. CJK is Qwen+Coqui only in v1.
+- **The other 10 XTTS languages** (ko/ar/hi/nl/pl/tr/cs/hu/it/pt) — fs-70 (#1303).
+- **Cross-book voice identity check** — fs-71 (#1304).
+- **UI localization** — fs-14. **TTS text normalization** (no
+  `normalize/lang/{zh,ja}.ts`) — fs-53.
+- **Traditional vs Simplified Chinese** — both map to `zh`; Qwen/XTTS handle both.
+- **Diminutive/inflection folding** — N/A for CJK.
+
+## 9. Risks & assumptions
+
+1. **Qwen JA quality** — the top on-box unknown (ZH is Qwen's native strength;
+   JA less certain). Gated in W5; if JA fails the audio gate, ZH can still flip
+   and JA defers — but D2 (flip together) means a JA miss holds ZH's flip; call
+   this out at the W5 gate and let the operator decide split-vs-hold.
+2. **XTTS `zh-cn` / `ja` quality** — cross-lingual voice cloning with the generic
+   speaker catalog is unverified for CJK; W4b validation may force a curated CJK
+   Coqui catalog.
+3. **Fluent ZH/JA translator + labeler availability** — gates W5 (fixtures +
+   labelled chapters). W1–W4 land regardless; the harness is proven on English
+   first.
+4. **`Intl.Segmenter` fidelity** — assumed "good enough for a ratio guard." If it
+   is not, the fallback is character-count (still self-consistent), **not** a
+   native-dep segmenter (jieba/fugashi) — that stays out of scope.
+5. **`detect.script` typing** — the new `'cjk'` tag on the registry
+   `detect: { script }` union is decoupled from the hardcoded han/kana tiebreak,
+   but the TypeScript union and any exhaustive `switch` over script classes must
+   be widened in the same change, or the build breaks / a script class is
+   silently unhandled.
+
+## 10. Reuse (not built here)
+
+fs-2 data-model + never-cross-language enforcement (`language.ts`,
+`synthesise-chapter.ts`, `verify-designed-voice-language.ts`); fs-60's entire
+engine-eligibility + Coqui-fallback + mixed-engine-serialization + UI machinery;
+the dialogue-structure pipeline; the `notifications` slice; the confirm-screen
+server-driven selector; `detect-language.ts` (zh/ja routing already present).
+
+## Ship notes
+
+_(filled at ship time: shipped date, commit SHAs per wave, W5 operator verdict,
+attribution FP/FN for ZH + JA, audio-gate result per engine × language, fs-70
+reconciliation link.)_

--- a/docs/superpowers/specs/2026-07-13-fs59-cjk-support-design.md
+++ b/docs/superpowers/specs/2026-07-13-fs59-cjk-support-design.md
@@ -19,8 +19,9 @@ This spec reuses the fs-50 framework unchanged and adds only the CJK-specific
 pieces. CJK renders on **both Qwen and Coqui XTTS** — uniquely among the wider
 non-English roadmap, because Qwen (an Alibaba model) natively supports zh/ja, so
 CJK is the one slice of fs-70's "XTTS languages beyond Qwen's five" that also has
-a Qwen path. Both `supported` flags flip together, only after an on-box dual gate
-(operator audio × both engines + attribution FP/FN from a new eval harness).
+a Qwen path. Each `supported` flag flips independently (per-language gate,
+expected to ship together), only after an on-box dual gate (operator audio ×
+both engines + attribution FP/FN from a new eval harness).
 
 ## 1. Context — what already exists (do not rebuild)
 
@@ -63,11 +64,36 @@ proven framework. Verified against the current tree:
 
 | # | Decision | Rationale |
 |---|---|---|
-| D1 | **Segmenter = `Intl.Segmenter`** (zero-dep, Node/ICU built-in) | Pays off twice: `granularity:'word'` gives real CJK word counts for the coverage guard; `granularity:'sentence'` gives native CJK sentence boundaries for the chunker. No new dependency (matches the "one dep = franc" Latin precedent). |
-| D2 | **ZH + JA validated together**, one combined go/no-go; both `supported` flip in the same tail PR | Shared foundations land once; both languages exercise them; a single operator/labeler session covers both. |
+| D1 | **Segmenter = `Intl.Segmenter`** (zero-dep, Node/ICU built-in) | Its load-bearing use is `granularity:'sentence'` for the CJK sentence-split in `stage2-chunk` (the genuinely-broken seam, §3.1). `granularity:'word'` for coverage-ratio stabilisation is an *optional* P2 refinement — §2.1 showed the coverage guard already tolerates CJK. No new dependency (matches the "one dep = franc" Latin precedent). Confirmed available: `node >=20.19.0`, `.nvmrc` 24, full-ICU default. |
+| D2 | **ZH + JA flip independently** (per-language gate); expected to ship together but not coupled | The `supported` flip is per-language: a JA audio-gate miss does **not** block ZH's flip. Foundations still land once and one operator/labeler session covers both, so in practice they ship together — but atomicity is not an invariant. (Resolves the earlier D2/Risk-1 tension.) |
 | D3 | **Build the full §4.8 attribution eval harness**, as **Wave 1 / its own PR**, language-agnostic | The Latin tranche skipped it and flipped `supported` on operator-audio alone. It is infrastructure every future language needs; building it first, proven on an existing language, de-risks the CJK waves and retro-enables an es/fr/de gate. |
 | D4 | **CJK renders on both Qwen and Coqui XTTS** | Qwen natively supports zh/ja; XTTS v2 natively supports `zh-cn`/`ja`; the sidecar has no language allowlist; fs-60's machinery is generic. Honors "it should also work for Coqui." |
 | D5 | **fs-59 owns the CJK slice; fs-70 (#1303) keeps the rest** | CJK is uniquely dual-engine (Qwen + Coqui); fs-70's other languages (ko/ar/hi/…) are XTTS-only. Reconcile by reference on both issues; do not silently absorb. |
+
+## 2.1 Empirical validation (2026-07-13 spike)
+
+Two of the assumption-checker's load-bearing risks were settled by running real
+CJK text through the actual code + a real Gemini pass (no local VRAM):
+
+- **The coverage guard does NOT trip on CJK.** Verbatim `words()` /
+  `validateStage2Coverage` on a 5-paragraph JA and ZH chapter: a faithful
+  attribution scores **ratio 1.000 → PASS** (16 clause-tokens each side); the
+  real truncate defect scores 0.438 → correctly FAIL; the real loop defect scores
+  2.0 + duplicated-block → correctly FAIL. Confirmed end-to-end with a live
+  `gemini-3.1-flash-lite` stage-2 attribution: both languages ratio 1.0, PASS.
+  **The issue's "coverage-guard infinite retry" premise is false** and W2's
+  coverage sub-item is reframed accordingly (§3.1).
+- **The real CJK hard problem is attribution correctness on interrupted quotes.**
+  The same live Gemini pass, with the *current* (non-CJK) prompt, attributed JA
+  「」 dialogue correctly but **mis-attributed Chinese** where a spoken turn is
+  split by a tag: `"小心点，"她轻声说，"下过雨以后…"` → it gave the first spoken
+  fragment to the speaker but the **second spoken half to the narrator**. This is
+  the concrete defect W1 (eval harness measures it) and W3 (dialogue-structure
+  conventions + in-language prompt examples fix it) target — it is now a named
+  regression case, not a hypothetical.
+
+The spike scripts were throwaway (not committed); the JA/ZH sample chapters are
+recorded here and should seed W2's synthetic fixtures and W1's proving material.
 
 ## 3. Architecture — the CJK seams (actual code)
 
@@ -77,20 +103,31 @@ wave that owns it (§5).
 ### 3.1 Analysis foundations (Wave 2 — engine-independent)
 
 - **Coverage guard** — `server/src/analyzer/stage2-coverage.ts`, `words()`
-  (`~:88-97`, `.split(/\s+/)`). A spaceless CJK sentence collapses to one "word",
-  so the attributed÷source coverage ratio is meaningless and
-  `runStage2WithCoverageGuard()` (`~:236`) burns every retry (the "infinite
-  retry" in the issue). **Fix:** when the book is CJK, count words via
-  `Intl.Segmenter(lang, { granularity: 'word' })` filtered to `isWordLike`
-  segments. The ratio stays self-consistent (both sides counted identically);
-  `endingTailWords` becomes ending-tail *segments*. The letter-class Unicode
-  work (`\p{L}\p{N}`) already done for Russian is preserved.
+  (`~:88-97`). **Empirically NOT broken for CJK** (see §2.1). `words()` replaces
+  every `[^\p{L}\p{N}]+` run with a space *before* splitting, and CJK punctuation
+  (`。！？、「」“”`) is all non-letter — so it already delimits a CJK chapter into
+  punctuation-bounded *clauses*. A faithful attribution reproduces them → ratio
+  ≈ 1.0 → PASS (measured: JA and ZH both 1.000). The issue's "`.split(/\s+/)`
+  collapses a spaceless CJK sentence to one token → infinite retry" **does not
+  reproduce** — it predates the `[^\p{L}\p{N}]+ → space` normalisation (the
+  2026-06-15 Russian fix). **No coverage-guard change is required for
+  correctness.** The residual is *granularity*: CJK counts clauses, not words, so
+  a **short or sparse-punctuation** chapter has few tokens and a noisier ratio.
+  **Optional quality improvement (deferrable):** count via
+  `Intl.Segmenter(lang,{granularity:'word'})` to stabilise the ratio on such
+  chapters — but the guard already tolerates CJK, so this is a P2 refinement, not
+  the wave's reason to exist. (It would also require threading the book language
+  into `validateStage2Coverage`/`words()`, which take none today — see §9.)
 - **Sentence splitting** — `server/src/analyzer/stage2-chunk.ts`,
   `splitParagraphIntoSentences()` (`:122`, split on `/(?<=[.!?]["')\]]?)\s+/`).
-  CJK has no whitespace and ends sentences with `。！？`. **Fix:** CJK path uses
+  **This is the genuinely-broken CJK seam:** CJK has no whitespace and ends
+  sentences with `。！？`, so the adaptive re-split fallback for an over-budget
+  CJK paragraph never divides. **Fix:** CJK path uses
   `Intl.Segmenter(lang, { granularity: 'sentence' })` (handles `。！？` + closing
-  `」』` natively). The pre-emptive `splitBodyIntoChunks` paragraph split
-  (`\n\n`) is script-independent and stays.
+  `」』` natively), self-detecting on per-paragraph Han/Kana presence (this runs
+  where the book language may not be threaded). The pre-emptive
+  `splitBodyIntoChunks` paragraph split (`\n\n`) is script-independent and stays.
+  This is the real home of the D1 `Intl.Segmenter` decision.
 - **`isNarrativeLine`** — `server/src/analyzer/strip-front-matter.ts:32`.
   Two CJK gaps: (a) `line.length < 60` assumes Latin density — a CJK line reaches
   equivalent information at far fewer chars; (b) `/\p{Ll}/u` (lowercase test)
@@ -211,12 +248,16 @@ desk/synthetic-verifiable.
 1. **Wave 1 — Attribution eval harness** (language-agnostic, own PR). §3.4.
    *Benefit (architectural): the supported-flip gate every future language needs.*
 2. **Wave 2 — CJK analyze foundations** (server). §3.1. Synthetic ZH/JA fixtures.
-   Registry rows land here (`supported:false`).
-   *Benefit (technical): kills the coverage-guard infinite-retry; CJK chapters
-   split + segment correctly.*
-3. **Wave 3 — CJK conventions + prompts** (server). §3.2.
-   *Benefit (user): CJK dialogue (「」) is recognised as spoken, not demoted to
-   narrator; attribution is CJK-aware.*
+   Registry rows land here (`supported:false`). The load-bearing fix is the
+   `stage2-chunk` CJK sentence-split (`Intl.Segmenter` sentence granularity) +
+   `isNarrativeLine` + token divisor; the coverage-guard word-count change is a
+   deferrable P2 (§2.1/§3.1), not a blocker.
+   *Benefit (technical): CJK chapters split + segment correctly; over-budget CJK
+   paragraphs re-split instead of truncating.*
+3. **Wave 3 — CJK conventions + prompts** (server). §3.2. Targets the §2.1
+   interrupted-quote defect directly.
+   *Benefit (user): CJK dialogue (「」/“”) — including a spoken turn split by a
+   tag — is attributed to the speaker, not silently handed to the narrator.*
 4. **Wave 4 — CJK synthesis, both engines** (sidecar + server). §3.3.
    *Benefit (user): CJK voices render on Qwen and Coqui XTTS.*
 5. **Wave 5 — Validation + flip** (operator tail, own PR).
@@ -225,7 +266,8 @@ desk/synthetic-verifiable.
      (attribution is engine-independent — one pass covers both engines).
    - Operator **audio** gate: Qwen×{zh,ja} **and** Coqui×{zh,ja}.
    - On-box confirm Qwen honours a CJK persona and XTTS `zh-cn`/`ja` quality.
-   - Flip `zh.supported` + `ja.supported` together (tiny PR).
+   - Flip `zh.supported` and `ja.supported` **per language** (D2 — independent;
+     a JA miss does not hold ZH). Expected in one PR, but either may flip alone.
    - **Reconcile fs-70 (#1303):** mark its zh-cn/ja bullets done-by-fs-59; narrow
      its charter to the remaining XTTS-only languages (ko/ar/hi/nl/pl/tr/cs/hu/
      it/pt). Note the reconciliation on #1004 and #1303.
@@ -244,11 +286,13 @@ coverage):
 - **W1:** scorer unit tests (FP/FN math, alias-merge, id-stability) against the
   labelled English fixture; a deliberately-wrong analyzer output asserts non-zero
   FP/FN.
-- **W2:** synthetic ZH + JA fixtures — coverage-guard ratio in-band on healthy CJK
-  text and the retry loop terminates (regression for the infinite-retry);
-  `splitParagraphIntoSentences` splits a CJK paragraph on `。！？`;
-  `isNarrativeLine` accepts a real CJK narrative line and rejects a short heading;
-  `estimateInputTokens` uses ~1.2 for CJK-dense input; registry lookups for zh/ja.
+- **W2:** synthetic ZH + JA fixtures — `splitParagraphIntoSentences` splits a CJK
+  paragraph on `。！？` (the load-bearing fix); a coverage-guard *characterisation*
+  test pinning that a faithful CJK attribution passes at ratio ≈ 1.0 and a
+  truncate/loop defect still fails (locks the §2.1 finding so a future change
+  can't silently break it); `isNarrativeLine` accepts a real CJK narrative line
+  and rejects a short heading; `estimateInputTokens` uses ~1.2 for CJK-dense
+  input; registry lookups for zh/ja.
 - **W3:** `dialogue-structure` recognises 「」 dialogue as spoken and attributes a
   tagged CJK line to its speaker, not the narrator (the issue's core acceptance);
   audio-tag + roster quote-set coverage; `languagePreamble('zh'|'ja')` contains
@@ -265,15 +309,21 @@ under fs-61), mirroring the existing en/de/es/fr/ru samples.
 ## 7. Acceptance (from #1004, mapped to waves)
 
 - [ ] ZH and JA each: detection routes correctly (already true; flips to
-      `supported` on registry rows — W2) and a CJK book splits into chapters,
-      segments into sentences, and **does not trip the coverage-guard infinite
-      retry** (W2).
-- [ ] CJK dialogue (「」) is recognised as spoken, not demoted to narrator (W3).
+      `supported` on registry rows — W2) and a CJK book splits into chapters and
+      segments into sentences, including over-budget CJK paragraphs re-splitting
+      via `Intl.Segmenter` rather than truncating (W2). *(Re §2.1: the issue's
+      "coverage-guard infinite retry" does not reproduce; the coverage guard
+      already tolerates CJK — this criterion is met by the sentence-split fix,
+      not a coverage-guard rewrite.)*
+- [ ] CJK dialogue (「」/“”) is attributed to the speaker — including a spoken
+      turn interrupted by a tag (the §2.1 defect) — not demoted to narrator (W3),
+      measured by the W1 eval harness.
 - [ ] Qwen **and** Coqui XTTS render ZH/JA at acceptable quality (operator audio
       gate, both engines) AND attribution is validated against a fluent-labelled
       sample with FP/FN recorded (W1 harness + W5 labelled chapters).
-- [ ] `supported` flips per language only after the dual gate; both flip together;
-      the never-cross-language invariant holds (W5).
+- [ ] `supported` flips per language only after that language's dual gate (D2 —
+      independent; expected together but not coupled); the never-cross-language
+      invariant holds (W5).
 - [ ] fs-70 (#1303) reconciled by reference (W5).
 
 ## 8. Scope boundaries
@@ -294,18 +344,21 @@ XTTS**, the attribution eval harness, zh + ja → `supported`.
 ## 9. Risks & assumptions
 
 1. **Qwen JA quality** — the top on-box unknown (ZH is Qwen's native strength;
-   JA less certain). Gated in W5; if JA fails the audio gate, ZH can still flip
-   and JA defers — but D2 (flip together) means a JA miss holds ZH's flip; call
-   this out at the W5 gate and let the operator decide split-vs-hold.
+   JA less certain). Gated in W5. Per D2 (independent flips), a JA miss lets ZH
+   flip alone and JA defers — no coupling to resolve.
 2. **XTTS `zh-cn` / `ja` quality** — cross-lingual voice cloning with the generic
    speaker catalog is unverified for CJK; W4b validation may force a curated CJK
    Coqui catalog.
 3. **Fluent ZH/JA translator + labeler availability** — gates W5 (fixtures +
    labelled chapters). W1–W4 land regardless; the harness is proven on English
    first.
-4. **`Intl.Segmenter` fidelity** — assumed "good enough for a ratio guard." If it
-   is not, the fallback is character-count (still self-consistent), **not** a
-   native-dep segmenter (jieba/fugashi) — that stays out of scope.
+4. **`Intl.Segmenter` sentence-boundary fidelity** — the load-bearing use
+   (`granularity:'sentence'` in `stage2-chunk`) is assumed to segment CJK
+   `。！？「」` correctly. If a boundary is missed, an over-budget CJK paragraph
+   still truncates loudly (the existing single-huge-sentence fallback), not
+   silently. Its optional coverage-ratio use (`granularity:'word'`) has a
+   character-count fallback; a native-dep segmenter (jieba/fugashi) stays out of
+   scope either way.
 5. **`detect.script` typing** — the new `'cjk'` tag on the registry
    `detect: { script }` union is decoupled from the hardcoded han/kana tiebreak,
    but the TypeScript union and any exhaustive `switch` over script classes must

--- a/docs/superpowers/specs/2026-07-13-fs59-cjk-support-design.md
+++ b/docs/superpowers/specs/2026-07-13-fs59-cjk-support-design.md
@@ -64,7 +64,7 @@ proven framework. Verified against the current tree:
 
 | # | Decision | Rationale |
 |---|---|---|
-| D1 | **Segmenter = `Intl.Segmenter`** (zero-dep, Node/ICU built-in) | Its load-bearing use is `granularity:'sentence'` for the CJK sentence-split in `stage2-chunk` (the genuinely-broken seam, §3.1). `granularity:'word'` for coverage-ratio stabilisation is an *optional* P2 refinement — §2.1 showed the coverage guard already tolerates CJK. No new dependency (matches the "one dep = franc" Latin precedent). Confirmed available: `node >=20.19.0`, `.nvmrc` 24, full-ICU default. |
+| D1 | **Segmenter = `Intl.Segmenter`** (zero-dep, Node/ICU built-in) | Two load-bearing uses (§3.1): `granularity:'sentence'` for the CJK sentence-split in `stage2-chunk`, and `granularity:'word'` in the coverage guard to restore defect-detection sensitivity (§2.1 measured false negatives without it). Both self-detect script, so no book-language threading. No new dependency (matches the "one dep = franc" precedent). Confirmed available: `node >=20.19.0`, `.nvmrc` 24, full-ICU default. |
 | D2 | **ZH + JA flip independently** (per-language gate); expected to ship together but not coupled | The `supported` flip is per-language: a JA audio-gate miss does **not** block ZH's flip. Foundations still land once and one operator/labeler session covers both, so in practice they ship together — but atomicity is not an invariant. (Resolves the earlier D2/Risk-1 tension.) |
 | D3 | **Build the full §4.8 attribution eval harness**, as **Wave 1 / its own PR**, language-agnostic | The Latin tranche skipped it and flipped `supported` on operator-audio alone. It is infrastructure every future language needs; building it first, proven on an existing language, de-risks the CJK waves and retro-enables an es/fr/de gate. |
 | D4 | **CJK renders on both Qwen and Coqui XTTS** | Qwen natively supports zh/ja; XTTS v2 natively supports `zh-cn`/`ja`; the sidecar has no language allowlist; fs-60's machinery is generic. Honors "it should also work for Coqui." |
@@ -75,14 +75,22 @@ proven framework. Verified against the current tree:
 Two of the assumption-checker's load-bearing risks were settled by running real
 CJK text through the actual code + a real Gemini pass (no local VRAM):
 
-- **The coverage guard does NOT trip on CJK.** Verbatim `words()` /
-  `validateStage2Coverage` on a 5-paragraph JA and ZH chapter: a faithful
-  attribution scores **ratio 1.000 → PASS** (16 clause-tokens each side); the
-  real truncate defect scores 0.438 → correctly FAIL; the real loop defect scores
-  2.0 + duplicated-block → correctly FAIL. Confirmed end-to-end with a live
-  `gemini-3.1-flash-lite` stage-2 attribution: both languages ratio 1.0, PASS.
-  **The issue's "coverage-guard infinite retry" premise is false** and W2's
-  coverage sub-item is reframed accordingly (§3.1).
+- **The coverage guard does NOT infinite-retry on CJK — but it is DEGRADED at
+  catching CJK defects (false negatives).** Two spikes on verbatim `words()` /
+  `validateStage2Coverage`:
+  - *Healthy text:* a faithful attribution of a 5-paragraph JA/ZH chapter scores
+    **ratio 1.000 → PASS**; confirmed end-to-end with a live
+    `gemini-3.1-flash-lite` stage-2 pass (both ratio 1.0). So the issue's
+    "infinite retry" premise is **false** — healthy CJK does not false-positive.
+  - *Defect detection (dialogue-heavy JA, 40 sentences):* a real **repeat-loop**
+    scores `ratio 1.15, dup=false → PASS` and a **30% truncation** scores
+    `ratio 0.70 → PASS` — **both false negatives.** Cause: coarse clause-level
+    tokens make the [0.6, 1.6] band far too slack against a small denominator,
+    and `findDuplicatedBlock`'s `key.length < 8` skip blinds it to CJK dialogue
+    (measured: **80% of dialogue "sentences" have <8-char keys**). A silent
+    loop/truncation to synthesis is worse than a wasted retry — so the coverage
+    fix is **in W2 scope** (§3.1), reframed from "fix infinite retry" (nonexistent)
+    to "restore defect-detection sensitivity."
 - **The real CJK hard problem is attribution correctness on interrupted quotes.**
   The same live Gemini pass, with the *current* (non-CJK) prompt, attributed JA
   「」 dialogue correctly but **mis-attributed Chinese** where a spoken turn is
@@ -103,21 +111,20 @@ wave that owns it (§5).
 ### 3.1 Analysis foundations (Wave 2 — engine-independent)
 
 - **Coverage guard** — `server/src/analyzer/stage2-coverage.ts`, `words()`
-  (`~:88-97`). **Empirically NOT broken for CJK** (see §2.1). `words()` replaces
-  every `[^\p{L}\p{N}]+` run with a space *before* splitting, and CJK punctuation
-  (`。！？、「」“”`) is all non-letter — so it already delimits a CJK chapter into
-  punctuation-bounded *clauses*. A faithful attribution reproduces them → ratio
-  ≈ 1.0 → PASS (measured: JA and ZH both 1.000). The issue's "`.split(/\s+/)`
-  collapses a spaceless CJK sentence to one token → infinite retry" **does not
-  reproduce** — it predates the `[^\p{L}\p{N}]+ → space` normalisation (the
-  2026-06-15 Russian fix). **No coverage-guard change is required for
-  correctness.** The residual is *granularity*: CJK counts clauses, not words, so
-  a **short or sparse-punctuation** chapter has few tokens and a noisier ratio.
-  **Optional quality improvement (deferrable):** count via
-  `Intl.Segmenter(lang,{granularity:'word'})` to stabilise the ratio on such
-  chapters — but the guard already tolerates CJK, so this is a P2 refinement, not
-  the wave's reason to exist. (It would also require threading the book language
-  into `validateStage2Coverage`/`words()`, which take none today — see §9.)
+  (`~:88-97`) + `findDuplicatedBlock` (`~:117`). The issue's "infinite retry" is
+  false (§2.1) — but the guard is **degraded at catching CJK defects** and that
+  IS in scope. Two Latin assumptions break for CJK: (1) `words()` splits on the
+  `[^\p{L}\p{N}]+ → space` normalisation, which on CJK yields coarse *clause*
+  tokens, not words — so the [0.6, 1.6] ratio band is far too slack (measured: a
+  real repeat-loop passes at 1.15, a 30% truncation at 0.70); (2)
+  `findDuplicatedBlock` skips keys `key.length < 8`, and ~80% of CJK dialogue
+  "sentences" are shorter — so loop-detection is blind on dialogue. **Fix (W2):**
+  count words via `Intl.Segmenter({granularity:'word'})` for a meaningful
+  denominator, and replace the fixed `<8` key floor with a CJK-aware one
+  (script-self-detecting, so **no book-language threading needed** — `words()`
+  keys off Han/Kana presence in the text, like the `isNarrativeLine` fix). Goal:
+  a real CJK loop/truncation FAILS, a faithful CJK attribution still PASSES. The
+  `\p{L}\p{N}` letter-class work (Russian) is preserved.
 - **Sentence splitting** — `server/src/analyzer/stage2-chunk.ts`,
   `splitParagraphIntoSentences()` (`:122`, split on `/(?<=[.!?]["')\]]?)\s+/`).
   **This is the genuinely-broken CJK seam:** CJK has no whitespace and ends
@@ -198,6 +205,10 @@ wave that owns it (§5).
   is the load-bearing input. Thread CJK into `EMOTION_INSTRUCT`
   (`qwen-voice.ts`) + `fill-tone` NUDGES or explicitly document deferral.
 - **Coqui XTTS (4b).** Net-new is small:
+  0. **Pre-check (blocks the rest of 4b):** confirm XTTS v2's exact language code
+     for Chinese — `zh-cn` vs `zh`/`zh_cn` — against the installed `TTS` package's
+     accepted set before writing the mapping. The whole path rests on this string
+     (unverifiable in-repo; the sidecar has no allowlist).
   1. Add `'zh','ja'` to `ENGINE_LANGUAGE_SUPPORT.coqui` (`voice-mapping.ts:41`).
   2. A `zh` → `zh-cn` language-code map at the Coqui synth call
      (`normaliseBookLanguage` collapses `zh-CN`→`zh`; XTTS wants `zh-cn`; `ja` is
@@ -226,6 +237,13 @@ Build, in its own PR, independent of CJK:
   so the harness is validated without a fluent CJK labeler.
 - The §7 dual gate consumes this for every language going forward; ZH/JA labelled
   chapters are added in Wave 5.
+- **W5 labelled-chapter requirement (so the harness measures what matters):** the
+  ZH and JA labelled chapters MUST deliberately include (a) **interrupted-quote**
+  turns (spoken—tag—spoken across a fullwidth comma, the §2.1 defect) and (b)
+  **roster-false-positive** constructions (a name-like token that is not a speaker
+  tag — the cases tag-grammar gate-off (§3.2) stops guarding). A clean chapter of
+  easy cases would report a passing FP/FN while hiding exactly the CJK errors this
+  spec exists to catch.
 
 ## 4. Data / control flow (unchanged framework)
 
@@ -248,12 +266,15 @@ desk/synthetic-verifiable.
 1. **Wave 1 — Attribution eval harness** (language-agnostic, own PR). §3.4.
    *Benefit (architectural): the supported-flip gate every future language needs.*
 2. **Wave 2 — CJK analyze foundations** (server). §3.1. Synthetic ZH/JA fixtures.
-   Registry rows land here (`supported:false`). The load-bearing fix is the
-   `stage2-chunk` CJK sentence-split (`Intl.Segmenter` sentence granularity) +
-   `isNarrativeLine` + token divisor; the coverage-guard word-count change is a
-   deferrable P2 (§2.1/§3.1), not a blocker.
+   Registry rows land here (`supported:false`). Two load-bearing fixes: the
+   `stage2-chunk` CJK sentence-split (`Intl.Segmenter` sentence granularity) and
+   the **coverage-guard sensitivity fix** (`Intl.Segmenter` word count + CJK-aware
+   dup-key floor — §2.1 measured false negatives on loop/truncation without it),
+   plus `isNarrativeLine` + token divisor. All self-detect script (no language
+   threading).
    *Benefit (technical): CJK chapters split + segment correctly; over-budget CJK
-   paragraphs re-split instead of truncating.*
+   paragraphs re-split instead of truncating; a looped/truncated CJK chapter is
+   caught instead of shipped silently to synthesis.*
 3. **Wave 3 — CJK conventions + prompts** (server). §3.2. Targets the §2.1
    interrupted-quote defect directly.
    *Benefit (user): CJK dialogue (「」/“”) — including a spoken turn split by a
@@ -287,12 +308,12 @@ coverage):
   labelled English fixture; a deliberately-wrong analyzer output asserts non-zero
   FP/FN.
 - **W2:** synthetic ZH + JA fixtures — `splitParagraphIntoSentences` splits a CJK
-  paragraph on `。！？` (the load-bearing fix); a coverage-guard *characterisation*
-  test pinning that a faithful CJK attribution passes at ratio ≈ 1.0 and a
-  truncate/loop defect still fails (locks the §2.1 finding so a future change
-  can't silently break it); `isNarrativeLine` accepts a real CJK narrative line
-  and rejects a short heading; `estimateInputTokens` uses ~1.2 for CJK-dense
-  input; registry lookups for zh/ja.
+  paragraph on `。！？`; **coverage-guard sensitivity regression** (the two §2.1
+  false-negative cases — a dialogue-heavy CJK repeat-loop and a 30% truncation —
+  must FAIL after the fix; a faithful CJK attribution must still PASS); the
+  dup-detector flags a short-quote CJK loop (the `<8`-key blind spot closed);
+  `isNarrativeLine` accepts a real CJK narrative line and rejects a short heading;
+  `estimateInputTokens` uses ~1.2 for CJK-dense input; registry lookups for zh/ja.
 - **W3:** `dialogue-structure` recognises 「」 dialogue as spoken and attributes a
   tagged CJK line to its speaker, not the narrator (the issue's core acceptance);
   audio-tag + roster quote-set coverage; `languagePreamble('zh'|'ja')` contains
@@ -309,12 +330,14 @@ under fs-61), mirroring the existing en/de/es/fr/ru samples.
 ## 7. Acceptance (from #1004, mapped to waves)
 
 - [ ] ZH and JA each: detection routes correctly (already true; flips to
-      `supported` on registry rows — W2) and a CJK book splits into chapters and
-      segments into sentences, including over-budget CJK paragraphs re-splitting
-      via `Intl.Segmenter` rather than truncating (W2). *(Re §2.1: the issue's
-      "coverage-guard infinite retry" does not reproduce; the coverage guard
-      already tolerates CJK — this criterion is met by the sentence-split fix,
-      not a coverage-guard rewrite.)*
+      `supported` on registry rows — W2); a CJK book splits into chapters and
+      segments into sentences, over-budget CJK paragraphs re-split via
+      `Intl.Segmenter` rather than truncating, AND the coverage guard **catches a
+      looped/truncated CJK chapter** (the §2.1 false-negatives now FAIL) while a
+      faithful CJK attribution still passes (W2). *(Re §2.1: the issue's
+      "infinite retry" does not reproduce, but the guard was measurably degraded
+      at CJK defect detection — this criterion covers the sensitivity fix, not an
+      infinite-retry fix.)*
 - [ ] CJK dialogue (「」/“”) is attributed to the speaker — including a spoken
       turn interrupted by a tag (the §2.1 defect) — not demoted to narrator (W3),
       measured by the W1 eval harness.
@@ -352,14 +375,19 @@ XTTS**, the attribution eval harness, zh + ja → `supported`.
 3. **Fluent ZH/JA translator + labeler availability** — gates W5 (fixtures +
    labelled chapters). W1–W4 land regardless; the harness is proven on English
    first.
-4. **`Intl.Segmenter` sentence-boundary fidelity** — the load-bearing use
-   (`granularity:'sentence'` in `stage2-chunk`) is assumed to segment CJK
-   `。！？「」` correctly. If a boundary is missed, an over-budget CJK paragraph
-   still truncates loudly (the existing single-huge-sentence fallback), not
-   silently. Its optional coverage-ratio use (`granularity:'word'`) has a
-   character-count fallback; a native-dep segmenter (jieba/fugashi) stays out of
-   scope either way.
-5. **`detect.script` typing** — the new `'cjk'` tag on the registry
+4. **`Intl.Segmenter` fidelity — both uses load-bearing.** (a)
+   `granularity:'sentence'` in `stage2-chunk`: a missed boundary truncates loudly
+   (existing single-huge-sentence fallback), not silently. (b)
+   `granularity:'word'` in the coverage guard: must produce enough tokens that a
+   real loop/truncation crosses the ratio band — validate against the §2.1
+   false-negative fixtures, since char-count is a *fallback* but may not restore
+   the same sensitivity. A native-dep segmenter (jieba/fugashi) stays out of scope
+   either way.
+5. **The §2.1 spike is indicative, not exhaustive.** Clean 5-paragraph synthetics
+   with dense fullwidth punctuation; real CJK EPUBs mix ASCII punctuation, ruby/
+   furigana, U+3000 ideographic spaces, and dashless dialogue. W2's fixtures
+   should include at least one messy real-world-shaped chapter.
+6. **`detect.script` typing** — the new `'cjk'` tag on the registry
    `detect: { script }` union is decoupled from the hardcoded han/kana tiebreak,
    but the TypeScript union and any exhaustive `switch` over script classes must
    be widened in the same change, or the build breaks / a script class is

--- a/docs/superpowers/specs/2026-07-13-fs59-cjk-support-design.md
+++ b/docs/superpowers/specs/2026-07-13-fs59-cjk-support-design.md
@@ -28,12 +28,19 @@ both engines + attribution FP/FN from a new eval harness).
 The fs-50 tranche (es/fr/de) **shipped** and left CJK a small delta on top of a
 proven framework. Verified against the current tree:
 
-- **Detection is done.** `server/src/tts/detect-language.ts` already runs an
-  authoritative script pre-pass: Cyrillic→`ru`, then `(han + kana)/letters ≥ 0.3`
+- **Detection routing is done, but the `supported` flag is NOT read-through.**
+  `server/src/tts/detect-language.ts` already runs an authoritative script
+  pre-pass: Cyrillic→`ru`, then `(han + kana)/letters ≥ 0.3`
   → `{ language: kana > han ? 'ja' : 'zh', supported: false }` (front-matter
   stripped first, 20 k-char sample). The Han-vs-Kana disambiguation and the
-  `detected-but-unsupported` return are already in place. **Adding registry rows
-  flips detection to `supported` automatically — no detection code changes.**
+  `detected-but-unsupported` return are already in place.
+  **CORRECTION (independent plan review):** the earlier claim "adding registry
+  rows flips detection automatically — no detection code changes" is FALSE. That
+  CJK branch (`:49-52`) returns a **literal** `supported: false`, bypassing the
+  `result(code)` registry read the ru/latin branches use — so a W5 registry flip
+  would be a no-op end-to-end. The branch MUST be changed to
+  `return result(kana > han ? 'ja' : 'zh')` (plan Task 2.1). This is the ONE
+  detection code change fs-59 needs.
 - **Fail-loud block is in place.** `sidecarLanguageName()`
   (`server/src/tts/language.ts:34`) throws for any code not in the registry, so
   CJK cannot bake an English manifest today. This stays as the safety net.
@@ -161,6 +168,22 @@ wave that owns it (§5).
   (第一章 / 第1話 / 序章 / 終章 …) and `frontMatterKeywords` (目次 / 著作権 /
   献辞 · 目录 / 版权 / 致谢). Number-word lexicons are largely N/A for CJK
   (digits are used directly) — document, don't force.
+
+**Seams the plan's independent review added to §3.1 (not in the original sweep):**
+- **CJK chapter-heading split** — the `headingLexicon` does NOT split CJK
+  chapters: `parsers/text.ts` `CHAPTER_HEADING_RE` expects `keyword→whitespace→
+  number` (Latin), but CJK is the circumfix `第<number>章` (no whitespace, kanji +
+  fullwidth numerals). Needs a dedicated, **whole-line-anchored** CJK pattern (a
+  naive prefix regex matches `第三章で述べた…`/`第二部隊…` and `parseText` deletes
+  that prose as a title). Plan Task 2.6 — acceptance-critical.
+- **Import word-count / front-matter miscount** — `routes/import.ts` `countWords`
+  splits on whitespace, so a spaceless CJK chapter counts ~40 "words" and is
+  pre-ticked `isLikelyFrontMatter` (≤150) → every CJK chapter auto-excluded at
+  confirm. Needs a script-aware count. Plan Task 2.7.
+- **CJK roster-name tag anchoring** — `dialogue-structure/name-matcher.ts`
+  `findRosterName` tokenises on `[^\p{L}]+`, so a CJK tag clause is one token and
+  never matches the roster; `tag-name` (highest-precedence) evidence never fires
+  for CJK. Needs substring-containment matching. Plan Task 3.5.
 
 ### 3.2 Dialogue conventions + prompts (Wave 3 — engine-independent)
 

--- a/docs/superpowers/specs/2026-07-13-fs59-cjk-support-design.md
+++ b/docs/superpowers/specs/2026-07-13-fs59-cjk-support-design.md
@@ -64,7 +64,7 @@ proven framework. Verified against the current tree:
 
 | # | Decision | Rationale |
 |---|---|---|
-| D1 | **Segmenter = `Intl.Segmenter`** (zero-dep, Node/ICU built-in) | Two load-bearing uses (§3.1): `granularity:'sentence'` for the CJK sentence-split in `stage2-chunk`, and `granularity:'word'` in the coverage guard to restore defect-detection sensitivity (§2.1 measured false negatives without it). Both self-detect script, so no book-language threading. No new dependency (matches the "one dep = franc" precedent). Confirmed available: `node >=20.19.0`, `.nvmrc` 24, full-ICU default. |
+| D1 | **Segmenter = `Intl.Segmenter`** (zero-dep, Node/ICU built-in) | One load-bearing use (§3.1): `granularity:'sentence'` for the CJK sentence-split in `stage2-chunk`. (Word-granularity is NOT used for the coverage guard — §2.1 verified it doesn't move the ratio; the coverage fix is a dup-key floor.) Self-detects script, so no book-language threading. No new dependency (matches the "one dep = franc" precedent). Confirmed available: `node >=20.19.0`, `.nvmrc` 24, full-ICU default. |
 | D2 | **ZH + JA flip independently** (per-language gate); expected to ship together but not coupled | The `supported` flip is per-language: a JA audio-gate miss does **not** block ZH's flip. Foundations still land once and one operator/labeler session covers both, so in practice they ship together — but atomicity is not an invariant. (Resolves the earlier D2/Risk-1 tension.) |
 | D3 | **Build the full §4.8 attribution eval harness**, as **Wave 1 / its own PR**, language-agnostic | The Latin tranche skipped it and flipped `supported` on operator-audio alone. It is infrastructure every future language needs; building it first, proven on an existing language, de-risks the CJK waves and retro-enables an es/fr/de gate. |
 | D4 | **CJK renders on both Qwen and Coqui XTTS** | Qwen natively supports zh/ja; XTTS v2 natively supports `zh-cn`/`ja`; the sidecar has no language allowlist; fs-60's machinery is generic. Honors "it should also work for Coqui." |
@@ -75,22 +75,27 @@ proven framework. Verified against the current tree:
 Two of the assumption-checker's load-bearing risks were settled by running real
 CJK text through the actual code + a real Gemini pass (no local VRAM):
 
-- **The coverage guard does NOT infinite-retry on CJK — but it is DEGRADED at
-  catching CJK defects (false negatives).** Two spikes on verbatim `words()` /
-  `validateStage2Coverage`:
+- **The coverage guard does NOT infinite-retry on CJK; it has ONE narrow
+  CJK-specific gap.** Spikes on verbatim `words()` / `validateStage2Coverage`:
   - *Healthy text:* a faithful attribution of a 5-paragraph JA/ZH chapter scores
     **ratio 1.000 → PASS**; confirmed end-to-end with a live
     `gemini-3.1-flash-lite` stage-2 pass (both ratio 1.0). So the issue's
     "infinite retry" premise is **false** — healthy CJK does not false-positive.
-  - *Defect detection (dialogue-heavy JA, 40 sentences):* a real **repeat-loop**
-    scores `ratio 1.15, dup=false → PASS` and a **30% truncation** scores
-    `ratio 0.70 → PASS` — **both false negatives.** Cause: coarse clause-level
-    tokens make the [0.6, 1.6] band far too slack against a small denominator,
-    and `findDuplicatedBlock`'s `key.length < 8` skip blinds it to CJK dialogue
-    (measured: **80% of dialogue "sentences" have <8-char keys**). A silent
-    loop/truncation to synthesis is worse than a wasted retry — so the coverage
-    fix is **in W2 scope** (§3.1), reframed from "fix infinite retry" (nonexistent)
-    to "restore defect-detection sensitivity."
+  - *The one genuine CJK bug (dialogue-heavy JA, 40 sentences):* a real
+    **repeat-loop** scores `ratio 1.15, dup=false → PASS`. The ratio band can't
+    catch a mild loop (English wouldn't either), but English is saved by
+    `findDuplicatedBlock`; CJK is **not**, because that detector skips keys
+    `key.length < 8` and ~80% of CJK dialogue "sentences" are shorter. **Fix (W2):
+    a CJK-aware dup-key floor — that, and only that, is the CJK coverage bug.**
+  - *Ruled OUT as CJK bugs (verified, so the plan doesn't chase them):* (a) a 30%
+    **truncation** passing at `ratio 0.70` is the guard's *designed* tolerance
+    (floor 0.6 admits healthy 0.65–1.0 compression) and is **language-agnostic** —
+    English behaves identically; not a CJK defect. (b) `Intl.Segmenter` **word**-
+    counting does **not** move the ratio: measured clause-vs-word counts are
+    1.150 vs 1.155 (loop) and 0.700 vs 0.670 (truncation) — ratio is
+    scale-invariant, so finer tokens change no verdict. Word-granularity is
+    therefore **not** part of the coverage fix; it stays load-bearing only for the
+    `stage2-chunk` sentence split.
 - **The real CJK hard problem is attribution correctness on interrupted quotes.**
   The same live Gemini pass, with the *current* (non-CJK) prompt, attributed JA
   「」 dialogue correctly but **mis-attributed Chinese** where a spoken turn is
@@ -110,21 +115,19 @@ wave that owns it (§5).
 
 ### 3.1 Analysis foundations (Wave 2 — engine-independent)
 
-- **Coverage guard** — `server/src/analyzer/stage2-coverage.ts`, `words()`
-  (`~:88-97`) + `findDuplicatedBlock` (`~:117`). The issue's "infinite retry" is
-  false (§2.1) — but the guard is **degraded at catching CJK defects** and that
-  IS in scope. Two Latin assumptions break for CJK: (1) `words()` splits on the
-  `[^\p{L}\p{N}]+ → space` normalisation, which on CJK yields coarse *clause*
-  tokens, not words — so the [0.6, 1.6] ratio band is far too slack (measured: a
-  real repeat-loop passes at 1.15, a 30% truncation at 0.70); (2)
-  `findDuplicatedBlock` skips keys `key.length < 8`, and ~80% of CJK dialogue
-  "sentences" are shorter — so loop-detection is blind on dialogue. **Fix (W2):**
-  count words via `Intl.Segmenter({granularity:'word'})` for a meaningful
-  denominator, and replace the fixed `<8` key floor with a CJK-aware one
-  (script-self-detecting, so **no book-language threading needed** — `words()`
-  keys off Han/Kana presence in the text, like the `isNarrativeLine` fix). Goal:
-  a real CJK loop/truncation FAILS, a faithful CJK attribution still PASSES. The
-  `\p{L}\p{N}` letter-class work (Russian) is preserved.
+- **Coverage guard** — `server/src/analyzer/stage2-coverage.ts`,
+  `findDuplicatedBlock` (`~:117`). The issue's "infinite retry" is false (§2.1),
+  and — verified — the ratio band and `Intl.Segmenter` word-counting are **not**
+  the fix (ratio is scale-invariant; a 30% truncation passing at 0.70 is the
+  guard's designed, language-agnostic tolerance). The **one** CJK-specific bug is
+  `findDuplicatedBlock`'s `key.length < 8` skip: ~80% of CJK dialogue "sentences"
+  have shorter keys, so a CJK repeat-loop evades the dup-detector (measured:
+  passes at ratio 1.15, dup=false). **Fix (W2):** a CJK-aware dup-key floor
+  (char-based or a lower CJK threshold), script-self-detecting on Han/Kana
+  presence — **no book-language threading needed** (like the `isNarrativeLine`
+  fix). Goal: a CJK short-dialogue repeat-loop FAILS; a faithful CJK attribution
+  still PASSES. `words()` itself needs no change (its `\p{L}\p{N}` normalisation
+  already tokenises CJK into clauses correctly for the ratio).
 - **Sentence splitting** — `server/src/analyzer/stage2-chunk.ts`,
   `splitParagraphIntoSentences()` (`:122`, split on `/(?<=[.!?]["')\]]?)\s+/`).
   **This is the genuinely-broken CJK seam:** CJK has no whitespace and ends
@@ -266,15 +269,14 @@ desk/synthetic-verifiable.
 1. **Wave 1 — Attribution eval harness** (language-agnostic, own PR). §3.4.
    *Benefit (architectural): the supported-flip gate every future language needs.*
 2. **Wave 2 — CJK analyze foundations** (server). §3.1. Synthetic ZH/JA fixtures.
-   Registry rows land here (`supported:false`). Two load-bearing fixes: the
-   `stage2-chunk` CJK sentence-split (`Intl.Segmenter` sentence granularity) and
-   the **coverage-guard sensitivity fix** (`Intl.Segmenter` word count + CJK-aware
-   dup-key floor — §2.1 measured false negatives on loop/truncation without it),
-   plus `isNarrativeLine` + token divisor. All self-detect script (no language
+   Registry rows land here (`supported:false`). Fixes: the `stage2-chunk` CJK
+   sentence-split (`Intl.Segmenter` sentence granularity), the **coverage-guard
+   dup-key floor** (CJK-aware, closing the short-dialogue loop blind spot — §2.1),
+   `isNarrativeLine`, and the token divisor. All self-detect script (no language
    threading).
    *Benefit (technical): CJK chapters split + segment correctly; over-budget CJK
-   paragraphs re-split instead of truncating; a looped/truncated CJK chapter is
-   caught instead of shipped silently to synthesis.*
+   paragraphs re-split instead of truncating; a CJK dialogue repeat-loop is caught
+   instead of shipped silently to synthesis.*
 3. **Wave 3 — CJK conventions + prompts** (server). §3.2. Targets the §2.1
    interrupted-quote defect directly.
    *Benefit (user): CJK dialogue (「」/“”) — including a spoken turn split by a
@@ -308,12 +310,13 @@ coverage):
   labelled English fixture; a deliberately-wrong analyzer output asserts non-zero
   FP/FN.
 - **W2:** synthetic ZH + JA fixtures — `splitParagraphIntoSentences` splits a CJK
-  paragraph on `。！？`; **coverage-guard sensitivity regression** (the two §2.1
-  false-negative cases — a dialogue-heavy CJK repeat-loop and a 30% truncation —
-  must FAIL after the fix; a faithful CJK attribution must still PASS); the
-  dup-detector flags a short-quote CJK loop (the `<8`-key blind spot closed);
-  `isNarrativeLine` accepts a real CJK narrative line and rejects a short heading;
-  `estimateInputTokens` uses ~1.2 for CJK-dense input; registry lookups for zh/ja.
+  paragraph on `。！？`; **dup-detector regression** (a CJK short-dialogue
+  repeat-loop — the §2.1 `<8`-key blind spot — must FAIL after the CJK-aware
+  dup-key floor; a faithful CJK attribution must still PASS; and a characterisation
+  test pinning that healthy CJK sits at ratio ≈ 1.0 so the floor change doesn't
+  regress it); `isNarrativeLine` accepts a real CJK narrative line and rejects a
+  short heading; `estimateInputTokens` uses ~1.2 for CJK-dense input; registry
+  lookups for zh/ja.
 - **W3:** `dialogue-structure` recognises 「」 dialogue as spoken and attributes a
   tagged CJK line to its speaker, not the narrator (the issue's core acceptance);
   audio-tag + roster quote-set coverage; `languagePreamble('zh'|'ja')` contains
@@ -332,12 +335,11 @@ under fs-61), mirroring the existing en/de/es/fr/ru samples.
 - [ ] ZH and JA each: detection routes correctly (already true; flips to
       `supported` on registry rows — W2); a CJK book splits into chapters and
       segments into sentences, over-budget CJK paragraphs re-split via
-      `Intl.Segmenter` rather than truncating, AND the coverage guard **catches a
-      looped/truncated CJK chapter** (the §2.1 false-negatives now FAIL) while a
-      faithful CJK attribution still passes (W2). *(Re §2.1: the issue's
-      "infinite retry" does not reproduce, but the guard was measurably degraded
-      at CJK defect detection — this criterion covers the sensitivity fix, not an
-      infinite-retry fix.)*
+      `Intl.Segmenter` rather than truncating, AND the dup-detector **catches a
+      CJK short-dialogue repeat-loop** (the §2.1 blind spot now FAILS) while a
+      faithful CJK attribution still passes (W2). *(Re §2.1: the issue's "infinite
+      retry" does not reproduce; the sole CJK coverage bug is the dup-key floor —
+      mild truncation passing is by-design and language-agnostic, not chased.)*
 - [ ] CJK dialogue (「」/“”) is attributed to the speaker — including a spoken
       turn interrupted by a tag (the §2.1 defect) — not demoted to narrator (W3),
       measured by the W1 eval harness.
@@ -355,9 +357,17 @@ under fs-61), mirroring the existing en/de/es/fr/ru samples.
 XTTS**, the attribution eval harness, zh + ja → `supported`.
 
 **Out:**
+- **Korean (`ko`)** — nominally "CJK", but deliberately **excluded**. Hangul is a
+  **spaced** script, so Korean shares *none* of the spaceless-script foundations
+  this spec is built on (no segmenter, no sentence-split rewrite, coverage guard
+  works as-is, whitespace tokenisation is valid). It also uses a distinct script
+  (`\p{Script=Hangul}`, not Han/Kana, so a new detection branch) and Qwen's
+  Korean quality is unverified. Korean is a Russian/Latin-shaped "add-a-language"
+  job, not CJK-foundation work — it belongs to **fs-70** (#1303), which already
+  lists it. (This spec is really "CJ" — Chinese + Japanese, the spaceless pair.)
 - **Kokoro-CJK** — Kokoro is English-only with no CJK G2P (misaki[ja,zh]); that is
   fs-69 (#1302) / §11.2, not here. CJK is Qwen+Coqui only in v1.
-- **The other 10 XTTS languages** (ko/ar/hi/nl/pl/tr/cs/hu/it/pt) — fs-70 (#1303).
+- **The other XTTS languages** (ko/ar/hi/nl/pl/tr/cs/hu/it/pt) — fs-70 (#1303).
 - **Cross-book voice identity check** — fs-71 (#1304).
 - **UI localization** — fs-14. **TTS text normalization** (no
   `normalize/lang/{zh,ja}.ts`) — fs-53.
@@ -375,14 +385,12 @@ XTTS**, the attribution eval harness, zh + ja → `supported`.
 3. **Fluent ZH/JA translator + labeler availability** — gates W5 (fixtures +
    labelled chapters). W1–W4 land regardless; the harness is proven on English
    first.
-4. **`Intl.Segmenter` fidelity — both uses load-bearing.** (a)
-   `granularity:'sentence'` in `stage2-chunk`: a missed boundary truncates loudly
-   (existing single-huge-sentence fallback), not silently. (b)
-   `granularity:'word'` in the coverage guard: must produce enough tokens that a
-   real loop/truncation crosses the ratio band — validate against the §2.1
-   false-negative fixtures, since char-count is a *fallback* but may not restore
-   the same sensitivity. A native-dep segmenter (jieba/fugashi) stays out of scope
-   either way.
+4. **`Intl.Segmenter` sentence-boundary fidelity** — the one load-bearing use
+   (`granularity:'sentence'` in `stage2-chunk`) must segment CJK `。！？「」`
+   correctly; a missed boundary truncates loudly (existing single-huge-sentence
+   fallback), not silently. (Word-granularity is not used — §2.1 verified it
+   doesn't move the coverage ratio.) A native-dep segmenter (jieba/fugashi) stays
+   out of scope.
 5. **The §2.1 spike is indicative, not exhaustive.** Clean 5-paragraph synthetics
    with dense fullwidth punctuation; real CJK EPUBs mix ASCII punctuation, ruby/
    furigana, U+3000 ideographic spaces, and dashless dialogue. W2's fixtures


### PR DESCRIPTION
## Summary

Design-only deliverable for **fs-59 — CJK (Chinese/Japanese) language support** (#1004). No product code; two documents:

- **Spec** (design of record): `docs/superpowers/specs/2026-07-13-fs59-cjk-support-design.md`
- **Plan** (26 TDD tasks, 5 waves): `docs/superpowers/plans/2026-07-13-fs59-cjk-support.md`

CJK is a follow-on to the shipped fs-50 language framework, rendering on **both Qwen and Coqui XTTS** (the only slice of fs-70 with a Qwen path). Decisions: `Intl.Segmenter` (no new dep) · zh/ja flip independently · a language-agnostic attribution eval harness lands first (Wave 1) · fs-59 takes the CJK slice, fs-70 keeps the rest · **Korean explicitly excluded** (spaced Hangul shares none of the foundations).

## How this was validated

The spec and plan each went through **two self adversarial passes + empirical validation** (a live Gemini stage-2 pass, no local VRAM, which overturned the issue's "coverage-guard infinite retry" premise), then an **independent cold-eyes review** that caught ~10 real issues the self-passes missed — all verified against code and folded in, including a detection hardcode that would have made the feature a dead end, a chapter-heading regex that silently deleted prose, an import-time front-matter miscount, and broken CJK roster-name matching. Both docs carry an "independent review findings" trail for the implementer.

## Test plan

N/A — docs-only (qualifies for the doc-only PR fast-path; no runtime surface). The plan itself is the test contract for the implementation thread.

Refs #1004
