### PR TITLE
docs(docs): fe-51 language-aware engine-recommendation plan + design

### DIFF
--- a/docs/superpowers/plans/2026-07-15-fe51-language-aware-engine-recommendation.md
+++ b/docs/superpowers/plans/2026-07-15-fe51-language-aware-engine-recommendation.md
@@ -1,0 +1,861 @@
+# Wizard Language-Aware Engine Recommendation (Part B / fe-51) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the wizard's hardcoded "Kokoro is the default voice engine" with a one-question, needs-based recommendation — expressive/multilingual → Qwen (Coqui optional), simple English → Kokoro — that leads the matching install card, prioritizes its pull, and pre-seeds the Defaults step, with detected VRAM as a soft caveat only.
+
+**Architecture:** A pure server function `recommendEngines(vramTotalMb)` reads an authored capability map (extended onto Part A's `VOICE_ENGINES` registry) plus the *derived* multilingual flag (from `ENGINE_LANGUAGE_SUPPORT`), and precomputes the recommendation for **both** answers to the single guided question. The result rides Part A's existing `ModelsStatus` payload (the wizard already fetches it once), so the client adds **no new endpoint and no new fetch** — `step-voice.tsx` renders a guided-question control, reorders the install cards so the recommended engine leads with a "Recommended for you" badge + primary CTA, and dispatches the Defaults handoff (`defaultTtsModelKey`) when the user answers.
+
+**Tech Stack:** TypeScript, Node/Express (server), Vitest (server + frontend), React 18 + Redux Toolkit (frontend), Playwright (e2e).
+
+**Spec:** `docs/superpowers/specs/2026-07-14-wizard-models-status-and-recommendation-design.md` — **Part B section** (amended 2026-07-15 against the landed Part A interfaces; server-side recommendation placement decided).
+
+**Issue:** `#1614` (fe-51, child of epic `#1613` / fs-75). This plan `Closes #1614`. **Depends on Part A (#1612 / PR #1644)** — this branch builds on Part A's `VOICE_ENGINES` registry, `ModelsStatus` payload, and controlled install cards. fe-49 (#1610) is **merged (PR #1642)**, so the pull-priority presentation is fully in-scope.
+
+## Global Constraints
+
+Every task's requirements implicitly include this section.
+
+- **No hex literals in component code** — use the CSS custom-property design tokens (`--peach`, `--ink`, `--magenta`, …) via Tailwind classes.
+- **OpenAPI / hand-written mirror parity** — the client `ModelsStatus` type in `src/lib/api.ts` is a **hand-written mirror** of the server `ModelsStatus` (there is no generated type for it). Any server shape change ships with the matching mirror edit **in the same task**, or the client typechecks against a stale contract.
+- **Mocks parity** — `mockGetModelsStatus()` (`src/lib/api.ts`) must return the same shape as the real endpoint; adding a field to `ModelsStatus` means updating the mock in the same task or every `step-voice`/`model-manager` test that renders off the mock breaks.
+- **`defaultTtsModelKey`, NOT `defaultTtsEngine`** carries the kokoro/qwen/coqui choice. `defaultTtsEngine` is the `'local' | 'gemini'` provider *tier* and cannot hold an engine id. The handoff sets `defaultTtsModelKey` (+ `defaultTtsModelKeyExplicit: true`) and `defaultTtsEngine: 'local'` (all recommended engines are on-device).
+- **Capability is a hard filter; VRAM is a soft preference.** Never recommend an engine that cannot meet the stated need (multilingual → Kokoro is ineligible). VRAM never *reorders* the capable branch — it only attaches a caveat. Nothing is ever blocked; every engine stays installable.
+- **Qwen leads the capable branch, Coqui is the optional alternate** (per #1614, explicit). The capable preference order is authored (`['qwen', 'coqui']`), not derived from VRAM floors (which would wrongly rank Coqui first).
+- **Truthfulness — caveat wording.** Do **not** promise "runs on CPU, slower" for a constrained-VRAM Qwen. The project's incident history (8 GB bulk-design OOM #1155; 1.7B-tier OOM storms) shows constrained Qwen can OOM-crash rather than fall back to CPU. Use the safe wording **"may not fit comfortably on this GPU"** until real low-VRAM sidecar behavior is verified (Task 6 note).
+- **Testing discipline** — every task ships paired automated tests (fails-before/passes-after for the behavior it adds). Server pure functions get Vitest unit tests mirroring the `diagnose*` pattern; UI crossing redux/fetch/layout seams earns one Playwright e2e.
+- **Commit convention** — `<type>(<scope>): <subject>`; scopes here are `server` and `frontend` (and `docs` for the plan/regression-doc commits). Multi-file client+server changes stay split by task so scope stays single.
+
+## File Structure
+
+**New files:**
+- `server/src/tts/engine-recommendation.ts` — the pure recommendation module: `NeedsAnswer`, `EngineRecommendation`, `RecommendationSet` types; `isMultilingualEngine()` (derives from `ENGINE_LANGUAGE_SUPPORT`); `recommendEngines(vramTotalMb)`. One responsibility: turn hardware + capability into a recommendation. No I/O.
+- `server/src/tts/engine-recommendation.test.ts` — unit tests for the four spec cases + multilingual derivation.
+- `src/components/setup/engine-recommendation-copy.ts` — tiny client-side presentation helpers (question label, answer labels, "Recommended for you" badge text). Pure, keeps copy out of the component body and unit-testable.
+- `e2e/setup-engine-recommendation.spec.ts` — one golden-path spec.
+- `docs/features/259-fe51-engine-recommendation.md` — regression plan (verify `259` is still free at implementation time; bump if a concurrent plan claimed it).
+
+**Modified files:**
+- `server/src/tts/voice-engine-registry.ts` — extend `VoiceEngineEntry` with authored capability fields (`expressive`, `genVramFloorMb`, `designVramFloorMb?`); populate the three entries.
+- `server/src/tts/models-status.ts` — add `recommendation: RecommendationSet` to `ModelsStatus`; `buildModelsStatus` calls `recommendEngines(input.info.vramTotalMb)`.
+- `src/lib/api.ts` — mirror the `recommendation` field onto the client `ModelsStatus` interface; add it to `mockGetModelsStatus()`.
+- `src/components/setup/step-voice.tsx` — guided-question control; recommendation-driven card ordering + "Recommended for you" badge + primary CTA; de-defaulting copy; Defaults handoff dispatch.
+- `src/components/setup/step-voice.test.tsx` — extend with the new behaviors.
+
+**Untouched (verified, receives the pre-seed only):**
+- `src/components/setup/step-defaults.tsx` — already reads/writes `defaultTtsModelKey` + `defaultTtsModelKeyExplicit` via its "Voice model" dropdown; it shows the recommended model pre-selected with **no new plumbing**.
+
+---
+
+## Task 1: Authored capability fields on the voice-engine registry
+
+Extend Part A's `VoiceEngineEntry` with the authored capability constants the recommendation reads. `multilingual` is **not** stored here (it is derived in Task 2 from `ENGINE_LANGUAGE_SUPPORT`); only the authored facts live here.
+
+**Files:**
+- Modify: `server/src/tts/voice-engine-registry.ts`
+- Test: `server/src/tts/voice-engine-registry.test.ts` (create if absent)
+
+**Interfaces:**
+- Consumes: existing `VoiceEngineEntry` / `VOICE_ENGINES` (Part A).
+- Produces: `VoiceEngineEntry.expressive: boolean`, `VoiceEngineEntry.genVramFloorMb: number`, `VoiceEngineEntry.designVramFloorMb?: number` — read by `recommendEngines` (Task 2).
+
+**Grounded VRAM constants** (cited basis — real numbers, not guesses; the *structure* is fixed, confirm the exact values against `server/src/config/registry.ts` help text + measurement during implementation and adjust if the registry is authoritative):
+- **Kokoro** `genVramFloorMb: 1024` — ~1 GB, fits CPU (CLAUDE.md model-lifecycle notes). `expressive: false`.
+- **Qwen** `genVramFloorMb: 6144` — 0.6B generation path fits comfortably ~6 GB (#1614 threshold + spec); `designVramFloorMb: 5120` — VoiceDesign 1.7B ~4–5 GB transient (registry `qwen.design.idleTtlSec` help, line ~700). `expressive: true`.
+- **Coqui** `genVramFloorMb: 4096` — XTTS v2 ~3 GB load + gen headroom (registry `tts.preload.coqui` help, line ~568). `expressive: true`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create/extend `server/src/tts/voice-engine-registry.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { VOICE_ENGINES } from './voice-engine-registry.js';
+
+describe('VOICE_ENGINES capability fields', () => {
+  const byId = Object.fromEntries(VOICE_ENGINES.map((e) => [e.id, e]));
+
+  it('carries authored expressive + VRAM floors per engine', () => {
+    expect(byId.kokoro.expressive).toBe(false);
+    expect(byId.kokoro.genVramFloorMb).toBe(1024);
+    expect(byId.kokoro.designVramFloorMb).toBeUndefined();
+
+    expect(byId.qwen.expressive).toBe(true);
+    expect(byId.qwen.genVramFloorMb).toBe(6144);
+    expect(byId.qwen.designVramFloorMb).toBe(5120);
+
+    expect(byId.coqui.expressive).toBe(true);
+    expect(byId.coqui.genVramFloorMb).toBe(4096);
+  });
+
+  it('every entry has a positive generation floor', () => {
+    for (const e of VOICE_ENGINES) expect(e.genVramFloorMb).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/tts/voice-engine-registry.test.ts`
+Expected: FAIL — `expressive`/`genVramFloorMb` are `undefined` (type error at compile or `toBe` mismatch at runtime).
+
+- [ ] **Step 3: Extend the interface and populate entries**
+
+In `server/src/tts/voice-engine-registry.ts`, add to `VoiceEngineEntry` (after `liveLoaded`):
+
+```ts
+  /** Authored: the engine produces expressive/emotive speech (no code source for
+      this — a curated fact). Kokoro is flat/fast; Qwen + Coqui are expressive. */
+  expressive: boolean;
+  /** Authored: comfortable VRAM (MB) for the GENERATION path. Grounded in the
+      registry help text + measurement, not derived. */
+  genVramFloorMb: number;
+  /** Authored: comfortable VRAM (MB) for a heavy transient DESIGN model, when the
+      engine has one (Qwen VoiceDesign 1.7B). Governs the voice-design feature, NOT
+      a reason to steer generation away from the engine. */
+  designVramFloorMb?: number;
+```
+
+Then add the fields to each entry:
+
+```ts
+  {
+    id: 'kokoro',
+    defaultModelKey: 'kokoro-v1',
+    // …existing probe fns…
+    expressive: false,
+    genVramFloorMb: 1024,
+  },
+  {
+    id: 'qwen',
+    defaultModelKey: 'qwen3-tts-0.6b',
+    // …existing probe fns…
+    expressive: true,
+    genVramFloorMb: 6144,
+    designVramFloorMb: 5120,
+  },
+  {
+    id: 'coqui',
+    defaultModelKey: 'coqui-xtts-v2',
+    // …existing probe fns…
+    expressive: true,
+    genVramFloorMb: 4096,
+  },
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/tts/voice-engine-registry.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/tts/voice-engine-registry.ts server/src/tts/voice-engine-registry.test.ts
+git commit -m "feat(server): add authored capability fields to voice-engine registry"
+```
+
+---
+
+## Task 2: `recommendEngines()` pure recommendation function
+
+The heart of Part B: a pure function over authored capability + derived multilingual + detected VRAM, precomputing the recommendation for **both** answers to the guided question.
+
+**Files:**
+- Create: `server/src/tts/engine-recommendation.ts`
+- Test: `server/src/tts/engine-recommendation.test.ts`
+
+**Interfaces:**
+- Consumes: `VOICE_ENGINES` (with capability fields from Task 1); `ENGINE_LANGUAGE_SUPPORT` (`server/src/tts/voice-mapping.ts`); `DEFAULT_LANGUAGE` (`server/src/tts/language.ts`).
+- Produces:
+  - `type NeedsAnswer = 'expressive-or-multilingual' | 'simple-english'`
+  - `interface EngineRecommendation { engine: VoiceEngineId; modelKey: VoiceEngineEntry['defaultModelKey']; reason: string; caveat: string | null; alternate: VoiceEngineId | null }`
+  - `interface RecommendationSet { expressiveOrMultilingual: EngineRecommendation; simpleEnglish: EngineRecommendation }`
+  - `function isMultilingualEngine(id: VoiceEngineId): boolean`
+  - `function recommendEngines(vramTotalMb: number | null): RecommendationSet`
+
+**Logic (verbatim — do not paraphrase into "handle edge cases"):**
+- `simpleEnglish` → **always Kokoro** (`kokoro-v1`), `caveat: null`, `alternate: null`, `reason: 'Fast and light — runs comfortably on low VRAM or CPU.'`
+- `expressiveOrMultilingual` → the capable engines are those where `expressive || isMultilingualEngine`. Ordered by the **authored preference** `['qwen', 'coqui']`, intersected with that capable set. `engine` = first (Qwen today); `alternate` = second if present (Coqui today); `reason: 'Expressive and multilingual — the multi-cast default.'`
+- **Caveat** (soft, never reorders): `null` when `vramTotalMb != null && vramTotalMb >= <lead>.genVramFloorMb`; otherwise `'May not fit comfortably on this GPU — install anyway, or pick a lighter engine below.'` (covers both low-VRAM and CPU-only/`null`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/src/tts/engine-recommendation.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { recommendEngines, isMultilingualEngine } from './engine-recommendation.js';
+
+describe('isMultilingualEngine', () => {
+  it('derives multilingual from ENGINE_LANGUAGE_SUPPORT', () => {
+    expect(isMultilingualEngine('qwen')).toBe(true); // support '*'
+    expect(isMultilingualEngine('coqui')).toBe(true); // ['en','ru',…]
+    expect(isMultilingualEngine('kokoro')).toBe(false); // ['en'] only
+  });
+});
+
+describe('recommendEngines', () => {
+  it('simple-english → Kokoro always, no caveat, regardless of VRAM', () => {
+    for (const vram of [null, 512, 8192, 24576]) {
+      const r = recommendEngines(vram).simpleEnglish;
+      expect(r.engine).toBe('kokoro');
+      expect(r.modelKey).toBe('kokoro-v1');
+      expect(r.caveat).toBeNull();
+      expect(r.alternate).toBeNull();
+    }
+  });
+
+  it('need + adequate VRAM (>= Qwen floor) → Qwen, Coqui alternate, no caveat', () => {
+    const r = recommendEngines(8192).expressiveOrMultilingual;
+    expect(r.engine).toBe('qwen');
+    expect(r.modelKey).toBe('qwen3-tts-0.6b');
+    expect(r.alternate).toBe('coqui');
+    expect(r.caveat).toBeNull();
+  });
+
+  it('need + low VRAM (< Qwen floor) → Qwen with caveat (never downgraded to Kokoro)', () => {
+    const r = recommendEngines(4096).expressiveOrMultilingual;
+    expect(r.engine).toBe('qwen');
+    expect(r.caveat).toMatch(/may not fit comfortably/i);
+  });
+
+  it('need + CPU-only (vram null) → Qwen with caveat, still not Kokoro', () => {
+    const r = recommendEngines(null).expressiveOrMultilingual;
+    expect(r.engine).toBe('qwen');
+    expect(r.caveat).toMatch(/may not fit comfortably/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/tts/engine-recommendation.test.ts`
+Expected: FAIL — module `./engine-recommendation.js` not found.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `server/src/tts/engine-recommendation.ts`:
+
+```ts
+/* fe-51 (Part B) — language-aware voice-engine recommendation. Pure over authored
+   capability (voice-engine-registry) + derived multilingual (ENGINE_LANGUAGE_SUPPORT)
+   + detected VRAM. Precomputes BOTH answers to the wizard's one guided question so
+   the client renders off the models-status payload with no extra round-trip.
+
+   Capability is a HARD filter (never recommend an engine that can't meet the need);
+   VRAM is a SOFT preference (caveat only, never reorders). Qwen leads the capable
+   branch, Coqui is the optional alternate (#1614). */
+import { VOICE_ENGINES, type VoiceEngineId, type VoiceEngineEntry } from './voice-engine-registry.js';
+import { ENGINE_LANGUAGE_SUPPORT } from './voice-mapping.js';
+import { DEFAULT_LANGUAGE } from './language.js';
+
+export type NeedsAnswer = 'expressive-or-multilingual' | 'simple-english';
+
+export interface EngineRecommendation {
+  engine: VoiceEngineId;
+  modelKey: VoiceEngineEntry['defaultModelKey'];
+  reason: string;
+  caveat: string | null;
+  alternate: VoiceEngineId | null;
+}
+
+export interface RecommendationSet {
+  expressiveOrMultilingual: EngineRecommendation;
+  simpleEnglish: EngineRecommendation;
+}
+
+/** Authored preference for the capable (expressive/multilingual) branch: Qwen is
+    the multi-cast default, Coqui the optional alternate (#1614). NOT ordered by
+    VRAM floor — that would wrongly rank Coqui first. */
+const CAPABLE_PREFERENCE: VoiceEngineId[] = ['qwen', 'coqui'];
+
+const CAVEAT_VRAM =
+  'May not fit comfortably on this GPU — install anyway, or pick a lighter engine below.';
+
+const byId = new Map<VoiceEngineId, VoiceEngineEntry>(VOICE_ENGINES.map((e) => [e.id, e]));
+
+/** Derived, not stored: an engine is multilingual if it supports any language
+    beyond English in ENGINE_LANGUAGE_SUPPORT ('*' or a non-'en' entry). */
+export function isMultilingualEngine(id: VoiceEngineId): boolean {
+  const support = ENGINE_LANGUAGE_SUPPORT[id];
+  if (support === '*') return true;
+  return support.some((lang) => lang !== DEFAULT_LANGUAGE);
+}
+
+function entry(id: VoiceEngineId): VoiceEngineEntry {
+  const e = byId.get(id);
+  if (!e) throw new Error(`[engine-recommendation] unknown engine id: ${id}`);
+  return e;
+}
+
+export function recommendEngines(vramTotalMb: number | null): RecommendationSet {
+  // Capable = expressive OR multilingual, in authored preference order.
+  const capable = CAPABLE_PREFERENCE.filter(
+    (id) => entry(id).expressive || isMultilingualEngine(id),
+  );
+  const leadId = capable[0] ?? 'qwen';
+  const lead = entry(leadId);
+  const alternate = capable[1] ?? null;
+
+  const fits = vramTotalMb != null && vramTotalMb >= lead.genVramFloorMb;
+
+  const kokoro = entry('kokoro');
+
+  return {
+    expressiveOrMultilingual: {
+      engine: leadId,
+      modelKey: lead.defaultModelKey,
+      reason: 'Expressive and multilingual — the multi-cast default.',
+      caveat: fits ? null : CAVEAT_VRAM,
+      alternate,
+    },
+    simpleEnglish: {
+      engine: 'kokoro',
+      modelKey: kokoro.defaultModelKey,
+      reason: 'Fast and light — runs comfortably on low VRAM or CPU.',
+      caveat: null,
+      alternate: null,
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/tts/engine-recommendation.test.ts`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/tts/engine-recommendation.ts server/src/tts/engine-recommendation.test.ts
+git commit -m "feat(server): pure language-aware engine recommendation function"
+```
+
+---
+
+## Task 3: Surface the recommendation on the `ModelsStatus` payload (+ client mirror + mock)
+
+Thread the recommendation through Part A's existing computation so the wizard gets it in the one fetch it already makes.
+
+**Files:**
+- Modify: `server/src/tts/models-status.ts`
+- Modify: `src/lib/api.ts` (client `ModelsStatus` mirror + `mockGetModelsStatus`)
+- Test: `server/src/tts/models-status.test.ts` (extend Part A's suite)
+
+**Interfaces:**
+- Consumes: `recommendEngines` (Task 2); `BuildModelsStatusInput.info.vramTotalMb` (Part A).
+- Produces: `ModelsStatus.recommendation: RecommendationSet` — read by `step-voice.tsx` (Task 4).
+
+- [ ] **Step 1: Write the failing test**
+
+Extend `server/src/tts/models-status.test.ts` (add near the existing `buildModelsStatus` cases — reuse whatever `baseInput` helper the suite already has; the block below shows the minimal standalone form):
+
+```ts
+import { buildModelsStatus } from './models-status.js';
+
+function inputWith(vramTotalMb: number | null) {
+  const probe = { packageOnDisk: false, weightsOnDisk: false, loaded: false, importable: undefined };
+  return {
+    runtime: { installedOnDisk: false, pythonFound: false, process: 'down' as const },
+    engines: { kokoro: probe, qwen: probe, coqui: probe },
+    info: { gpu: 'test', vramTotalMb },
+  };
+}
+
+it('surfaces a recommendation derived from vramTotalMb', () => {
+  const hi = buildModelsStatus(inputWith(8192));
+  expect(hi.recommendation.expressiveOrMultilingual.engine).toBe('qwen');
+  expect(hi.recommendation.expressiveOrMultilingual.caveat).toBeNull();
+  expect(hi.recommendation.simpleEnglish.engine).toBe('kokoro');
+
+  const lo = buildModelsStatus(inputWith(2048));
+  expect(lo.recommendation.expressiveOrMultilingual.caveat).toMatch(/may not fit/i);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/tts/models-status.test.ts`
+Expected: FAIL — `recommendation` is not a property of `ModelsStatus`.
+
+- [ ] **Step 3: Add the field and wire the computation**
+
+In `server/src/tts/models-status.ts`:
+
+```ts
+import { recommendEngines, type RecommendationSet } from './engine-recommendation.js';
+```
+
+Add to the `ModelsStatus` interface (after `info`):
+
+```ts
+  /** fe-51 — precomputed recommendation for both answers to the wizard's guided
+      question. Derived from info.vramTotalMb + the engine capability map. */
+  recommendation: RecommendationSet;
+```
+
+In `buildModelsStatus`, change the return to include it:
+
+```ts
+  return {
+    runtime: input.runtime,
+    engines,
+    info: input.info,
+    recommendation: recommendEngines(input.info.vramTotalMb),
+  };
+```
+
+- [ ] **Step 4: Mirror the field on the client + update the mock**
+
+In `src/lib/api.ts`, extend the hand-written `ModelsStatus` mirror (the `fs-38 Part A` block, ~line 7196). Add the mirrored types **above** the interface and the field **inside** it:
+
+```ts
+export type NeedsAnswer = 'expressive-or-multilingual' | 'simple-english';
+export interface EngineRecommendation {
+  engine: 'kokoro' | 'qwen' | 'coqui';
+  modelKey: 'kokoro-v1' | 'qwen3-tts-0.6b' | 'coqui-xtts-v2';
+  reason: string;
+  caveat: string | null;
+  alternate: 'kokoro' | 'qwen' | 'coqui' | null;
+}
+export interface RecommendationSet {
+  expressiveOrMultilingual: EngineRecommendation;
+  simpleEnglish: EngineRecommendation;
+}
+export interface ModelsStatus {
+  runtime: { installedOnDisk: boolean; pythonFound: boolean; process: RuntimeProcessState };
+  engines: Record<'kokoro' | 'qwen' | 'coqui', { state: EngineHealthState; packageBroken: boolean }>;
+  info: { gpu: string; vramTotalMb: number | null };
+  recommendation: RecommendationSet;
+}
+```
+
+Update `mockGetModelsStatus()` (~line 7272) to return a recommendation (mock is CPU-only → `vramTotalMb: null` → Qwen caveat present):
+
+```ts
+    info: { gpu: 'CPU — no GPU detected', vramTotalMb: null },
+    recommendation: {
+      expressiveOrMultilingual: {
+        engine: 'qwen',
+        modelKey: 'qwen3-tts-0.6b',
+        reason: 'Expressive and multilingual — the multi-cast default.',
+        caveat: 'May not fit comfortably on this GPU — install anyway, or pick a lighter engine below.',
+        alternate: 'coqui',
+      },
+      simpleEnglish: {
+        engine: 'kokoro',
+        modelKey: 'kokoro-v1',
+        reason: 'Fast and light — runs comfortably on low VRAM or CPU.',
+        caveat: null,
+        alternate: null,
+      },
+    },
+```
+
+- [ ] **Step 5: Update local `ModelsStatus` test fixtures**
+
+Making `recommendation` **required** breaks any hand-built `ModelsStatus` fixture. Grep and fix each:
+
+Run: `git grep -l "installedOnDisk" -- 'src/**/*.test.tsx' 'src/**/*.test.ts'`
+Expected hits include `src/components/setup/step-voice.test.tsx` (its local `modelsStatus()` helper) and any `model-manager.test.tsx` fixture. Add a `recommendation` field to each — reuse the same object shape as the Task-3 `mockGetModelsStatus` (Qwen lead, CPU-only caveat). A shared helper is fine.
+
+- [ ] **Step 6: Run tests + typecheck to verify green**
+
+Run: `cd server && npx vitest run src/tts/models-status.test.ts`
+Expected: PASS.
+Run: `npm run typecheck`
+Expected: PASS (client mirror matches server; no runtime consumer of `ModelsStatus` breaks — `setup-readiness.ts` and `model-manager.tsx` read `.runtime`/`.engines` only and ignore the additive field; test fixtures fixed above).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/src/tts/models-status.ts server/src/tts/models-status.test.ts src/lib/api.ts src/components/setup/step-voice.test.tsx
+git commit -m "feat(server): surface engine recommendation on models-status payload"
+```
+
+---
+
+## Task 4: Guided question + recommendation-driven card ordering (client)
+
+Add the one needs-based question above the engine cards and reorder them so the recommended engine leads with a "Recommended for you" badge + primary CTA. De-default: order is now derived, not fixed on Kokoro.
+
+**Files:**
+- Create: `src/components/setup/engine-recommendation-copy.ts`
+- Modify: `src/components/setup/step-voice.tsx`
+- Test: `src/components/setup/engine-recommendation-copy.test.ts`, `src/components/setup/step-voice.test.tsx`
+
+**Interfaces:**
+- Consumes: `ModelsStatus['recommendation']` (Task 3); the existing controlled `KokoroInstall`/`QwenInstall`/`CoquiInstall` (`status` + `onInstalled` props, Part A).
+- Produces: the `NeedsAnswer` local state + `activeRecommendation` selection consumed by the handoff (Task 5).
+
+**Behavior:**
+- A two-option control (segmented radio) with the question. Default: **unanswered** (`null`).
+- Unanswered → render cards in today's order (Kokoro lead, Qwen/Coqui under "More voice engines"), with a hint prompting the user to answer.
+- Answered → the recommended engine's card leads with a `Recommended for you` badge; its Install CTA is the primary emphasis (pull priority); the other two engines render below under a **"Other engines"** disclosure (renamed from "More voice engines"). The lead's `caveat`, when present, renders as a neutral (sky, not amber) note under the badge.
+
+- [ ] **Step 1: Write the failing copy-helper test**
+
+Create `src/components/setup/engine-recommendation-copy.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { NEEDS_QUESTION, needsAnswerLabel, engineDisplayName } from './engine-recommendation-copy';
+
+describe('engine-recommendation-copy', () => {
+  it('exposes the one guided question and answer labels', () => {
+    expect(NEEDS_QUESTION).toMatch(/expressive|multilingual/i);
+    expect(needsAnswerLabel('expressive-or-multilingual')).toMatch(/expressive|multilingual/i);
+    expect(needsAnswerLabel('simple-english')).toMatch(/english/i);
+  });
+  it('maps engine ids to display names', () => {
+    expect(engineDisplayName('kokoro')).toBe('Kokoro');
+    expect(engineDisplayName('qwen')).toBe('Qwen3-TTS');
+    expect(engineDisplayName('coqui')).toBe('Coqui XTTS v2');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/setup/engine-recommendation-copy.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the copy helper**
+
+Create `src/components/setup/engine-recommendation-copy.ts`:
+
+```ts
+import type { NeedsAnswer } from '../../lib/api';
+
+export const NEEDS_QUESTION = 'Do you want expressive and/or multilingual audio?';
+
+export function needsAnswerLabel(answer: NeedsAnswer): string {
+  return answer === 'expressive-or-multilingual'
+    ? 'Yes — expressive and/or non-English'
+    : 'No — simple English narration';
+}
+
+export const RECOMMENDED_BADGE = 'Recommended for you';
+
+const DISPLAY: Record<'kokoro' | 'qwen' | 'coqui', string> = {
+  kokoro: 'Kokoro',
+  qwen: 'Qwen3-TTS',
+  coqui: 'Coqui XTTS v2',
+};
+export function engineDisplayName(id: 'kokoro' | 'qwen' | 'coqui'): string {
+  return DISPLAY[id];
+}
+```
+
+- [ ] **Step 4: Run the copy-helper test to verify it passes**
+
+Run: `npx vitest run src/components/setup/engine-recommendation-copy.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing step-voice test**
+
+Extend `src/components/setup/step-voice.test.tsx` (the suite already mocks `api.getModelsStatus`; reuse its render harness). Add:
+
+```tsx
+it('shows the guided question and, once answered "yes", leads with the recommended engine', async () => {
+  renderStepVoice(); // existing harness; mock returns the Task-3 mock recommendation (qwen lead)
+  expect(await screen.findByText(/expressive and\/or multilingual/i)).toBeInTheDocument();
+
+  await userEvent.click(screen.getByRole('radio', { name: /yes — expressive/i }));
+
+  const badge = await screen.findByText(/recommended for you/i);
+  // The recommended (Qwen) card leads: badge appears before the Kokoro card in DOM order.
+  const kokoro = screen.getByText(/Kokoro/i);
+  expect(badge.compareDocumentPosition(kokoro) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  // CPU-only mock → Qwen caveat is shown, neutral (not an amber blocker).
+  expect(screen.getByText(/may not fit comfortably/i)).toBeInTheDocument();
+});
+
+it('answering "no" recommends Kokoro', async () => {
+  renderStepVoice();
+  await userEvent.click(await screen.findByRole('radio', { name: /no — simple english/i }));
+  const badge = await screen.findByText(/recommended for you/i);
+  // Badge sits on the Kokoro card.
+  expect(badge.closest('[data-engine-card="kokoro"]')).not.toBeNull();
+});
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+Run: `npx vitest run src/components/setup/step-voice.test.tsx`
+Expected: FAIL — no guided-question radios / no "Recommended for you" badge.
+
+- [ ] **Step 7: Implement the guided question + ordering in `step-voice.tsx`**
+
+Add state + a small `RecommendedBadge`, and render cards ordered by the active recommendation. Key edits (keep the existing badges/runtime/venv block untouched):
+
+```tsx
+import { NEEDS_QUESTION, needsAnswerLabel, RECOMMENDED_BADGE, engineDisplayName } from './engine-recommendation-copy';
+import type { NeedsAnswer, EngineRecommendation } from '../../lib/api';
+
+// …inside StepVoice, after `const [models, setModels] = useState…`
+const [needs, setNeeds] = useState<NeedsAnswer | null>(null);
+
+const activeRec: EngineRecommendation | null =
+  models && needs
+    ? needs === 'expressive-or-multilingual'
+      ? models.recommendation.expressiveOrMultilingual
+      : models.recommendation.simpleEnglish
+    : null;
+```
+
+Render the question above the cards (inside the `models !== null` branch, before `<VenvBootstrap …>`):
+
+```tsx
+<fieldset className="rounded-2xl border border-ink/10 p-4 space-y-2">
+  <legend className="text-sm font-medium text-ink px-1">{NEEDS_QUESTION}</legend>
+  {(['expressive-or-multilingual', 'simple-english'] as NeedsAnswer[]).map((a) => (
+    <label key={a} className="flex items-center gap-2 text-sm text-ink/80 min-h-[44px] fine-pointer:min-h-0">
+      <input
+        type="radio"
+        name="voice-needs"
+        checked={needs === a}
+        onChange={() => setNeeds(a)}
+      />
+      {needsAnswerLabel(a)}
+    </label>
+  ))}
+</fieldset>
+```
+
+Order the engine cards by `activeRec`. Define an ordered id list and render generically. Replace the fixed Kokoro-lead + "More voice engines" block with:
+
+```tsx
+const ALL: Array<'kokoro' | 'qwen' | 'coqui'> = ['kokoro', 'qwen', 'coqui'];
+const leadId = activeRec?.engine ?? 'kokoro';
+const ordered = [leadId, ...ALL.filter((id) => id !== leadId)];
+
+const CARD = {
+  kokoro: (rec: boolean) => (
+    <KokoroInstall status={models.engines.kokoro} onInstalled={refetchBoth} />
+  ),
+  qwen: () => <QwenInstall status={models.engines.qwen} onInstalled={refetchBoth} />,
+  coqui: () => <CoquiInstall status={models.engines.coqui} onInstalled={refetchBoth} />,
+} as const;
+```
+
+Then render lead + rest (the lead wrapped with the badge + caveat):
+
+```tsx
+<div data-engine-card={leadId} className="space-y-2">
+  {activeRec && (
+    <div className="space-y-1">
+      <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold bg-emerald-100 text-emerald-800">
+        {RECOMMENDED_BADGE}
+      </span>
+      {activeRec.caveat && (
+        <p data-testid="recommendation-caveat" className="text-xs text-sky-700">{activeRec.caveat}</p>
+      )}
+    </div>
+  )}
+  {CARD[leadId]()}
+</div>
+
+<details className="group rounded-2xl border border-ink/10" open={!activeRec}>
+  <summary className="flex cursor-pointer items-center justify-between px-4 py-3 text-sm font-medium text-ink select-none">
+    <span>{activeRec ? 'Other engines' : 'More voice engines'}</span>
+    <span className="text-xs text-ink/50 group-open:hidden">
+      {ordered.slice(1).map(engineDisplayName).join(' · ')}
+    </span>
+    <span className="text-xs text-ink/50 hidden group-open:inline">Hide</span>
+  </summary>
+  <div className="px-4 pb-4 space-y-4">
+    {ordered.slice(1).map((id) => (
+      <div key={id} data-engine-card={id}>{CARD[id]()}</div>
+    ))}
+  </div>
+</details>
+```
+
+Keep `VenvBootstrap` above this block (runtime is shared, engine-agnostic). Wrap the Kokoro lead case with `data-engine-card="kokoro"` too (already handled by the `data-engine-card={leadId}` wrapper). Remove the now-unused hardcoded Qwen-auto-install paragraph, or fold its Qwen/Coqui hint into the "Other engines" body.
+
+> **De-defaulting note:** this replaces the fixed "Kokoro leads, others hidden under *More voice engines*" structure with derived ordering. That IS the "stop labelling Kokoro the default" acceptance item — no copy anywhere should call any engine "the default voice engine."
+
+- [ ] **Step 8: Run test to verify it passes**
+
+Run: `npx vitest run src/components/setup/step-voice.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/components/setup/engine-recommendation-copy.ts src/components/setup/engine-recommendation-copy.test.ts src/components/setup/step-voice.tsx src/components/setup/step-voice.test.tsx
+git commit -m "feat(frontend): guided question + recommendation-driven voice-engine ordering"
+```
+
+---
+
+## Task 5: Defaults handoff — seed `defaultTtsModelKey` on answer
+
+When the user answers the guided question, pre-seed the account default to the recommended model key so the Defaults step shows it pre-selected (the user reconfirms there).
+
+**Files:**
+- Modify: `src/components/setup/step-voice.tsx`
+- Test: `src/components/setup/step-voice.test.tsx`
+
+**Interfaces:**
+- Consumes: `activeRec.modelKey` (Task 4); `saveAccountSettings` (`src/store/…` account slice, the same thunk `step-defaults.tsx` uses); `useAppDispatch` (`src/store`).
+- Produces: dispatched `saveAccountSettings({ defaultTtsModelKey, defaultTtsModelKeyExplicit: true, defaultTtsEngine: 'local' })`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/components/setup/step-voice.test.tsx` (spy on the account thunk — mirror how `step-defaults.test.tsx` asserts `saveAccountSettings`; if that suite mocks the thunk module, reuse the same mock here):
+
+```tsx
+it('seeds defaultTtsModelKey when the recommendation is answered', async () => {
+  const { store } = renderStepVoice();
+  await userEvent.click(await screen.findByRole('radio', { name: /yes — expressive/i }));
+  await waitFor(() => {
+    expect(store.getState().account.defaultTtsModelKey).toBe('qwen3-tts-0.6b');
+    expect(store.getState().account.defaultTtsModelKeyExplicit).toBe(true);
+    expect(store.getState().account.defaultTtsEngine).toBe('local');
+  });
+});
+```
+
+> If `renderStepVoice` does not currently return the `store`, extend the harness to render inside a real `configureStore`-backed `<Provider>` (the account slice + `saveAccountSettings` thunk), matching `step-defaults.test.tsx`. This is part of this task's setup.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/setup/step-voice.test.tsx -t "seeds defaultTtsModelKey"`
+Expected: FAIL — no dispatch happens on answer; `defaultTtsModelKey` unchanged.
+
+- [ ] **Step 3: Wire the handoff**
+
+In `step-voice.tsx`:
+
+```tsx
+import { useAppDispatch } from '../../store';
+import { saveAccountSettings } from '../../store/account-slice'; // match the import path step-defaults.tsx uses
+
+// …inside StepVoice
+const dispatch = useAppDispatch();
+
+const chooseNeeds = useCallback(
+  (answer: NeedsAnswer) => {
+    setNeeds(answer);
+    if (!models) return;
+    const rec =
+      answer === 'expressive-or-multilingual'
+        ? models.recommendation.expressiveOrMultilingual
+        : models.recommendation.simpleEnglish;
+    void dispatch(
+      saveAccountSettings({
+        defaultTtsModelKey: rec.modelKey,
+        defaultTtsModelKeyExplicit: true,
+        defaultTtsEngine: 'local',
+      }),
+    );
+  },
+  [dispatch, models],
+);
+```
+
+Change the radio `onChange={() => setNeeds(a)}` to `onChange={() => chooseNeeds(a)}`.
+
+> **Reconfirmation is intentional** (spec): the Models-step pick is a *suggestion*; `step-defaults.tsx` is the *commit*. `defaultTtsModelKeyExplicit: true` stops a later resolved default from silently overriding the seed — matching `step-defaults`/`model-settings-form` behavior exactly.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/components/setup/step-voice.test.tsx`
+Expected: PASS (all step-voice tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/setup/step-voice.tsx src/components/setup/step-voice.test.tsx
+git commit -m "feat(frontend): seed default voice model from wizard recommendation"
+```
+
+---
+
+## Task 6: E2E golden path + regression plan + release notes
+
+Lock the cross-seam behavior (fetch → redux → layout) with one Playwright spec, and close the before-shipping checklist.
+
+**Files:**
+- Create: `e2e/setup-engine-recommendation.spec.ts`
+- Create: `docs/features/259-fe51-engine-recommendation.md`
+- Modify: `docs/features/INDEX.md`, `docs/release-notes-next.md`, `RELEASE_NOTES.md`
+
+**Interfaces:**
+- Consumes: the mock `getModelsStatus` recommendation (Task 3) — e2e runs in Vite mock mode.
+
+- [ ] **Step 1: Write the e2e spec**
+
+Create `e2e/setup-engine-recommendation.spec.ts`. Navigate to the wizard's Voice step (reuse the Next-click pattern from `e2e/setup-*.spec.ts` — **the Voice step is stepIndex 3 post-fe-49**; count the clicks against the current wizard, do not hardcode a stale count):
+
+```ts
+import { test, expect } from '@playwright/test';
+
+test('answering the guided question leads with the recommended engine', async ({ page }) => {
+  await page.goto('/#/setup');
+  // …advance to the Voice step (see sibling setup specs for the exact Next sequence)…
+  await expect(page.getByText(/do you want expressive and\/or multilingual/i)).toBeVisible();
+
+  await page.getByRole('radio', { name: /yes — expressive/i }).click();
+  await expect(page.getByText(/recommended for you/i)).toBeVisible();
+  // Recommended (Qwen) card is not buried under the disclosure.
+  await expect(page.getByText(/may not fit comfortably/i)).toBeVisible(); // CPU-only mock
+});
+```
+
+> **Wizard step-count caution (from fe-49's post-mortem):** a Next-click count is fragile. Run the FULL e2e suite locally before pushing — `npm run test:e2e` — not just this one spec; a step-order assumption here or in a sibling `setup-*.spec.ts` only surfaces across the whole suite.
+
+- [ ] **Step 2: Run the e2e spec**
+
+Run: `npm run test:e2e -- setup-engine-recommendation`
+Expected: PASS. Then `npm run test:e2e` (full suite) Expected: PASS (no sibling step-count regressions).
+
+- [ ] **Step 3: Write the regression plan**
+
+Create `docs/features/259-fe51-engine-recommendation.md` from `docs/features/TEMPLATE.md` (verify `259` is still free; bump if a concurrent plan claimed it). `status: active`. Cover: the guided question; capability-hard-filter / VRAM-soft-caveat invariant; the four recommendation cases; the defaults handoff via `defaultTtsModelKey` (+ reconfirmation in Defaults); the de-defaulting (no "default voice engine" copy). Cite the spec and `#1614`. **Include the open truthfulness item** below as a documented manual-verification step, not a code TODO.
+
+> **Caveat-truthfulness item (record in the plan, verify on-box):** the caveat wording is deliberately the safe "may not fit comfortably on this GPU." Do NOT upgrade it to "runs on CPU, slower" until the sidecar's real constrained-VRAM Qwen behavior is verified (project history: 8 GB bulk-design OOM #1155; 1.7B OOM storms) — it may OOM-crash rather than fall back to CPU. This is a manual on-box acceptance check, listed here so it isn't silently promised.
+
+- [ ] **Step 4: Update INDEX + release notes**
+
+- `docs/features/INDEX.md` — add the new plan under its area (setup/wizard).
+- `docs/release-notes-next.md` — technical entry, PR-refed: "fe-51: first-run wizard recommends the voice engine from a one-question needs check + detected VRAM (Qwen for expressive/multilingual, Kokoro for simple English), pre-seeds the default, and stops hardcoding Kokoro. `Closes #1614`."
+- `RELEASE_NOTES.md` — brand-voice user line in the in-progress version section: e.g. *"First run now asks one question and picks the right voice engine for your books and your machine — no more guessing."*
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e/setup-engine-recommendation.spec.ts docs/features/259-fe51-engine-recommendation.md docs/features/INDEX.md docs/release-notes-next.md RELEASE_NOTES.md
+git commit -m "test(frontend): e2e for wizard engine recommendation + regression plan + release notes"
+```
+
+- [ ] **Step 6: Full branch verification**
+
+Run: `npm run verify:fast:branch`
+Expected: PASS. Then open the PR (`Closes #1614`), let cloud `verify.yml` + the mandatory Premium `code-review` (single-scope `feat` → `medium` effort) run, triage findings, merge.
+
+---
+
+## Self-Review
+
+**Spec coverage** (Part B section of the design doc):
+- Guided question → Task 4. ✅
+- Yes → Qwen, Coqui optional alternate → Task 2 (`CAPABLE_PREFERENCE`) + Task 4 (`alternate` rendered under "Other engines"). ✅
+- No → Kokoro → Task 2 (`simpleEnglish`). ✅
+- Capability hard filter / VRAM soft caveat → Task 2 logic + Global Constraints. ✅
+- VRAM `<` floor → caveat, never downgraded → Task 2 (need+low-VRAM, need+null cases). ✅
+- Grounded capability map (multilingual derived from `resolveEligibleEngines`/`ENGINE_LANGUAGE_SUPPORT`; expressive+floors authored) → Task 1 (authored) + Task 2 (`isMultilingualEngine`). ✅
+- Defaults handoff via `defaultTtsModelKey` (+ `Explicit`, `defaultTtsEngine: 'local'`), reconfirmed in Defaults → Task 5. ✅
+- Drop "the default voice engine" copy / pull-priority → Task 4 (derived ordering + primary CTA + de-default note). ✅
+- Tests: needs × capability × VRAM → engine (server unit) → Task 2; three regressions live in Part A's suite; recommendation UI e2e → Task 6. ✅
+- `Closes #1614` (fe-49 merged) → header + Task 6. ✅
+
+**Placeholder scan:** no "TBD"/"add error handling"/"similar to Task N" — every code step carries actual content; VRAM floors are concrete grounded numbers (with a verify-against-registry instruction, not a placeholder). ✅
+
+**Type consistency:** `NeedsAnswer`, `EngineRecommendation`, `RecommendationSet`, `recommendEngines`, `isMultilingualEngine`, `RECOMMENDED_BADGE`, `engineDisplayName`, `defaultModelKey` values (`kokoro-v1`/`qwen3-tts-0.6b`/`coqui-xtts-v2`) are named identically across server (Tasks 1–3) and the client mirror (Task 3) and consumers (Tasks 4–5). ✅
+
+**Open items deliberately carried (not placeholders):** (1) exact VRAM floor numbers — verify against `registry.ts`/measurement in Task 1; (2) caveat-truthfulness — safe wording now, on-box verification recorded in the regression plan (Task 6).

--- a/docs/superpowers/plans/2026-07-15-fe51-language-aware-engine-recommendation.md
+++ b/docs/superpowers/plans/2026-07-15-fe51-language-aware-engine-recommendation.md
@@ -439,7 +439,7 @@ export interface ModelsStatus {
 }
 ```
 
-Update `mockGetModelsStatus()` (~line 7272) to return a recommendation (mock is CPU-only → `vramTotalMb: null` → Qwen caveat present):
+Update `mockGetModelsStatus()` (~line 7272) to return a recommendation (mock is CPU-only → `vramTotalMb: null` → Qwen caveat present). Note the caveat string here is a **hand-copy** of the server's `CAVEAT_VRAM` (Task 2) — the client mirror can't import a server const. This only affects mock-mode display + tests, and every assertion is a `/may not fit/i` substring (not exact equality), so the two can't break a test by drifting; the real runtime caveat always comes from the server. Add a `// keep in sync with server CAVEAT_VRAM` comment:
 
 ```ts
     info: { gpu: 'CPU — no GPU detected', vramTotalMb: null },
@@ -464,10 +464,10 @@ Update `mockGetModelsStatus()` (~line 7272) to return a recommendation (mock is 
 
 - [ ] **Step 5: Update local `ModelsStatus` test fixtures**
 
-Making `recommendation` **required** breaks any hand-built `ModelsStatus` fixture. Grep and fix each:
+Making `recommendation` **required** breaks any hand-built **full `ModelsStatus`** literal. Find them, but add the field **only to full-`ModelsStatus` builders — NOT to `RuntimeStatus`-shaped literals** (`{ installedOnDisk, pythonFound, process }` passed to `VenvBootstrap`/`runtimeIsBlocking`), which have no `recommendation` field and would type-error if you add one:
 
-Run: `git grep -l "installedOnDisk" -- 'src/**/*.test.tsx' 'src/**/*.test.ts'`
-Expected hits include `src/components/setup/step-voice.test.tsx` (its local `modelsStatus()` helper) and any `model-manager.test.tsx` fixture. Add a `recommendation` field to each — reuse the same object shape as the Task-3 `mockGetModelsStatus` (Qwen lead, CPU-only caveat). A shared helper is fine.
+Run: `git grep -ln "installedOnDisk" -- 'src/**/*.test.tsx' 'src/**/*.test.ts'`
+The only **full-`ModelsStatus`** builders are `src/components/setup/step-voice.test.tsx` (its local `modelsStatus()` helper — add `recommendation` to that helper's default object) and `src/views/model-manager.test.tsx` (its `getModelsStatus` mock — untyped `vi.fn().mockResolvedValue({…})`, so it won't type-error, but add the field for realism). `venv-bootstrap.test.tsx` and `engine-card-status.test.ts` build `RuntimeStatus`, **not** `ModelsStatus` — leave them alone. Reuse the Task-3 `mockGetModelsStatus` recommendation shape (Qwen lead, CPU caveat). A shared exported fixture is fine.
 
 - [ ] **Step 6: Run tests + typecheck to verify green**
 
@@ -496,7 +496,7 @@ Add the one needs-based question above the engine cards and reorder them so the 
 
 **Interfaces:**
 - Consumes: `ModelsStatus['recommendation']` (Task 3); the existing controlled `KokoroInstall`/`QwenInstall`/`CoquiInstall` (`status` + `onInstalled` props, Part A).
-- Produces: the `NeedsAnswer` local state + `activeRecommendation` selection consumed by the handoff (Task 5).
+- Produces: the `NeedsAnswer` local state + the `activeRec` selection consumed by the handoff (Task 5).
 
 **Behavior:**
 - A two-option control (segmented radio) with the question. Default: **unanswered** (`null`).
@@ -566,30 +566,51 @@ Expected: PASS.
 
 **Critical — there is NO `renderStepVoice` today.** `src/components/setup/step-voice.test.tsx` currently `render(<StepVoice readiness={…} onRefetch={…} />)` **inline with no redux Provider** across ~6 tests (they pass differing `readiness`: all-pass, `crashed`, `starting`). Task 5 adds `useAppDispatch` to `StepVoice`, which makes a Provider **mandatory** — so the harness must exist and every current test must route through it, or Task 5 lands 6 red tests. Build it now (this task adds no redux to the component yet, so the Provider is harmless here and ready for Task 5).
 
-Add to `step-voice.test.tsx` (copy the pattern from `step-defaults.test.tsx`, which already renders a store-backed `<Provider>` and stubs the account thunk's `putUserSettings` echo):
+**Copy `step-defaults.test.tsx`'s exact store + module-mock pattern — do NOT invent one.** Verified against the code: `account-slice.ts` exports `accountSlice` **named** (no default export), so use `accountSlice.reducer` + `accountSlice.getInitialState()`. `saveAccountSettings` calls `api.putUserSettings(patch)` and its `.fulfilled` does `Object.assign(s, a.payload)`, so the test must stub `putUserSettings` to **echo** `{...getInitialState(), ...patch}` or the account state never updates. And under vitest `VITE_USE_MOCKS` is **false** (`.env.development` = `false`, no `.env.test`), so `api.getModelsStatus` is the REAL fetch — every test must keep its own `vi.spyOn(api, 'getModelsStatus').mockResolvedValue(...)` (as the 6 existing tests already do).
+
+At the **top of `step-voice.test.tsx`**, add the module mock (copied verbatim from `step-defaults.test.tsx:15-30` — it `importActual`s so `getModelsStatus` stays real for the per-test spies, and only overrides `putUserSettings`):
 
 ```tsx
 import { configureStore } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
-import { render } from '@testing-library/react';
-import accountReducer from '../../store/account-slice'; // match step-defaults.test.tsx's import
+import { accountSlice } from '../../store/account-slice';
 
-function renderStepVoice(opts?: { readiness?: SetupReadiness; account?: Record<string, unknown> }) {
+const putUserSettingsMock = vi.fn();
+vi.mock('../../lib/api', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/api')>('../../lib/api');
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      putUserSettings: (patch: unknown) => {
+        putUserSettingsMock(patch);
+        return Promise.resolve({ ...accountSlice.getInitialState(), ...(patch as object) });
+      },
+    },
+  };
+});
+```
+
+> Adapt the `api: { ...actual.api, putUserSettings }` shape to whatever `step-defaults.test.tsx` actually does — mirror it exactly (it may override the top-level export instead of the `api` object; copy the working form). `saveAccountSettings` dispatches through `api.putUserSettings`, so that's the binding the stub must intercept. `beforeEach(() => putUserSettingsMock.mockReset())`.
+
+Then add the harness (reuses the suite's existing `allPassReadiness` const — a **value**, not `passingReadiness()`):
+
+```tsx
+function renderStepVoice(opts: { readiness?: SetupReadiness; account?: Partial<ReturnType<typeof accountSlice.getInitialState>> } = {}) {
   const store = configureStore({
-    reducer: { account: accountReducer },
-    preloadedState: opts?.account ? { account: opts.account } : undefined,
+    reducer: { account: accountSlice.reducer },
+    preloadedState: { account: { ...accountSlice.getInitialState(), ...opts.account } },
   });
-  const readiness = opts?.readiness ?? passingReadiness(); // reuse the suite's existing readiness fixture
   const utils = render(
     <Provider store={store}>
-      <StepVoice readiness={readiness} onRefetch={() => {}} />
+      <StepVoice readiness={opts.readiness ?? allPassReadiness} onRefetch={() => {}} />
     </Provider>,
   );
   return { ...utils, store };
 }
 ```
 
-Then **rewrite each of the 6 existing inline `render(<StepVoice … />)` calls** to `renderStepVoice({ readiness: <that test's readiness> })`. Reuse whatever `readiness` fixtures the suite already defines (all-pass, crashed, starting); if the account thunk (`saveAccountSettings`) hits the API on dispatch, reuse `step-defaults.test.tsx`'s `vi.mock('../../lib/api', …)` `putUserSettings` echo stub so no test performs a real fetch. (Confirm `accountReducer`'s export shape — default vs named — against `src/store/account-slice.ts`.)
+Then **rewrite all 6 existing tests**: each keeps its own leading `vi.spyOn(api, 'getModelsStatus').mockResolvedValue(modelsStatus({…}))`, and its `render(<StepVoice readiness={X} onRefetch={…} />)` becomes `renderStepVoice({ readiness: X })` (the two tests that build an inline `readiness` pass it through; the rest omit it and get `allPassReadiness`).
 
 - [ ] **Step 6: Write the failing new-behavior tests**
 
@@ -743,21 +764,21 @@ When the user answers the guided question, pre-seed the account default to the r
 
 - [ ] **Step 1: Write the failing test**
 
-Add to `src/components/setup/step-voice.test.tsx` (spy on the account thunk — mirror how `step-defaults.test.tsx` asserts `saveAccountSettings`; if that suite mocks the thunk module, reuse the same mock here):
+Add to `src/components/setup/step-voice.test.tsx`. The `renderStepVoice` harness (returns `{ store }`) and the `putUserSettings` echo mock were **already built in Task 4 Step 5** — this test just needs the leading `getModelsStatus` spy + the assertion. The echo mock makes `saveAccountSettings` resolve `.fulfilled` with `{...getInitialState(), ...patch}`, so the account state actually updates:
 
 ```tsx
 it('seeds defaultTtsModelKey when the recommendation is answered', async () => {
+  vi.spyOn(api, 'getModelsStatus').mockResolvedValue(modelsStatus()); // qwen-lead recommendation
   const { store } = renderStepVoice();
   await userEvent.click(await screen.findByRole('radio', { name: /yes — expressive/i }));
   await waitFor(() => {
+    expect(putUserSettingsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultTtsModelKey: 'qwen3-tts-0.6b', defaultTtsModelKeyExplicit: true, defaultTtsEngine: 'local' }),
+    );
     expect(store.getState().account.defaultTtsModelKey).toBe('qwen3-tts-0.6b');
-    expect(store.getState().account.defaultTtsModelKeyExplicit).toBe(true);
-    expect(store.getState().account.defaultTtsEngine).toBe('local');
   });
 });
 ```
-
-> If `renderStepVoice` does not currently return the `store`, extend the harness to render inside a real `configureStore`-backed `<Provider>` (the account slice + `saveAccountSettings` thunk), matching `step-defaults.test.tsx`. This is part of this task's setup.
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -879,7 +900,7 @@ Expected: PASS. Then open the PR (`Closes #1614`), let cloud `verify.yml` + the 
 
 ## Self-Review
 
-> **Post-review revision (2026-07-15):** an adversarial `assumption-checker` pass caught two blockers and the items below; all folded in. The one **deliberate divergence from the spec** — CPU-only + "yes" → Qwen-with-CPU-caveat instead of the spec's case-4 "→ Kokoro" — is a **user-approved decision** (Qwen runs on CPU; Kokoro can't do non-English; the one question can't separate the sub-needs), flagged in Global Constraints + Task 2, not silent.
+> **Post-review revisions (2026-07-15) — TWO adversarial `assumption-checker` passes.** Pass 1 caught two blockers (non-existent harness; silent spec-case-4 override) + the data-driven/YAGNI items. Pass 2 caught that the pass-1 harness *fix* was still non-functional (wrong reducer import, missing `getModelsStatus` spy + `putUserSettings` echo — all now corrected against `account-slice.ts`/`step-defaults.test.tsx`) and a leftover spec↔plan contradiction (spec step-2 said VRAM *reorders* the capable set; reconciled to caveat-only, matching the plan). The one **deliberate divergence** — CPU-only + "yes" → Qwen-with-CPU-caveat, not the spec's case-4 "→ Kokoro" — is a **user-approved decision**, flagged in Global Constraints + Task 2 + the spec, not silent.
 
 **Spec coverage** (Part B section of the design doc):
 - Guided question → Task 4. ✅

--- a/docs/superpowers/plans/2026-07-15-fe51-language-aware-engine-recommendation.md
+++ b/docs/superpowers/plans/2026-07-15-fe51-language-aware-engine-recommendation.md
@@ -21,8 +21,9 @@ Every task's requirements implicitly include this section.
 - **Mocks parity** — `mockGetModelsStatus()` (`src/lib/api.ts`) must return the same shape as the real endpoint; adding a field to `ModelsStatus` means updating the mock in the same task or every `step-voice`/`model-manager` test that renders off the mock breaks.
 - **`defaultTtsModelKey`, NOT `defaultTtsEngine`** carries the kokoro/qwen/coqui choice. `defaultTtsEngine` is the `'local' | 'gemini'` provider *tier* and cannot hold an engine id. The handoff sets `defaultTtsModelKey` (+ `defaultTtsModelKeyExplicit: true`) and `defaultTtsEngine: 'local'` (all recommended engines are on-device).
 - **Capability is a hard filter; VRAM is a soft preference.** Never recommend an engine that cannot meet the stated need (multilingual → Kokoro is ineligible). VRAM never *reorders* the capable branch — it only attaches a caveat. Nothing is ever blocked; every engine stays installable.
-- **Qwen leads the capable branch, Coqui is the optional alternate** (per #1614, explicit). The capable preference order is authored (`['qwen', 'coqui']`), not derived from VRAM floors (which would wrongly rank Coqui first).
-- **Truthfulness — caveat wording.** Do **not** promise "runs on CPU, slower" for a constrained-VRAM Qwen. The project's incident history (8 GB bulk-design OOM #1155; 1.7B-tier OOM storms) shows constrained Qwen can OOM-crash rather than fall back to CPU. Use the safe wording **"may not fit comfortably on this GPU"** until real low-VRAM sidecar behavior is verified (Task 6 note).
+- **Data-driven capability (decided 2026-07-15).** The capable set is **derived** — `VOICE_ENGINES.filter(e => e.expressive || isMultilingualEngine(e.id))` — so a future expressive/multilingual engine qualifies automatically (the spec's stated goal). Ordering within the capable set uses an **authored `capablePreferenceRank`** field (Qwen `0`, Coqui `1`), *not* VRAM floors (which would wrongly rank Coqui first). Today this yields Qwen-leads-Coqui, per #1614 — but via live capability + rank, not a hardcoded id list. `expressive` is therefore load-bearing (it's read by the filter); `designVramFloorMb` is **dropped** (no consumer in Part B).
+- **CPU-only / no-GPU + "yes" answer → Qwen with a CPU caveat (decided 2026-07-15 — a deliberate revision of the spec's case-4 "CPU-only → Kokoro").** Rationale: Qwen *does* run on CPU (slower) via the voice-engine device setting, and the single "expressive **and/or** multilingual" question can't tell a non-English need (Kokoro literally cannot serve) from expressive-English (Kokoro can). Leading Qwen serves the multilingual user correctly; the caveat nudges the expressive-English user to Kokoro. Recommending Kokoro here (spec-literal) would hand a non-English user an engine that cannot do their language at all. **This override is flagged in Task 2 and in Self-Review — it is NOT silent.**
+- **Truthfulness — caveat wording.** The caveat for a low/no-VRAM Qwen recommendation is **"May not fit this GPU's memory — you can run Qwen on CPU (slower) via the voice-engine device setting, or pick Kokoro below for fast English-only voices."** This is honest per the product owner (Qwen runs on CPU, just slow) — distinct from the *constrained-GPU auto-fallback* OOM history (#1155), which is a different path. On-box acceptance still confirms forcing CPU actually renders (Task 6 note).
 - **Testing discipline** — every task ships paired automated tests (fails-before/passes-after for the behavior it adds). Server pure functions get Vitest unit tests mirroring the `diagnose*` pattern; UI crossing redux/fetch/layout seams earns one Playwright e2e.
 - **Commit convention** — `<type>(<scope>): <subject>`; scopes here are `server` and `frontend` (and `docs` for the plan/regression-doc commits). Multi-file client+server changes stay split by task so scope stays single.
 
@@ -36,7 +37,7 @@ Every task's requirements implicitly include this section.
 - `docs/features/259-fe51-engine-recommendation.md` — regression plan (verify `259` is still free at implementation time; bump if a concurrent plan claimed it).
 
 **Modified files:**
-- `server/src/tts/voice-engine-registry.ts` — extend `VoiceEngineEntry` with authored capability fields (`expressive`, `genVramFloorMb`, `designVramFloorMb?`); populate the three entries.
+- `server/src/tts/voice-engine-registry.ts` — extend `VoiceEngineEntry` with authored capability fields (`expressive`, `genVramFloorMb`, `capablePreferenceRank`); populate the three entries.
 - `server/src/tts/models-status.ts` — add `recommendation: RecommendationSet` to `ModelsStatus`; `buildModelsStatus` calls `recommendEngines(input.info.vramTotalMb)`.
 - `src/lib/api.ts` — mirror the `recommendation` field onto the client `ModelsStatus` interface; add it to `mockGetModelsStatus()`.
 - `src/components/setup/step-voice.tsx` — guided-question control; recommendation-driven card ordering + "Recommended for you" badge + primary CTA; de-defaulting copy; Defaults handoff dispatch.
@@ -57,12 +58,14 @@ Extend Part A's `VoiceEngineEntry` with the authored capability constants the re
 
 **Interfaces:**
 - Consumes: existing `VoiceEngineEntry` / `VOICE_ENGINES` (Part A).
-- Produces: `VoiceEngineEntry.expressive: boolean`, `VoiceEngineEntry.genVramFloorMb: number`, `VoiceEngineEntry.designVramFloorMb?: number` — read by `recommendEngines` (Task 2).
+- Produces: `VoiceEngineEntry.expressive: boolean`, `VoiceEngineEntry.genVramFloorMb: number`, `VoiceEngineEntry.capablePreferenceRank: number` — all read by `recommendEngines` (Task 2). (`expressive` drives the capable-set filter; `capablePreferenceRank` orders the capable set; `genVramFloorMb` sets the caveat threshold.)
 
-**Grounded VRAM constants** (cited basis — real numbers, not guesses; the *structure* is fixed, confirm the exact values against `server/src/config/registry.ts` help text + measurement during implementation and adjust if the registry is authoritative):
-- **Kokoro** `genVramFloorMb: 1024` — ~1 GB, fits CPU (CLAUDE.md model-lifecycle notes). `expressive: false`.
-- **Qwen** `genVramFloorMb: 6144` — 0.6B generation path fits comfortably ~6 GB (#1614 threshold + spec); `designVramFloorMb: 5120` — VoiceDesign 1.7B ~4–5 GB transient (registry `qwen.design.idleTtlSec` help, line ~700). `expressive: true`.
-- **Coqui** `genVramFloorMb: 4096` — XTTS v2 ~3 GB load + gen headroom (registry `tts.preload.coqui` help, line ~568). `expressive: true`.
+**Authored constants** (estimates, not measured — only the *structure* is fixed; treat the numbers as best-effort authored values grounded in CLAUDE.md's model-lifecycle notes, and refine on-box if measurement contradicts them. **Only the capable lead's `genVramFloorMb` is read today** — see Task 2 — but every engine carries one as a coherent per-engine property for when it leads):
+- **Kokoro** — `expressive: false`, `genVramFloorMb: 1024` (~1 GB, fits CPU), `capablePreferenceRank: 99` (never in the capable set — `expressive` false + English-only — so its rank is inert; a high sentinel documents that).
+- **Qwen** — `expressive: true`, `genVramFloorMb: 6144` (0.6B generation path; the one #1614-derived threshold), `capablePreferenceRank: 0` (leads the capable branch — the multi-cast default).
+- **Coqui** — `expressive: true`, `genVramFloorMb: 4096`, `capablePreferenceRank: 1` (optional alternate).
+
+`designVramFloorMb` from the spec's draft `EngineCapability` is intentionally **omitted** — Part B's recommendation never reads it (it governs voice-design VRAM steering, a separate future feature). Add it when a consumer exists (YAGNI).
 
 - [ ] **Step 1: Write the failing test**
 
@@ -75,17 +78,18 @@ import { VOICE_ENGINES } from './voice-engine-registry.js';
 describe('VOICE_ENGINES capability fields', () => {
   const byId = Object.fromEntries(VOICE_ENGINES.map((e) => [e.id, e]));
 
-  it('carries authored expressive + VRAM floors per engine', () => {
+  it('carries authored expressive + VRAM floor + capable rank per engine', () => {
     expect(byId.kokoro.expressive).toBe(false);
     expect(byId.kokoro.genVramFloorMb).toBe(1024);
-    expect(byId.kokoro.designVramFloorMb).toBeUndefined();
+    expect(byId.kokoro.capablePreferenceRank).toBe(99);
 
     expect(byId.qwen.expressive).toBe(true);
     expect(byId.qwen.genVramFloorMb).toBe(6144);
-    expect(byId.qwen.designVramFloorMb).toBe(5120);
+    expect(byId.qwen.capablePreferenceRank).toBe(0);
 
     expect(byId.coqui.expressive).toBe(true);
     expect(byId.coqui.genVramFloorMb).toBe(4096);
+    expect(byId.coqui.capablePreferenceRank).toBe(1);
   });
 
   it('every entry has a positive generation floor', () => {
@@ -104,16 +108,19 @@ Expected: FAIL — `expressive`/`genVramFloorMb` are `undefined` (type error at 
 In `server/src/tts/voice-engine-registry.ts`, add to `VoiceEngineEntry` (after `liveLoaded`):
 
 ```ts
-  /** Authored: the engine produces expressive/emotive speech (no code source for
-      this — a curated fact). Kokoro is flat/fast; Qwen + Coqui are expressive. */
+  /** Authored: the engine produces expressive/emotive speech (no code source —
+      a curated fact). Kokoro is flat/fast; Qwen + Coqui are expressive. Read by
+      the recommendation's capable-set filter (expressive || multilingual). */
   expressive: boolean;
-  /** Authored: comfortable VRAM (MB) for the GENERATION path. Grounded in the
-      registry help text + measurement, not derived. */
+  /** Authored estimate: comfortable VRAM (MB) for the GENERATION path. The
+      recommendation reads the capable LEAD's floor to decide whether to attach a
+      caveat. Not measured — refine on-box if contradicted. */
   genVramFloorMb: number;
-  /** Authored: comfortable VRAM (MB) for a heavy transient DESIGN model, when the
-      engine has one (Qwen VoiceDesign 1.7B). Governs the voice-design feature, NOT
-      a reason to steer generation away from the engine. */
-  designVramFloorMb?: number;
+  /** Authored: lead preference within the capable (expressive||multilingual) set.
+      Lower wins. Only meaningful for capable engines (Qwen 0, Coqui 1); a
+      non-capable engine (Kokoro) never enters the set, so its rank is a high
+      sentinel (99). */
+  capablePreferenceRank: number;
 ```
 
 Then add the fields to each entry:
@@ -125,6 +132,7 @@ Then add the fields to each entry:
     // …existing probe fns…
     expressive: false,
     genVramFloorMb: 1024,
+    capablePreferenceRank: 99,
   },
   {
     id: 'qwen',
@@ -132,7 +140,7 @@ Then add the fields to each entry:
     // …existing probe fns…
     expressive: true,
     genVramFloorMb: 6144,
-    designVramFloorMb: 5120,
+    capablePreferenceRank: 0,
   },
   {
     id: 'coqui',
@@ -140,6 +148,7 @@ Then add the fields to each entry:
     // …existing probe fns…
     expressive: true,
     genVramFloorMb: 4096,
+    capablePreferenceRank: 1,
   },
 ```
 
@@ -176,8 +185,8 @@ The heart of Part B: a pure function over authored capability + derived multilin
 
 **Logic (verbatim — do not paraphrase into "handle edge cases"):**
 - `simpleEnglish` → **always Kokoro** (`kokoro-v1`), `caveat: null`, `alternate: null`, `reason: 'Fast and light — runs comfortably on low VRAM or CPU.'`
-- `expressiveOrMultilingual` → the capable engines are those where `expressive || isMultilingualEngine`. Ordered by the **authored preference** `['qwen', 'coqui']`, intersected with that capable set. `engine` = first (Qwen today); `alternate` = second if present (Coqui today); `reason: 'Expressive and multilingual — the multi-cast default.'`
-- **Caveat** (soft, never reorders): `null` when `vramTotalMb != null && vramTotalMb >= <lead>.genVramFloorMb`; otherwise `'May not fit comfortably on this GPU — install anyway, or pick a lighter engine below.'` (covers both low-VRAM and CPU-only/`null`).
+- `expressiveOrMultilingual` → **data-driven**: capable set = `VOICE_ENGINES.filter(e => e.expressive || isMultilingualEngine(e.id))`, sorted ascending by `capablePreferenceRank`. `engine` = first (Qwen today); `alternate` = second's id if present (Coqui today), else `null`; `reason: 'Expressive and multilingual — the multi-cast default.'`
+- **Caveat** (soft, never reorders): `null` when `vramTotalMb != null && vramTotalMb >= lead.genVramFloorMb`; otherwise the CPU caveat string. This covers **both** low-VRAM and CPU-only/`null` — the CPU-only case **deliberately still leads Qwen** (not Kokoro), a flagged revision of the spec's case-4 (see Global Constraints): Qwen runs on CPU (slower) and Kokoro can't do non-English, so the caveat — not a downgrade — is the honest tool.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -214,16 +223,17 @@ describe('recommendEngines', () => {
     expect(r.caveat).toBeNull();
   });
 
-  it('need + low VRAM (< Qwen floor) → Qwen with caveat (never downgraded to Kokoro)', () => {
+  it('need + low VRAM (< Qwen floor) → Qwen with CPU caveat (never downgraded to Kokoro)', () => {
     const r = recommendEngines(4096).expressiveOrMultilingual;
     expect(r.engine).toBe('qwen');
-    expect(r.caveat).toMatch(/may not fit comfortably/i);
+    expect(r.caveat).toMatch(/may not fit/i);
+    expect(r.caveat).toMatch(/CPU/i); // caveat offers the CPU-mode escape hatch
   });
 
-  it('need + CPU-only (vram null) → Qwen with caveat, still not Kokoro', () => {
+  it('need + CPU-only (vram null) → Qwen with CPU caveat, still not Kokoro (deliberate case-4 revision)', () => {
     const r = recommendEngines(null).expressiveOrMultilingual;
     expect(r.engine).toBe('qwen');
-    expect(r.caveat).toMatch(/may not fit comfortably/i);
+    expect(r.caveat).toMatch(/may not fit/i);
   });
 });
 ```
@@ -265,13 +275,15 @@ export interface RecommendationSet {
   simpleEnglish: EngineRecommendation;
 }
 
-/** Authored preference for the capable (expressive/multilingual) branch: Qwen is
-    the multi-cast default, Coqui the optional alternate (#1614). NOT ordered by
-    VRAM floor — that would wrongly rank Coqui first. */
-const CAPABLE_PREFERENCE: VoiceEngineId[] = ['qwen', 'coqui'];
-
+/* CPU caveat for a low/no-VRAM Qwen recommendation. Honest per the product owner:
+   Qwen runs on CPU (slower) via the voice-engine device setting; Kokoro is the fast
+   English-only escape hatch. This is a caveat, NOT a downgrade — the CPU-only case
+   still LEADS Qwen (deliberate revision of the spec's case-4 "CPU-only → Kokoro",
+   because Kokoro can't serve a non-English book at all and the one guided question
+   can't tell non-English from expressive-English). */
 const CAVEAT_VRAM =
-  'May not fit comfortably on this GPU — install anyway, or pick a lighter engine below.';
+  "May not fit this GPU's memory — you can run Qwen on CPU (slower) via the voice-engine " +
+  'device setting, or pick Kokoro below for fast English-only voices.';
 
 const byId = new Map<VoiceEngineId, VoiceEngineEntry>(VOICE_ENGINES.map((e) => [e.id, e]));
 
@@ -283,28 +295,23 @@ export function isMultilingualEngine(id: VoiceEngineId): boolean {
   return support.some((lang) => lang !== DEFAULT_LANGUAGE);
 }
 
-function entry(id: VoiceEngineId): VoiceEngineEntry {
-  const e = byId.get(id);
-  if (!e) throw new Error(`[engine-recommendation] unknown engine id: ${id}`);
-  return e;
-}
-
 export function recommendEngines(vramTotalMb: number | null): RecommendationSet {
-  // Capable = expressive OR multilingual, in authored preference order.
-  const capable = CAPABLE_PREFERENCE.filter(
-    (id) => entry(id).expressive || isMultilingualEngine(id),
-  );
-  const leadId = capable[0] ?? 'qwen';
-  const lead = entry(leadId);
-  const alternate = capable[1] ?? null;
+  // Capable = expressive OR multilingual (DERIVED — a future qualifying engine joins
+  // automatically), ordered by authored capablePreferenceRank (Qwen 0, Coqui 1).
+  const capable = VOICE_ENGINES.filter(
+    (e) => e.expressive || isMultilingualEngine(e.id),
+  ).sort((a, b) => a.capablePreferenceRank - b.capablePreferenceRank);
+
+  const lead = capable[0];
+  const alternate: VoiceEngineId | null = capable[1]?.id ?? null;
 
   const fits = vramTotalMb != null && vramTotalMb >= lead.genVramFloorMb;
 
-  const kokoro = entry('kokoro');
+  const kokoro = byId.get('kokoro')!;
 
   return {
     expressiveOrMultilingual: {
-      engine: leadId,
+      engine: lead.id,
       modelKey: lead.defaultModelKey,
       reason: 'Expressive and multilingual — the multi-cast default.',
       caveat: fits ? null : CAVEAT_VRAM,
@@ -441,7 +448,8 @@ Update `mockGetModelsStatus()` (~line 7272) to return a recommendation (mock is 
         engine: 'qwen',
         modelKey: 'qwen3-tts-0.6b',
         reason: 'Expressive and multilingual — the multi-cast default.',
-        caveat: 'May not fit comfortably on this GPU — install anyway, or pick a lighter engine below.',
+        caveat:
+          "May not fit this GPU's memory — you can run Qwen on CPU (slower) via the voice-engine device setting, or pick Kokoro below for fast English-only voices.",
         alternate: 'coqui',
       },
       simpleEnglish: {
@@ -554,40 +562,69 @@ export function engineDisplayName(id: 'kokoro' | 'qwen' | 'coqui'): string {
 Run: `npx vitest run src/components/setup/engine-recommendation-copy.test.ts`
 Expected: PASS.
 
-- [ ] **Step 5: Write the failing step-voice test**
+- [ ] **Step 5: Build a Provider-backed `renderStepVoice` harness and migrate the existing tests**
 
-Extend `src/components/setup/step-voice.test.tsx` (the suite already mocks `api.getModelsStatus`; reuse its render harness). Add:
+**Critical — there is NO `renderStepVoice` today.** `src/components/setup/step-voice.test.tsx` currently `render(<StepVoice readiness={…} onRefetch={…} />)` **inline with no redux Provider** across ~6 tests (they pass differing `readiness`: all-pass, `crashed`, `starting`). Task 5 adds `useAppDispatch` to `StepVoice`, which makes a Provider **mandatory** — so the harness must exist and every current test must route through it, or Task 5 lands 6 red tests. Build it now (this task adds no redux to the component yet, so the Provider is harmless here and ready for Task 5).
+
+Add to `step-voice.test.tsx` (copy the pattern from `step-defaults.test.tsx`, which already renders a store-backed `<Provider>` and stubs the account thunk's `putUserSettings` echo):
+
+```tsx
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
+import { render } from '@testing-library/react';
+import accountReducer from '../../store/account-slice'; // match step-defaults.test.tsx's import
+
+function renderStepVoice(opts?: { readiness?: SetupReadiness; account?: Record<string, unknown> }) {
+  const store = configureStore({
+    reducer: { account: accountReducer },
+    preloadedState: opts?.account ? { account: opts.account } : undefined,
+  });
+  const readiness = opts?.readiness ?? passingReadiness(); // reuse the suite's existing readiness fixture
+  const utils = render(
+    <Provider store={store}>
+      <StepVoice readiness={readiness} onRefetch={() => {}} />
+    </Provider>,
+  );
+  return { ...utils, store };
+}
+```
+
+Then **rewrite each of the 6 existing inline `render(<StepVoice … />)` calls** to `renderStepVoice({ readiness: <that test's readiness> })`. Reuse whatever `readiness` fixtures the suite already defines (all-pass, crashed, starting); if the account thunk (`saveAccountSettings`) hits the API on dispatch, reuse `step-defaults.test.tsx`'s `vi.mock('../../lib/api', …)` `putUserSettings` echo stub so no test performs a real fetch. (Confirm `accountReducer`'s export shape — default vs named — against `src/store/account-slice.ts`.)
+
+- [ ] **Step 6: Write the failing new-behavior tests**
+
+Add to `step-voice.test.tsx`:
 
 ```tsx
 it('shows the guided question and, once answered "yes", leads with the recommended engine', async () => {
-  renderStepVoice(); // existing harness; mock returns the Task-3 mock recommendation (qwen lead)
+  renderStepVoice(); // mock getModelsStatus returns the Task-3 recommendation (qwen lead, CPU caveat)
   expect(await screen.findByText(/expressive and\/or multilingual/i)).toBeInTheDocument();
 
   await userEvent.click(screen.getByRole('radio', { name: /yes — expressive/i }));
 
   const badge = await screen.findByText(/recommended for you/i);
-  // The recommended (Qwen) card leads: badge appears before the Kokoro card in DOM order.
-  const kokoro = screen.getByText(/Kokoro/i);
-  expect(badge.compareDocumentPosition(kokoro) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-  // CPU-only mock → Qwen caveat is shown, neutral (not an amber blocker).
-  expect(screen.getByText(/may not fit comfortably/i)).toBeInTheDocument();
+  // The recommended (Qwen) card leads: the badge sits on the qwen card wrapper.
+  expect(badge.closest('[data-engine-card="qwen"]')).not.toBeNull();
+  // CPU-only mock → Qwen caveat shown, neutral (sky) not an amber blocker.
+  expect(screen.getByTestId('recommendation-caveat')).toHaveTextContent(/may not fit/i);
 });
 
 it('answering "no" recommends Kokoro', async () => {
   renderStepVoice();
   await userEvent.click(await screen.findByRole('radio', { name: /no — simple english/i }));
   const badge = await screen.findByText(/recommended for you/i);
-  // Badge sits on the Kokoro card.
   expect(badge.closest('[data-engine-card="kokoro"]')).not.toBeNull();
 });
 ```
 
-- [ ] **Step 6: Run test to verify it fails**
+> **Assertion note (finding #5):** do NOT `getByText(/Kokoro/i)` for ordering — with Qwen leading, "Kokoro" also appears in the "Other engines" `<summary>` preview string, so `getByText` throws on multiple matches. Anchor on the `data-engine-card` wrapper instead (emitted by Step 7).
+
+- [ ] **Step 7: Run tests to verify they fail**
 
 Run: `npx vitest run src/components/setup/step-voice.test.tsx`
 Expected: FAIL — no guided-question radios / no "Recommended for you" badge.
 
-- [ ] **Step 7: Implement the guided question + ordering in `step-voice.tsx`**
+- [ ] **Step 8: Implement the guided question + ordering in `step-voice.tsx`**
 
 Add state + a small `RecommendedBadge`, and render cards ordered by the active recommendation. Key edits (keep the existing badges/runtime/venv block untouched):
 
@@ -632,13 +669,11 @@ const ALL: Array<'kokoro' | 'qwen' | 'coqui'> = ['kokoro', 'qwen', 'coqui'];
 const leadId = activeRec?.engine ?? 'kokoro';
 const ordered = [leadId, ...ALL.filter((id) => id !== leadId)];
 
-const CARD = {
-  kokoro: (rec: boolean) => (
-    <KokoroInstall status={models.engines.kokoro} onInstalled={refetchBoth} />
-  ),
+const CARD: Record<'kokoro' | 'qwen' | 'coqui', () => JSX.Element> = {
+  kokoro: () => <KokoroInstall status={models.engines.kokoro} onInstalled={refetchBoth} />,
   qwen: () => <QwenInstall status={models.engines.qwen} onInstalled={refetchBoth} />,
   coqui: () => <CoquiInstall status={models.engines.coqui} onInstalled={refetchBoth} />,
-} as const;
+};
 ```
 
 Then render lead + rest (the lead wrapped with the badge + caveat):
@@ -677,13 +712,15 @@ Then render lead + rest (the lead wrapped with the badge + caveat):
 Keep `VenvBootstrap` above this block (runtime is shared, engine-agnostic). Wrap the Kokoro lead case with `data-engine-card="kokoro"` too (already handled by the `data-engine-card={leadId}` wrapper). Remove the now-unused hardcoded Qwen-auto-install paragraph, or fold its Qwen/Coqui hint into the "Other engines" body.
 
 > **De-defaulting note:** this replaces the fixed "Kokoro leads, others hidden under *More voice engines*" structure with derived ordering. That IS the "stop labelling Kokoro the default" acceptance item — no copy anywhere should call any engine "the default voice engine."
+>
+> **"Pull priority" = presentation, not a queue (finding #6):** there is no fe-49 pull *queue* to reprioritize — each install card fires its own independent install job on click. "Prioritize the recommended engine's pull" is therefore satisfied by making that engine lead with the primary/emphasized Install CTA (the lead card's CTA is the visually dominant one; the others sit under the "Other engines" disclosure). Do **not** wire anything into fe-49's install machinery — that acceptance item is met by ordering + CTA emphasis alone.
 
-- [ ] **Step 8: Run test to verify it passes**
+- [ ] **Step 9: Run test to verify it passes**
 
 Run: `npx vitest run src/components/setup/step-voice.test.tsx`
-Expected: PASS.
+Expected: PASS (the 6 migrated tests + the 2 new ones).
 
-- [ ] **Step 9: Commit**
+- [ ] **Step 10: Commit**
 
 ```bash
 git add src/components/setup/engine-recommendation-copy.ts src/components/setup/engine-recommendation-copy.test.ts src/components/setup/step-voice.tsx src/components/setup/step-voice.test.tsx
@@ -803,7 +840,7 @@ test('answering the guided question leads with the recommended engine', async ({
   await page.getByRole('radio', { name: /yes — expressive/i }).click();
   await expect(page.getByText(/recommended for you/i)).toBeVisible();
   // Recommended (Qwen) card is not buried under the disclosure.
-  await expect(page.getByText(/may not fit comfortably/i)).toBeVisible(); // CPU-only mock
+  await expect(page.getByTestId('recommendation-caveat')).toContainText(/may not fit/i); // CPU-only mock
 });
 ```
 
@@ -816,9 +853,9 @@ Expected: PASS. Then `npm run test:e2e` (full suite) Expected: PASS (no sibling 
 
 - [ ] **Step 3: Write the regression plan**
 
-Create `docs/features/259-fe51-engine-recommendation.md` from `docs/features/TEMPLATE.md` (verify `259` is still free; bump if a concurrent plan claimed it). `status: active`. Cover: the guided question; capability-hard-filter / VRAM-soft-caveat invariant; the four recommendation cases; the defaults handoff via `defaultTtsModelKey` (+ reconfirmation in Defaults); the de-defaulting (no "default voice engine" copy). Cite the spec and `#1614`. **Include the open truthfulness item** below as a documented manual-verification step, not a code TODO.
+Create `docs/features/259-fe51-engine-recommendation.md` from `docs/features/TEMPLATE.md` (verify `259` is still free; bump if a concurrent plan claimed it). `status: active`. Cover: the guided question; capability-hard-filter / VRAM-soft-caveat invariant; the four recommendation cases (incl. the **deliberate case-4 revision** — CPU-only + "yes" → Qwen-with-CPU-caveat, not Kokoro); the defaults handoff via `defaultTtsModelKey` (+ reconfirmation in Defaults); the de-defaulting (no "default voice engine" copy). Cite the spec and `#1614`. **Include the on-box acceptance item** below.
 
-> **Caveat-truthfulness item (record in the plan, verify on-box):** the caveat wording is deliberately the safe "may not fit comfortably on this GPU." Do NOT upgrade it to "runs on CPU, slower" until the sidecar's real constrained-VRAM Qwen behavior is verified (project history: 8 GB bulk-design OOM #1155; 1.7B OOM storms) — it may OOM-crash rather than fall back to CPU. This is a manual on-box acceptance check, listed here so it isn't silently promised.
+> **On-box acceptance item (record in the plan):** the caveat tells a low/no-VRAM user they can *run Qwen on CPU (slower) via the voice-engine device setting*. Confirm on-box that forcing the device to CPU **actually renders** (per the product owner it does — slow, not crashing; distinct from the constrained-*GPU* auto-fallback OOM path in #1155/1.7B storms). If forcing CPU turns out not to render, soften the caveat to drop the CPU-mode offer and keep only the "pick Kokoro" nudge.
 
 - [ ] **Step 4: Update INDEX + release notes**
 
@@ -842,20 +879,26 @@ Expected: PASS. Then open the PR (`Closes #1614`), let cloud `verify.yml` + the 
 
 ## Self-Review
 
+> **Post-review revision (2026-07-15):** an adversarial `assumption-checker` pass caught two blockers and the items below; all folded in. The one **deliberate divergence from the spec** — CPU-only + "yes" → Qwen-with-CPU-caveat instead of the spec's case-4 "→ Kokoro" — is a **user-approved decision** (Qwen runs on CPU; Kokoro can't do non-English; the one question can't separate the sub-needs), flagged in Global Constraints + Task 2, not silent.
+
 **Spec coverage** (Part B section of the design doc):
 - Guided question → Task 4. ✅
-- Yes → Qwen, Coqui optional alternate → Task 2 (`CAPABLE_PREFERENCE`) + Task 4 (`alternate` rendered under "Other engines"). ✅
+- Yes → Qwen, Coqui optional alternate → Task 1 (`capablePreferenceRank`) + Task 2 (data-driven capable filter/sort) + Task 4 (`alternate` under "Other engines"). ✅
 - No → Kokoro → Task 2 (`simpleEnglish`). ✅
 - Capability hard filter / VRAM soft caveat → Task 2 logic + Global Constraints. ✅
 - VRAM `<` floor → caveat, never downgraded → Task 2 (need+low-VRAM, need+null cases). ✅
-- Grounded capability map (multilingual derived from `resolveEligibleEngines`/`ENGINE_LANGUAGE_SUPPORT`; expressive+floors authored) → Task 1 (authored) + Task 2 (`isMultilingualEngine`). ✅
+- CPU-only / no-GPU + "yes" → **DELIBERATE REVISION of spec case-4** (Qwen+caveat, not Kokoro) — user-approved, flagged in Global Constraints + Task 2. ⚠️ (documented divergence, not silent)
+- Grounded capability map (multilingual **derived** from `ENGINE_LANGUAGE_SUPPORT`; expressive load-bearing in the filter; VRAM floors authored estimates) → Task 1 + Task 2 (`isMultilingualEngine`). ✅
 - Defaults handoff via `defaultTtsModelKey` (+ `Explicit`, `defaultTtsEngine: 'local'`), reconfirmed in Defaults → Task 5. ✅
-- Drop "the default voice engine" copy / pull-priority → Task 4 (derived ordering + primary CTA + de-default note). ✅
-- Tests: needs × capability × VRAM → engine (server unit) → Task 2; three regressions live in Part A's suite; recommendation UI e2e → Task 6. ✅
+- Drop "the default voice engine" copy / pull-priority (presentation) → Task 4 (derived ordering + primary CTA + de-default + pull-priority notes). ✅
+- Tests: needs × capability × VRAM → engine (server unit) → Task 2; the three Part-A status regressions stay in Part A's suite; recommendation UI e2e → Task 6. ✅
 - `Closes #1614` (fe-49 merged) → header + Task 6. ✅
+- `designVramFloorMb` (in the spec's draft `EngineCapability`) → **intentionally omitted** (YAGNI — no Part B consumer); noted in Task 1. ⚠️
 
-**Placeholder scan:** no "TBD"/"add error handling"/"similar to Task N" — every code step carries actual content; VRAM floors are concrete grounded numbers (with a verify-against-registry instruction, not a placeholder). ✅
+**Placeholder scan:** no "TBD"/"add error handling"/"similar to Task N" — every code step carries actual content. VRAM floors are concrete authored estimates (refine on-box if contradicted — a documented instruction, not a placeholder). ✅
 
-**Type consistency:** `NeedsAnswer`, `EngineRecommendation`, `RecommendationSet`, `recommendEngines`, `isMultilingualEngine`, `RECOMMENDED_BADGE`, `engineDisplayName`, `defaultModelKey` values (`kokoro-v1`/`qwen3-tts-0.6b`/`coqui-xtts-v2`) are named identically across server (Tasks 1–3) and the client mirror (Task 3) and consumers (Tasks 4–5). ✅
+**Type consistency:** `NeedsAnswer`, `EngineRecommendation`, `RecommendationSet`, `recommendEngines`, `isMultilingualEngine`, `capablePreferenceRank`, `RECOMMENDED_BADGE`, `engineDisplayName`, and the `defaultModelKey` values (`kokoro-v1`/`qwen3-tts-0.6b`/`coqui-xtts-v2`) are named identically across server (Tasks 1–3), the client mirror (Task 3), and consumers (Tasks 4–5). The `CAPABLE_PREFERENCE` hardcoded array from the first draft is **gone** — replaced by the data-driven filter + `capablePreferenceRank`. ✅
 
-**Open items deliberately carried (not placeholders):** (1) exact VRAM floor numbers — verify against `registry.ts`/measurement in Task 1; (2) caveat-truthfulness — safe wording now, on-box verification recorded in the regression plan (Task 6).
+**Test-harness blast radius (was blocker #2):** Task 4 Step 5 creates the Provider-backed `renderStepVoice` and migrates all 6 existing inline renders **before** Task 5 adds redux to the component — so no test lands red. ✅
+
+**Open items deliberately carried (not placeholders):** (1) VRAM floor numbers — authored estimates, refine on-box (Task 1); (2) on-box confirmation that forcing Qwen to CPU actually renders, with the caveat-softening fallback if not (Task 6).

--- a/docs/superpowers/plans/2026-07-15-fe51-language-aware-engine-recommendation.md
+++ b/docs/superpowers/plans/2026-07-15-fe51-language-aware-engine-recommendation.md
@@ -599,7 +599,9 @@ Then add the harness (reuses the suite's existing `allPassReadiness` const — a
 function renderStepVoice(opts: { readiness?: SetupReadiness; account?: Partial<ReturnType<typeof accountSlice.getInitialState>> } = {}) {
   const store = configureStore({
     reducer: { account: accountSlice.reducer },
-    preloadedState: { account: { ...accountSlice.getInitialState(), ...opts.account } },
+    preloadedState: {
+      account: { ...accountSlice.getInitialState(), ...opts.account } as ReturnType<typeof accountSlice.getInitialState>,
+    },
   });
   const utils = render(
     <Provider store={store}>
@@ -609,6 +611,8 @@ function renderStepVoice(opts: { readiness?: SetupReadiness; account?: Partial<R
   return { ...utils, store };
 }
 ```
+
+> Keep the `as ReturnType<typeof accountSlice.getInitialState>` cast on `preloadedState.account` — RTK's strict `preloadedState` typing (as in `step-defaults.test.tsx:62`) rejects a bare spread otherwise. Also add the test imports this task's new/handoff tests need but the current file lacks: `import userEvent from '@testing-library/user-event'` and add `waitFor` to the `@testing-library/react` import (the file imports only `render, screen` today).
 
 Then **rewrite all 6 existing tests**: each keeps its own leading `vi.spyOn(api, 'getModelsStatus').mockResolvedValue(modelsStatus({…}))`, and its `render(<StepVoice readiness={X} onRefetch={…} />)` becomes `renderStepVoice({ readiness: X })` (the two tests that build an inline `readiness` pass it through; the rest omit it and get `allPassReadiness`).
 

--- a/docs/superpowers/specs/2026-07-14-wizard-models-status-and-recommendation-design.md
+++ b/docs/superpowers/specs/2026-07-14-wizard-models-status-and-recommendation-design.md
@@ -294,26 +294,32 @@ isn't over-claimed):
 
 Each engine carries:
 
+Authored fields live on the `VOICE_ENGINES` registry entry (`expressive`,
+`genVramFloorMb`, `capablePreferenceRank`); `multilingual` is **derived**, not stored
+(see below). (The plan revised the draft `EngineCapability` shape: `multilingual`
+became derived and `designVramFloorMb` was dropped as unused in Part B — add it back
+when voice-design VRAM steering has a consumer.)
+
 ```ts
-interface EngineCapability {
-  expressive: boolean;
-  multilingual: boolean;
-  genVramFloorMb: number;       // comfortable VRAM for the GENERATION path
-  designVramFloorMb?: number;   // only for engines with a heavy design model (Qwen VoiceDesign 1.7B)
-}
+// On VoiceEngineEntry (voice-engine-registry.ts):
+  expressive: boolean;          // authored
+  genVramFloorMb: number;       // authored estimate — comfortable VRAM for GENERATION
+  capablePreferenceRank: number;// authored — lead order within the capable set (Qwen 0, Coqui 1)
+// multilingual is DERIVED from ENGINE_LANGUAGE_SUPPORT (isMultilingualEngine), NOT stored.
 ```
 
-The recommendation **reads** this map rather than hardcoding "Qwen," so a future
-engine that gains multilingual becomes eligible automatically. Rough floors, grounded
-in the CLAUDE.md model-lifecycle notes (exact numbers pulled from real measurement /
-the model registry, not guessed in code):
+The recommendation **derives** the capable set from `expressive || isMultilingualEngine`
+rather than hardcoding "Qwen," so a future engine that gains multilingual becomes
+eligible automatically; ordering uses the authored `capablePreferenceRank`. Rough
+floors — **authored estimates** grounded in the CLAUDE.md model-lifecycle notes (refine
+on-box if measurement contradicts; not guaranteed measured):
 
 - **Kokoro** — ~1 GB; fits anything, incl. CPU. English-only, non-expressive.
 - **Qwen Base 0.6B (generation)** — fits comfortably around 6 GB. Expressive,
-  multilingual. The **VoiceDesign 1.7B** model (~4–5 GB, transient, only during
-  cast-review voice design) is tracked as `designVramFloorMb` — a *separate* signal
-  that governs the voice-design feature, **not** a reason to steer generation away
-  from Qwen.
+  multilingual. Its **VoiceDesign 1.7B** model (~4–5 GB, transient, only during
+  cast-review voice design) is a *separate* signal that governs the voice-design
+  feature, **not** a reason to steer generation away from Qwen — so Part B does **not**
+  factor it into the recommendation (the dropped `designVramFloorMb`).
 - **Coqui XTTS v2** — higher generation headroom; zero-shot cloning.
 
 ### The guided question
@@ -336,8 +342,12 @@ The recommendation logic:
 1. **Hard filter by capability** — never recommend an engine that cannot meet the
    stated need. If the user needs multilingual, Kokoro (English-only) is *not*
    eligible.
-2. **Soft-prefer the lightest fitting engine** — among capable engines, prefer the
-   lightest whose `genVramFloorMb` fits detected `vramTotalMb`.
+2. **Order the capable set by authored `capablePreferenceRank`** (Qwen 0 → Coqui 1);
+   the lead is rank-0. **VRAM never reorders the capable set** — it only decides
+   whether the lead gets a caveat. (This corrects the earlier draft's "soft-prefer the
+   lightest *fitting* engine," which would have led Coqui over Qwen on a ~5 GB box —
+   wrong, since Qwen is the multi-cast default and #1614 requires it to lead. VRAM is a
+   caveat signal, not a reordering key.)
 
 Consequences:
 
@@ -448,8 +458,9 @@ the `diagnose*` pure-function test pattern; the client only renders the result o
 
 - `server/src/tts/voice-engine-registry.ts` — **extend `VoiceEngineEntry`** (landed in
   Part A with a `defaultModelKey` seam already tagged "for the Defaults handoff (Part B)")
-  with the capability fields (`expressive`, `multilingual`, `genVramFloorMb`,
-  `designVramFloorMb?`).
+  with the authored capability fields (`expressive`, `genVramFloorMb`,
+  `capablePreferenceRank`). `multilingual` is **derived** (not stored); `designVramFloorMb`
+  is **not** added in Part B (no consumer — YAGNI).
 - `server/src/tts/` (new module, e.g. `engine-recommendation.ts`) — pure
   `recommend(needsAnswer, vramTotalMb)` over the registry; `multilingual` **derived** from
   `resolveEligibleEngines` (`server/src/tts/language.ts`), `expressive` + VRAM floors are
@@ -531,6 +542,7 @@ Each PR runs the full before-shipping checklist: regression plan, release-notes-
   model-manager in the same PR AND forces a rewrite of all four `*-install.test.tsx`
   suites + `model-manager.test.tsx` (they mock `/detect` self-fetch today). Verified
   feasible but real, enumerable work — listed as explicit plan tasks, not incidental.
-- **Capability-map floor numbers:** the exact `genVramFloorMb` / `designVramFloorMb`
-  values must come from real measurement or the model registry, not guessed literals.
-  The *structure* is fixed here; the numbers are a plan-time task.
+- **Capability-map floor numbers:** the `genVramFloorMb` values are **authored
+  estimates** (grounded in CLAUDE.md's model-lifecycle notes, refined on-box if
+  measurement contradicts). The *structure* is fixed here; only the capable lead's
+  floor is read at runtime (to decide the caveat).

--- a/docs/superpowers/specs/2026-07-14-wizard-models-status-and-recommendation-design.md
+++ b/docs/superpowers/specs/2026-07-14-wizard-models-status-and-recommendation-design.md
@@ -341,25 +341,34 @@ The recommendation logic:
 
 Consequences:
 
-- **Very low VRAM or CPU-only** (below Qwen-base's generation floor, or
-  `vramTotalMb` null on a box with no capable GPU) → **recommend Kokoro** ("Recommended
-  — runs comfortably on low VRAM / CPU"). Kokoro is genuinely the engine for very low
-  VRAM or CPU-only machines.
+- **"Simple English" answer, any VRAM (incl. CPU-only)** → **recommend Kokoro**
+  ("Recommended — runs comfortably on low VRAM / CPU"). Kokoro is genuinely the engine
+  for very low VRAM or CPU-only machines when the need is English-only, non-expressive.
 - **~6 GB + expressive/multilingual need** → **recommend Qwen** (its 0.6B generation
   path fits), with a soft aside that *voice design* (the 1.7B model) may be tight on
   this GPU. We do **not** steer generation to Kokoro here.
-- **Low VRAM but multilingual is needed** → recommend Qwen anyway (Kokoro literally
-  cannot do the job), with an honest **"may not fit comfortably on this GPU"** caveat.
+- **Low VRAM OR CPU-only, but expressive/multilingual is needed** → recommend Qwen
+  **anyway** (Kokoro literally cannot do a non-English book), with an honest CPU caveat.
   We never steer someone to an engine that cannot meet their stated need.
 - **Nothing is ever blocked.** Every engine stays installable and usable; the VRAM
   signal only changes which engine *leads* and what caveat is shown.
 
-**Caveat wording is a truthfulness open item (plan-time):** do NOT promise "will run
-on CPU, slower" until the sidecar's actual low-VRAM behavior is verified. The
-project's own incident history (8 GB bulk-design OOM; 1.7B-tier OOM storms) suggests
-a constrained-VRAM Qwen can **OOM-crash rather than gracefully fall back to CPU**. The
-plan must confirm the real behavior and either promise CPU fallback (if true) or keep
-the softer "may not fit comfortably on this GPU."
+**CPU-only + "yes" answer → Qwen-with-CPU-caveat (decided 2026-07-15, user-approved
+— a deliberate revision of a literal read of this section + the Testing case-4
+"CPU-only → Kokoro").** The single "expressive **and/or** multilingual?" question
+cannot separate a non-English need (Kokoro can't serve at all) from expressive-English
+(Kokoro can). So on a CPU-only / no-GPU box the "yes" branch still **leads Qwen** and
+uses the caveat — not a downgrade to Kokoro — to nudge the expressive-English user
+while serving the multilingual user correctly. The Testing case-4 "CPU-only → Kokoro"
+applies to the **"simple English" answer**, not the "yes" branch.
+
+**Caveat wording (resolved):** the low/no-VRAM "yes"-branch caveat is **"May not fit
+this GPU's memory — you can run Qwen on CPU (slower) via the voice-engine device
+setting, or pick Kokoro below for fast English-only voices."** Per the product owner,
+Qwen *does* run on CPU (slower) via the device setting — this is distinct from the
+constrained-*GPU* auto-fallback OOM history (8 GB bulk-design OOM; 1.7B storms), which
+is a different path. On-box acceptance confirms forcing CPU actually renders; if not,
+soften the caveat to drop the CPU offer and keep only the "pick Kokoro" nudge.
 
 **This deliberately revises #1614's literal acceptance criterion** ("detected VRAM
 < 6 GB → Kokoro recommended regardless"). That flat rule is inaccurate: Qwen's 0.6B
@@ -482,8 +491,9 @@ Paired automated tests are required (testing-discipline rule), not optional.
   `installedOnDisk` vs `process` independence; `vramTotalMb` surfacing (incl. null).
 - **Server unit — recommendation function (pure, mirrors `diagnose*` tests):**
   needs-answer × capability map × `vramTotalMb` → recommended engine + caveats. Cover
-  the four cases: no-need→Kokoro; need+adequate VRAM→Qwen; need+low VRAM→Qwen+CPU
-  caveat; no capable GPU / CPU-only→Kokoro.
+  the four cases: **"simple English"→Kokoro (any VRAM)**; need+adequate VRAM→Qwen;
+  need+low VRAM→Qwen+CPU caveat; **need+CPU-only (`vramTotalMb` null)→Qwen+CPU caveat**
+  (the deliberate case-4 revision — NOT Kokoro; see the CPU-only note above).
 - **Frontend (Vitest + RTL) — `step-models.test.tsx`:** the three regressions
   (weights-missing card wording matches badge; `starting` renders neutral not amber;
   re-check refreshes the badge); controlled-card rendering; broken-Coqui-shown-while-

--- a/docs/superpowers/specs/2026-07-14-wizard-models-status-and-recommendation-design.md
+++ b/docs/superpowers/specs/2026-07-14-wizard-models-status-and-recommendation-design.md
@@ -283,13 +283,16 @@ Built on Part A's status surface.
 A small table with a **partly-derived, partly-authored** basis (stated plainly so it
 isn't over-claimed):
 
-- **`multilingual` is derived** from the existing eligibility source —
-  `resolveEligibleEngines(lang, …)` in `server/src/tts/language.ts` (e.g. `zh →
-  [coqui, qwen]`, `ko → [qwen]`), exercised in `language.test.ts`. An engine is
-  "multilingual" if it's eligible for some non-English language there.
+- **`multilingual` is derived** from the existing eligibility source — the
+  `ENGINE_LANGUAGE_SUPPORT` map (`server/src/tts/voice-mapping.ts`) that
+  `resolveEligibleEngines` itself reads (`qwen: '*'`, `coqui: [en,ru,es,fr,de,zh,ja]`,
+  `kokoro: [en]`). The plan's `isMultilingualEngine(id)` (Task 2) reads that map
+  directly — an engine is "multilingual" if it supports any non-English language
+  there. (Reading the map vs calling `resolveEligibleEngines(lang, …)` yields identical
+  results for these three engines; the plan takes the direct-map form.)
 - **`expressive` and the VRAM floors are authored constants** — there is no code
-  source for "expressive," and `genVramFloorMb` / `designVramFloorMb` are authored
-  from measurement / the model-lifecycle notes, not derived. They live in one place
+  source for "expressive," and `genVramFloorMb` is an authored estimate
+  from the model-lifecycle notes, not derived. They live in one place
   with a cited basis.
 
 Each engine carries:
@@ -462,9 +465,9 @@ the `diagnose*` pure-function test pattern; the client only renders the result o
   `capablePreferenceRank`). `multilingual` is **derived** (not stored); `designVramFloorMb`
   is **not** added in Part B (no consumer — YAGNI).
 - `server/src/tts/` (new module, e.g. `engine-recommendation.ts`) — pure
-  `recommend(needsAnswer, vramTotalMb)` over the registry; `multilingual` **derived** from
-  `resolveEligibleEngines` (`server/src/tts/language.ts`), `expressive` + VRAM floors are
-  authored constants.
+  `recommend(needsAnswer, vramTotalMb)` over the registry; `multilingual` **derived** via
+  `isMultilingualEngine` from `ENGINE_LANGUAGE_SUPPORT` (`server/src/tts/voice-mapping.ts`,
+  the map `resolveEligibleEngines` reads), `expressive` + VRAM floor are authored constants.
 - `server/src/tts/models-status.ts` / `server/src/routes/models-status.ts` — surface the
   recommendation (or its inputs) alongside the existing `info.vramTotalMb`.
 - `src/components/setup/step-voice.tsx` — **(NOT the deleted `step-models.tsx`;** fe-49

--- a/docs/superpowers/specs/2026-07-14-wizard-models-status-and-recommendation-design.md
+++ b/docs/superpowers/specs/2026-07-14-wizard-models-status-and-recommendation-design.md
@@ -431,14 +431,30 @@ nvidia-smi) means "unknown" → no VRAM-based nudge beyond the CPU-only lean.
 
 ### Files (Part B)
 
-- `src/components/setup/step-models.tsx` — guided question + recommendation
-  presentation.
-- `src/lib/models.ts` (or a new `src/lib/engine-capability.ts`) — capability map +
-  pure recommendation function.
-- `server/voice-mapping` / language-code maps — source for the capability map.
+**Recommendation placement — server-side** (resolves the earlier draft's Files-vs-Testing
+contradiction, confirmed 2026-07-15 against the landed Part A interfaces). The capability
+map + pure `recommend()` live beside the `VOICE_ENGINES` registry on the server, mirroring
+the `diagnose*` pure-function test pattern; the client only renders the result off the
+`models-status` response it already fetches.
+
+- `server/src/tts/voice-engine-registry.ts` — **extend `VoiceEngineEntry`** (landed in
+  Part A with a `defaultModelKey` seam already tagged "for the Defaults handoff (Part B)")
+  with the capability fields (`expressive`, `multilingual`, `genVramFloorMb`,
+  `designVramFloorMb?`).
+- `server/src/tts/` (new module, e.g. `engine-recommendation.ts`) — pure
+  `recommend(needsAnswer, vramTotalMb)` over the registry; `multilingual` **derived** from
+  `resolveEligibleEngines` (`server/src/tts/language.ts`), `expressive` + VRAM floors are
+  authored constants.
+- `server/src/tts/models-status.ts` / `server/src/routes/models-status.ts` — surface the
+  recommendation (or its inputs) alongside the existing `info.vramTotalMb`.
+- `src/components/setup/step-voice.tsx` — **(NOT the deleted `step-models.tsx`;** fe-49
+  split it into `step-analysis.tsx` + `step-voice.tsx`, voice cards now here) — guided
+  question + recommendation presentation.
 - `src/components/setup/step-defaults.tsx` — unchanged mechanics; receives the
-  pre-seeded default.
-- fe-49 (#1610) shared pull machinery — composed for pull-priority wiring.
+  pre-seeded default via `defaultTtsModelKey` + `defaultTtsModelKeyExplicit`.
+- fe-49 (#1610) **shipped/MERGED (PR #1642)** — its shared pull machinery is available now,
+  so Part B composes pull-priority in-scope and `Closes #1614` outright (no `Refs`
+  deferral).
 
 ---
 
@@ -487,9 +503,9 @@ two PRs, Part A before Part B:
   controlled cards, model-manager migration, the three status fixes. No fe-49
   dependency → ships first. `Closes #1612`.
 - **PR 2 — Part B (fe-51 / #1614):** capability map, guided question, VRAM
-  soft-recommendation, defaults handoff, copy de-defaulting. Built on PR 1; the
-  pull-priority wiring composes with fe-49 (#1610) when it lands. `Closes #1614`
-  (`Refs` if fe-49 gates full close).
+  soft-recommendation, defaults handoff, copy de-defaulting. Built on PR 1; fe-49
+  (#1610) is **merged (PR #1642)**, so the pull-priority wiring composes in-scope and
+  this PR `Closes #1614` outright.
 
 Each PR runs the full before-shipping checklist: regression plan, release-notes-next
 + RELEASE_NOTES entries, verified issue link, `verify:fast:branch`, and the mandatory
@@ -497,11 +513,10 @@ Each PR runs the full before-shipping checklist: regression plan, release-notes-
 
 ## Risks & open questions
 
-- **fe-49 dependency (Part B):** the recommendation/ordering/VRAM logic is
-  independently buildable and testable; only the actual weights-pull wiring needs
-  fe-49's shared machinery. If fe-49 slips, Part B ships with the recommendation +
-  ordering + defaults handoff and a follow-up `Refs` for the pull-priority
-  composition.
+- **fe-49 dependency (Part B): RESOLVED.** fe-49 merged (PR #1642, 2026-07-14), so its
+  shared pull machinery is available and the pull-priority wiring is in-scope for Part B's
+  single PR — no `Refs` deferral. (The recommendation/ordering/VRAM logic was always
+  independently buildable; this only removes the pull-wiring caveat.)
 - **Controlled-card migration blast radius:** making the status prop required touches
   model-manager in the same PR AND forces a rewrite of all four `*-install.test.tsx`
   suites + `model-manager.test.tsx` (they mock `/detect` self-fetch today). Verified


### PR DESCRIPTION
## Summary

Lands the **design-of-record + implementation plan for fs-38 Part B (fe-51)** — the
language-aware voice-engine recommendation the setup wizard surfaces off the
server-computed `vramTotalMb`. Part A (single-source model status, #1612) shipped in
#1644; this is the planning artifact for its follow-up, written against Part A's
now-landed interfaces. **Docs-only — no runtime code.**

Two files:

- **New:** `docs/superpowers/plans/2026-07-15-fe51-language-aware-engine-recommendation.md`
  — the 6-task TDD plan. Server-side `recommendEngines(vramTotalMb)`
  (`server/src/tts/engine-recommendation.ts`) precomputes both guided-question answers
  onto `ModelsStatus.recommendation`; `step-voice.tsx` renders the one needs-question,
  orders cards so the pick leads, and dispatches the defaults handoff.
- **Modified:** `docs/superpowers/specs/2026-07-14-wizard-models-status-and-recommendation-design.md`
  — Part B section amended: server-side placement, data-driven capability set (derived
  from `expressive || isMultilingualEngine`, ordered by authored `capablePreferenceRank`),
  VRAM as a caveat-only signal that never reorders, and the CPU-only → Qwen-with-caveat
  case-4 revision.

Design locked through **three adversarial assumption-checker passes (converged)**; the
plan prescribes copying `step-defaults.test.tsx`'s proven Provider + `vi.mock` harness
verbatim, since `step-voice.test.tsx` has no store-backed harness today.

## Test plan

Docs-only — no tests. `verify.yml` completes green as a docs-only diff (every leg's scope
condition is false). Implementation of the plan (a separate SDD thread off `main`) lands
the paired unit/e2e coverage described in the plan's Task 6.

Refs #1614
