### PR TITLE
feat(server): CJK dialogue conventions + prompts (fs-59 Wave 3)

### DIFF
--- a/server/src/analyzer/dialogue-structure/evidence.test.ts
+++ b/server/src/analyzer/dialogue-structure/evidence.test.ts
@@ -24,7 +24,8 @@ describe('buildStructureEvidence', () => {
   it('(unsupported language) returns an empty map', () => {
     const body = '"Hello," Marlow said.';
     const sentences = [mkSentence(1, 'marlow', 'Hello')];
-    const out = buildStructureEvidence(body, sentences, [{ id: 'marlow', name: 'Marlow' }], 'ja');
+    // 'ja' now has a conventions table (fs-59 W3) — use a genuinely unsupported code.
+    const out = buildStructureEvidence(body, sentences, [{ id: 'marlow', name: 'Marlow' }], 'xx');
     expect(out.size).toBe(0);
   });
 

--- a/server/src/analyzer/dialogue-structure/lang/index.test.ts
+++ b/server/src/analyzer/dialogue-structure/lang/index.test.ts
@@ -10,8 +10,12 @@ describe('conventionsFor', () => {
     }
   });
   it('returns null for unsupported/absent language (engine no-op path)', () => {
-    expect(conventionsFor('ja')).toBeNull();
+    expect(conventionsFor('zz')).toBeNull();
     expect(conventionsFor(undefined)).toBeNull();
+  });
+  it('registers zh/ja conventions', () => {
+    expect(conventionsFor('ja')?.quotePairs).toContainEqual(['「', '」']);
+    expect(conventionsFor('zh')?.quotePairs).toContainEqual(['“', '”']);
   });
   it('ru stemmer strips case endings so Антона/Антону/Антоном share a stem', () => {
     const ru = conventionsFor('ru')!;

--- a/server/src/analyzer/dialogue-structure/lang/index.ts
+++ b/server/src/analyzer/dialogue-structure/lang/index.ts
@@ -4,8 +4,10 @@ import { en } from './en.js';
 import { es } from './es.js';
 import { fr } from './fr.js';
 import { de } from './de.js';
+import { zh } from './zh.js';
+import { ja } from './ja.js';
 
-const TABLES: Record<string, LanguageConventions> = { ru, en, es, fr, de };
+const TABLES: Record<string, LanguageConventions> = { ru, en, es, fr, de, zh, ja };
 
 /** Normalizes 'ru-RU' → 'ru'. Returns null when the language has no table —
     callers treat null as "engine disabled, current behaviour". */

--- a/server/src/analyzer/dialogue-structure/lang/ja.ts
+++ b/server/src/analyzer/dialogue-structure/lang/ja.ts
@@ -1,0 +1,23 @@
+import type { LanguageConventions } from '../types.js';
+
+/* Japanese: quote-only dialogue, no dash-dialogue convention. No inflection
+   to strip (nameStemmer is identity) and CJK has no inter-word spacing, so
+   minStemLength stays permissive (1) — the CJK tokenizer gap itself is Task
+   3.5's problem, not this table's. */
+export const ja: LanguageConventions = {
+  language: 'ja',
+  dialogueOpen: null,
+  quotePairs: [
+    ['「', '」'],
+    ['『', '』'],
+  ],
+  speechVerbStems: ['言', '話', '答', '尋', '叫', '呟', '囁', '続け', '応え'],
+  beatVerbStems: ['頷', '笑', '頬', '息'],
+  nameStemmer: (t) => t,
+  minStemLength: 1,
+  pronouns: {
+    firstPerson: /(私|僕|俺)/u,
+    male: /彼(?!女)/u,
+    female: /彼女/u,
+  },
+};

--- a/server/src/analyzer/dialogue-structure/lang/zh.ts
+++ b/server/src/analyzer/dialogue-structure/lang/zh.ts
@@ -1,0 +1,24 @@
+import type { LanguageConventions } from '../types.js';
+
+/* Mandarin (Simplified + Traditional): quote-only dialogue, no dash-dialogue
+   convention. No inflection to strip (nameStemmer is identity) and CJK has no
+   inter-word spacing, so minStemLength stays permissive (1) — the CJK
+   tokenizer gap itself is Task 3.5's problem, not this table's. */
+export const zh: LanguageConventions = {
+  language: 'zh',
+  dialogueOpen: null,
+  quotePairs: [
+    ['「', '」'],
+    ['『', '』'],
+    ['“', '”'],
+  ],
+  speechVerbStems: ['说', '道', '问', '答', '喊', '叫', '回答', '说道', '问道', '喃喃', '低语'],
+  beatVerbStems: ['点头', '笑', '皱眉', '叹'],
+  nameStemmer: (t) => t,
+  minStemLength: 1,
+  pronouns: {
+    firstPerson: /我/u,
+    male: /他/u,
+    female: /她/u,
+  },
+};

--- a/server/src/analyzer/dialogue-structure/name-matcher.test.ts
+++ b/server/src/analyzer/dialogue-structure/name-matcher.test.ts
@@ -48,3 +48,29 @@ describe('name-matcher (ru)', () => {
     expect(findRosterName('он позвал Марса', marsIdx)).toBe('mars');
   });
 });
+
+describe('name-matcher (ja, CJK substring containment — fs-59 W3, Task 3.5)', () => {
+  const ja = conventionsFor('ja')!;
+  it('matches a roster name with no inter-word spacing around it (the tokenizer-gap case)', () => {
+    const idx = buildNameIndex([{ id: 'tanaka', name: '田中' }], ja);
+    expect(findRosterName('と田中は言った', idx)).toBe('tanaka');
+  });
+  it('prefers the longest matching stem (田中太郎 over 田中)', () => {
+    const idx = buildNameIndex(
+      [
+        { id: 'tanaka', name: '田中' },
+        { id: 'tanaka-taro', name: '田中太郎' },
+      ],
+      ja,
+    );
+    expect(findRosterName('と田中太郎は言った', idx)).toBe('tanaka-taro');
+  });
+  it('ignores 1-char roster stems (guard against false-positive substring hits)', () => {
+    const idx = buildNameIndex([{ id: 'ta', name: '田' }], ja);
+    expect(findRosterName('と田中は言った', idx)).toBeNull();
+  });
+  it('returns null when no roster stem is contained in the clause', () => {
+    const idx = buildNameIndex([{ id: 'tanaka', name: '田中' }], ja);
+    expect(findRosterName('と鈴木は言った', idx)).toBeNull();
+  });
+});

--- a/server/src/analyzer/dialogue-structure/name-matcher.ts
+++ b/server/src/analyzer/dialogue-structure/name-matcher.ts
@@ -23,8 +23,30 @@ export function buildNameIndex(roster: RosterEntry[], conventions: LanguageConve
   return { stems, conventions };
 }
 
+/** Han/Kana script — signals CJK text with no inter-word spacing, where the
+    whitespace/letter-boundary tokenizer below never splits a tag clause into
+    separate words (see findRosterName's CJK branch). */
+const CJK_RE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u;
+
 /** First unique roster match among the text's word tokens, or null. */
 export function findRosterName(text: string, index: NameIndex): string | null {
+  if (CJK_RE.test(text)) {
+    // CJK has no inter-word spacing, so `と田中は言った` is one token under
+    // the tokenizer below and never matches. Fall back to substring
+    // containment against the indexed stems, preferring the longest match
+    // (so "田中太郎" wins over "田中" when both are roster stems). Guard out
+    // 1-char stems -- too short to anchor without false-positive risk.
+    let bestId: string | null = null;
+    let bestLen = 0;
+    for (const [stem, id] of index.stems) {
+      if (stem.length < 2 || !CJK_RE.test(stem)) continue;
+      if (stem.length > bestLen && text.includes(stem)) {
+        bestId = id;
+        bestLen = stem.length;
+      }
+    }
+    return bestId;
+  }
   for (const tok of text.toLowerCase().split(/[^\p{L}]+/u)) {
     if (!tok) continue;
     const stem = index.conventions.nameStemmer(tok);

--- a/server/src/analyzer/dialogue-structure/name-matcher.ts
+++ b/server/src/analyzer/dialogue-structure/name-matcher.ts
@@ -39,6 +39,13 @@ export function findRosterName(text: string, index: NameIndex): string | null {
     let bestId: string | null = null;
     let bestLen = 0;
     for (const [stem, id] of index.stems) {
+      // `stem.length < 2` is UTF-16 code units, not codepoints: a lone
+      // supplementary-plane Han char (CJK Ext-B+, U+20000+) is one glyph but
+      // length 2, so it slips this guard. Accepted — obscure beyond-BMP names
+      // are out of the contemporary zh/ja fiction scope (fs-59 W3).
+      // `!CJK_RE.test(stem)` skips Latin/Cyrillic stems: in a mixed clause with
+      // a stray Han glyph we enter this branch, and substring-matching a short
+      // romanized stem here would be a cross-script false positive.
       if (stem.length < 2 || !CJK_RE.test(stem)) continue;
       if (stem.length > bestLen && text.includes(stem)) {
         bestId = id;

--- a/server/src/analyzer/dialogue-structure/parser.test.ts
+++ b/server/src/analyzer/dialogue-structure/parser.test.ts
@@ -114,6 +114,31 @@ describe('parser — quote conventions', () => {
   });
 });
 
+describe('parser — ja quote conventions (CJK, fs-59 W3)', () => {
+  const jaIdx = buildNameIndex([{ id: 'tanaka', name: '田中' }], conventionsFor('ja')!);
+  it('ja quotes: 「気をつけて」と彼女は言った。 — quote run anchors as speech, "と…言った" reclassifies to tag, pronoun 彼女 sets pendingPronoun (speaker resolution is windows.ts\'s job, not the parser\'s — same contract as the ru pronoun-only-tag case above)', () => {
+    const paras = parseChapterStructure('「気をつけて」と彼女は言った。', jaIdx);
+    const spans = paras[0].spans;
+    expect(spans.map((s) => s.kind)).toEqual(['speech', 'tag']);
+    expect(spans[0].speaker).toBeUndefined();
+    expect((spans[0] as SpanEvidence & { pendingPronoun?: string }).pendingPronoun).toBe('female');
+  });
+
+  // NOTE (independent-review, §2.1): 彼女 is a *pronoun* — it resolves via the
+  // pronoun regex above and masks the fact that NAME-tag anchoring is broken
+  // for CJK. findRosterName (name-matcher.ts) tokenizes on `[^\p{L}]+`, which
+  // never splits contiguous CJK text with no inter-word spacing — the whole
+  // "と田中は言った" reads as ONE token, never matching the roster's "田中"
+  // stem. This case is the driver for Task 3.5 (CJK roster-name tag anchoring).
+  it.skip('ja quotes: roster NAME tag anchors 「わかった」と田中は言った。 → 田中', () => {
+    // un-skip in Task 3.5 (CJK roster-name tag anchoring)
+    const paras = parseChapterStructure('「わかった」と田中は言った。', jaIdx);
+    const spans = paras[0].spans;
+    expect(spans.map((s) => s.kind)).toEqual(['speech', 'tag']);
+    expect(spans[0].speaker).toEqual({ characterId: 'tanaka', source: 'tag-name' });
+  });
+});
+
 describe('anchorSpansFromTags — anchoring contract (Finding 3)', () => {
   it('a leading tag with no preceding speech never reaches forward past its own following-window to steal a later, legitimate tag\'s speech span (regression: the old lastSpeech-fallback tracker, removed in the anchorSpansFromTags extraction, would have let it)', () => {
     // Hand-built spans array (not derived from real text) so the shape is

--- a/server/src/analyzer/dialogue-structure/parser.test.ts
+++ b/server/src/analyzer/dialogue-structure/parser.test.ts
@@ -130,8 +130,7 @@ describe('parser — ja quote conventions (CJK, fs-59 W3)', () => {
   // never splits contiguous CJK text with no inter-word spacing — the whole
   // "と田中は言った" reads as ONE token, never matching the roster's "田中"
   // stem. This case is the driver for Task 3.5 (CJK roster-name tag anchoring).
-  it.skip('ja quotes: roster NAME tag anchors 「わかった」と田中は言った。 → 田中', () => {
-    // un-skip in Task 3.5 (CJK roster-name tag anchoring)
+  it('ja quotes: roster NAME tag anchors 「わかった」と田中は言った。 → 田中', () => {
     const paras = parseChapterStructure('「わかった」と田中は言った。', jaIdx);
     const spans = paras[0].spans;
     expect(spans.map((s) => s.kind)).toEqual(['speech', 'tag']);

--- a/server/src/analyzer/gemini.ts
+++ b/server/src/analyzer/gemini.ts
@@ -210,7 +210,7 @@ export function languagePreamble(language?: string): string {
   const ru = primary === 'ru';
   const entry = getLanguageEntry(primary);
   const where = entry
-    ? `${entry.sidecarName}${entry.detect.script === 'cyrillic' ? ' (Cyrillic script)' : ''}`
+    ? `${entry.sidecarName}${entry.detect.script === 'cyrillic' ? ' (Cyrillic script)' : entry.detect.script === 'cjk' ? ' (Chinese/Japanese script)' : ''}`
     : `${language} (a non-English language)`;
   /* Per-language dialogue conventions for the Latin tranche (Russian keeps its own
      tuned string below). The German caution is load-bearing: every German noun is
@@ -220,9 +220,27 @@ export function languagePreamble(language?: string): string {
     fr: ' Dialogue is marked with « … » (with spaces) or an em-dash —, not English "quotes".',
     de: ' Dialogue is marked with „…" (low/high quotes) or «…». NOTE: every German noun is capitalised, so a capitalised word is NOT necessarily a character name.',
   };
+  /* CJK dialogue conventions (fs-59 W3, Task 3.3). Chinese and Japanese mark
+     dialogue with corner brackets 「…」/『…』 (nested quotes) or, for Chinese,
+     fullwidth "…" — never a dash-dialogue line like Russian/French. The
+     tag-is-narrator note targets the §2.1 hard case: when a single spoken turn
+     is split by a narrator tag (e.g. 她说 / 彼女は言った), BOTH halves belong to
+     the speaker — the tag itself is the narrator, but the second spoken half
+     after the tag is NOT the narrator's; it continues the same speaker's line. */
+  const CJK_CONVENTIONS =
+    ' Dialogue is marked with corner brackets 「…」 or 『…』 (Japanese/nested), or fullwidth quotes "…" (Chinese) — not a dash-dialogue line. IMPORTANT: when a spoken turn is split by a narrative tag naming who spoke (e.g. 她说 / 彼女は言った), that tag is the narrator, NOT the speaker — but the SECOND spoken half after the tag still belongs to the same speaker, not the narrator.';
   const conventions = ru
     ? ' Dialogue is often marked with guillemets «…» or an em-dash —, not English "quotes". Characters may be named by first name, patronymic, surname, or diminutive (e.g. "Соня" for "Софья") — treat these as the same person. IMPORTANT: a dashed line that is a narrative TAG describing who spoke or what they did — e.g. «— сказал юноша.», «— тихо произнесла девушка.», «— Девушка улыбнулась.» (verbs like сказал/произнёс(ла)/воскликнул(а)/спросил(а)/засмеялся/улыбнулась/нахмурился) — is the narrator, NOT the speaker. Only the actually-spoken words belong to the speaker.'
-    : (LATIN_CONVENTIONS[primary] ?? '');
+    : entry?.detect.script === 'cjk'
+      ? CJK_CONVENTIONS
+      : (LATIN_CONVENTIONS[primary] ?? '');
+  /* In-language few-shot roster + attribution examples (fs-59 W3, Task 3.3).
+     Registered on the language-registry entry per-language (unset for languages
+     without an example yet), written IN the target language/script so the model
+     sees a worked example rather than only an English rule statement. */
+  const examples = entry?.promptExamples
+    ? ` Roster example: ${entry.promptExamples.roster} Attribution example: ${entry.promptExamples.attribution}`
+    : '';
   /* Cast-field guards for any non-English manuscript (validated on Russian +
      gemma4-e4b, 2026-06-19: without these the local model emits gender/age
      100% but `tone` 0% and writes role/description in mixed English/target
@@ -230,7 +248,7 @@ export function languagePreamble(language?: string): string {
      stage-2 attribution pass (which lists sentences, not characters). Field
      NAMES + enum values stay English as the line above already mandates. */
   const castFields = ` When you output a character, ALWAYS include the \`tone\` object (integers 0–100 for warmth, pace, authority, emotion) estimated from how they speak — never omit it. Write the human-readable text — \`role\`, \`description\`, and each \`attributes\` tag, for every character INCLUDING the narrator — in ${where} (the manuscript's language), and always include a \`description\`.`;
-  return `\n\nIMPORTANT: the manuscript text is in ${where}. Quote evidence VERBATIM from the manuscript (do not translate or transliterate it). Keep all JSON field names and enum values in English exactly as the schema shows.${castFields}${conventions}`;
+  return `\n\nIMPORTANT: the manuscript text is in ${where}. Quote evidence VERBATIM from the manuscript (do not translate or transliterate it). Keep all JSON field names and enum values in English exactly as the schema shows.${castFields}${conventions}${examples}`;
 }
 
 interface GeminiOptions {

--- a/server/src/analyzer/language-preamble.test.ts
+++ b/server/src/analyzer/language-preamble.test.ts
@@ -17,4 +17,15 @@ describe('languagePreamble — es/fr/de naming + conventions (seam 3e)', () => {
     expect(languagePreamble(undefined)).toBe('');
     expect(languagePreamble('ru')).toMatch(/Russian \(Cyrillic script\)/);
   });
+
+  it('languagePreamble carries CJK conventions + in-language examples', () => {
+    // NOTE (independent-review): do NOT assert on the language NAME — after Task 2.1
+    // registers the rows, `where` already contains "Japanese"/"Chinese" (gemini.ts:233),
+    // so /Japanese/ passes before any W3 change. Assert on the CJK-specific convention
+    // text + the in-language few-shot marker instead.
+    const ja = languagePreamble('ja');
+    expect(ja).toContain('「');                 // corner-bracket convention hint (new in W3)
+    expect(ja).toMatch(/tag[^]*narrator|話者ではない/); // interrupted-quote/tag-is-narrator few-shot
+    expect(languagePreamble('zh')).toContain('“'); // zh fullwidth-quote hint
+  });
 });

--- a/server/src/analyzer/tag-grammar.test.ts
+++ b/server/src/analyzer/tag-grammar.test.ts
@@ -143,6 +143,10 @@ describe('fr/de grammar rows (#1051)', () => {
   it('unmapped languages stay gated', () => {
     expect(grammarFor('pt')).toBeNull();
   });
+  it('CJK languages (zh/ja) stay gated — case-based roster guard inapplicable', () => {
+    expect(grammarFor('zh')).toBeNull();
+    expect(grammarFor('ja')).toBeNull();
+  });
 });
 
 describe('QUOTE_GLYPHS recognises German low-opening quote (R2-3)', () => {

--- a/server/src/analyzer/tag-grammar.ts
+++ b/server/src/analyzer/tag-grammar.ts
@@ -84,7 +84,8 @@ const UNI_NAME = "\\p{Lu}[\\p{L}’'-]+";
 
 /* CJK GATE-OFF (fs-59): zh/ja are deliberately NOT in TAG_GRAMMARS. The roster-false-positive
    guard relies on case-based nameCapture, which is structurally inapplicable to caseless CJK.
-   CJK attribution is instead carried by dialogue-structure conventions (server/src/lang/{zh,ja}.ts)
+   CJK attribution is instead carried by dialogue-structure conventions
+   (server/src/analyzer/dialogue-structure/lang/{zh,ja}.ts)
    + the fs-59 Wave 1 attribution-eval harness. The caller stays gated and applies no tag
    scanning for CJK languages. */
 const TAG_GRAMMARS: Record<string, TagGrammar> = {

--- a/server/src/analyzer/tag-grammar.ts
+++ b/server/src/analyzer/tag-grammar.ts
@@ -82,6 +82,11 @@ const EN_NAME = "[A-Z][A-Za-z’'-]+";
 // Unicode name token (es/ru): a capital letter + letters/apostrophes/hyphens.
 const UNI_NAME = "\\p{Lu}[\\p{L}’'-]+";
 
+/* CJK GATE-OFF (fs-59): zh/ja are deliberately NOT in TAG_GRAMMARS. The roster-false-positive
+   guard relies on case-based nameCapture, which is structurally inapplicable to caseless CJK.
+   CJK attribution is instead carried by dialogue-structure conventions (server/src/lang/{zh,ja}.ts)
+   + the fs-59 Wave 1 attribution-eval harness. The caller stays gated and applies no tag
+   scanning for CJK languages. */
 const TAG_GRAMMARS: Record<string, TagGrammar> = {
   en: { verbs: DIALOGUE_VERBS, orders: ['name-verb'], nameCapture: EN_NAME, flipStrategy: 'preceding' },
   es: { verbs: ES_VERBS, orders: ['verb-name', 'name-verb'], nameCapture: UNI_NAME, flipStrategy: 'adjacent', stopwords: ES_STOPWORDS },

--- a/server/src/parsers/audio-tags.test.ts
+++ b/server/src/parsers/audio-tags.test.ts
@@ -187,4 +187,18 @@ describe('audio-tags — non-English quotes + Unicode case (seam 3c)', () => {
   it('leaves English smart-quote behaviour unchanged', () => {
     expect(tagShoutingDialog('She yelled "GET OUT".')).toBe('She yelled "[shouting] Get Out".');
   });
+
+  it('tags excited dialogue inside CJK corner-bracket 「…」 quotes (fs-59 W3)', () => {
+    // 「Watch out!」 — corner brackets wrap the ASCII-cue dialogue the way
+    // 「」 wrap dialogue in zh/ja manuscripts. Without 「』 in QUOTE_OPENS/
+    // QUOTE_CLOSES the scanner never treats this as a quote span, so the
+    // `!` cue inside is never seen and no [excited] tag is added.
+    const out = tagExcitedDialog('「Watch out!」');
+    expect(out).toBe('「[excited] Watch out!」');
+  });
+
+  it('tags shouting dialogue inside CJK double corner-bracket 『…』 quotes (fs-59 W3)', () => {
+    const out = tagShoutingDialog('『GET OUT!』');
+    expect(out).toBe('『[shouting] Get Out!』');
+  });
 });

--- a/server/src/parsers/audio-tags.ts
+++ b/server/src/parsers/audio-tags.ts
@@ -14,13 +14,22 @@ export const AUDIO_TAGS = [
 ] as const;
 export type AudioTag = (typeof AUDIO_TAGS)[number];
 
-/* Dialogue-wrapping quotes across English + Latin-script + Cyrillic books.
-   A monolingual manuscript contains only its own pair, so the union is safe.
-   Opens: “ (straight) “ (smart) « (ES/FR/RU guillemet) „ (DE low-9).
+/* Dialogue-wrapping quotes across English + Latin-script + Cyrillic + CJK
+   books. A monolingual manuscript contains only its own pair, so the union
+   is safe.
+   Opens: “ (straight) “ (smart) « (ES/FR/RU guillemet) „ (DE low-9)
+   「 (zh/ja corner bracket) 『 (zh/ja double corner bracket, nested/emphasis).
    Closes: “ (straight) “ (smart) » (guillemet) “ (DE high-6 = also EN open;
-   safe for monolingual — the scanner closes on the first closer after an open). */
-const QUOTE_OPENS = '"“«„';
-const QUOTE_CLOSES = '"”»“';
+   safe for monolingual — the scanner closes on the first closer after an
+   open) 」 (zh/ja corner bracket close) 』 (zh/ja double corner bracket
+   close).
+   NOTE (fs-59 W3 scope): this only makes a tag/cue INSIDE 「…」/『…』 findable
+   by the quote-span scanner. It does NOT add fullwidth-punctuation triggers
+   (！？。…) to the detectors below — tagExcitedDialog/tagShoutingDialog/
+   tagHesitantDialog still key off ASCII `!`/caps/`…`/`..`. Fullwidth-cue
+   detection is a deferred nice-to-have, not an fs-59 acceptance item. */
+const QUOTE_OPENS = '"“«„「『';
+const QUOTE_CLOSES = '"”»“」』';
 
 /* Already-tagged-at-the-start check. Lets every detector be idempotent and
    keeps later detectors from stacking a second tag onto something an

--- a/server/src/routes/analysis.structure-engine.test.ts
+++ b/server/src/routes/analysis.structure-engine.test.ts
@@ -116,8 +116,9 @@ describe('attributeChapterStage2 — structure engine wiring (srv-59)', () => {
     expect(result.structureReport).toBeUndefined();
   });
 
-  it("(e): unsupported language ('ja') is identical to the engine-OFF/applyNarratorDefault path", async () => {
-    const result = await attributeChapterStage2(baseOpts('ja', mockSentences()));
+  it("(e): unsupported language ('xx') is identical to the engine-OFF/applyNarratorDefault path", async () => {
+    // 'ja' now has a conventions table (fs-59 W3) — use a genuinely unsupported code.
+    const result = await attributeChapterStage2(baseOpts('xx', mockSentences()));
 
     const expected = applyNarratorDefault(mockSentences());
     expect(result.sentences).toEqual(expected);

--- a/server/src/tts/language-registry.test.ts
+++ b/server/src/tts/language-registry.test.ts
@@ -52,7 +52,7 @@ describe('getLanguageEntry', () => {
 
   it('returns the zh entry, not yet supported (fs-59 W2; promptExamples added W3)', () => {
     const zh = getLanguageEntry('zh');
-    expect(zh).toMatchObject<Partial<LanguageEntry>>({
+    expect(zh).toEqual<LanguageEntry>({
       code: 'zh',
       sidecarName: 'Chinese',
       supported: false,
@@ -64,17 +64,16 @@ describe('getLanguageEntry', () => {
       },
       frontMatterKeywords: ['目录', '版权', '致谢', '序言', '后记', '附录', '关于作者'],
       narratorName: '旁白',
+      promptExamples: {
+        roster: '例如："林芳"（女主角，二十多岁，语气温柔）、"陈警官"（旁白之外的配角，说话直接）。',
+        attribution: '例："“我们该走了，”她说，“天要黑了。”" — 引号内的两段话都是这个角色说的；"她说"是旁白的叙述标签，不是说话人，"天要黑了"这后半句仍然属于说话的角色，不是旁白。',
+      },
     });
-    // promptExamples populated (fs-59 W3, Task 3.3): a roster + attribution few-shot
-    // written in Chinese. Verbatim content is exercised via languagePreamble in
-    // analyzer/language-preamble.test.ts — here just confirm the fields are present.
-    expect(zh?.promptExamples?.roster).toBeTruthy();
-    expect(zh?.promptExamples?.attribution).toBeTruthy();
   });
 
   it('returns the ja entry, not yet supported (fs-59 W2; promptExamples added W3)', () => {
     const ja = getLanguageEntry('ja');
-    expect(ja).toMatchObject<Partial<LanguageEntry>>({
+    expect(ja).toEqual<LanguageEntry>({
       code: 'ja',
       sidecarName: 'Japanese',
       supported: false,
@@ -86,9 +85,11 @@ describe('getLanguageEntry', () => {
       },
       frontMatterKeywords: ['目次', '著作権', '献辞', '謝辞', 'まえがき', 'あとがき', '付録', '著者について'],
       narratorName: '語り手',
+      promptExamples: {
+        roster: '例：「美咲」（主人公、二十代、口調は穏やか）、「田中刑事」（脇役、話し方は率直）。',
+        attribution: '例：「もう行かないと」彼女は言った。「日が暮れる前に」 — 「」内の二つの発言はどちらもこの人物のセリフである。「彼女は言った」は語り手のタグであり話者ではない。後半の「日が暮れる前に」もタグの後に続く同じ話者のセリフであり、語り手のものではない。',
+      },
     });
-    expect(ja?.promptExamples?.roster).toBeTruthy();
-    expect(ja?.promptExamples?.attribution).toBeTruthy();
   });
 });
 

--- a/server/src/tts/language-registry.test.ts
+++ b/server/src/tts/language-registry.test.ts
@@ -50,9 +50,9 @@ describe('getLanguageEntry', () => {
     expect(getLanguageEntry('')).toBeUndefined();
   });
 
-  it('returns the zh entry, not yet supported (fs-59 W2)', () => {
+  it('returns the zh entry, not yet supported (fs-59 W2; promptExamples added W3)', () => {
     const zh = getLanguageEntry('zh');
-    expect(zh).toEqual<LanguageEntry>({
+    expect(zh).toMatchObject<Partial<LanguageEntry>>({
       code: 'zh',
       sidecarName: 'Chinese',
       supported: false,
@@ -65,11 +65,16 @@ describe('getLanguageEntry', () => {
       frontMatterKeywords: ['目录', '版权', '致谢', '序言', '后记', '附录', '关于作者'],
       narratorName: '旁白',
     });
+    // promptExamples populated (fs-59 W3, Task 3.3): a roster + attribution few-shot
+    // written in Chinese. Verbatim content is exercised via languagePreamble in
+    // analyzer/language-preamble.test.ts — here just confirm the fields are present.
+    expect(zh?.promptExamples?.roster).toBeTruthy();
+    expect(zh?.promptExamples?.attribution).toBeTruthy();
   });
 
-  it('returns the ja entry, not yet supported (fs-59 W2)', () => {
+  it('returns the ja entry, not yet supported (fs-59 W2; promptExamples added W3)', () => {
     const ja = getLanguageEntry('ja');
-    expect(ja).toEqual<LanguageEntry>({
+    expect(ja).toMatchObject<Partial<LanguageEntry>>({
       code: 'ja',
       sidecarName: 'Japanese',
       supported: false,
@@ -82,6 +87,8 @@ describe('getLanguageEntry', () => {
       frontMatterKeywords: ['目次', '著作権', '献辞', '謝辞', 'まえがき', 'あとがき', '付録', '著者について'],
       narratorName: '語り手',
     });
+    expect(ja?.promptExamples?.roster).toBeTruthy();
+    expect(ja?.promptExamples?.attribution).toBeTruthy();
   });
 });
 

--- a/server/src/tts/language-registry.ts
+++ b/server/src/tts/language-registry.ts
@@ -99,12 +99,29 @@ const ENTRIES: readonly LanguageEntry[] = [
     headingLexicon: { keywords: ['章', '部', '巻', '節', '幕'], numberWords: [],
       standalone: ['序章', '終章', '序', '跋', 'プロローグ', 'エピローグ'] },
     frontMatterKeywords: ['目录', '版权', '致谢', '序言', '后记', '附录', '关于作者'],
-    narratorName: '旁白' },
+    narratorName: '旁白',
+    // In-language few-shot for the analyzer preamble (fs-59 W3, Task 3.3). Starting
+    // set — a native reviewer refines before the W5 supported:true flip. The
+    // attribution example demonstrates the interrupted-quote rule: a spoken turn
+    // split by a narrator tag ("她说") — the SECOND spoken half belongs to the
+    // speaker, not the narrator.
+    promptExamples: {
+      roster: '例如："林芳"（女主角，二十多岁，语气温柔）、"陈警官"（旁白之外的配角，说话直接）。',
+      attribution: '例："“我们该走了，”她说，“天要黑了。”" — 引号内的两段话都是这个角色说的；"她说"是旁白的叙述标签，不是说话人，"天要黑了"这后半句仍然属于说话的角色，不是旁白。',
+    } },
   { code: 'ja', sidecarName: 'Japanese', supported: false, detect: { script: 'cjk', iso6393: 'jpn' },
     headingLexicon: { keywords: ['章', '部', '巻', '節', '話', '幕'], numberWords: [],
       standalone: ['序章', '終章', 'プロローグ', 'エピローグ', 'あとがき', '前書き'] },
     frontMatterKeywords: ['目次', '著作権', '献辞', '謝辞', 'まえがき', 'あとがき', '付録', '著者について'],
-    narratorName: '語り手' },
+    narratorName: '語り手',
+    // In-language few-shot (fs-59 W3, Task 3.3) — starting set, refined by a native
+    // reviewer before W5. The attribution example demonstrates the interrupted-quote
+    // rule: a spoken turn split by a narrator tag ("彼女は言った") — the SECOND spoken
+    // half belongs to the speaker, not the narrator (the tag is narrator, not speaker).
+    promptExamples: {
+      roster: '例：「美咲」（主人公、二十代、口調は穏やか）、「田中刑事」（脇役、話し方は率直）。',
+      attribution: '例：「もう行かないと」彼女は言った。「日が暮れる前に」 — 「」内の二つの発言はどちらもこの人物のセリフである。「彼女は言った」は語り手のタグであり話者ではない。後半の「日が暮れる前に」もタグの後に続く同じ話者のセリフであり、語り手のものではない。',
+    } },
 ];
 
 const BY_CODE: ReadonlyMap<string, LanguageEntry> = new Map(


### PR DESCRIPTION
## Summary

Wave 3 of fs-59 CJK (Chinese/Japanese) support: the **CJK dialogue conventions + analyzer prompts** that make attribution work for zh/ja. zh/ja remain **`supported:false`** (not user-selectable; the Wave-5 gate flips them). All CJK logic is self-detecting on Han/Kana; every Latin/Cyrillic path is functionally byte-identical.

Five pieces:
1. **Dialogue-structure convention tables** `lang/zh.ts` + `lang/ja.ts` (`「」`/`『』`/zh `“”` quote pairs, no dash-dialogue, speech/beat verb stems, pronoun regexes, identity name-stemmer), registered in `TABLES`.
2. **CJK quote glyphs** (`「『`/`」』`) in the audio-tag detectors so an inline tag inside corner brackets is found. (roster-coverage deliberately left untouched — it's unreachable for CJK; fullwidth-punctuation triggers deferred with a comment.)
3. **CJK prompt conventions + in-language few-shot** in `languagePreamble`, plus populated `promptExamples` on zh/ja and a CJK script-annotation. The few-shot demonstrates the interrupted-quote rule (a tag-split spoken turn's *second* half → the speaker, not the narrator).
4. **tag-grammar gate-OFF for CJK, documented** — `grammarFor('zh'/'ja') === null` (deliberately not in `TAG_GRAMMARS`; the uppercase-based roster guard is structurally inapplicable to caseless CJK). CJK attribution is carried by the conventions + name-anchoring + the W1 eval harness instead.
5. **CJK-aware roster-name tag anchoring** in `findRosterName` — the highest-precedence `tag-name` anchor now fires for CJK via substring containment (the whitespace tokenizer never split a spaceless clause like `と田中は言った`), longest-match, with a ≥2-char guard and a cross-script guard.

### Behavior note (intended; contained)
Because `analyzer.structure.enabled` defaults **on**, a zh/ja book now runs the deterministic dialogue-structure engine **live at analysis time** (Wave 2 took the no-op path). This is the whole point of the convention tables. It is fully contained: **zh/ja stay `supported:false`, so no audio is generated from these corrections until the Wave-5 flip.** en/es/fr/de/ru analysis is byte-identical (the `if (conventions)` guard is unchanged for them).

### Distant-dependency handling (Wave-2 lesson)
Adding zh/ja conventions makes `conventionsFor('ja'|'zh')` non-null, which broke three pre-existing tests that used `'ja'` as their "unsupported / no-conventions" example (`evidence.test.ts`, `analysis.structure-engine.test.ts`, `lang/index.test.ts`). These were **retargeted to genuinely-unregistered codes (`xx`/`zz`)** with intent preserved and no assertions weakened. The Opus whole-branch review traced every consumer of the three changed functions (`conventionsFor`, `findRosterName`, and the tag-grammar gate) and confirmed the blast radius is contained to zh/ja; a full local `test:server` (4600 passed, 0 failures) confirmed no other distant break.

### Notes for reviewers
- `findRosterName`'s CJK branch adds a `!CJK_RE.test(stem)` cross-script guard (skips Latin/Cyrillic stems when a mixed clause enters the CJK path) — additive logic beyond the literal ask, documented inline.
- zh/ja `promptExamples` prose is a non-native starting set (flagged in-code for native-reviewer refinement before the Wave-5 flip).

## Test plan
- Per-task focused suites all green: `dialogue-structure/lang/index` + `parser` (with the name-tag driver case, `it.skip` in 3.1 then **un-skipped and passing** in 3.5 via genuine name-anchoring), `audio-tags` (34), `language-preamble` (3), `tag-grammar` (30), `name-matcher` (incl. longest-match + ≥2-char guard + negative cases). Full `dialogue-structure/` 95/95.
- **Full local `test:server`: 385 files passed, 4600 tests passed, 0 failures, 0 errors** (identity-verified — no `FAIL` line, no worker-exit). Cloud `verify.yml` is the authoritative gate.

## Notes
- **Release notes:** intentionally skipped — zh/ja remain `supported:false` (not user-selectable), no user- or operator-visible delta yet (the Wave-5 flip PR carries the user-facing note). Per the before-shipping checklist's explicit-skip carve-out.
- **Regression plan:** covered by the existing fs-59 plan/spec; no separate `docs/features/` doc for this intermediate wave.

Refs #1004 (Wave 3 of 5 — partial delivery; zh/ja stay `supported:false` until the Wave-5 dual gate). Refs #1576 (pre-flip follow-ups still open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
