### PR TITLE
feat(server): CJK analyze foundations + zh/ja narrator names (fs-59 Wave 2)

### DIFF
--- a/server/src/analyzer/gemini.test.ts
+++ b/server/src/analyzer/gemini.test.ts
@@ -388,6 +388,16 @@ describe('fs-2 — languagePreamble + estimateInputTokens', () => {
     expect(mixedEst).toBeGreaterThan(latinEst);
     expect(mixedEst).toBeLessThan(cyrEst);
   });
+
+  it('estimateInputTokens: CJK uses ~1.2 chars/token', async () => {
+    const { estimateInputTokens } = await import('./gemini.js');
+    const cjk = '彼は歩いた'.repeat(200); // 1000 CJK chars ≈ ~833 tokens at 1.2
+    const wrap = (text: string) => [{ role: 'user' as const, parts: [{ text }] }];
+    const est = estimateInputTokens('', wrap(cjk));
+    // NOTE (independent-review): current code = ceil(1000/4) + 1000 flat margin (gemini.ts:898) = 1250,
+    // so the bound MUST exceed 1250 to actually fail before the fix (post-fix ≈ 833 + 1000 = 1833).
+    expect(est).toBeGreaterThan(1500);
+  });
 });
 
 describe('GeminiAnalyzer.generateWithLimiter — retry policy', () => {

--- a/server/src/analyzer/gemini.ts
+++ b/server/src/analyzer/gemini.ts
@@ -870,9 +870,17 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
    the Cyrillic fraction of the actual text and interpolate the divisor between
    4 (all-Latin) and 2.5 (all-Cyrillic). Reconciled against
    `usageMetadata.promptTokenCount` once the call returns, so the blend only has
-   to be close, not exact. */
+   to be close, not exact.
+
+   fs-59 — CJK (Han ideographs + Kana) is denser still (~1.2 chars/token), so
+   a CJK-dense prompt under-counted even worse than Cyrillic did. We measure
+   the Han/Kana fraction the same way as `countCyrillic` and fold it into the
+   same additive interpolation — Cyrillic and CJK never overlap in the same
+   codepoint, so each fraction pulls the divisor down from the Latin baseline
+   independently. */
 const LATIN_CHARS_PER_TOKEN = 4;
 const CYRILLIC_CHARS_PER_TOKEN = 2.5;
+const HAN_KANA_CHARS_PER_TOKEN = 1.2;
 
 export function estimateInputTokens(
   systemInstruction: string,
@@ -880,21 +888,30 @@ export function estimateInputTokens(
 ): number {
   let chars = systemInstruction.length;
   let cyrillic = 0;
+  let hanKana = 0;
   const countCyrillic = (s: string): number => {
     const m = s.match(/[Ѐ-ӿ]/g);
     return m ? m.length : 0;
   };
+  const countHanKana = (s: string): number => {
+    const m = s.match(/[぀-ヿ㐀-䶿一-鿿]/g);
+    return m ? m.length : 0;
+  };
   cyrillic += countCyrillic(systemInstruction);
+  hanKana += countHanKana(systemInstruction);
   for (const turn of contents) {
     for (const part of turn.parts) {
       chars += part.text.length;
       cyrillic += countCyrillic(part.text);
+      hanKana += countHanKana(part.text);
     }
   }
   const cyrillicFraction = chars > 0 ? cyrillic / chars : 0;
+  const hanKanaFraction = chars > 0 ? hanKana / chars : 0;
   const divisor =
     LATIN_CHARS_PER_TOKEN -
-    cyrillicFraction * (LATIN_CHARS_PER_TOKEN - CYRILLIC_CHARS_PER_TOKEN);
+    cyrillicFraction * (LATIN_CHARS_PER_TOKEN - CYRILLIC_CHARS_PER_TOKEN) -
+    hanKanaFraction * (LATIN_CHARS_PER_TOKEN - HAN_KANA_CHARS_PER_TOKEN);
   return Math.ceil(chars / divisor) + 1_000;
 }
 

--- a/server/src/analyzer/stage2-chunk.test.ts
+++ b/server/src/analyzer/stage2-chunk.test.ts
@@ -91,6 +91,14 @@ describe('splitParagraphIntoSentences', () => {
     const blob = 'word '.repeat(40).trim(); // no terminal punctuation
     expect(splitParagraphIntoSentences(blob, 10)).toEqual([blob]);
   });
+
+  it('splits a spaceless CJK paragraph on 。 boundaries, lossless with no injected spaces', () => {
+    const para = '彼は歩いた。彼女は走った。二人は止まった。';
+    const chunks = splitParagraphIntoSentences(para, 14); // packs ~2 segments/chunk → exercises the joiner
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join('')).toBe(para); // no ASCII space injected (would fail with the Latin space-join)
+    expect(chunks.join('')).not.toContain(' '); // belt-and-suspenders
+  });
 });
 
 describe('stage2ChunkBudgetForEngine (num_ctx-aware budget sizing)', () => {

--- a/server/src/analyzer/stage2-chunk.ts
+++ b/server/src/analyzer/stage2-chunk.ts
@@ -118,11 +118,42 @@ export function splitBodyIntoChunks(body: string, charBudget: number): string[] 
     insensitive) and this path only fires as a recovery from a hard failure.
     Returns `[para]` unchanged when it fits, or when there is no sentence
     boundary to split on (a single huge sentence still surfaces the truncation
-    loudly rather than being cut mid-sentence). */
+    loudly rather than being cut mid-sentence).
+
+    CJK fallback (fs-59 W2): CJK prose has no inter-word whitespace, so the
+    Latin regex above finds no boundary and returns `[para]` unsplit even
+    though the paragraph is packed with sentence-ending 。！？ punctuation. If
+    the paragraph contains Han/Kana AND the Latin split above yielded ≤1 unit,
+    re-split using `Intl.Segmenter`'s sentence granularity (ICU-backed, no new
+    dependency) — `'ja'` when Kana is present (mixed kanji+kana is Japanese),
+    else `'zh'`. Repacked chunks are joined with an EMPTY string, not a space:
+    injecting ASCII spaces into CJK prose is lossy prose corruption, unlike the
+    Latin path where a space is the correct inter-sentence separator. */
 export function splitParagraphIntoSentences(para: string, charBudget: number): string[] {
   if (para.length <= charBudget) return [para];
   const sentences = para.split(/(?<=[.!?]["')\]]?)\s+/).filter(Boolean);
-  if (sentences.length <= 1) return [para]; // no boundary — nothing to split
+  if (sentences.length <= 1) {
+    if (/[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u.test(para)) {
+      const lang = /[\p{Script=Hiragana}\p{Script=Katakana}]/u.test(para) ? 'ja' : 'zh';
+      const segmenter = new Intl.Segmenter(lang, { granularity: 'sentence' });
+      const cjkSentences = Array.from(segmenter.segment(para), (s) => s.segment).filter(Boolean);
+      if (cjkSentences.length > 1) {
+        const cjkChunks: string[] = [];
+        let cjkCur = '';
+        for (const s of cjkSentences) {
+          if (cjkCur && cjkCur.length + s.length > charBudget) {
+            cjkChunks.push(cjkCur);
+            cjkCur = s;
+          } else {
+            cjkCur += s;
+          }
+        }
+        if (cjkCur) cjkChunks.push(cjkCur);
+        return cjkChunks.length > 0 ? cjkChunks : [para];
+      }
+    }
+    return [para]; // no boundary — nothing to split
+  }
   const chunks: string[] = [];
   let cur = '';
   for (const s of sentences) {

--- a/server/src/analyzer/stage2-coverage.test.ts
+++ b/server/src/analyzer/stage2-coverage.test.ts
@@ -131,6 +131,24 @@ describe('validateStage2Coverage', () => {
     expect(v.endingPresent).toBe(false);
   });
 
+  it('flags a CJK short-dialogue repeat-loop the <8 key floor used to miss', () => {
+    const line = (t: string) => ({ text: t });
+    const base = ['「そうだ」', '「本当に」', '「行こう」', '「まだだ」'].map(line);
+    const sentences = [...base, ...base]; // a 4-run repeat at constant offset
+    const v = validateStage2Coverage('', sentences, DEFAULT_STAGE2_COVERAGE_THRESHOLDS);
+    expect(v.duplicatedBlock).not.toBeNull();
+  });
+
+  it('does NOT false-positive a faithful CJK dialogue attribution (short but unique lines)', () => {
+    // Guard test: ensure the CJK floor of 2 doesn't flag legitimate unique short CJK text
+    const line = (t: string) => ({ text: t });
+    const sentences = ['「そうだ」', '「本当に」', '「行こう」', '「まだだ」', '「違うな」'].map(line);
+    const body = sentences.map((s) => s.text).join('');
+    const v = validateStage2Coverage(body, sentences, DEFAULT_STAGE2_COVERAGE_THRESHOLDS);
+    expect(v.ok).toBe(true);
+    expect(v.duplicatedBlock).toBeNull();
+  });
+
   it('does NOT flag a word-free source (e.g. a *** scene break) as truncated', () => {
     // Regression (2026-06-19 Ночной дозор ch7): a lone scene-break paragraph
     // ("***") normalises to ZERO words, so the ratio was forced to 0.00 and the

--- a/server/src/analyzer/stage2-coverage.ts
+++ b/server/src/analyzer/stage2-coverage.ts
@@ -115,7 +115,8 @@ function findDuplicatedBlock(
   const repeats: Array<{ i: number; offset: number }> = [];
   sentences.forEach((s, i) => {
     const key = words(s.text).join(' ');
-    if (key.length < 8) return; // ignore very short sentences ("No.", "What?")
+    const hasCjk = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u.test(key);
+    if (key.length < (hasCjk ? 2 : 8)) return; // ignore very short sentences ("No.", "What?"); 2-char CJK is meaningful
     if (firstSeen.has(key)) repeats.push({ i, offset: i - firstSeen.get(key)! });
     else firstSeen.set(key, i);
   });

--- a/server/src/analyzer/strip-front-matter.test.ts
+++ b/server/src/analyzer/strip-front-matter.test.ts
@@ -67,4 +67,12 @@ describe('stripFrontMatterBoilerplate', () => {
     expect(out).not.toMatch(/Rechte vorbehalten/i);
     expect(out).toMatch(/El horno se había enfriado/); // narrative kept
   });
+
+  it('a CJK narrative line closes the front-matter region so a later author echo is NOT stripped', () => {
+    // 献辞 (dedication) → narrative line → then a line equal to the author name
+    const body = '献辞\n\n彼は古い石段の上で足を止め、霧に沈んだ谷を見下ろした。\n\n田中太郎';
+    const out = stripFrontMatterBoilerplate(body, { author: '田中太郎' });
+    expect(out).toContain('彼は古い石段'); // narrative kept
+    expect(out).toContain('田中太郎'); // author echo AFTER a real narrative line is NOT front-matter
+  });
 });

--- a/server/src/analyzer/strip-front-matter.ts
+++ b/server/src/analyzer/strip-front-matter.ts
@@ -28,8 +28,19 @@ function isGlobalBoilerplate(line: string): boolean {
 
 /* A line that reads as narrative prose: reasonably long, contains sentence
    punctuation AND a lowercase letter. All-caps headings ("ПРОЛОГ", "ИСТОРИЯ
-   ПЕРВАЯ") and bare bylines are short / have no lowercase → not narrative. */
+   ПЕРВАЯ") and bare bylines are short / have no lowercase → not narrative.
+
+   CJK (Han/Kana) has no case distinction, so `/\p{Ll}/u` never matches, and
+   CJK prose is denser than Latin so the 60-char threshold is too high. For a
+   line containing Han/Kana, use a lower length threshold (~15) plus a CJK
+   sentence-ending punctuation mark instead of the lowercase-letter test. */
+const CJK_CHAR = /[぀-ヿ㐀-䶿一-鿿]/;
+const CJK_SENTENCE_END = /[。！？…]/;
+
 function isNarrativeLine(line: string): boolean {
+  if (CJK_CHAR.test(line)) {
+    return line.length >= 15 && CJK_SENTENCE_END.test(line);
+  }
   if (line.length < 60) return false;
   return /[.!?…]/.test(line) && /\p{Ll}/u.test(line);
 }

--- a/server/src/parsers/text.test.ts
+++ b/server/src/parsers/text.test.ts
@@ -351,6 +351,37 @@ describe('parseText — non-English chapter splitting (seam 3a)', () => {
   });
 });
 
+describe('parseText — CJK chapter splitting (fs-59 W2, acceptance-critical)', () => {
+  it('splits CJK headings but does not eat 第N-prefixed prose', () => {
+    const body = [
+      '第一章', '', '彼は歩いた。第三章で述べたように、彼は振り返らなかった。', '',
+      '第２章', '', '第二部隊が丘を越えて進軍した。二人は止まった。', '',
+      '第十二話', '', '終わり。',
+    ].join('\n');
+    const { chapters } = parseText(body, { format: 'plaintext' });
+    expect(chapters.length).toBe(3); // 第一章 / 第２章 / 第十二話
+    expect(chapters.map((c) => c.body).join('')).toContain('第三章で述べた'); // prose NOT deleted
+    expect(chapters.map((c) => c.body).join('')).toContain('第二部隊が丘'); // compound NOT a title
+  });
+
+  it('splits a standalone 序章 heading as its own chapter', () => {
+    const body = ['序章', '', '静かな朝だった。', '', '第一章', '', '物語が始まる。'].join('\n');
+    const { chapters } = parseText(body, { format: 'plaintext' });
+    expect(chapters.length).toBe(2);
+    expect(chapters[0].title).toBe('序章');
+    expect(chapters[0].body).toContain('静かな朝だった');
+  });
+
+  it('does NOT split a heading-like prefix followed by a particle (第五章のこと)', () => {
+    const body = ['第一章', '', '第五章のことを思い出した。彼は笑った。', '', '第二章', '', '終わり。'].join(
+      '\n',
+    );
+    const { chapters } = parseText(body, { format: 'plaintext' });
+    expect(chapters.length).toBe(2); // only 第一章 / 第二章 — 第五章のこと is NOT a 3rd chapter
+    expect(chapters.map((c) => c.body).join('')).toContain('第五章のことを思い出した');
+  });
+});
+
 describe('parseText — audio-tag passthrough', () => {
   it('applies tagShoutingDialog to chapter bodies', () => {
     const out = parseText('Chapter 1\nShe yelled "GET OUT NOW".', { format: 'plaintext' });

--- a/server/src/parsers/text.ts
+++ b/server/src/parsers/text.ts
@@ -48,8 +48,30 @@ const ALL_STANDALONE = [
 /* Numbered-section number: Arabic digit, Roman numeral, or English/non-English word
    form (with optional compound for 21–99: "twenty-one", "thirty two", …). */
 const NUMBER_PART = `(?:[ivxlcdm\\d]+|(?:${ALL_NUMBER_WORDS})(?:[-\\s](?:${ALL_NUMBER_WORDS}))?)`;
+
+/* CJK (zh/ja) chapter headings are the CIRCUMFIX `第<number>章` — keyword
+   *after* the number, no whitespace between them, and kanji/fullwidth
+   numerals that NUMBER_PART doesn't cover. The Latin `KEYWORD \s NUMBER`
+   shape above can never match this, so it needs its own alternative.
+
+   MUST be whole-line anchored: the number+ender must be followed by
+   end-of-line or a separator, never arbitrary prose. A naive prefix match
+   (`^第[…]+[章話…]`) also matches mid-sentence text like `第三章で述べたよう
+   に…` ("as stated in chapter 3…") and compounds like `第二部隊が丘を…`
+   (第N部隊 = "the Nth squad") — and parseText deletes a matched line as the
+   chapter title, silently eating prose. The lookahead below caps the whole
+   line at CJK_HEADING_MAX_LEN chars (a real CJK heading is short) and the
+   trailing group only allows a separator or end-of-string right after the
+   ender character, so a continuation like `で`/`が`/`隊` fails the match. */
+const CJK_HEADING_MAX_LEN = 20;
+const CJK_NUMBER = '[0-9０-９〇一二三四五六七八九十百千]+';
+const CJK_ENDER = '[章話回節部幕巻]'; // 章話回節部幕巻
+const CJK_SEP = '(?:[\\s：:—-]|$)'; // whitespace, fullwidth/halfwidth colon, em-dash, hyphen, or end-of-line
+const CJK_STANDALONE = '序章|終章|プロローグ|エピローグ'; // 序章|終章|プロローグ|エピローグ
+const CJK_HEADING_ALT = `(?=.{1,${CJK_HEADING_MAX_LEN}}$)(?:第${CJK_NUMBER}${CJK_ENDER}${CJK_SEP}|(?:${CJK_STANDALONE})${CJK_SEP})`; // 第<number><ender>
+
 const CHAPTER_HEADING_RE = new RegExp(
-  `^(?:#{1,2}\\s+\\S|(?:${ALL_HEADING_KEYWORDS})\\s+${NUMBER_PART}\\b|(?:${ALL_STANDALONE})\\b)`,
+  `^(?:#{1,2}\\s+\\S|(?:${ALL_HEADING_KEYWORDS})\\s+${NUMBER_PART}\\b|(?:${ALL_STANDALONE})\\b|${CJK_HEADING_ALT})`,
   'iu',
 );
 

--- a/server/src/routes/import.test.ts
+++ b/server/src/routes/import.test.ts
@@ -457,3 +457,54 @@ describe('POST /api/import — language detection (fs-41/fs-50)', () => {
     ]);
   });
 });
+
+/* fs-59 W2 task 2.7 — CJK-aware word count so a spaceless CJK chapter isn't
+   pre-ticked for front-matter exclusion (countWords splits on \s+, which
+   yields ~1 "word" per CJK paragraph). */
+describe('POST /api/import — CJK-aware word count (fs-59 W2)', () => {
+  it('does not flag a spaceless ~2000-char CJK chapter as front matter and reports a plausible (hundreds, not ~40) word count', async () => {
+    const sentence = '这是一个用来测试字数统计功能是否正确无误的句子';
+    const body = sentence.repeat(Math.ceil(2000 / sentence.length));
+    const text = ['第一章', '', body].join('\n');
+    const res = await request(app).post('/api/import').send({ text }).expect(200);
+    const ch1 = res.body.candidate.chapters.find((c: any) => c.title === '第一章');
+    expect(ch1).toBeTruthy();
+    expect(ch1.isLikelyFrontMatter).toBe(false);
+    expect(ch1.wordCount).toBeGreaterThan(300);
+    expect(ch1.wordCount).toBeLessThan(2000);
+  });
+
+  it('still flags a short CJK chapter (word-equivalent count <= 150) as front matter, threshold unaffected', async () => {
+    const sentence = '这是一个用来测试字数统计功能是否正确无误的句子';
+    const longBody = sentence.repeat(Math.ceil(2000 / sentence.length));
+    const text = ['序章', '', '这是一段很短的引子。', '', '第一章', '', longBody].join('\n');
+    const res = await request(app).post('/api/import').send({ text }).expect(200);
+    const prologue = res.body.candidate.chapters.find((c: any) => c.title === '序章');
+    const ch1 = res.body.candidate.chapters.find((c: any) => c.title === '第一章');
+    expect(prologue).toBeTruthy();
+    expect(ch1).toBeTruthy();
+    expect(prologue.isLikelyFrontMatter).toBe(true);
+    expect(ch1.isLikelyFrontMatter).toBe(false);
+  });
+
+  it('keeps the Latin whitespace-token path byte-identical for non-CJK text', async () => {
+    const text = ['Chapter One', '', 'word '.repeat(400)].join('\n');
+    const res = await request(app).post('/api/import').send({ text }).expect(200);
+    const ch1 = res.body.candidate.chapters.find((c: any) => c.title === 'Chapter One');
+    expect(ch1).toBeTruthy();
+    expect(ch1.wordCount).toBe(400);
+  });
+
+  it('does not double-count mixed Latin + CJK text', async () => {
+    /* "hello world" (2 Latin whitespace-tokens) + "你好世界" (4 Han chars,
+       no separating whitespace from the CJK char-equivalent count) —
+       2 + round(4 / 1.7) = 2 + 2 = 4. A naive implementation that counts
+       the CJK run as a Latin whitespace-token (1) AND separately as a
+       char-equivalent (2) would over-count to 5. */
+    const text = ['第一章', '', 'hello world 你好世界'].join('\n');
+    const res = await request(app).post('/api/import').send({ text }).expect(200);
+    const ch1 = res.body.candidate.chapters.find((c: any) => c.title === '第一章');
+    expect(ch1).toBeTruthy();
+    expect(ch1.wordCount).toBe(4);
+  });
+});

--- a/server/src/routes/import.ts
+++ b/server/src/routes/import.ts
@@ -70,8 +70,30 @@ function deterministicGradient(seed: string): [string, string] {
   return palette[Math.abs(h) % palette.length];
 }
 
+/* CJK (Han/Kana) scripts don't use inter-word whitespace, so a whitespace
+   split yields ~1 "word" per paragraph — a full CJK chapter then reads as
+   ~30-60 "words" and trips the front-matter word-count floor (fs-59 W2
+   task 2.7). Self-detects on Han/Kana presence: absent CJK chars, this is
+   byte-identical to the original whitespace-split behaviour. When present,
+   CJK chars are stripped to whitespace first (so they aren't ALSO counted
+   as a Latin token) and re-added as char-equivalents at ~1.7 chars/word —
+   the same ratio used elsewhere for CJK reading-time estimates. */
+const HAN_RE = /\p{Script=Han}/gu;
+const KANA_RE = /[\p{Script=Hiragana}\p{Script=Katakana}]/gu;
+const CJK_CHARS_PER_WORD = 1.7;
+
 function countWords(s: string): number {
-  return s.trim().split(/\s+/).filter(Boolean).length;
+  const cjkCharCount = (s.match(HAN_RE)?.length ?? 0) + (s.match(KANA_RE)?.length ?? 0);
+  if (cjkCharCount === 0) {
+    return s.trim().split(/\s+/).filter(Boolean).length;
+  }
+  const latinWordCount = s
+    .replace(HAN_RE, ' ')
+    .replace(KANA_RE, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean).length;
+  return latinWordCount + Math.round(cjkCharCount / CJK_CHARS_PER_WORD);
 }
 
 /* ── POST /api/import — parse-only, no disk write ─────────────────────── */

--- a/server/src/tts/detect-language.test.ts
+++ b/server/src/tts/detect-language.test.ts
@@ -1,8 +1,9 @@
 /* Server-side manuscript language detection (fs-41/fs-50 seam 2).
    Script pre-pass is authoritative; franc disambiguates Latin; front-matter
    stripped before detecting; es/fr/de detected but not yet `supported`. */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { detectManuscriptLanguage } from './detect-language.js';
+import { getLanguageEntry } from './language-registry.js';
 
 describe('detectManuscriptLanguage', () => {
   it('detects Russian via the Cyrillic pre-pass (supported)', () => {
@@ -49,10 +50,51 @@ describe('detectManuscriptLanguage', () => {
     expect(detectManuscriptLanguage(text)).toEqual({ language: 'es', supported: true });
   });
 
-  it('flags a CJK manuscript as detected-but-unsupported (no zh/ja registry entry yet)', () => {
+  it('flags a CJK manuscript as detected-but-unsupported, reading `supported` THROUGH the registry (fs-59 W2) rather than hardcoding it', () => {
     const zh = '熔炉已经冷却到被灰烬覆盖的落日的颜色，当有人敲响她作坊的门时，雷恩正在刮掉最后的炉渣。';
     const r = detectManuscriptLanguage(zh);
-    expect(r.supported).toBe(false);
+    // read-through, not a literal: mirrors whatever the registry says today
+    // (false today; flips automatically once fs-59 W5 sets zh.supported = true).
+    expect(r.supported).toBe(getLanguageEntry('zh')?.supported ?? false);
     expect(['zh', 'ja']).toContain(r.language);
+  });
+
+  it('detects Japanese via the CJK pre-pass, supported reads through the registry (false today)', () => {
+    const ja = '彼は歩いた。彼女は走った。'.repeat(50);
+    const r = detectManuscriptLanguage(ja);
+    expect(r.language).toBe('ja');
+    expect(r.supported).toBe(getLanguageEntry('ja')?.supported ?? false);
+  });
+});
+
+describe('detectManuscriptLanguage — CJK read-through proof (fs-59 W2, independent-review CRITICAL finding)', () => {
+  /* Each test must: vi.resetModules() → vi.doMock() → dynamic import, so the
+     dynamic `import('./detect-language.js')` inside the test picks up the
+     stubbed registry rather than the module cache (see ensure-sidecar-loaded.test.ts
+     for the same pattern). This is the load-bearing test: it does NOT rely on
+     the false==false coincidence (today's real zh.supported is false) — it
+     stubs the registry to zh.supported=true and proves detection propagates
+     that, which only happens if the CJK branch calls the `result()` helper
+     instead of returning a hardcoded `{ supported: false }` literal. */
+  afterEach(() => {
+    vi.doUnmock('./language-registry.js');
+    vi.resetModules();
+  });
+
+  it('propagates a stubbed zh.supported=true through to the detection result', async () => {
+    vi.resetModules();
+    vi.doMock('./language-registry.js', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('./language-registry.js')>();
+      return {
+        ...actual,
+        allLanguageEntries: () =>
+          actual.allLanguageEntries().map((e) => (e.code === 'zh' ? { ...e, supported: true } : e)),
+      };
+    });
+    const { detectManuscriptLanguage: detectWithStub } = await import('./detect-language.js');
+    const zh = '熔炉已经冷却到被灰烬覆盖的落日的颜色，当有人敲响她作坊的门时，雷恩正在刮掉最后的炉渣。';
+    const r = detectWithStub(zh);
+    expect(r.language).toBe('zh');
+    expect(r.supported).toBe(true); // only true if the CJK branch reads THROUGH the registry
   });
 });

--- a/server/src/tts/detect-language.ts
+++ b/server/src/tts/detect-language.ts
@@ -47,8 +47,9 @@ export function detectManuscriptLanguage(
   const han = sample.match(HAN_RE)?.length ?? 0;
   const kana = sample.match(KANA_RE)?.length ?? 0;
   if ((han + kana) / letters >= SCRIPT_THRESHOLD) {
-    // CJK has no registry entry in this tranche → detected-but-unsupported (fs-59).
-    return { language: kana > han ? 'ja' : 'zh', supported: false };
+    // zh/ja are registered supported:false (fs-59 W2) — read THROUGH the
+    // registry (not a literal) so a later supported:true flip propagates here.
+    return result(kana > han ? 'ja' : 'zh');
   }
 
   /* 3. franc disambiguates Latin, restricted to the registry's Latin codes. */

--- a/server/src/tts/language-registry.test.ts
+++ b/server/src/tts/language-registry.test.ts
@@ -63,6 +63,7 @@ describe('getLanguageEntry', () => {
         standalone: ['序章', '終章', '序', '跋', 'プロローグ', 'エピローグ'],
       },
       frontMatterKeywords: ['目录', '版权', '致谢', '序言', '后记', '附录', '关于作者'],
+      narratorName: '旁白',
     });
   });
 
@@ -79,6 +80,7 @@ describe('getLanguageEntry', () => {
         standalone: ['序章', '終章', 'プロローグ', 'エピローグ', 'あとがき', '前書き'],
       },
       frontMatterKeywords: ['目次', '著作権', '献辞', '謝辞', 'まえがき', 'あとがき', '付録', '著者について'],
+      narratorName: '語り手',
     });
   });
 });
@@ -216,11 +218,18 @@ describe('narratorName', () => {
   it('omits narratorName on en (defaults to "Narrator" at the call site)', () => {
     expect(getLanguageEntry('en')?.narratorName).toBeUndefined();
   });
+
+  it('exposes localized narrator names for zh/ja (fs-59, still supported:false)', () => {
+    // Seeded now so a CJK book's narrator localizes the moment zh/ja flip to
+    // supported at W5 — the seed reads getLanguageEntry(lang)?.narratorName.
+    expect(getLanguageEntry('zh')?.narratorName).toBe('旁白');
+    expect(getLanguageEntry('ja')?.narratorName).toBe('語り手');
+  });
 });
 
 describe('isDefaultNarratorName', () => {
   it('is true for the English default and every localized default, case-insensitively', () => {
-    for (const n of ['Narrator', 'narrator', ' NARRATOR ', 'Erzähler', 'Рассказчик', 'Narrador', 'Narrateur']) {
+    for (const n of ['Narrator', 'narrator', ' NARRATOR ', 'Erzähler', 'Рассказчик', 'Narrador', 'Narrateur', '旁白', '語り手']) {
       expect(isDefaultNarratorName(n)).toBe(true);
     }
   });

--- a/server/src/tts/language-registry.test.ts
+++ b/server/src/tts/language-registry.test.ts
@@ -49,6 +49,38 @@ describe('getLanguageEntry', () => {
     expect(getLanguageEntry('xy')).toBeUndefined();
     expect(getLanguageEntry('')).toBeUndefined();
   });
+
+  it('returns the zh entry, not yet supported (fs-59 W2)', () => {
+    const zh = getLanguageEntry('zh');
+    expect(zh).toEqual<LanguageEntry>({
+      code: 'zh',
+      sidecarName: 'Chinese',
+      supported: false,
+      detect: { script: 'cjk', iso6393: 'cmn' },
+      headingLexicon: {
+        keywords: ['章', '部', '巻', '節', '幕'],
+        numberWords: [],
+        standalone: ['序章', '終章', '序', '跋', 'プロローグ', 'エピローグ'],
+      },
+      frontMatterKeywords: ['目录', '版权', '致谢', '序言', '后记', '附录', '关于作者'],
+    });
+  });
+
+  it('returns the ja entry, not yet supported (fs-59 W2)', () => {
+    const ja = getLanguageEntry('ja');
+    expect(ja).toEqual<LanguageEntry>({
+      code: 'ja',
+      sidecarName: 'Japanese',
+      supported: false,
+      detect: { script: 'cjk', iso6393: 'jpn' },
+      headingLexicon: {
+        keywords: ['章', '部', '巻', '節', '話', '幕'],
+        numberWords: [],
+        standalone: ['序章', '終章', 'プロローグ', 'エピローグ', 'あとがき', '前書き'],
+      },
+      frontMatterKeywords: ['目次', '著作権', '献辞', '謝辞', 'まえがき', 'あとがき', '付録', '著者について'],
+    });
+  });
 });
 
 describe('isSupportedLanguage', () => {
@@ -58,7 +90,8 @@ describe('isSupportedLanguage', () => {
     expect(isSupportedLanguage('es')).toBe(true);
     expect(isSupportedLanguage('fr')).toBe(true);
     expect(isSupportedLanguage('de')).toBe(true);
-    expect(isSupportedLanguage('zh')).toBe(false); // absent from the registry (fs-59)
+    expect(isSupportedLanguage('zh')).toBe(false); // registered but not yet validated (fs-59 W2)
+    expect(isSupportedLanguage('ja')).toBe(false); // registered but not yet validated (fs-59 W2)
     expect(isSupportedLanguage('')).toBe(false);
   });
 });
@@ -85,12 +118,18 @@ describe('detect field + Latin entries', () => {
 });
 
 describe('isSupportedLanguage distinguishes absent from present', () => {
-  // With en/ru/es/fr/de all supported, no present-but-`false` entry remains;
-  // an absent code (zh, until fs-59 adds it as supported:false) exercises the
-  // `?? false` path. The present-but-false distinction returns when fs-59 lands.
-  it('is false for an absent code (zh not in the registry)', () => {
-    expect(getLanguageEntry('zh')).toBeUndefined();
+  // zh/ja (fs-59 W2) are the present-but-`false` case; a code truly absent
+  // from the registry (e.g. 'ko') exercises the `?? false` fallback path.
+  it('is false-but-present for zh/ja (registered, not yet validated)', () => {
+    expect(getLanguageEntry('zh')).toBeDefined();
+    expect(getLanguageEntry('ja')).toBeDefined();
     expect(isSupportedLanguage('zh')).toBe(false);
+    expect(isSupportedLanguage('ja')).toBe(false);
+  });
+
+  it('is false for a genuinely absent code (ko not in the registry)', () => {
+    expect(getLanguageEntry('ko')).toBeUndefined();
+    expect(isSupportedLanguage('ko')).toBe(false);
   });
 });
 
@@ -108,8 +147,10 @@ describe('supportedLanguages', () => {
 });
 
 describe('allLanguageEntries', () => {
-  it('includes all five codes', () => {
-    expect(allLanguageEntries().map((e) => e.code).sort()).toEqual(['de', 'en', 'es', 'fr', 'ru']);
+  it('includes all seven codes (fs-59 W2 adds zh/ja)', () => {
+    expect(allLanguageEntries().map((e) => e.code).sort()).toEqual([
+      'de', 'en', 'es', 'fr', 'ja', 'ru', 'zh',
+    ]);
   });
 });
 

--- a/server/src/tts/language-registry.ts
+++ b/server/src/tts/language-registry.ts
@@ -10,7 +10,8 @@
    `es` flipped `supported:true` 2026-06-23 after canary validation + operator
    acceptance (fs-41/fs-50 Spanish rollout). `fr` and `de` flipped `supported:true`
    2026-06-25 after operator audio acceptance of designed FR/DE Coalfall samples
-   (plan 229). zh/ja stay out of the registry until fs-59. */
+   (plan 229). zh/ja were added `supported:false` in fs-59 W2 — registered but
+   not yet validated; flipping to `supported:true` is a later fs-59 wave. */
 
 export interface LanguageEntry {
   /** BCP-47 primary subtag, lower-cased (e.g. 'en', 'ru', 'es'). */
@@ -20,7 +21,7 @@ export interface LanguageEntry {
   /** True only once the language has passed its validation gate. */
   supported: boolean;
   /** Detection routing: the script class + the franc ISO-639-3 code for this language. */
-  detect: { script: 'latin' | 'cyrillic'; iso6393: string };
+  detect: { script: 'latin' | 'cyrillic' | 'cjk'; iso6393: string };
   /** Non-English chapter-heading lexicon (used to build the language-agnostic
       split regex; English stays inline in parsers/text.ts). Absent on `en`. */
   headingLexicon?: { keywords: string[]; numberWords: string[]; standalone: string[] };
@@ -30,6 +31,9 @@ export interface LanguageEntry {
   /** Localized narrator display name for this language. Absent on `en`
       (call sites default to "Narrator"). */
   narratorName?: string;
+  /** Language-specific few-shot examples for the analyzer roster/attribution
+      prompts (fs-59 W3). Unset until a wave populates it. */
+  promptExamples?: { roster: string; attribution: string };
 }
 
 const ENTRIES: readonly LanguageEntry[] = [
@@ -85,6 +89,20 @@ const ENTRIES: readonly LanguageEntry[] = [
       'epigraph'],
     narratorName: 'Erzähler',
   },
+  // zh/ja: registered fs-59 W2, supported:false — script routing + lexicons only.
+  // headingLexicon.keywords do NOT split CJK chapters yet (Latin-shape regex in
+  // parsers/text.ts expects `keyword <whitespace> number`; CJK is the circumfix
+  // "第<number>章" with no whitespace — that's Task 2.6). frontMatterKeywords DO
+  // feed FRONT_MATTER_RX as substrings today. Terms are a starting set — adjust
+  // with a native reviewer before flipping `supported:true` at W5.
+  { code: 'zh', sidecarName: 'Chinese',  supported: false, detect: { script: 'cjk', iso6393: 'cmn' },
+    headingLexicon: { keywords: ['章', '部', '巻', '節', '幕'], numberWords: [],
+      standalone: ['序章', '終章', '序', '跋', 'プロローグ', 'エピローグ'] },
+    frontMatterKeywords: ['目录', '版权', '致谢', '序言', '后记', '附录', '关于作者'] },
+  { code: 'ja', sidecarName: 'Japanese', supported: false, detect: { script: 'cjk', iso6393: 'jpn' },
+    headingLexicon: { keywords: ['章', '部', '巻', '節', '話', '幕'], numberWords: [],
+      standalone: ['序章', '終章', 'プロローグ', 'エピローグ', 'あとがき', '前書き'] },
+    frontMatterKeywords: ['目次', '著作権', '献辞', '謝辞', 'まえがき', 'あとがき', '付録', '著者について'] },
 ];
 
 const BY_CODE: ReadonlyMap<string, LanguageEntry> = new Map(

--- a/server/src/tts/language-registry.ts
+++ b/server/src/tts/language-registry.ts
@@ -98,11 +98,13 @@ const ENTRIES: readonly LanguageEntry[] = [
   { code: 'zh', sidecarName: 'Chinese',  supported: false, detect: { script: 'cjk', iso6393: 'cmn' },
     headingLexicon: { keywords: ['章', '部', '巻', '節', '幕'], numberWords: [],
       standalone: ['序章', '終章', '序', '跋', 'プロローグ', 'エピローグ'] },
-    frontMatterKeywords: ['目录', '版权', '致谢', '序言', '后记', '附录', '关于作者'] },
+    frontMatterKeywords: ['目录', '版权', '致谢', '序言', '后记', '附录', '关于作者'],
+    narratorName: '旁白' },
   { code: 'ja', sidecarName: 'Japanese', supported: false, detect: { script: 'cjk', iso6393: 'jpn' },
     headingLexicon: { keywords: ['章', '部', '巻', '節', '話', '幕'], numberWords: [],
       standalone: ['序章', '終章', 'プロローグ', 'エピローグ', 'あとがき', '前書き'] },
-    frontMatterKeywords: ['目次', '著作権', '献辞', '謝辞', 'まえがき', 'あとがき', '付録', '著者について'] },
+    frontMatterKeywords: ['目次', '著作権', '献辞', '謝辞', 'まえがき', 'あとがき', '付録', '著者について'],
+    narratorName: '語り手' },
 ];
 
 const BY_CODE: ReadonlyMap<string, LanguageEntry> = new Map(

--- a/server/src/tts/language.test.ts
+++ b/server/src/tts/language.test.ts
@@ -49,9 +49,20 @@ describe('sidecarLanguageName', () => {
     expect(() => sidecarLanguageName('xy')).toThrow(/xy/);
   });
 
-  it('throws for a language not in the registry (e.g. Japanese)', () => {
-    expect(() => sidecarLanguageName('ja')).toThrow(/unsupported language/);
-    expect(() => sidecarLanguageName('ja-JP')).toThrow(/unsupported language/);
+  it('throws for a language not in the registry (e.g. Korean)', () => {
+    // Korean is explicitly out of fs-59 (→ fs-70), so it stays unregistered and
+    // must still fail loud. (Japanese used to be the example here — fs-59 W2
+    // registered zh/ja, so they resolve now; see the next test.)
+    expect(() => sidecarLanguageName('ko')).toThrow(/unsupported language/);
+    expect(() => sidecarLanguageName('ko-KR')).toThrow(/unsupported language/);
+  });
+
+  it('resolves zh/ja now that fs-59 W2 registered them (even though supported:false)', () => {
+    // Registering zh/ja means sidecarLanguageName no longer throws for them — the
+    // old fail-loud net is replaced by the supported:false confirm gate (fs-59 F9).
+    expect(sidecarLanguageName('ja')).toBe('Japanese');
+    expect(sidecarLanguageName('ja-JP')).toBe('Japanese');
+    expect(sidecarLanguageName('zh')).toBe('Chinese');
   });
 
   it('throw message includes the bcp47 tag and the primary subtag', () => {


### PR DESCRIPTION
## Summary

Wave 2 of fs-59 CJK (Chinese/Japanese) support: the **server-side CJK analyze foundations**. zh/ja are now **registered but still `supported:false`** — detection routes them, the analyze pipeline handles them, but they are not yet user-selectable (a later wave flips them after an on-box gate). Every fix is **self-detecting on per-text Han/Kana presence** (no book-language threading) and leaves the Latin/Cyrillic paths byte-identical. No new runtime dependency — segmentation uses the Node/ICU built-in `Intl.Segmenter`.

Eight commits:
1. **Register zh/ja** in the language registry (`supported:false`) **+ fix `detect-language.ts`** to read `supported` *through* the registry (it previously returned a hardcoded `false` literal for CJK — which would have made the Wave-5 flip a silent no-op).
2. **CJK sentence split** in `stage2-chunk` — `Intl.Segmenter` sentence granularity, **empty joiner** (lossless: no ASCII space injected into CJK prose).
3. **CJK-aware dup-key floor** in the coverage guard — script-aware (CJK clauses floor at 2 chars, Latin stays 8), so a CJK short-dialogue repeat-loop is caught.
4. **CJK-aware `isNarrativeLine`** — a CJK narrative line now closes the front-matter strip region (was blind to caseless Han/Kana).
5. **CJK token-estimate divisor** in `gemini.ts` — ~1.2 chars/token for CJK-dense prompts (vs Latin 4 / Cyrillic 2.5).
6. **CJK `第N章` chapter-heading split** (acceptance-critical) — **whole-line anchored** with fullwidth+kanji numerals and a length cap, so it splits real headings without eating `第N`-prefixed prose (`第三章で述べた…`, `第二部隊…`).
7. **CJK-aware import word count** — so a spaceless CJK chapter isn't miscounted as ~40 "words" and auto-excluded as front-matter.
8. **Localized narrator names** zh=`旁白` / ja=`語り手`, integrating the just-merged localized-folkloric-narrator feature (#1574): the branch was rebased onto main-with-#1574 and the `language-registry.ts` interface conflict resolved (entry carries both `narratorName?` and fs-59's `promptExamples?`). `isDefaultNarratorName` derives from the registry, so `旁白`/`語り手` are recognized defaults and `applyNarratorIdentity('zh')` → `旁白` with no change to the #1574 code.

Follows the fs-59 plan (`docs/superpowers/plans/2026-07-13-fs59-cjk-support.md`, Wave 2). Executed subagent-driven (per-task spec+quality review + Opus whole-branch review → **Ready-to-merge: Yes, 0 Critical/Important**).

### Follow-ups filed (#1576) — must resolve before the Wave-5 flip, contained by `supported:false` today
- CJK single-char/kana standalone headings (`序`/`跋`/`あとがき`/`前書き`) are unreachable via the `\b`-bounded standalone alternation (JS `\b` never borders CJK). Common full forms `序章`/`終章` split correctly; front-matter *detection* is unaffected.
- Two of the six CJK-detection regexes use a subset range form vs the property-escape form — immaterial for the common CJK range; unify for seam-fire consistency.

## Test plan

- Per-task focused suites all green: `language-registry` + `detect-language` (read-through proven via a `vi.doMock` registry stub), `stage2-chunk` (23), `stage2-coverage` (20), `strip-front-matter` (6), `gemini` (44, slow lane), `parsers/text` (53 — 0 Latin/ES/DE/RU regression), `routes/import` (20), `narrator-identity` (unchanged, green).
- **#1574 reconciliation verified end-to-end:** `language-registry` 33/33 after the rebase; `applyNarratorIdentity('zh') → 旁白`, `('ja') → 語り手`, `('en') → Narrator`; `tsc --noEmit` clean.
- Full local `test:server`: **4580 passed**, 1 "failed" = the known tinypool worker-exit teardown flake (no assertion failure). **Cloud `verify.yml` is the authoritative gate on this PR** (the local worktree's git hooks were unreliable, so the local full run is belt-and-suspenders).

## Notes

- **Release notes:** intentionally skipped — zh/ja remain `supported:false` (not user-selectable), so there is no user- or operator-visible delta yet. Per the before-shipping checklist's explicit-skip carve-out for changes with no shippable delta. (The Wave-5 flip PR carries the user-facing release note.)
- **Regression plan:** covered by the existing fs-59 plan/spec; no separate `docs/features/` doc for this intermediate wave.

Refs #1004 (Wave 2 of 5 — partial delivery; zh/ja stay `supported:false` until the Wave-5 dual gate). Refs #1576 (follow-ups before the flip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
