### PR TITLE
fix(frontend): replace live cast roster per-snapshot to kill duplicate pills

### DIFF
--- a/src/store/cast-slice.test.ts
+++ b/src/store/cast-slice.test.ts
@@ -356,6 +356,75 @@ describe('castSlice — mergeCharacters (Phase 0a live cast snapshots)', () => {
   });
 });
 
+describe('castSlice — replaceLiveRoster (Phase 0a full-snapshot replace)', () => {
+  it('drops locally-known characters the snapshot omits (verifier-dropped names do not resurrect)', () => {
+    /* "Светлане" / "Как" were detected early then dropped by the verifier;
+       a later full snapshot omits them and they must NOT linger in the pills. */
+    const start = baseState([
+      makeChar('svetlana', { name: 'Светлана' }),
+      makeChar('svetlane', { name: 'Светлане' }),
+      makeChar('kak', { name: 'Как' }),
+    ]);
+    const next = castSlice.reducer(
+      start,
+      castActions.replaceLiveRoster([makeChar('svetlana', { name: 'Светлана' })]),
+    );
+    expect(next.characters.map((c) => c.id)).toEqual(['svetlana']);
+  });
+
+  it('collapses a same-name id-flip to the single snapshot row', () => {
+    /* The earlier singleton "Ольга" was emitted under a raw id; once a Tier-1
+       group formed the server re-keyed the survivor to a canonical id. The
+       stale singleton id must not survive as a duplicate pill. */
+    const start = baseState([makeChar('ольга-2', { name: 'Ольга' })]);
+    const next = castSlice.reducer(
+      start,
+      castActions.replaceLiveRoster([makeChar('ольга', { name: 'Ольга' })]),
+    );
+    expect(next.characters.map((c) => c.id)).toEqual(['ольга']);
+    expect(next.characters.filter((c) => c.name === 'Ольга')).toHaveLength(1);
+  });
+
+  it('preserves locked voice / designed-Qwen fields by id-match on a surviving row (#518)', () => {
+    const start = baseState([
+      makeChar('wren', {
+        voiceState: 'locked',
+        voiceId: 'v_wren_from_book1',
+        matchedFrom: { bookTitle: 'KOTC #1', confidence: 0.94 },
+        overrideTtsVoices: { qwen: { name: 'qwen-wren' } },
+      }),
+    ]);
+    const next = castSlice.reducer(
+      start,
+      castActions.replaceLiveRoster([
+        { id: 'wren', name: 'Wren Sparrow', role: 'protagonist', color: 'orange', description: 'richer' },
+      ]),
+    );
+    const wren = next.characters.find((c) => c.id === 'wren')!;
+    expect(wren.voiceId).toBe('v_wren_from_book1');
+    expect(wren.voiceState).toBe('locked');
+    expect(wren.matchedFrom).toEqual({ bookTitle: 'KOTC #1', confidence: 0.94 });
+    expect(wren.overrideTtsVoices).toEqual({ qwen: { name: 'qwen-wren' } });
+    expect(wren.name).toBe('Wren Sparrow'); // fresh fields still flow through
+  });
+
+  it('mirrors the snapshot order and defaults voiceState for brand-new rows', () => {
+    const start = baseState([makeChar('narrator')]);
+    const next = castSlice.reducer(
+      start,
+      castActions.replaceLiveRoster([makeChar('narrator'), makeChar('wren'), makeChar('marlow')]),
+    );
+    expect(next.characters.map((c) => c.id)).toEqual(['narrator', 'wren', 'marlow']);
+    expect(next.characters.find((c) => c.id === 'wren')!.voiceState).toBe('generated');
+  });
+
+  it('is a no-op for an empty snapshot (a stray empty event must not wipe the roster)', () => {
+    const start = baseState([makeChar('wren')]);
+    const next = castSlice.reducer(start, castActions.replaceLiveRoster([]));
+    expect(next.characters).toEqual(start.characters);
+  });
+});
+
 describe('castSlice — applyMerge (manual character merge response)', () => {
   it('replaces the local cast with the server payload while preserving local voice state on survivors', () => {
     /* User had locked the target's voice in a prior session. The server's

--- a/src/store/cast-slice.ts
+++ b/src/store/cast-slice.ts
@@ -25,6 +25,29 @@ function unionAliases(a?: string[], b?: string[]): string[] | undefined {
   return out.length ? out : undefined;
 }
 
+/* Overlay locally-known voice / design fields onto a fresh analyser-snapshot
+   entry, matched by id. The analyser doesn't know about the user's voice
+   matches, designed Qwen voices, "not the same person" decisions or manually-
+   added aliases, so a live roster snapshot must never clobber them (#518 —
+   Berrin/Sela/Quill stripped on re-analysis; srv-13). Shared by both the
+   delta-merge (`mergeCharacters`) and full-snapshot-replace (`replaceLiveRoster`)
+   paths so the preservation rules can't drift between them. */
+function overlaySnapshotEntry(existing: Character | undefined, inc: Character): Character {
+  if (!existing) return inc.voiceState ? inc : { ...inc, voiceState: 'generated' };
+  return {
+    ...inc,
+    voiceId: existing.voiceId ?? inc.voiceId,
+    matchedFrom: existing.matchedFrom ?? inc.matchedFrom,
+    matchFactors: existing.matchFactors ?? inc.matchFactors,
+    voiceState: existing.voiceState ?? inc.voiceState ?? 'generated',
+    overrideTtsVoices: existing.overrideTtsVoices ?? inc.overrideTtsVoices,
+    ttsEngine: existing.ttsEngine ?? inc.ttsEngine,
+    voiceStyle: existing.voiceStyle ?? inc.voiceStyle,
+    notLinkedTo: existing.notLinkedTo ?? inc.notLinkedTo,
+    aliases: unionAliases(existing.aliases, inc.aliases),
+  };
+}
+
 export interface CastState {
   characters: Character[];
   /** fe-16 — characterId → engine the character actually rendered in when it
@@ -201,42 +224,36 @@ export const castSlice = createSlice({
       const next: Character[] = [];
       const seen = new Set<string>();
       for (const inc of incoming) {
-        const existing = byId.get(inc.id);
-        if (existing) {
-          /* Preserve voice matching / design fields from the local entry —
-             those came from voice matching or the user's voice design and must
-             NOT be clobbered by an analyser snapshot that doesn't know about
-             them. `overrideTtsVoices` holds the designed Qwen voice for
-             generated characters (no voiceId); omitting it here dropped the
-             voice in Redux and a later cast persist wrote it out of cast.json
-             (#518 — Berrin/Sela/Quill stripped on re-analysis). */
-          next.push({
-            ...inc,
-            voiceId: existing.voiceId ?? inc.voiceId,
-            matchedFrom: existing.matchedFrom ?? inc.matchedFrom,
-            matchFactors: existing.matchFactors ?? inc.matchFactors,
-            voiceState: existing.voiceState ?? inc.voiceState ?? 'generated',
-            overrideTtsVoices: existing.overrideTtsVoices ?? inc.overrideTtsVoices,
-            ttsEngine: existing.ttsEngine ?? inc.ttsEngine,
-            voiceStyle: existing.voiceStyle ?? inc.voiceStyle,
-            /* The user's "not the same person" decision and any manually-added
-               aliases must survive a live Phase-0a roster snapshot (srv-13). */
-            notLinkedTo: existing.notLinkedTo ?? inc.notLinkedTo,
-            aliases: unionAliases(existing.aliases, inc.aliases),
-          });
-        } else {
-          next.push(inc.voiceState ? inc : { ...inc, voiceState: 'generated' });
-        }
+        next.push(overlaySnapshotEntry(byId.get(inc.id), inc));
         seen.add(inc.id);
       }
       /* Carry forward any locally-known characters the snapshot omitted.
-         Defensive — Phase 0a sends the full roster on every event so this
-         set should always be empty in practice, but keeps the slice safe
-         against future delta-style updates. */
+         REQUIRED for the generation-time SUBSET path (generation.tsx feeds
+         a single re-analysed chapter's characters here), which is a genuine
+         delta — dropping the untouched rows would wipe the rest of the cast.
+         The full-roster analysis live view uses `replaceLiveRoster` instead. */
       for (const c of s.characters) {
         if (!seen.has(c.id)) next.push(c);
       }
       s.characters = next;
+    },
+    /* Full-roster snapshot from Phase-0a live cast detection (analysis view).
+       Unlike `mergeCharacters`, this REPLACES the roster with the snapshot —
+       rows absent from the snapshot are DROPPED, not carried forward. The
+       server's live snapshots are already name-deduped and verifier-pruned
+       (previewFoldForLiveView), so faithfully mirroring each one keeps the
+       "Cast so far" pills free of two display artefacts the carry-forward
+       loop caused: (a) same-name duplicates left behind when a Tier-1 merge
+       re-keys a survivor's id mid-stream (the earlier singleton id lingers),
+       and (b) characters the verifier later dropped resurrecting on every
+       later event. Voice / design fields are still preserved by id-match for
+       any surviving row (#518 / srv-13). No-op on an empty snapshot so a stray
+       empty event can't wipe a populated roster. */
+    replaceLiveRoster: (s, a: PayloadAction<Character[]>) => {
+      const incoming = a.payload;
+      if (!incoming?.length) return;
+      const byId = new Map(s.characters.map((c) => [c.id, c]));
+      s.characters = incoming.map((inc) => overlaySnapshotEntry(byId.get(inc.id), inc));
     },
     /* From POST /api/books/:bookId/cast/merge — replaces the local cast
        with the server's merged list. The server is authoritative because

--- a/src/views/analysing.tsx
+++ b/src/views/analysing.tsx
@@ -520,11 +520,12 @@ export function AnalysingView({
             if (cancelled) return;
             setConn('streaming');
             markEvent();
-            /* Merge into the cast slice so the cast view (and Phase 0
-               live preview below) reflect the chapter-by-chapter roster
-               as it grows. Replay-safe — late-arriving snapshots upsert
-               by id, preserving locked voices on existing entries. */
-            dispatch(castActions.mergeCharacters(characters));
+            /* Replace the cast slice with each full roster snapshot so the
+               cast view (and Phase 0 live preview below) mirror the server's
+               already-deduped, verifier-pruned roster exactly — no stale
+               same-name dups or verifier-dropped names lingering. Replay-safe
+               — snapshots upsert by id, preserving locked voices on survivors. */
+            dispatch(castActions.replaceLiveRoster(characters));
           },
           onChapterFailed: ({ chapterId, message, code, remediation }) => {
             if (cancelled) return;
@@ -838,7 +839,9 @@ export function AnalysingView({
         },
         onCastUpdate: ({ characters }) => {
           markEvent();
-          dispatch(castActions.mergeCharacters(characters));
+          /* Full roster snapshot — replace, don't accumulate (see the other
+             onCastUpdate handler above and replaceLiveRoster's rationale). */
+          dispatch(castActions.replaceLiveRoster(characters));
         },
         onChapterFailed: ({ chapterId: failedId, message, code, remediation }) => {
           markEvent();


### PR DESCRIPTION
## Problem

Re-analysing a book (repro: *Ночной дозор*, ru, gemma4-e4b), the live **"Cast so far"** pills during Phase-0a show the same name several times (`Ольга`×2, `Гарик`×2, `Игнат`×2, …) and even names the verifier already **dropped** (`Светлане`, `Как`). Reads as "the cast didn't merge."

## The data was always correct

On-disk `cast.json` is right — 38 unique rows, each name once, all gendered. The final/interim write path (`buildInterimCast` → `previewFoldForLiveView` → `dedupeRosterByName`) dedups correctly. **This is a live-display bug only; no re-analysis is needed.**

## Root cause

`cast-slice.mergeCharacters` upserts the roster by `id` and carries forward any local row omitted by the newest snapshot. During analysis the dedup survivor's `id` is **not stable across snapshots**: a singleton is first emitted under its raw analyzer id (e.g. `ольга-2`), then Tier-1 re-keys the survivor to `safeId(name)` = `ольга` once a same-name group forms. The upsert adds `ольга` as new and the carry-forward loop resurrects the stale `ольга-2` → a duplicate pill. Verifier-dropped names resurrect the same way. The carry-forward is genuinely required by the generation-time **subset** path (a single re-analysed chapter is a real delta), so it can't just be deleted.

## Fix

- New `replaceLiveRoster` reducer: full-snapshot **replace** (drops rows absent from the snapshot) while preserving locked/designed voices by id-match.
- Wire the two analysis-view `onCastUpdate` sites to it; the generation subset path keeps `mergeCharacters`.
- Both paths now share one `overlaySnapshotEntry` helper so the #518/srv-13 voice-preservation rules can't drift.

Frontend-only. Considered but **rejected** a server-side "stable survivor id" change: it would alter persisted `cast.json` ids (broad blast radius) and re-tread the ingest-canonicalization approach already rejected in #1666, and the id-flip never occurs during generation (roster is complete/stable there), so the frontend guard is sufficient.

## Tests

- 6 new `cast-slice.test.ts` cases: drop-omitted (dropped-name), same-name id-flip collapse, #518 voice preservation, snapshot order, empty no-op.
- Frontend typecheck clean; full frontend suite 3956/3956 green.

Closes #1674

🤖 Generated with [Claude Code](https://claude.com/claude-code)