### PR TITLE
test(app): cover demo _exitDemo disk-cleanup via deleteDemoRoot seam

### DIFF
--- a/apps/android/lib/main.dart
+++ b/apps/android/lib/main.dart
@@ -30,6 +30,21 @@ Future<String> _defaultDemoRoot() async =>
 Future<List<int>> _defaultDemoAsset(String key) async =>
     (await rootBundle.load(key)).buffer.asUint8List();
 
+/// Best-effort removal of the demo runtime's on-disk footprint (the app-private
+/// demo root — the only disk the demo leaves). Extracted as a testable seam
+/// because a full widget-driven exit deadlocks on runtime dispose while
+/// [LibraryHomeScreen] is still mounted (`library.close()` blocks on the live
+/// `_refresh` stream — see the reference note), so `_exitDemo`'s cleanup half is
+/// unit-tested through this helper instead. A null root or a delete failure is
+/// swallowed — cleanup must never block or throw out of exit.
+@visibleForTesting
+Future<void> deleteDemoRoot(FileStore fs, String? root) async {
+  if (root == null) return;
+  try {
+    await fs.deleteDir(root);
+  } catch (_) {}
+}
+
 /// Castwright — the native listening client (plan 188). app-1 shell +
 /// app-2 pairing + the app-3..14 library / sync / player wired on top, with
 /// OFFLINE launch (the runtime is rebuilt from the stored cert — no network
@@ -382,11 +397,7 @@ class _HomePageState extends State<HomePage> {
       });
     }
     await rt?.dispose();
-    if (root != null) {
-      try {
-        await fs.deleteDir(root);
-      } catch (_) {}
-    }
+    await deleteDemoRoot(fs, root);
   }
 
   @override

--- a/apps/android/test/ui/demo_exit_cleanup_test.dart
+++ b/apps/android/test/ui/demo_exit_cleanup_test.dart
@@ -1,0 +1,78 @@
+import 'package:castwright/main.dart';
+import 'package:castwright/src/data/file_store.dart';
+import 'package:castwright/src/data/pairing_store.dart';
+import 'package:castwright/src/domain/paired_server.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A production-shaped store: unpaired, and records whether save() was called.
+class _SpyStore implements PairingStore {
+  bool saved = false;
+  @override
+  Future<PairedServer?> load() async => null;
+  @override
+  Future<String?> loadCaPem() async => null;
+  @override
+  Future<void> save(PairedServer server) async => saved = true;
+  @override
+  Future<void> saveCaPem(String pem) async {}
+  @override
+  Future<void> clear() async {}
+}
+
+Future<List<int>> _fakeAsset(String key) async => const <int>[1, 2, 3];
+
+/// A [FileStore] whose [deleteDir] always throws — proves cleanup swallows a
+/// failing delete rather than propagating out of exit.
+class _ThrowingFileStore extends InMemoryFileStore {
+  @override
+  Future<void> deleteDir(String path) async => throw StateError('boom');
+}
+
+void main() {
+  // The cleanup half of `_exitDemo`. A full widget-driven exit deadlocks on
+  // runtime dispose while LibraryHomeScreen is mounted (see the reference note),
+  // so the leak-cleanup invariant is exercised through the extracted
+  // `deleteDemoRoot` seam — the same helper `_exitDemo` calls.
+  testWidgets('the demo leaves an on-disk root that cleanup removes; store untouched',
+      (tester) async {
+    const root = '/demo-test';
+    final store = _SpyStore();
+    final fs = InMemoryFileStore();
+
+    await tester.pumpWidget(AudiobookCompanionApp(
+      store: store,
+      deepLinks: const Stream.empty(),
+      demoRootResolver: () async => root,
+      demoFileStore: fs,
+      demoAssetLoader: _fakeAsset,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('try-demo')));
+    await tester.pumpAndSettle();
+
+    // The demo actually wrote its covers under the demo root — a real footprint.
+    expect(await fs.exists('$root/covers/hollow-tide-1.png'), isTrue);
+
+    // Cleanup removes everything under the root.
+    await deleteDemoRoot(fs, root);
+    expect(await fs.exists('$root/covers/hollow-tide-1.png'), isFalse);
+    expect(await fs.exists('$root/covers/coalfall-commission.png'), isFalse);
+
+    // Exiting never wrote the pairing keystore — the demo leaves no trace there.
+    expect(store.saved, isFalse);
+  });
+
+  test('deleteDemoRoot is a no-op when the demo never started (null root)', () async {
+    final fs = InMemoryFileStore();
+    await fs.writeBytes('/keep/me.txt', const [1]);
+    await deleteDemoRoot(fs, null);
+    expect(await fs.exists('/keep/me.txt'), isTrue);
+  });
+
+  test('deleteDemoRoot swallows a failing deleteDir', () async {
+    // A throwing delete must not propagate out of exit.
+    await expectLater(deleteDemoRoot(_ThrowingFileStore(), '/demo-test'), completes);
+  });
+}

--- a/docs/features/253-app-20-on-device-demo.md
+++ b/docs/features/253-app-20-on-device-demo.md
@@ -123,6 +123,13 @@ owner: null
   four-books contract.
 - Widget — exit demo returns to "Not paired yet"; asserts the pairing store was never written
   (a spy store whose `save` was never called and whose `load()` is still `null`).
+- Widget + unit (`apps/android/test/ui/demo_exit_cleanup_test.dart`, #1592) — the leak-safety
+  disk cleanup. A full widget-driven exit deadlocks on runtime dispose while
+  `LibraryHomeScreen` is mounted (`library.close()` blocks on the live `_refresh` stream), so
+  `_exitDemo`'s cleanup half is extracted into a `deleteDemoRoot(fs, root)` seam and tested
+  directly: drive the real `_startDemo` (which writes covers under the demo root), assert the
+  footprint exists, then `deleteDemoRoot` removes it and the pairing store stays untouched.
+  Plus unit cases for the null-root no-op and swallowed-delete-failure guards.
 - Widget — in `demoMode`, `AppSettingsScreen` shows the demo badge / "Exit demo" wording and
   renders no Server section (no URL, no fingerprint, no "Paired since").
 - Unit (`apps/android/test/demo/demo_ticking_audio_engine_test.dart`) —


### PR DESCRIPTION
## Summary

Closes the app-20 follow-up #1592: the demo's leak-safety invariant — the app-private demo root is `deleteDir`'d on exit — had **no automated coverage**. A full widget-driven exit deadlocks on runtime dispose while `LibraryHomeScreen` is still mounted (`library.close()` blocks on the live `_refresh` stream — see the reference note in the issue).

This extracts `_exitDemo`'s cleanup half into a small testable seam and covers it directly:

- **`deleteDemoRoot(FileStore fs, String? root)`** — new top-level `@visibleForTesting` helper in `main.dart`, the same one `_exitDemo` now calls. Pure extraction, no behaviour change (null-root and delete-failure guards preserved).
- **`test/ui/demo_exit_cleanup_test.dart`** — drives the real `_startDemo` (which writes covers under the demo root via an `InMemoryFileStore`), asserts the footprint exists, then `deleteDemoRoot` removes it while the pairing store stays untouched. Plus unit cases for the null-root no-op and swallowed delete-failure guards.

The disk-cleanup invariant was previously verified only by the manual on-device walkthrough (plan 253, step 6). It now has a deadlock-free automated regression net.

## Test plan

- `flutter test test/ui/demo_exit_cleanup_test.dart` — 3/3 pass.
- Mutation-checked: neutering `deleteDemoRoot` (early return) fails the cleanup assertion, and the pre-assert that the footprint exists guards against a placebo. Reverted after.
- `flutter test` demo suites (`test/ui/demo_*`, `test/demo/`) — 24/24 pass (refactor didn't regress siblings).
- `flutter analyze lib/main.dart test/ui/demo_exit_cleanup_test.dart` — no issues.

Regression plan `docs/features/253-app-20-on-device-demo.md` updated with the new coverage bullet.

Refs #1591. Closes #1592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)