### PR TITLE
chore(frontend): refresh stale zh/ja 'unsupported' comments after fs-59 W5

### DIFF
--- a/src/modals/profile-drawer.test.tsx
+++ b/src/modals/profile-drawer.test.tsx
@@ -1851,7 +1851,7 @@ describe('ProfileDrawer — fs-60 eligibility-based engine lock', () => {
     expect(screen.getByRole('option', { name: 'Coqui XTTS' })).toBeInTheDocument();
   });
 
-  it('still hard-locks to Qwen for a still-unsupported non-English language (zh)', () => {
+  it('still hard-locks to Qwen when Qwen is the only eligible engine (zh, no Coqui installed)', () => {
     renderDrawer(baseChar, {
       bookId: 'zh-book-1',
       libraryBook: { ...ruBook, bookId: 'zh-book-1', language: 'zh', eligibleTtsEngines: ['qwen'] },

--- a/src/modals/profile-drawer.tsx
+++ b/src/modals/profile-drawer.tsx
@@ -287,12 +287,13 @@ export function ProfileDrawer({
      bespoke Qwen embedding server-side and returns an audition the drawer
      plays; on Save we pin the designed voiceId series-scoped. The
      narrator usually stays default — no character to design a voice for. */
-  /* fs-2 — a non-English book hard-locks every character to Qwen (Kokoro is
-     English-only). Default the choice to 'qwen' regardless of any stale/reused
-     ttsEngine on disk, matching the server's force-Qwen gate. */
+  /* fs-2/fs-60 — when a book hard-locks to Qwen (no Coqui/Kokoro fallback for
+     its language; see `lockedToQwen` below), default the choice to 'qwen'
+     regardless of any stale/reused ttsEngine on disk, matching the server's
+     force-Qwen gate. */
   /* fs-60 — lockedToQwen means "the ONLY eligible engine is Qwen" (a
-     still-unsupported non-English language), NOT "there's exactly one
-     eligible engine" — a Kokoro-only or Coqui-only install on an ENGLISH
+     non-English language with no Coqui/Kokoro fallback), NOT "there's exactly
+     one eligible engine" — a Kokoro-only or Coqui-only install on an ENGLISH
      book must not hard-lock to a disabled, uninstalled Qwen option. */
   const lockedToQwen = eligibleTtsEngines.length === 1 && eligibleTtsEngines[0] === 'qwen';
   const [engineChoice, setEngineChoice] = useState<EngineChoice>(

--- a/src/modals/voice-readiness-gate.test.tsx
+++ b/src/modals/voice-readiness-gate.test.tsx
@@ -92,7 +92,7 @@ describe('VoiceReadinessGateModal', () => {
     expect(screen.getByText('Alice')).toBeInTheDocument();
   });
 
-  it('a still-unsupported non-English book (zh) omits the proceed affordance entirely', () => {
+  it('a book with no fallback engine (zh, Qwen-only eligibility) omits the proceed affordance entirely', () => {
     const store = makeStore({
       characters: [qwenChar({ id: 'a', name: 'Alice', lines: 3 })],
       language: 'zh',

--- a/src/modals/voice-readiness-gate.tsx
+++ b/src/modals/voice-readiness-gate.tsx
@@ -3,9 +3,9 @@
    voice: "Design full cast" kicks the bulk job (same payload shape as the
    cast view's "Design full cast" button, so it drives the same
    DesignPill/progress UI); English AND Coqui-eligible non-English books (fs-60
-   — ru/es/fr/de) get a "Proceed anyway" fallback, naming whichever engine
-   would actually render (Kokoro or Coqui); only a still-unsupported language
-   (Qwen is the sole eligible engine) has no proceed affordance at all —
+   — ru/es/fr/de/zh/ja) get a "Proceed anyway" fallback, naming whichever engine
+   would actually render (Kokoro or Coqui); only a language with no Coqui/Kokoro
+   fallback (Qwen is the sole eligible engine) has no proceed affordance at all —
    every speaking character needs a designed voice before that book can
    generate. */
 

--- a/src/store/voice-readiness-selectors.test.ts
+++ b/src/store/voice-readiness-selectors.test.ts
@@ -133,7 +133,7 @@ describe('selectHasNoFallbackEngine', () => {
     expect(selectHasNoFallbackEngine(s, 'b1')).toBe(false);
   });
 
-  it('is true for a still-unsupported non-English language (zh)', () => {
+  it('is true when Qwen is the only eligible engine (zh with no Coqui fallback installed)', () => {
     const s = mk({ books: [{ bookId: 'b1', language: 'zh', eligibleTtsEngines: ['qwen'] }] });
     expect(selectHasNoFallbackEngine(s, 'b1')).toBe(true);
   });
@@ -178,7 +178,7 @@ describe('voiceReadinessGateMessage', () => {
     expect(voiceReadinessGateMessage(s, 'b1')).toMatch(/haven't been designed yet/);
   });
 
-  it('returns the hard-block copy for a still-unsupported non-English book', () => {
+  it('returns the hard-block copy when the book has no fallback engine (Qwen-only eligibility)', () => {
     const s = mk({
       characters: [qwenChar({ id: 'a', name: 'Alice', lines: 1 })],
       books: [{ bookId: 'b1', language: 'zh', eligibleTtsEngines: ['qwen'] }],

--- a/src/store/voice-readiness-selectors.ts
+++ b/src/store/voice-readiness-selectors.ts
@@ -59,10 +59,10 @@ export function selectVoiceReadinessGateShouldFire(state: RootState, bookId: str
 }
 
 /** fs-60 — true only when this book's language has NO fallback engine at
-    all (a still-unsupported non-English language — Coqui isn't in
-    eligibleTtsEngines either). A Coqui-eligible language (en/ru/es/fr/de)
-    gets the soft-gate below instead of a hard block, since an undesigned
-    Qwen character falls back to Coqui rather than failing. */
+    all (neither Coqui nor Kokoro is in eligibleTtsEngines). A Coqui-eligible
+    language (en/ru/es/fr/de/zh/ja) gets the soft-gate below instead of a hard
+    block, since an undesigned Qwen character falls back to Coqui rather than
+    failing. */
 export function selectHasNoFallbackEngine(state: RootState, bookId: string): boolean {
   const book = state.library?.books?.find((b) => b.bookId === bookId);
   /* Missing book data (not yet loaded) defaults to "assume every engine is
@@ -81,9 +81,9 @@ export function selectHasNoFallbackEngine(state: RootState, bookId: string): boo
     book is non-English AND coqui is eligible; Kokoro otherwise. Same
     book-lookup + eligibleTtsEngines default as `selectHasNoFallbackEngine`
     above — don't fork the derivation. If `selectHasNoFallbackEngine` is true
-    (a still-unsupported language), the return value here is irrelevant since
-    no proceed button is shown in that case — 'Kokoro' is just the harmless
-    default. */
+    (no Coqui/Kokoro fallback for this language), the return value here is
+    irrelevant since no proceed button is shown in that case — 'Kokoro' is just
+    the harmless default. */
 export function selectFallbackEngineName(state: RootState, bookId: string): 'Coqui' | 'Kokoro' {
   const book = state.library?.books?.find((b) => b.bookId === bookId);
   const eligible = book?.eligibleTtsEngines ?? ['qwen', 'kokoro', 'coqui', 'gemini', 'piper'];
@@ -92,8 +92,8 @@ export function selectFallbackEngineName(state: RootState, bookId: string): 'Coq
 }
 
 /** fs-46/fs-60 — message-builder pair mirroring `analysisBusyMessage`. Three
-    branches: English's existing soft-gate (Kokoro fallback), the NEW
-    Coqui-eligible soft-gate (ru/es/fr/de), and the still-unsupported-language
+    branches: English's existing soft-gate (Kokoro fallback), the
+    Coqui-eligible soft-gate (ru/es/fr/de/zh/ja), and the no-fallback-engine
     hard block (unchanged copy). Returns null when the gate shouldn't fire. */
 export function voiceReadinessGateMessage(state: RootState, bookId: string): string | null {
   if (!selectVoiceReadinessGateShouldFire(state, bookId)) return null;

--- a/src/views/cast.test.tsx
+++ b/src/views/cast.test.tsx
@@ -1490,8 +1490,9 @@ describe('CastView — non-English Qwen banner + auto-load (fe-16)', () => {
   });
 
   /* fs-60 addendum — the banner's second sentence is eligibility-aware:
-     Coqui-eligible languages (ru/es/fr/de) get a Coqui-fallback tail instead
-     of the old "can't be generated" claim, which is now false for them. */
+     Coqui-eligible languages (ru/es/fr/de/zh/ja) get a Coqui-fallback tail
+     instead of the old "can't be generated" claim, which is now false for
+     them. */
   it('shows the Coqui-fallback tail for a Coqui-eligible non-English book', () => {
     vi.stubGlobal(
       'fetch',
@@ -1503,8 +1504,9 @@ describe('CastView — non-English Qwen banner + auto-load (fe-16)', () => {
     expect(banner.textContent).not.toMatch(/can't be generated/);
   });
 
-  /* fs-60 addendum — Qwen-only languages (e.g. zh, not yet Coqui-eligible)
-     keep the original "can't be generated" wording. */
+  /* fs-60 addendum — a book whose only installed eligible engine is Qwen (here
+     zh with Coqui not installed) keeps the original "can't be generated"
+     wording. */
   it('shows the original "can\'t be generated" tail for a Qwen-only non-English book', () => {
     vi.stubGlobal(
       'fetch',

--- a/src/views/cast.tsx
+++ b/src/views/cast.tsx
@@ -84,9 +84,9 @@ interface Props {
   bookLanguage?: string;
   /** fs-60 — TTS engines eligible for this book's language, from the API.
       Drives whether the non-English banner's second sentence says
-      "undesigned characters can't be generated" (Qwen-only languages, e.g.
-      zh) or "fall back to a generic Coqui voice" (Coqui-eligible languages,
-      e.g. ru/es/fr/de) — see `qwenOnly` below. */
+      "undesigned characters can't be generated" (Qwen is the only eligible
+      engine) or "fall back to a generic Coqui voice" (Coqui-eligible
+      languages, e.g. ru/es/fr/de/zh/ja) — see `qwenOnly` below. */
   eligibleTtsEngines?: TtsEngine[];
   onOpenProfile: (id: string | null) => void;
   onShowMatchDetail: (id: string) => void;
@@ -159,9 +159,10 @@ export function CastView({
      silent (the banner already tells the user what to do). */
   const isNonEnglish = bookLanguage !== 'en';
   /* fs-60 — mirrors profile-drawer.tsx's `lockedToQwen`: true only when Qwen
-     is the SOLE eligible engine for this book's language (a still-unsupported
-     language, e.g. zh). For Coqui-eligible languages (ru/es/fr/de) this is
-     false — undesigned characters fall back to Coqui instead of failing. */
+     is the SOLE eligible engine for this book's language (no Coqui/Kokoro
+     fallback installed for it). For Coqui-eligible languages (ru/es/fr/de/zh/ja)
+     this is false — undesigned characters fall back to Coqui instead of
+     failing. */
   const qwenOnly = eligibleTtsEngines.length === 1 && eligibleTtsEngines[0] === 'qwen';
   const qwenAutoLoadFired = useRef(false);
   useEffect(() => {
@@ -896,9 +897,9 @@ export function CastView({
             book) benefits from a designed Qwen voice per speaking character
             for best quality; Qwen is being loaded in the background (see the
             entry effect above). fs-60 — the second sentence is eligibility-
-            aware: Qwen-only languages (e.g. zh) still can't generate
-            undesigned characters, but Coqui-eligible languages (ru/es/fr/de)
-            fall back to a generic Coqui voice instead. */}
+            aware: when Qwen is the only eligible engine, undesigned characters
+            still can't be generated, but Coqui-eligible languages (ru/es/fr/de/
+            zh/ja) fall back to a generic Coqui voice instead. */}
         {isNonEnglish && (
           <div
             role="status"


### PR DESCRIPTION
## Summary

fs-59 W5 (#1004, PR #1604) flipped `zh`/`ja` to `supported: true`, and Wave 4 already made them Coqui-eligible (`ENGINE_LANGUAGE_SUPPORT.coqui = [en, ru, es, fr, de, zh, ja]`). A zh/ja book therefore takes the **Coqui-eligible soft-gate** path (an undesigned Qwen character falls back to Coqui; no hard block). The behaviour is already correct and fully data-driven off each book's `eligibleTtsEngines` — but several frontend comments/copy still described zh (and CJK generally) as a "still-unsupported non-English language" and enumerated the soft-gate set as only `ru/es/fr/de`, which is now stale.

This PR refreshes those **comments and test labels only** — no behaviour change:

- `src/store/voice-readiness-selectors.ts` — three doc-comments: the no-fallback bucket is now described accurately as "neither Coqui nor Kokoro is eligible" (not "still-unsupported non-English language"), and the Coqui-eligible enumerations now read `ru/es/fr/de/zh/ja`.
- `src/modals/voice-readiness-gate.tsx` — header comment's fallback-language list + the "still-unsupported language" phrasing.
- `src/modals/profile-drawer.tsx` — the `lockedToQwen` comment, plus the adjacent stale `fs-2` comment 3 lines above it (which claimed "a non-English book hard-locks every character to Qwen" — now false for Coqui-eligible languages, and it directly contradicted the edited `lockedToQwen` comment).
- `src/views/cast.tsx` — three comments the issue's file list missed but that carry the identical stale phrasing ("Qwen-only languages, e.g. zh", "(ru/es/fr/de)"). The `qwenOnly` logic is unchanged.
- Test **labels/comments** in `profile-drawer.test.tsx`, `voice-readiness-gate.test.tsx`, `voice-readiness-selectors.test.ts`, `cast.test.tsx` — `it()` descriptions that called a `eligibleTtsEngines: ['qwen']` zh setup a "still-unsupported non-English language". Reframed as "Qwen is the only eligible engine / no Coqui installed". Assertions and setup unchanged.

Note: the registry now has exactly 7 supported languages (`en/ru/es/fr/de/zh/ja`), **all** Coqui-eligible — so no *supported* language is inherently Qwen-only anymore; that bucket is reached only when Coqui isn't installed for the book's language. The refreshed comments describe the bucket by that condition rather than by a (now-wrong) example language.

### Out of scope / follow-up
- `src/lib/api-types.ts:2872` ("additionally eligible for en/ru/es/fr/de") is **generated** from `openapi.yaml`; its stale enumeration should be fixed at the `openapi.yaml` source + regenerated (a server/contract change), not hand-edited here. Flagging for a separate follow-up.

## Test plan

Comments/labels only — no runtime surface and no behaviour delta, so no new automated coverage is warranted (the existing gate/selector tests already lock the zh/ja soft-gate behaviour). Verified the full frontend Vitest suite stays green (3901 passed) and the pre-push battery (lint + typecheck + build) passed.

Release notes: **skipped** — internal chore with no user- or operator-visible effect (source comments + test descriptions only).

Closes #1605

🤖 Generated with [Claude Code](https://claude.com/claude-code)