### PR TITLE
fix(server): CJK standalone-heading word-boundary gap + unify CJK regexes

### DIFF
--- a/docs/superpowers/plans/2026-07-13-fs59-cjk-support.md
+++ b/docs/superpowers/plans/2026-07-13-fs59-cjk-support.md
@@ -332,6 +332,22 @@ it('splits CJK headings but does not eat 第N-prefixed prose', () => {
 - [ ] **Step 4: Run to verify it passes;** confirm English/ES/RU heading tests stay green (the new alternative only fires on CJK glyphs, whole-line anchored).
 - [ ] **Step 5: Commit** — `fix(server): CJK 第N章 chapter-heading split (fs-59 W2)`.
 
+**Follow-up (issue #1576, fixed before W5):** the shipped Step 3 only routed the
+*full-form* CJK standalone terms (`序章`/`終章`/`プロローグ`/`エピローグ`) into the
+whole-line-anchored alternative; the single-token terms also in the registry's
+`headingLexicon.standalone` — `序`/`跋` (zh), `あとがき`/`前書き` (ja) — were still
+falling through to the `\b`-bounded `ALL_STANDALONE` alternative, and `\b` never
+borders a CJK codepoint, so those four terms silently never split. Fixed by
+partitioning the registry's standalone-term union on `hasCjkChar` at module load
+(new `server/src/util/cjk.ts`) rather than hardcoding a second list: the CJK
+subset feeds the whole-line-anchored alternative (alongside the four full-form
+terms above), the rest still feeds the `\b`-bounded one. Same fix also unified
+the two divergent CJK char-class regexes flagged by the Wave 2 review
+(`analyzer/gemini.ts` `countHanKana`, `analyzer/strip-front-matter.ts`
+`CJK_CHAR`) onto the shared `\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}`
+form. See `server/src/parsers/text.test.ts` (CJK chapter-splitting describe
+block) and `server/src/util/cjk.test.ts`.
+
 ### Task 2.7: CJK word-count / front-matter miscount at import (independent-review finding)
 
 **Files:**

--- a/server/src/analyzer/gemini.ts
+++ b/server/src/analyzer/gemini.ts
@@ -39,6 +39,7 @@ import { getLanguageEntry } from '../tts/language-registry.js';
 import { AnalysisAbortedError } from './ollama.js';
 import { AnalyzerTruncatedError } from './errors.js';
 import { geminiRateLimiter, DailyQuotaExhaustedError } from './rate-limit.js';
+import { countCjkChars } from '../util/cjk.js';
 
 /* Idle-chunk watchdog: if the SDK stream goes more than this long between
    chunks (or before the first chunk), assume the upstream is wedged and
@@ -911,17 +912,13 @@ export function estimateInputTokens(
     const m = s.match(/[Ѐ-ӿ]/g);
     return m ? m.length : 0;
   };
-  const countHanKana = (s: string): number => {
-    const m = s.match(/[぀-ヿ㐀-䶿一-鿿]/g);
-    return m ? m.length : 0;
-  };
   cyrillic += countCyrillic(systemInstruction);
-  hanKana += countHanKana(systemInstruction);
+  hanKana += countCjkChars(systemInstruction);
   for (const turn of contents) {
     for (const part of turn.parts) {
       chars += part.text.length;
       cyrillic += countCyrillic(part.text);
-      hanKana += countHanKana(part.text);
+      hanKana += countCjkChars(part.text);
     }
   }
   const cyrillicFraction = chars > 0 ? cyrillic / chars : 0;

--- a/server/src/analyzer/strip-front-matter.ts
+++ b/server/src/analyzer/strip-front-matter.ts
@@ -9,6 +9,7 @@
        the book author or title, removed only before substantial narrative prose
        begins, so a story that *mentions* the author mid-prose is untouched. */
 import { normaliseNameKey } from '../util/safe-id.js';
+import { hasCjkChar } from '../util/cjk.js';
 
 const GLOBAL_BOILERPLATE: RegExp[] = [
   /_###ICE#BOOK#READER/i, // reader-tool header marker (whole line is the header)
@@ -34,11 +35,10 @@ function isGlobalBoilerplate(line: string): boolean {
    CJK prose is denser than Latin so the 60-char threshold is too high. For a
    line containing Han/Kana, use a lower length threshold (~15) plus a CJK
    sentence-ending punctuation mark instead of the lowercase-letter test. */
-const CJK_CHAR = /[぀-ヿ㐀-䶿一-鿿]/;
 const CJK_SENTENCE_END = /[。！？…]/;
 
 function isNarrativeLine(line: string): boolean {
-  if (CJK_CHAR.test(line)) {
+  if (hasCjkChar(line)) {
     return line.length >= 15 && CJK_SENTENCE_END.test(line);
   }
   if (line.length < 60) return false;

--- a/server/src/parsers/text.test.ts
+++ b/server/src/parsers/text.test.ts
@@ -380,6 +380,25 @@ describe('parseText — CJK chapter splitting (fs-59 W2, acceptance-critical)', 
     expect(chapters.length).toBe(2); // only 第一章 / 第二章 — 第五章のこと is NOT a 3rd chapter
     expect(chapters.map((c) => c.body).join('')).toContain('第五章のことを思い出した');
   });
+
+  /* Issue #1576 (fs-59 W2 review follow-up): 序/跋 (zh) and あとがき/前書き
+     (ja) live in the registry's standalone lexicon but were only reachable
+     via the `\b`-bounded ALL_STANDALONE alternative — and `\b` never
+     borders a CJK codepoint, so these single-token headings silently failed
+     to split. They must now split via the whole-line-anchored CJK
+     alternative, same as 序章/終章 already did. */
+  it.each([
+    ['序', 'zh 序 (preface)'],
+    ['跋', 'zh 跋 (afterword)'],
+    ['あとがき', 'ja あとがき (afterword)'],
+    ['前書き', 'ja 前書き (foreword)'],
+  ])('splits a standalone %s heading (%s) as its own chapter', (heading) => {
+    const body = [heading, '', '短い文章です。', '', '第一章', '', '物語が始まる。'].join('\n');
+    const { chapters } = parseText(body, { format: 'plaintext' });
+    expect(chapters.length).toBe(2);
+    expect(chapters[0].title).toBe(heading);
+    expect(chapters[0].body).toContain('短い文章です');
+  });
 });
 
 describe('parseText — audio-tag passthrough', () => {

--- a/server/src/parsers/text.ts
+++ b/server/src/parsers/text.ts
@@ -11,6 +11,7 @@ import {
   tagShoutingDialog,
 } from './audio-tags.js';
 import { nonEnglishHeadingLexicon } from '../tts/language-registry.js';
+import { hasCjkChar } from '../util/cjk.js';
 
 /* Heading detection — built from three alternatives:
    1) Markdown H1/H2 (`# Foo` or `## Foo`).
@@ -40,10 +41,22 @@ const ALL_NUMBER_WORDS = [
   'eighty','ninety','hundred',
   ...NE_LEX.numberWords,
 ].join('|');
-const ALL_STANDALONE = [
-  ...['prologue','epilogue','interlude','preface','introduction','afterword','foreword'],
+
+/* `ALL_STANDALONE_TERMS` is every standalone-heading word across every
+   registry language (Latin/Cyrillic AND CJK) — used as-is by
+   `BARE_STANDALONE_HEADING_RE` below, which anchors on `\s*$` and so has no
+   trouble with CJK codepoints. `CHAPTER_HEADING_RE`'s standalone alternative
+   is different: it anchors with `\b`, and `\b` is ASCII-\w-based — it never
+   borders a Han/Kana codepoint, so a CJK term placed there can never match
+   (issue #1576). Split the union in two: `ALL_STANDALONE` (Latin/Cyrillic
+   only) feeds the `\b`-bounded alternative; the CJK subset is folded into
+   the whole-line-anchored `CJK_STANDALONE` alternative instead, which uses
+   `CJK_SEP` (whitespace/separator/end-of-line) rather than `\b`. */
+const ALL_STANDALONE_TERMS = [
+  'prologue','epilogue','interlude','preface','introduction','afterword','foreword',
   ...NE_LEX.standalone,
-].join('|');
+];
+const ALL_STANDALONE = ALL_STANDALONE_TERMS.filter((s) => !hasCjkChar(s)).join('|');
 
 /* Numbered-section number: Arabic digit, Roman numeral, or English/non-English word
    form (with optional compound for 21–99: "twenty-one", "thirty two", …). */
@@ -67,7 +80,15 @@ const CJK_HEADING_MAX_LEN = 20;
 const CJK_NUMBER = '[0-9０-９〇一二三四五六七八九十百千]+';
 const CJK_ENDER = '[章話回節部幕巻]'; // 章話回節部幕巻
 const CJK_SEP = '(?:[\\s：:—-]|$)'; // whitespace, fullwidth/halfwidth colon, em-dash, hyphen, or end-of-line
-const CJK_STANDALONE = '序章|終章|プロローグ|エピローグ'; // 序章|終章|プロローグ|エピローグ
+/* Base full-form CJK standalone headings, unioned with the CJK subset of
+   the registry's per-language `headingLexicon.standalone` (issue #1576) —
+   single-token terms like 序/跋 (zh) and あとがき/前書き (ja) that can only
+   ever reach a chapter split through this whole-line-anchored alternative,
+   never the `\b`-bounded `ALL_STANDALONE` above. */
+const CJK_STANDALONE_TERMS = [
+  ...new Set(['序章', '終章', 'プロローグ', 'エピローグ', ...ALL_STANDALONE_TERMS.filter(hasCjkChar)]),
+];
+const CJK_STANDALONE = CJK_STANDALONE_TERMS.join('|'); // 序章|終章|プロローグ|エピローグ|序|跋|あとがき|前書き
 const CJK_HEADING_ALT = `(?=.{1,${CJK_HEADING_MAX_LEN}}$)(?:第${CJK_NUMBER}${CJK_ENDER}${CJK_SEP}|(?:${CJK_STANDALONE})${CJK_SEP})`; // 第<number><ender>
 
 const CHAPTER_HEADING_RE = new RegExp(
@@ -84,7 +105,14 @@ const BARE_NUMBERED_HEADING_RE = new RegExp(
   `^(?:${ALL_HEADING_KEYWORDS})\\s+${NUMBER_PART}\\s*$`,
   'iu',
 );
-const BARE_STANDALONE_HEADING_RE = new RegExp(`^(?:${ALL_STANDALONE})\\s*$`, 'iu');
+/* Uses the FULL (Latin/Cyrillic + CJK) term union, not the `\b`-bounded
+   `ALL_STANDALONE` above — this pattern anchors on `\s*$`, which has no
+   CJK boundary problem, so a CJK bare heading (`序`, `跋`, …) still needs
+   to be recognised here. */
+const BARE_STANDALONE_HEADING_RE = new RegExp(
+  `^(?:${ALL_STANDALONE_TERMS.join('|')})\\s*$`,
+  'iu',
+);
 
 /* Cap on subtitle line length. Real chapter names rarely exceed 80 chars;
    anything longer is almost certainly a body sentence. Re-used by the

--- a/server/src/util/cjk.test.ts
+++ b/server/src/util/cjk.test.ts
@@ -1,0 +1,48 @@
+/* Unit tests for the shared CJK-char primitives (issue #1576 — fs-59 W2
+   review follow-up: unify the two divergent CJK regexes). Pins both the
+   common-case behaviour the old range-form regexes already handled, AND the
+   supplementary-plane / compatibility / halfwidth codepoints the old range
+   form (`[぀-ヿ㐀-䶿一-鿿]`, formerly in `analyzer/gemini.ts` and
+   `analyzer/strip-front-matter.ts`) silently missed. */
+import { describe, expect, it } from 'vitest';
+import { CJK_CHAR_RE, hasCjkChar, countCjkChars } from './cjk.js';
+
+describe('hasCjkChar', () => {
+  it('is true for common Han, Hiragana, and Katakana', () => {
+    expect(hasCjkChar('序')).toBe(true); // Han
+    expect(hasCjkChar('あとがき')).toBe(true); // Hiragana
+    expect(hasCjkChar('プロローグ')).toBe(true); // Katakana
+  });
+
+  it('is false for Latin and Cyrillic text', () => {
+    expect(hasCjkChar('Prologue')).toBe(false);
+    expect(hasCjkChar('Пролог')).toBe(false);
+    expect(hasCjkChar('')).toBe(false);
+  });
+
+  it('is true for codepoints the old range-form regex missed', () => {
+    expect(hasCjkChar('ｱ')).toBe(true); // halfwidth katakana ｱ
+    expect(hasCjkChar('\u{F900}')).toBe(true); // CJK Compatibility Ideograph 豈
+    expect(hasCjkChar('\u{20000}')).toBe(true); // supplementary-plane Han (Ext. B)
+  });
+});
+
+describe('countCjkChars', () => {
+  it('counts each CJK char, ignoring Latin/whitespace', () => {
+    expect(countCjkChars('序章 Hello 終章')).toBe(4); // 序, 章, 終, 章
+  });
+
+  it('returns 0 for text with no CJK chars', () => {
+    expect(countCjkChars('Hello world')).toBe(0);
+  });
+
+  it('counts supplementary-plane codepoints as one char, not two UTF-16 units', () => {
+    expect(countCjkChars('\u{20000}')).toBe(1);
+  });
+});
+
+describe('CJK_CHAR_RE', () => {
+  it('is the single property-escape source both call sites now share', () => {
+    expect(CJK_CHAR_RE.source).toBe('[\\p{Script=Han}\\p{Script=Hiragana}\\p{Script=Katakana}]');
+  });
+});

--- a/server/src/util/cjk.ts
+++ b/server/src/util/cjk.ts
@@ -1,0 +1,26 @@
+/* Shared "is this a CJK character?" primitive (fs-59 W2 review follow-up,
+   issue #1576). Two call sites (`analyzer/gemini.ts` token estimation and
+   `analyzer/strip-front-matter.ts` narrative-line detection) each hand-rolled
+   an equivalent codepoint-range regex (`[぀-ヿ㐀-䶿一-鿿]`) that had quietly
+   drifted into a strict SUBSET of "CJK": it omits supplementary-plane Han,
+   CJK Compatibility Ideographs, and halfwidth Katakana that the
+   property-escape form below covers. Four other seams in the codebase
+   (`tts/detect-language.ts`, `routes/import.ts`,
+   `analyzer/dialogue-structure/name-matcher.ts`, `analyzer/stage2-chunk.ts`,
+   `analyzer/stage2-coverage.ts`) already used the property-escape form —
+   this module is the single source of truth so the two range-form sites
+   can't diverge from it (or each other) again. */
+
+/** Matches a single Han (CJK ideograph), Hiragana, or Katakana codepoint. */
+export const CJK_CHAR_RE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u;
+
+/** True if `s` contains at least one CJK character. */
+export function hasCjkChar(s: string): boolean {
+  return CJK_CHAR_RE.test(s);
+}
+
+/** Count of CJK characters in `s`. */
+export function countCjkChars(s: string): number {
+  const m = s.match(new RegExp(CJK_CHAR_RE.source, 'gu'));
+  return m ? m.length : 0;
+}


### PR DESCRIPTION
## Summary
- `CHAPTER_HEADING_RE`'s standalone alternative anchored on `\b`, which never borders a Han/Kana codepoint — so single-token CJK standalone headings from the registry (`序`/`跋` zh, `あとがき`/`前書き` ja) silently never split into their own chapter, even though the full-form terms (`序章`/`終章`/`プロローグ`/`エピローグ`) already worked. Fixed by routing the registry's CJK standalone terms into the existing whole-line-anchored CJK alternative instead of the `\b`-bounded one, using a new `hasCjkChar` script-partition helper. `BARE_STANDALONE_HEADING_RE` (already `\s*$`-anchored, no `\b`) is unaffected and keeps working on the full term union.
- Unified the two divergent CJK char-class regexes flagged by the Wave 2 review (`analyzer/gemini.ts` `countHanKana`, `analyzer/strip-front-matter.ts` `CJK_CHAR`) — both used a hand-rolled codepoint range that's a strict subset of "CJK" (misses supplementary-plane Han, compatibility ideographs, halfwidth katakana) — onto a single shared `server/src/util/cjk.ts` source of truth using the property-escape form already used at four other seams.

Both defects are contained today by zh/ja being `supported:false`, but had to be fixed before the fs-59 Wave 5 flip per #1576.

## Test plan
- [x] New `it.each` block in `server/src/parsers/text.test.ts` pins each of the four newly-reachable standalone headings (序/跋/あとがき/前書き) — confirmed RED against pre-fix `text.ts` (`git stash` round-trip), GREEN after.
- [x] Existing Latin/Cyrillic/full-form-CJK heading tests in the same file stay green (no regression).
- [x] New `server/src/util/cjk.test.ts` pins the shared helper directly, including codepoints the old range-form regex missed (halfwidth katakana, CJK Compatibility Ideographs, supplementary-plane Han).
- [x] `cd server && npx vitest run src/parsers/text src/analyzer/strip-front-matter src/util/cjk src/tts/language-registry src/parsers/front-matter` — 104/104 passed.
- [x] `analyzer/gemini.test.ts` (server-slow lane) run directly against `vitest.config.slow.ts` — 44/44 passed, confirming `countCjkChars` swap-in has no behavior change for the token-estimate tests.
- Not run: full `npm run verify` / typecheck (box is busy with other work; this worktree's `node_modules` is also incomplete pre-existing to this change — targeted vitest runs above are the compensating check).

Closes #1576

https://claude.ai/code/session_018b1HgxPqAyKgnFLXS24CZK