### PR TITLE
chore(openapi): add zh/ja to Coqui eligibility note in eligibleTtsEngines

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3709,7 +3709,7 @@ components:
             deployment — the frontend intersects this with its own
             installed-engines list). Qwen is always eligible (the
             unconditional non-English⇒Qwen invariant, fs-2); Coqui is
-            additionally eligible for en/ru/es/fr/de. Optional — like `tags`,
+            additionally eligible for en/ru/es/fr/de/zh/ja. Optional — like `tags`,
             `scan.ts` always populates it in practice, but the schema keeps it
             optional (NOT added to `required`) so existing test fixtures that
             construct a `LibraryBook` object literal without every field don't

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -2869,7 +2869,7 @@ export interface components {
              *     deployment — the frontend intersects this with its own
              *     installed-engines list). Qwen is always eligible (the
              *     unconditional non-English⇒Qwen invariant, fs-2); Coqui is
-             *     additionally eligible for en/ru/es/fr/de. Optional — like `tags`,
+             *     additionally eligible for en/ru/es/fr/de/zh/ja. Optional — like `tags`,
              *     `scan.ts` always populates it in practice, but the schema keeps it
              *     optional (NOT added to `required`) so existing test fixtures that
              *     construct a `LibraryBook` object literal without every field don't


### PR DESCRIPTION
## Summary

The `eligibleTtsEngines` schema description in `openapi.yaml` said Coqui is "additionally eligible for **en/ru/es/fr/de**", but since fs-59 W4b `ENGINE_LANGUAGE_SUPPORT.coqui` is `[en, ru, es, fr, de, zh, ja]` (`server/src/tts/voice-mapping.ts`). This updates the description to include `zh`/`ja` and regenerates `src/lib/api-types.ts` from it (`npm run openapi:types`).

Description/doc only — **no schema shape or behaviour change** (2 lines: the yaml source + the generated type's mirrored JSDoc comment).

Follow-up to #1605 / PR #1635, which deliberately left this generated/contract surface for a separate change.

## Test plan

Doc/description only, no runtime surface — no new automated coverage warranted. `npm run openapi:types` regenerated the types cleanly (diff is the comment text only, no type-shape change); pre-push `verify:fast:branch` (typecheck + frontend tests 3901✓ + build) green.

Release notes: **skipped** — internal API-contract doc, no user- or operator-visible effect.

Closes #1636

🤖 Generated with [Claude Code](https://claude.com/claude-code)