### PR TITLE
fix(server): merge tiny heading chunks so stage-2 attribution can't stick in a coverage loop

### DIFF
--- a/server/src/analyzer/stage2-chunk.test.ts
+++ b/server/src/analyzer/stage2-chunk.test.ts
@@ -276,6 +276,34 @@ describe('runStage2ChapterChunked', () => {
     expect(out.coverage.ok).toBe(true);
   });
 
+  it('merges a tiny heading chunk into a neighbour instead of attributing it alone', async () => {
+    /* Regression (2026-07-16 Ночной дозор ch6): an internal chapter heading
+       "Глава 4", trapped as its own paragraph between two over-budget
+       paragraphs, was isolated by splitBodyIntoChunks as a standalone chunk.
+       Unlike a word-free "***" (skipped), it normalises to 2 words — nonzero,
+       so it slipped the skip guard and was sent to the model ALONE. The model
+       looped on the near-empty span, producing 1405 output words vs ~2 source
+       (ratio 702.50 → "repeat-loop") and the chapter stuck on every retry, then
+       flagged. A tiny prose fragment must ride with an adjacent chunk — its text
+       PRESERVED (it is a heading, not a scene break) — never attributed alone. */
+    const big1 = 'Word '.repeat(40).trim();
+    const big2 = 'Other text here '.repeat(20).trim();
+    const body = `${big1}\n\nГлава 4\n\n${big2}`;
+    const call = vi.fn(async (subBody: string, _preceding: string | null) => fakeAttribute(subBody));
+    const out = await runStage2ChapterChunked({
+      body,
+      charBudget: 100, // both real paragraphs over budget → heading isolated
+      coverageRetries: 2,
+      callForBody: call,
+    });
+    // The tiny heading is never sent to the model as its own span.
+    expect(call.mock.calls.some(([sub]) => sub.trim() === 'Глава 4')).toBe(false);
+    // But its text is preserved (merged into a neighbour, not dropped like ***).
+    expect(out.sentences.some((s) => s.text.includes('Глава 4'))).toBe(true);
+    // And the chapter completes cleanly — no stuck coverage loop.
+    expect(out.coverage.ok).toBe(true);
+  });
+
   it('retries a chunk whose first attempt has low coverage', async () => {
     const body = makeBody(8);
     const onRetry = vi.fn();
@@ -315,7 +343,13 @@ describe('runStage2ChapterChunked', () => {
 
 describe('onSectionDone', () => {
   it('fires once per section with the section sentence count (multi-chunk)', async () => {
-    const body = 'A'.repeat(50) + '\n\n' + 'B'.repeat(50); // 2 paragraphs
+    /* Two REAL multi-word paragraphs (not single-token blobs like 'A'*50, which
+       normalise to one word and would be merged as fragments by mergeTinyChunks)
+       so the budget forces a genuine 2-section split. */
+    const body =
+      'Alpha alpha words here for the first section.' +
+      '\n\n' +
+      'Beta beta words here for the second section.';
     const calls: Array<[number, number]> = [];
     await runStage2ChapterChunked({
       body,
@@ -323,7 +357,7 @@ describe('onSectionDone', () => {
       coverageRetries: 0,
       callForBody: async (sub) => ({
         // 2 sentences for the first span, 3 for the second — distinguishable
-        sentences: (sub.includes('A') ? [1, 2] : [1, 2, 3]).map((id) => ({
+        sentences: (sub.includes('Alpha') ? [1, 2] : [1, 2, 3]).map((id) => ({
           id,
           chapterId: 1,
           characterId: 'narrator',

--- a/server/src/analyzer/stage2-chunk.test.ts
+++ b/server/src/analyzer/stage2-chunk.test.ts
@@ -67,6 +67,31 @@ describe('splitBodyIntoChunks', () => {
     // The huge paragraph is not fragmented across chunks.
     expect(chunks.filter((c) => c.includes(huge))).toHaveLength(1);
   });
+
+  it('merges a short heading-sized fragment into a neighbour (lossless)', () => {
+    // A lone heading "Глава 4" trapped between two over-budget paragraphs must
+    // ride with a neighbour, never stand alone (see mergeTinyChunks).
+    const big1 = 'Word '.repeat(60).trim();
+    const big2 = 'Other stuff here '.repeat(30).trim();
+    const body = `${big1}\n\nГлава 4\n\n${big2}`;
+    const chunks = splitBodyIntoChunks(body, 120);
+    expect(chunks.some((c) => c.trim() === 'Глава 4')).toBe(false); // never alone
+    expect(chunks.some((c) => c.includes('Глава 4'))).toBe(true); // text preserved
+    expect(chunks.join('')).toBe(body); // lossless
+  });
+
+  it('does NOT merge a char-large but word-sparse chunk (only short fragments merge)', () => {
+    // A chunk can be char-LARGE yet normalise to few words (a run with no word
+    // breaks); that is NOT a fragment and must keep its own chunk, or stage-1/2
+    // chunking would collapse. Only a chunk that is short in BOTH words and
+    // chars (a lone heading) is merged.
+    const bigSparse = 'a'.repeat(2000); // one long token → 1 attributable word
+    const other = 'b'.repeat(2000);
+    const body = `${bigSparse}\n\n${other}`;
+    const chunks = splitBodyIntoChunks(body, 2500);
+    expect(chunks.length).toBeGreaterThan(1); // NOT collapsed into one
+    expect(chunks.join('')).toBe(body);
+  });
 });
 
 describe('splitParagraphIntoSentences', () => {

--- a/server/src/analyzer/stage2-chunk.ts
+++ b/server/src/analyzer/stage2-chunk.ts
@@ -31,6 +31,8 @@ import {
   runStage2WithCoverageGuard,
   validateStage2Coverage,
   hasAttributableContent,
+  attributableWordCount,
+  STAGE2_MIN_EVALUABLE_WORDS,
   type Stage2CoverageThresholds,
   type Stage2CoverageVerdict,
 } from './stage2-coverage.js';
@@ -73,13 +75,51 @@ export function resolveStage2ChunkCharBudget(engine?: 'gemini' | 'local'): numbe
   );
 }
 
+/** Fold a fragment-sized chunk — one with a NONZERO but sub-`STAGE2_MIN_EVALUABLE_WORDS`
+    attributable-word count, e.g. a lone heading "Глава 4" — into an adjacent
+    chunk so it is never attributed as its own model call. Such a fragment gets
+    isolated when it sits between two over-budget paragraphs the packing loop
+    can't co-locate it with; alone, its tiny word count makes the coverage guard
+    un-evaluable and the model tends to loop on the near-empty span, sticking the
+    chapter on every retry (the 2026-07-16 Ночной дозор ch6 defect: 1405 output
+    words vs ~2 source → ratio 702.50). Unlike a WORD-FREE separator ("***"),
+    which has nothing to narrate and is skipped downstream, a fragment carries
+    real words (a heading) and is PRESERVED — merged forward into the next chunk
+    when there is one (a heading reads best leading its section), else back into
+    the previous. Merging only concatenates adjacent chunks, so `chunks.join('')`
+    still reproduces the body exactly; word-free chunks are left in place. */
+function mergeTinyChunks(chunks: string[]): string[] {
+  if (chunks.length <= 1) return chunks;
+  const isTinyFragment = (c: string): boolean => {
+    const wc = attributableWordCount(c);
+    return wc >= 1 && wc < STAGE2_MIN_EVALUABLE_WORDS;
+  };
+  const work = [...chunks];
+  const out: string[] = [];
+  for (let i = 0; i < work.length; i += 1) {
+    if (isTinyFragment(work[i]) && i + 1 < work.length) {
+      work[i + 1] = work[i] + work[i + 1]; // forward-merge into the next chunk
+    } else {
+      out.push(work[i]);
+    }
+  }
+  // A fragment that was LAST had no following chunk to join — fold it (and any
+  // fragment that merging left trailing) back into the previous chunk instead.
+  while (out.length >= 2 && isTinyFragment(out[out.length - 1])) {
+    out[out.length - 2] += out.pop()!;
+  }
+  return out;
+}
+
 /** Split `body` into chunks at blank-line (paragraph) boundaries, each ≤
     `charBudget` where possible. NEVER splits inside a paragraph (so a quote and
     its dialogue tag stay in the same call). A single paragraph longer than the
     budget becomes its own chunk — it can't be split without cutting a sentence.
-    Concatenating the returned chunks reproduces `body` exactly (the blank-line
-    separators ride along with the paragraph before them), so no prose is dropped
-    or duplicated across the seam. Returns `[body]` unchanged when it fits. */
+    A fragment-sized chunk (a lone heading) is merged into a neighbour rather
+    than left to stand alone (see {@link mergeTinyChunks}). Concatenating the
+    returned chunks reproduces `body` exactly (the blank-line separators ride
+    along with the paragraph before them), so no prose is dropped or duplicated
+    across the seam. Returns `[body]` unchanged when it fits. */
 export function splitBodyIntoChunks(body: string, charBudget: number): string[] {
   if (body.length <= charBudget) return [body];
   /* Capture the separators so reconstruction is lossless: split() with a
@@ -101,7 +141,7 @@ export function splitBodyIntoChunks(body: string, charBudget: number): string[] 
     }
   }
   if (cur) chunks.push(cur);
-  return chunks.length > 0 ? chunks : [body];
+  return mergeTinyChunks(chunks.length > 0 ? chunks : [body]);
 }
 
 /** Split a SINGLE paragraph (no blank-line boundaries) at sentence boundaries,

--- a/server/src/analyzer/stage2-chunk.ts
+++ b/server/src/analyzer/stage2-chunk.ts
@@ -75,22 +75,32 @@ export function resolveStage2ChunkCharBudget(engine?: 'gemini' | 'local'): numbe
   );
 }
 
-/** Fold a fragment-sized chunk — one with a NONZERO but sub-`STAGE2_MIN_EVALUABLE_WORDS`
-    attributable-word count, e.g. a lone heading "Глава 4" — into an adjacent
-    chunk so it is never attributed as its own model call. Such a fragment gets
-    isolated when it sits between two over-budget paragraphs the packing loop
-    can't co-locate it with; alone, its tiny word count makes the coverage guard
-    un-evaluable and the model tends to loop on the near-empty span, sticking the
-    chapter on every retry (the 2026-07-16 Ночной дозор ch6 defect: 1405 output
-    words vs ~2 source → ratio 702.50). Unlike a WORD-FREE separator ("***"),
-    which has nothing to narrate and is skipped downstream, a fragment carries
-    real words (a heading) and is PRESERVED — merged forward into the next chunk
-    when there is one (a heading reads best leading its section), else back into
-    the previous. Merging only concatenates adjacent chunks, so `chunks.join('')`
-    still reproduces the body exactly; word-free chunks are left in place. */
+/* A fragment must be short in CHARS too, not only in words: a chunk can be
+   char-LARGE yet normalise to few words (a long run with no word breaks — e.g. a
+   synthetic single-token blob, or an unusual glyph run). Merging such a chunk
+   would bloat a neighbour and defeat chunking, so only a genuinely SHORT low-word
+   span (a lone heading like "Глава 4" — 9 chars) qualifies. Real headings are far
+   under this; real prose reaches STAGE2_MIN_EVALUABLE_WORDS words long before it. */
+const STAGE2_TINY_FRAGMENT_MAX_CHARS = 200;
+
+/** Fold a fragment-sized chunk — SHORT in both chars and attributable words
+    (nonzero but sub-`STAGE2_MIN_EVALUABLE_WORDS`), e.g. a lone heading "Глава 4"
+    — into an adjacent chunk so it is never attributed as its own model call.
+    Such a fragment gets isolated when it sits between two over-budget paragraphs
+    the packing loop can't co-locate it with; alone, its tiny word count makes
+    the coverage guard un-evaluable and the model tends to loop on the near-empty
+    span, sticking the chapter on every retry (the 2026-07-16 Ночной дозор ch6
+    defect: 1405 output words vs ~2 source → ratio 702.50). Unlike a WORD-FREE
+    separator ("***"), which has nothing to narrate and is skipped downstream, a
+    fragment carries real words (a heading) and is PRESERVED — merged forward into
+    the next chunk when there is one (a heading reads best leading its section),
+    else back into the previous. Merging only concatenates adjacent chunks, so
+    `chunks.join('')` still reproduces the body exactly; word-free chunks and
+    large word-sparse chunks are left in place. */
 function mergeTinyChunks(chunks: string[]): string[] {
   if (chunks.length <= 1) return chunks;
   const isTinyFragment = (c: string): boolean => {
+    if (c.length >= STAGE2_TINY_FRAGMENT_MAX_CHARS) return false;
     const wc = attributableWordCount(c);
     return wc >= 1 && wc < STAGE2_MIN_EVALUABLE_WORDS;
   };

--- a/server/src/analyzer/stage2-coverage.test.ts
+++ b/server/src/analyzer/stage2-coverage.test.ts
@@ -161,6 +161,23 @@ describe('validateStage2Coverage', () => {
     expect(v.issues.some((i) => /truncat|dropped|cover|loop|excess/i.test(i))).toBe(false);
   });
 
+  it('does NOT gate the ratio when the source is too small to evaluate (heading-sized span)', () => {
+    /* Regression (2026-07-16 Ночной дозор ch6): an isolated "Глава 4" chunk
+       (2 source words) on which the model looped produced 1405 output words →
+       ratio 702.50, rejected as a "repeat-loop" on every retry → the chapter
+       stuck. A span this small can't be ratio-checked: the denominator is noise,
+       so any real output blows past maxCoverageRatio. Such a span is un-evaluable
+       for the ratio — a genuine loop is still caught by the duplicated-block
+       signal, and an empty result by the no-sentences check. Here the (unique)
+       output must NOT be flagged as excess coverage. */
+    const body = 'Глава 4'; // 2 attributable words
+    const looped = Array.from({ length: 300 }, (_, i) => ({ text: `word ${i} unique line here` }));
+    const v = validateStage2Coverage(body, looped);
+    expect(v.duplicatedBlock).toBeNull(); // unique lines → not a real loop
+    expect(v.issues.some((i) => /excess|loop|cover/i.test(i))).toBe(false);
+    expect(v.ok).toBe(true);
+  });
+
   it('does NOT false-positive a short-but-complete chapter (e.g. a preface)', () => {
     const body = 'PREFACE. A short opening note. For the future.';
     const sentences = [sent('PREFACE.'), sent('A short opening note.'), sent('For the future.')];

--- a/server/src/analyzer/stage2-coverage.ts
+++ b/server/src/analyzer/stage2-coverage.ts
@@ -105,6 +105,24 @@ export function hasAttributableContent(text: string): boolean {
   return words(text).length > 0;
 }
 
+/** How many attributable words this prose normalises to (see {@link words}). */
+export function attributableWordCount(text: string): number {
+  return words(text).length;
+}
+
+/* Below this many normalised source words a span is too small for the coverage
+   RATIO to be a reliable signal: a handful of stray or looped output words blows
+   the ratio past `maxCoverageRatio` even though nothing is wrong. The 2026-07-16
+   Ночной дозор ch6 defect: an internal heading "Глава 4" (2 source words) was
+   isolated as its own chunk between two over-budget paragraphs; the model looped
+   on the near-empty span → 1405 output words vs ~2 source → ratio 702.50, so the
+   excess-coverage guard rejected it on every retry and the chapter stuck, then
+   flagged. Such a span is treated as ratio-un-evaluable here (a genuine loop is
+   still caught by the duplicated-block signal, an empty result by the
+   no-sentences check). The stage-2 chunker uses the SAME floor to MERGE a
+   fragment-sized chunk into an adjacent one so it is never attributed alone. */
+export const STAGE2_MIN_EVALUABLE_WORDS = 5;
+
 /** Largest contiguous run of sentences whose normalised text repeats an earlier
     sentence's text at a CONSTANT offset (the loop signature). */
 function findDuplicatedBlock(
@@ -154,15 +172,19 @@ export function validateStage2Coverage(
   const bodyWords = words(bodyText);
   const outWords = sentences.flatMap((s) => words(s.text));
 
-  /* A source that normalises to zero words is UN-EVALUABLE — there is nothing
-     to under- or over-cover, so the ratio is meaningless and must not gate. The
-     old code forced ratio 0 and let `0 < minCoverage` flag it "truncated" on
-     every retry → a permanent stuck loop on a word-free span (2026-06-19
-     Ночной дозор ch7: a lone "***" chunk; cf. the 2026-06-15 Cyrillic case the
-     module header records). An empty OUTPUT is still caught below via the
-     "No sentences attributed" check, so a genuinely empty result never slips. */
-  const sourceEvaluable = bodyWords.length > 0;
-  const coverageRatio = sourceEvaluable ? outWords.length / bodyWords.length : 0;
+  /* A source with too few words is UN-EVALUABLE for the coverage RATIO — the
+     denominator is meaningless, so a handful of stray or looped output words
+     blows past `maxCoverageRatio` and it must not gate. Two shapes hit this: a
+     ZERO-word span (a lone "***" scene break — the 2026-06-19 Ночной дозор ch7
+     stuck loop; cf. the 2026-06-15 Cyrillic case in the module header), and a
+     tiny NONZERO span (an isolated "Глава 4" heading — the 2026-07-16 Ночной
+     дозор ch6 stuck loop, 1405 output words vs ~2 source → ratio 702.50). Below
+     `STAGE2_MIN_EVALUABLE_WORDS` the ratio is suppressed; a genuine loop is
+     still caught by the duplicated-block signal and an empty OUTPUT by the "No
+     sentences attributed" check, so nothing broken slips. The ratio itself is
+     still reported (informative in logs) — only the pass/fail gate is skipped. */
+  const sourceEvaluable = bodyWords.length >= STAGE2_MIN_EVALUABLE_WORDS;
+  const coverageRatio = bodyWords.length > 0 ? outWords.length / bodyWords.length : 0;
 
   // Ending present: do the source's trailing words appear (contiguously) in the
   // attributed word stream?


### PR DESCRIPTION
@
## Problem

A local (Ollama) analysis run appeared to hang for many minutes on a large chapter, then flagged it **"attribution may be incomplete."** Reproduced on a Russian book, Chapter 6:

```
Chapter 6/9 — attribution coverage check failed (Excess coverage — attributed 1405 words vs ~2 source (ratio 702.50 above 1.6); likely a repeat-loop.); re-analysing (attempt 2).
Chapter 6/9 — attribution coverage check failed (... ratio 702.50 ...); re-analysing (attempt 3).
Chapter 6/9 — ⚠ attribution may be incomplete (Duplicated block — 82 consecutive sentences repeat earlier ones at offset 209 (repeat-loop).); kept the best take and flagged the chapter for retry.
```

## Root cause (confirmed against the real book with the actual parser + chunker)

The chapter (76,817 chars) splits into 11 chunks. One chunk is the literal text of an internal heading ("Глава 4") — its own paragraph, wedged between two over-budget paragraphs — orphaned by `splitBodyIntoChunks` as a standalone 9-char chunk that normalises to exactly **2 attributable words**.

`hasAttributableContent` only skips **zero-word** spans (a `***` scene break), so this 2-word chunk slipped through and was sent to the model **alone**. The model looped on the near-empty span (1405 words); the per-section coverage guard computed `1405 ÷ 2 = 702.50`, far over `maxCoverageRatio` (1.6), and rejected **every** retry as a "repeat-loop". The tiny denominator makes the ratio un-evaluable, so retrying can never help — hence the apparent hang, then the flag.

Same failure family as the earlier Cyrillic and `***`-scene-break stuck loops, which were fixed only for the **zero-word** case. The `> 0` floor is too weak — a tiny **nonzero** span reproduces it.

## Fix

- **Chunker (root cause):** `splitBodyIntoChunks` merges a fragment-sized chunk (nonzero but `< STAGE2_MIN_EVALUABLE_WORDS` attributable words) into an adjacent chunk, so a lone heading is never attributed alone. Unlike a word-free `***` (dropped), a heading carries words and is **preserved** (merged forward into the next chunk). Merging only concatenates adjacent chunks, so the split stays lossless.
- **Coverage guard (defense-in-depth):** `validateStage2Coverage` suppresses the coverage **ratio** gate below the same word floor. Genuine loops are still caught by the duplicated-block signal and empty output by the no-sentences check.

## Verification

- TDD: two failing tests (RED) → passing (GREEN); full `stage2-chunk` + `stage2-coverage` suites pass (45/45).
- End-to-end against the real book: the chapter now splits **11 → 10** chunks, the heading fragment rides with its neighbour, no degenerate 1–4-word standalone chunks remain, split is lossless.
- Server typecheck clean.

Closes #1670

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@