### PR TITLE
fix(server): first-person narrator identity guards and aligner robustness

### DIFF
--- a/docs/superpowers/plans/2026-07-16-analyzer-first-person-narrator-fix.md
+++ b/docs/superpowers/plans/2026-07-16-analyzer-first-person-narrator-fix.md
@@ -1,0 +1,417 @@
+# Analyzer First-Person Narrator Identity Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the analyzer from scattering a Russian first-person narrator's «я» material across a phantom pronoun character, a mislabeled side-character, and the real protagonist — so re-analyzing Night Watch on the same local model attributes first-person correctly.
+
+**Architecture:** The bug is a compound of two independent root causes, fixed in two subsystems. **RC1 (stage-1 identity):** nothing stops the model from rostering a bare pronoun «Я» as a character or seeding first-person evidence onto the wrong character — fixed by a deterministic roster-dedup guard + a prompt id-rule. **RC2 (structure engine suppressed):** the dialogue-structure correction engine goes `flagOnly` below an 80% per-chapter alignment floor, and Night Watch aligned at only 65.6% because the aligner is an exact-substring match whose normalizer doesn't fold Russian ё↔е — fixed by widening the normalizer + letting the one high-precision narration demote run even below floor. Each fix is deterministic and unit-tested; a final fresh re-analysis proves it end-to-end.
+
+**Tech Stack:** TypeScript (server), Vitest, local Ollama analyzer (`gemma4-e4b-8gb:latest`), the `server/src/analyzer/dialogue-structure/` engine (srv-59).
+
+## Global Constraints
+
+- **Re-analysis model is fixed:** `gemma4-e4b-8gb:latest`, engine `local`. The fix MUST hold under a small local model — favor deterministic guards, never rely on the model obeying a prompt. (Optional Qwen-9b comparison run is informational only; Gemma is the acceptance bar due to stronger Russian.)
+- **Verification requires a FRESH analysis** (`fresh:true` / app "Start fresh"). The structure engine runs inside stage-2, downstream of the cache; a normal re-analyze hits the cache and the engine never runs.
+- **Language path:** Russian (`ru`). Conventions live in `server/src/analyzer/dialogue-structure/lang/ru.ts`.
+- **Environment:** the current worktree `server-analyzer-local-warm-gate` is broken (not in `git worktree list`, no checked-out `server/`). Create a FRESH worktree off `main` via `superpowers:using-git-worktrees` before Task 1. Junction `node_modules` per house practice.
+- TDD, one logical change per commit, DRY, YAGNI. Server is TypeScript — `npm run build` before any re-analysis.
+- Test runner: `cd server && npx vitest run <path>` (server has its own vitest project).
+
+---
+
+### Task 1: Fold ё↔е in the aligner normalizer (RC2 core)
+
+The aligner matches the model's per-sentence `text` against the chapter body by exact substring after a narrow normalization. Its fold set (case, whitespace, dash, quote, ellipsis) does NOT fold `ё↔е`. A small Russian model routinely swaps ё/е, and a single unfolded character orphans the whole sentence → sub-floor chapters → `flagOnly` → no corrections. Folding ё→е is 1:1 per-character so it preserves the offset map exactly.
+
+**Files:**
+- Modify: `server/src/analyzer/dialogue-structure/aligner.ts:68-70` (the `else` branch of `buildNormalizedMap`)
+- Test: `server/src/analyzer/dialogue-structure/aligner.test.ts`
+
+**Interfaces:**
+- Consumes: existing `alignSentences(sentences, paras, body)`, `buildNameIndex`, `parseChapterStructure`, `conventionsFor` (all already imported in the test).
+- Produces: no signature change — same `AlignmentResult`, strictly higher `alignedPct` on ё/е-divergent input.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `aligner.test.ts` inside `describe('alignSentences', ...)`:
+
+```ts
+it('(RC2) folds ё↔е so a model ё/е swap still aligns', () => {
+  const ruIdx = buildNameIndex([{ id: 'anton', name: 'Антон' }], conventionsFor('ru')!);
+  // Body uses ё in both "Ещё" and "всё".
+  const body = '— Ещё не всё, — сказал Антон.';
+  const paras = parseChapterStructure(body, ruIdx);
+  const speechSpan = paras.flatMap((p) => p.spans).find((s) => s.kind === 'speech')!;
+  expect(body.slice(speechSpan.start, speechSpan.end)).toBe('Ещё не всё,');
+
+  // Model returned the same line with е instead of ё (the classic RU drift).
+  const sentences = [mkSentence(1, 'anton', 'Еще не все,')];
+  const result = alignSentences(sentences, paras, body);
+
+  // Assert on membership + alignedPct, NOT strict array-equality: the overlap
+  // filter (aligner.ts:161) can graze the adjacent tag span depending on the
+  // comma-boundary offset, and that's not what this test is about.
+  expect(result.aligned[0].spans).toContain(speechSpan);
+  expect(result.alignedPct).toBe(100);
+});
+```
+
+> **Scope note (review fold, MAJOR 3):** ё→е is a correct, cheap, offset-preserving lever, but it is NOT proven to lift Night Watch from 65.6% to ≥80% on its own — the remaining misalignment may also be paraphrase/truncation/NFC. Treat ">80% alignment" as a **measured outcome in Task 5, not a guaranteed step**. Every speech-side correction and escalation is gated on clearing the floor (`analysis.ts:1742`), so if Task 5 shows chapters still sub-floor, the follow-up lever is NFC folding and/or a bounded fuzzy match in `findMatch` (deferred until measured — YAGNI).
+
+- [ ] **Step 2: Run it — verify it FAILS**
+
+Run: `cd server && npx vitest run src/analyzer/dialogue-structure/aligner.test.ts -t "folds ё"`
+Expected: FAIL — `alignedPct` is `0` (needle `еще не все,` not found in body normalized as `ещё не всё,`).
+
+- [ ] **Step 3: Implement the fold**
+
+In `aligner.ts`, change the `else` branch of `buildNormalizedMap` (currently lines 68-70):
+
+```ts
+    } else {
+      out = raw[i].toLowerCase();
+      // RU: models routinely swap ё↔е. Fold to е so a single ё/е divergence
+      // doesn't orphan the whole sentence (which would drag the chapter under
+      // the 80% alignment floor and suppress ALL structure corrections).
+      // 1:1 char replacement — preserves the offset map exactly.
+      if (out === 'ё') out = 'е';
+    }
+```
+
+- [ ] **Step 4: Run it — verify it PASSES**
+
+Run: `cd server && npx vitest run src/analyzer/dialogue-structure/aligner.test.ts`
+Expected: PASS (new test + all existing aligner tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/analyzer/dialogue-structure/aligner.ts server/src/analyzer/dialogue-structure/aligner.test.ts
+git commit -m "fix(analyzer): fold ё↔е in aligner normalizer so RU ё/е drift doesn't orphan sentences"
+```
+
+---
+
+### Task 2: Force-merge a bare first-person-pronoun character (RC1)
+
+`roster-dedup.ts` Tier-3 links a character X→Y when X's name-key is in Y's alias set, but auto-merges only when the link is MUTUAL or the linking name is MULTI-token — to protect single-token role-word minors (`шеф`). A phantom character literally named «Я» (name-key `я`) links to the real narrator (Антон, who carries alias «Я») but is single-token + non-mutual, so it survives as a standalone 0-line row. A bare first-person pronoun is never a real character; it must always merge into whoever claims that pronoun as an alias.
+
+**Files:**
+- Modify: `server/src/analyzer/roster-dedup.ts` (imports; rename `_opts`→`opts`; add `isFirstPersonName`; extend the Tier-3 `strong` condition ~line 212-215)
+- Test: `server/src/analyzer/roster-dedup.test.ts`
+
+**Interfaces:**
+- Consumes: `conventionsFor(language)` from `./dialogue-structure/lang/index.js` → `.pronouns.firstPerson: RegExp | undefined`.
+- Produces: `dedupeRosterByName(characters, sentences, { language })` unchanged signature; now emits a rewrite `phantom→narratorProtagonist` and drops the phantom when a pronoun-named char links to an alias-holder.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `roster-dedup.test.ts`:
+
+```ts
+describe('dedupeRosterByName — first-person pronoun phantom (RC1)', () => {
+  it('force-merges a bare «Я» character into the char that lists «Я» as an alias', () => {
+    const chars = [
+      c({ id: 'антон', name: 'Антон', gender: 'male', aliases: ['Антон Городецкий', 'Я'] }),
+      c({ id: 'я', name: 'Я', gender: 'male', aliases: [] }),
+    ];
+    const r = dedupeRosterByName(chars as any, [...sent('антон', 196), ...sent('я', 7)], { language: 'ru' });
+    expect(r.characters.map((x) => x.id)).toEqual(['антон']); // phantom gone, Антон survives (more lines)
+    expect(r.rewrites['я']).toBe('антон');
+  });
+
+  it('routes a bare «Я» to the narrator when NO character claims it as an alias (fallback)', () => {
+    const chars = [
+      c({ id: 'антон', name: 'Антон', gender: 'male', aliases: [] }),
+      c({ id: 'я', name: 'Я', gender: 'male', aliases: [] }),
+    ];
+    const r = dedupeRosterByName(chars as any, [...sent('антон', 196), ...sent('я', 7)], { language: 'ru' });
+    // A bare pronoun is NEVER a real character: with no alias-holder to absorb
+    // it, it routes to the narrator (first-person-with-no-owner = narrator voice).
+    expect(r.characters.map((x) => x.id)).toEqual(['антон']);
+    expect(r.rewrites['я']).toBe('narrator');
+  });
+});
+```
+
+> **Framing (review fold, MAJOR 4 + MINOR 6):** the Tier-3 edge fires ONLY when a roster peer aliases «я» — on a fresh run the model may not reproduce that alias. The narrator-fallback below makes "a bare-pronoun character never survives" **unconditional** regardless of aliasing. Note this also activates for en/es/fr/de/zh/ja (each `conventionsFor` table has a `firstPerson` pronoun) — a deliberate, desirable generalization beyond Russian.
+
+- [ ] **Step 2: Run — verify FAIL**
+
+Run: `cd server && npx vitest run src/analyzer/roster-dedup.test.ts -t "first-person pronoun phantom"`
+Expected: first test FAILS (both `антон` and `я` survive; `rewrites['я']` undefined). Second test already passes.
+
+- [ ] **Step 3: Implement**
+
+In `roster-dedup.ts`, add the import near the top (after line 4):
+
+```ts
+import { conventionsFor } from './dialogue-structure/lang/index.js';
+```
+
+Rename the parameter `_opts` → `opts` in the `dedupeRosterByName` signature (line 52) and use it. Then, immediately after `const nameKeyOf = (ch: CharacterOutput): string => normaliseNameKey(ch.name);` (~line 176), add:
+
+```ts
+  // A "character" whose NAME is the language's bare first-person pronoun (the
+  // model rostering «Я»/«I» as its own entity) is never real — it's the
+  // narrator-protagonist's self-reference. Force it to a STRONG edge so it
+  // merges into whichever real character claims that pronoun as an alias,
+  // overriding the single-token weak-link gate that protects role-word minors.
+  const firstPersonRx = conventionsFor(opts.language)?.pronouns.firstPerson ?? null;
+  const isFirstPersonName = (ch: CharacterOutput): boolean =>
+    firstPersonRx !== null && firstPersonRx.test(` ${nameKeyOf(ch)} `);
+```
+
+Extend the `strong` condition in the Tier-3 edge loop (currently lines 212-215):
+
+```ts
+      const strong =
+        mutual ||
+        (linkXY && (tokens(x.name).length >= 2 || isFirstPersonName(x))) ||
+        (linkYX && (tokens(y.name).length >= 2 || isFirstPersonName(y)));
+```
+
+Then add the unconditional fallback immediately AFTER the Tier-3 survivor filter (`roster = roster.filter((ch) => !droppedT3.has(ch.id));`, ~line 268) — before the Tier-3 weak-suggestion pass so a routed pronoun row never spawns a suggestion:
+
+```ts
+  // Fallback: a bare first-person-pronoun character that STILL stands (no
+  // roster peer aliased it above) is never a real character — route it and its
+  // lines to the narrator rather than leave a pronoun masquerading as a
+  // speaker. Terminal rewrite (→ narrator), so ordering vs the collapse below
+  // is irrelevant. Guarantees "no bare-pronoun row survives" unconditionally.
+  for (const ch of roster) {
+    if (ch.id !== NARRATOR_ID && isFirstPersonName(ch)) rewrites[ch.id] = NARRATOR_ID;
+  }
+  roster = roster.filter((ch) => ch.id === NARRATOR_ID || !isFirstPersonName(ch));
+```
+
+- [ ] **Step 4: Run — verify PASS**
+
+Run: `cd server && npx vitest run src/analyzer/roster-dedup.test.ts`
+Expected: PASS (both new tests + all existing tiers green; survivor ranks by tokens then lines so Антон (196) beats `я` (7)).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/analyzer/roster-dedup.ts server/src/analyzer/roster-dedup.test.ts
+git commit -m "fix(analyzer): force-merge bare first-person-pronoun phantom into its alias-holder"
+```
+
+---
+
+### Task 3: Apply the pure-narration demote even below the alignment floor (RC2 safety net)
+
+Below the 80% floor `crossExamine` runs `flagOnly` and corrects NOTHING — including `decideNarrationOnly`, which demotes a named-character-attributed pure-narration sentence to `narrator`. That demote is the rule that strips first-person narration («я скосил глаза…») off Егор, and it's high-precision (a narration paragraph is narrator voice on its own structural evidence, independent of window/alternation quality). Let this ONE correction run even below floor.
+
+> **Framing (review fold, BLOCKER 1):** this is NOT a new high-precision claim — it **restores Wave A parity**. The legacy `applyNarratorDefault` (still used for unsupported languages, `analysis.ts:1786`) demoted narration to narrator unconditionally; the srv-59 structure engine *regressed* ru books by doing nothing below floor (escalation is skipped too, `analysis.ts:1769`). Task 3 closes that regression. **It deliberately weakens the floor contract** from "below floor ⇒ zero corrections" to "below floor ⇒ only the pure-narration demote runs; all speech/tag/alternation/escalation corrections stay suppressed." That contract change is encoded in a shipped invariant test (`cross-examine.test.ts:247-260`) which MUST be consciously revised (Step 3b) — it is not a silent side effect.
+
+**Files:**
+- Modify: `server/src/analyzer/dialogue-structure/cross-examine.ts` (add `isPureNarrationAligned`; branch inside the `crossExamine` forEach, ~lines 281-286)
+- Test: `server/src/analyzer/dialogue-structure/cross-examine.test.ts`
+
+**Interfaces:**
+- Consumes: existing `AlignedSentence`, `decideNarrationOnly`, `flagOnlyDecision`, `NARRATOR_ID`.
+- Produces: `crossExamine` unchanged signature; below-floor pure-narration on a named char now returns a `narrator` correction instead of a flag-only pass-through.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `cross-examine.test.ts`:
+
+```ts
+it('(RC2) below the alignment floor, still demotes pure-narration off a named char to narrator', () => {
+  const as = {
+    sentence: mkSentence('егор'),
+    spans: [{ kind: 'narration', start: 0, end: 12 } as SpanEvidence],
+    lumped: false,
+  };
+  const result = crossExamine(
+    { alignedPct: 60, aligned: [as] } as any,
+    { rosterIds: new Set(['егор', 'narrator']), unknownBucketIds: new Set(), alignmentFloorPct: 80 },
+  );
+  expect(result.sentences[0].characterId).toBe('narrator');
+  expect(result.sentences[0].confidence).toBeLessThanOrEqual(0.5);
+});
+```
+
+(`mkSentence` and the `SpanEvidence` import already exist in this test file; if `mkSentence` there requires a different arg shape, match the file's existing helper.)
+
+- [ ] **Step 2: Run — verify FAIL**
+
+Run: `cd server && npx vitest run src/analyzer/dialogue-structure/cross-examine.test.ts -t "below the alignment floor, still demotes"`
+Expected: FAIL — `characterId` is `'егор'` (flag-only kept the model id).
+
+- [ ] **Step 3: Implement**
+
+In `cross-examine.ts`, add a helper above `crossExamine` (after `decideSentence`):
+
+```ts
+/** A pure-narration aligned sentence (spans present, no speech, not lumped) is
+    narrator voice on its own structural evidence — so this ONE demote is safe
+    to apply even below the alignment floor, where every other correction is
+    suppressed as unreliable. */
+function isPureNarrationAligned(as: AlignedSentence): boolean {
+  return as.spans.length > 0 && !as.lumped && !as.spans.some((s) => s.kind === 'speech');
+}
+```
+
+Replace the decision line in the `crossExamine` forEach (currently `const decision = flagOnly ? flagOnlyDecision(as) : decideSentence(as, opts, block);`) with:
+
+```ts
+    let decision: Decision;
+    if (flagOnly) {
+      // Suppress corrections below the floor EXCEPT the high-precision
+      // pure-narration demote, which doesn't depend on the (unreliable)
+      // window/alternation picture.
+      if (isPureNarrationAligned(as) && as.sentence.characterId !== NARRATOR_ID) {
+        decision = decideNarrationOnly(as.sentence.characterId, block);
+      } else {
+        block.active = false;
+        decision = flagOnlyDecision(as);
+      }
+    } else {
+      decision = decideSentence(as, opts, block);
+    }
+```
+
+- [ ] **Step 3b: Consciously revise the shipped below-floor invariant test**
+
+The existing test `cross-examine.test.ts:247-260` asserts below-floor = zero corrections, with an `olga` narration fixture commented `// would normally demote`. Task 3 makes that fixture demote. Rewrite the test to encode the NEW (weakened) contract — speech/tag corrections still suppressed, pure-narration now demotes:
+
+```ts
+  it('below the alignment floor -> speech/tag corrections suppressed, but pure-narration still demotes (Wave A parity)', () => {
+    const list = [
+      aligned(mkSentence('narrator'), [speechSpan({ characterId: 'anton', source: 'tag-name' })]), // tag-name correction SUPPRESSED below floor
+      aligned(mkSentence('olga', 0.9), [narrationSpan()]), // pure narration STILL demotes to narrator (Wave A parity)
+      aligned(mkSentence('anton'), []), // unaligned
+    ];
+    const result = run(list, 50); // 50% < 80% floor
+
+    expect(result.report.flagOnly).toBe(true);
+    // the tag-name-contradicting speech line is NOT corrected below floor; only the narration demote is
+    expect(result.sentences.map((s) => s.characterId)).toEqual(['narrator', 'narrator', 'anton']);
+    expect(result.report.corrected).toBe(1);
+    for (const s of result.sentences) expect(s.confidence).toBeLessThanOrEqual(CONFIDENCE.UNALIGNED_CAP);
+  });
+```
+
+(The demoted `olga` line clamps to ≤0.5 as run-first, which is ≤ `UNALIGNED_CAP` 0.74, so the confidence invariant still holds.)
+
+- [ ] **Step 4: Run — verify PASS**
+
+Run: `cd server && npx vitest run src/analyzer/dialogue-structure/cross-examine.test.ts`
+Expected: PASS (new below-floor demote test + the revised invariant test + all other cross-examine tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/analyzer/dialogue-structure/cross-examine.ts server/src/analyzer/dialogue-structure/cross-examine.test.ts
+git commit -m "fix(analyzer): run the pure-narration demote even below the alignment floor"
+```
+
+---
+
+### Task 4: Stage-1 prompt id-rule for the first-person voice (RC1 defense-in-depth)
+
+The stage-1 prompt tells the model the first-person voice is the protagonist/narrator but gives no id rule and never forbids rostering the bare pronoun. This is defense-in-depth only (Tasks 1-3 are the deterministic guarantees); it reduces the chance the small model seeds the problem. Verified by the Task 5 re-analysis, not a unit test (prompt-string assertions are brittle and the model behavior is the real signal).
+
+**Files:**
+- Modify: `server/src/routes/analysis.ts:1432-1436` (the narrator/first-person guidance block in `buildStage1ChapterInbox`)
+- Modify: `skills/audiobook-character-detection-per-chapter.md:78-80` (mirror the same rule)
+
+- [ ] **Step 1: Add the id-rule to the inline prompt**
+
+In `analysis.ts`, in the narrator/first-person guidance (~line 1432-1436), append these sentences to the existing block (keep the current text; add after it):
+
+```
+The first-person «я» voice is exactly ONE character. NEVER create a character whose name is a bare pronoun (я, I, ich, …) — that is not a character. Attribute first-person NARRATION to `narrator`; attribute first-person SPOKEN dialogue to the single protagonist and record «я» in that protagonist's aliases. Do NOT spread first-person lines across several characters, and never attach a first-person line as evidence to a secondary character.
+```
+
+- [ ] **Step 2: Mirror the rule in the skill prompt**
+
+In `skills/audiobook-character-detection-per-chapter.md` (~line 78-80), add the same paragraph so the system-instruction and inbox agree.
+
+- [ ] **Step 3: Build to confirm no syntax break**
+
+Run: `cd server && npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/src/routes/analysis.ts skills/audiobook-character-detection-per-chapter.md
+git commit -m "feat(analyzer): stage-1 prompt id-rule for the single first-person voice"
+```
+
+---
+
+### Task 5: Fresh re-analysis of Night Watch on Gemma — acceptance
+
+Prove the compound fix end-to-end on the reproduction book, using the same model, via a FRESH analysis (cache-bypassing).
+
+**Files:** none (operational). Book id: `mns_oyK7Po6BiT`; bookDir: `C:\AudiobookWorkspace\books\Сергей Лукьяненко\The Night Watch Tetralogy\Ночной дозор\.audiobook\`.
+
+- [ ] **Step 1: Rebuild + confirm engine config**
+
+```bash
+cd server && npm run build
+```
+Confirm `server/.env` (or defaults): `STRUCTURE_ENGINE=true`, `ATTRIBUTION_ESCALATION=local` (cloud not required), engine `local`, model `gemma4-e4b-8gb:latest`.
+
+- [ ] **Step 2: Snapshot BEFORE (for a real diff)**
+
+```bash
+bookDir="C:/AudiobookWorkspace/books/Сергей Лукьяненко/The Night Watch Tetralogy/Ночной дозор/.audiobook"
+jq '.analysisProvenance.report' "$bookDir/state.json"   # baseline: alignedPct 65.6, flagged 10637
+jq '[.characters[] | select(.id=="я")] | length' "$bookDir/cast.json"   # baseline: 1 (phantom present)
+jq '[.sentences[] | select(.characterId=="егор")] | length' "$bookDir/manuscript-edits.json"  # baseline includes ~732 first-person
+```
+
+- [ ] **Step 3: Trigger a FRESH analysis (NOT a cached re-analyze)**
+
+App: Night Watch → analysis → **"Start fresh"**. Or API: `POST /api/manuscripts/mns_oyK7Po6BiT/analysis` body `{ "fresh": true }`. Budget 30+ minutes (stage-1 + stage-2 over ~14k sentences on the local model + escalation).
+
+- [ ] **Step 4: Watch the live per-chapter signal**
+
+Tail server stdout / `server.log` for `[analysis:structure] ch=N aligned=..% confirmed=.. corrected=.. flagged=..`. Expect `aligned%` markedly higher than before (target: most chapters ≥ 80, so corrections + the narration demote actually run).
+
+- [ ] **Step 5: Read the verdict**
+
+```bash
+jq '.analysisProvenance.report' "$bookDir/state.json"   # alignedPct UP, flagged DOWN vs 10637
+jq '[.characters[] | select(.id=="я")] | length' "$bookDir/cast.json"   # EXPECT 0 (phantom gone)
+jq '[.characters[] | {id, role, lines}] ' "$bookDir/cast.json"          # Егор no longer "Protagonist", line count sane
+jq '.sentences | map(.characterId) | group_by(.) | map({id: .[0], n: length}) | sort_by(-.n)' "$bookDir/manuscript-edits.json"
+```
+
+**Acceptance (Gemma is the bar) — calibrated to what the deterministic fixes actually guarantee (review fold, MAJOR 2 & 3):**
+- **Phantom `я` character GONE from cast.json** (hard pass — Task 2 makes this unconditional).
+- **First-person NARRATION off Егор → ~0** (hard pass — `decideNarrationOnly`, now running below floor via Task 3). Егор keeps only his genuine dialogue + any residual first-person *speech*.
+- **First-person SPEECH on Егор: markedly reduced but NOT required to be 0.** Unanchored first-person quotes ("- Я упустил вампиршу") are structurally ambiguous (any speaker says «я») and are left *flagged* by design (#1676). Report the residual count as a bounded number, not a zero. Reattribution of these depends on alignment clearing 80% (so tag-anchored Антон lines auto-correct) + Task 4's prompt — measure, don't assume.
+- **`alignedPct` — MEASURED, not asserted.** Record the new book-wide value and the per-chapter `[analysis:structure] aligned=..%` lines vs the 65.6% baseline. If a majority of chapters are still sub-floor, that's the signal to add NFC/fuzzy matching (Task 1 scope note) — a follow-up, not a Task-5 failure.
+- No characterIds in `manuscript-edits.json` absent from `cast.json` (id-drift not reintroduced).
+
+- [ ] **Step 6: (Optional) Qwen-9b comparison run**
+
+Repeat Steps 3-5 with the Qwen-9b model for a comparison data point only. Expectation (user): Gemma ≥ Qwen on Russian. Do NOT gate acceptance on Qwen.
+
+- [ ] **Step 7: Record outcome**
+
+If pass: note it against issue for this fix + update memory (`project_analyzer_first_person_narrator_egor_misattribution` → shipped) and flag the srv-59 acceptance as likely unblocked. If fail/surprising: capture `state.json` `generationError` (not server.log), the `[analysis:structure]` lines for the bad chapters, and escalation artifacts under `server/handoff/`.
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** RC1 phantom → Task 2; RC1 stage-1 seeding → Task 4 (prompt) + downstream RC2 demote; RC2 low alignment → Task 1; RC2 floor suppression of narration demote → Task 3; same-model fresh re-analysis + Qwen compare → Task 5. All covered.
+- **Deliberately NOT doing:** forcing unanchored first-person QUOTES ("- Я упустил вампиршу") to the narrator — structurally ambiguous (any speaker says «я»); would over-correct. These remain flagged + escalated; Task 4 reduces them at the source. Features (b)/(c) are issue #1676, out of scope.
+- **Ordering:** Tasks 1-4 are independent and unit-tested; do them in any order; Task 5 depends on all. Task 1 is highest-leverage for RC2.
+
+## Independent review folds (2026-07-16, opus adversarial pass)
+
+- **BLOCKER 1 — folded:** Task 3 breaks shipped invariant `cross-examine.test.ts:247-260`. Added Step 3b to consciously revise it + reframed Task 3 as restoring Wave A below-floor narration demote (documents the weakened floor contract).
+- **MAJOR 2 — folded:** Task 5 acceptance split into first-person NARRATION (deterministic → ~0) vs SPEECH (flagged/bounded, #1676, not required 0).
+- **MAJOR 3 — folded:** Task 1 ">80% alignment" downgraded to a measured Task-5 outcome; NFC/fuzzy noted as the follow-up lever if chapters stay sub-floor.
+- **MAJOR 4 — folded:** Task 2 given an unconditional narrator-fallback so a bare-pronoun row never survives even when no peer aliases it; framed honestly; noted it generalizes to all languages (MINOR 6).
+- **MINOR 5 — acknowledged (no code):** `previewFoldForLiveView` (analysis.ts:749) dedups with empty sentences, so the *live* "Cast so far" pill could momentarily show «Я» surviving on roster order; cosmetic only — final cast.json (analysis.ts:726, real sentences) is correct and the frontend snapshot-replaces the roster (per prior live-cast fix).
+- **MINOR 7 — folded:** Task 1 test asserts `spans` membership + alignedPct, not strict array-equality (avoids the tag-span overlap off-by-one).
+- **Confirmed sound by review:** RC1/RC2 diagnosis; Task 1 fold correctness/offset-preservation/symmetry; Task 2 union + survivor-ranking picks Антон, no `isFirstPersonName` false-positive on Яков/Оля/Ян, no circular import, `opts.language` passed by callers.

--- a/docs/superpowers/plans/2026-07-16-analyzer-first-person-narrator-fix.md
+++ b/docs/superpowers/plans/2026-07-16-analyzer-first-person-narrator-fix.md
@@ -498,6 +498,96 @@ git commit -m "fix(analyzer): prefer scene-separator boundaries when splitting s
 
 ---
 
+### Task 8: Aligner robustness — combining-mark fold + bounded prefix-anchored fuzzy fallback (RC2 depth)
+
+The 2026-07-17 verification showed alignedPct STAYED low (54%) on gemma-e4b, keeping most chapters below the 80% floor so the structure engine's speech/pronoun corrections never ran — the residual «я»→Егор. ё→е alone (T1) wasn't enough: gemma also emits decomposed diacritics and paraphrases/drops words mid-sentence. Two additive, offset-preserving improvements to `aligner.ts`:
+
+**(A)** strip Unicode combining marks (`\p{Mn}`) in `buildNormalizedMap` — folds decomposed ё (е+U+0308) and other decomposed forms to match composed body text; 1:1-or-empty per char, offset-safe.
+
+**(B)** a **bounded prefix-anchored fuzzy fallback** in `alignSentences`: when exact match fails AND the needle is long (≥24 chars), anchor on its 16-char prefix (usually copied faithfully — a dialogue dash + first words) and approximate the extent from needle length, so a paraphrased sentence still attaches to its paragraph's spans. Bounded (long needles only) to avoid false anchors on short ambiguous lines. Approximate offsets are fine — the structure engine classifies by overlapping spans (speech/narration/tag), not exact boundaries.
+
+**Files:** Modify `server/src/analyzer/dialogue-structure/aligner.ts`; Test `server/src/analyzer/dialogue-structure/aligner.test.ts`.
+
+**Interfaces:** `alignSentences` / `buildNormalizedMap` unchanged signatures; strictly ≥ current alignedPct (fuzzy only fires when exact fails).
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+it('(RC2) aligns across composed vs decomposed ё (combining diaeresis)', () => {
+  const ruIdx = buildNameIndex([{ id: 'anton', name: 'Антон' }], conventionsFor('ru')!);
+  const body = '— Ещё раз, — сказал Антон.'; // composed ё
+  const paras = parseChapterStructure(body, ruIdx);
+  const speechSpan = paras.flatMap((p) => p.spans).find((s) => s.kind === 'speech')!;
+  const decomposed = 'Ещё раз,'.normalize('NFD'); // е + U+0308
+  const result = alignSentences([mkSentence(1, 'anton', decomposed)], paras, body);
+  expect(result.aligned[0].spans).toContain(speechSpan);
+  expect(result.alignedPct).toBe(100);
+});
+
+it('(RC2) prefix-anchored fuzzy fallback aligns a paraphrased long sentence to its paragraph', () => {
+  const ruIdx = buildNameIndex([{ id: 'anton', name: 'Антон' }], conventionsFor('ru')!);
+  const body = '— Я упустил вампиршу вчера ночью возле старого парка, — сказал Антон.';
+  const paras = parseChapterStructure(body, ruIdx);
+  const speechSpan = paras.flatMap((p) => p.spans).find((s) => s.kind === 'speech')!;
+  const drifted = 'Я упустил вампиршу вчера возле тёмного парка,'; // middle words changed/dropped
+  const result = alignSentences([mkSentence(1, 'anton', drifted)], paras, body);
+  expect(result.aligned[0].spans).toContain(speechSpan);
+  expect(result.alignedPct).toBe(100);
+});
+
+it('(RC2) does NOT fuzzy-match a short needle (avoids false anchors)', () => {
+  const ruIdx = buildNameIndex([{ id: 'anton', name: 'Антон' }], conventionsFor('ru')!);
+  const body = '— Да, конечно, я помню тот давний день очень хорошо, — кивнул Антон.';
+  const paras = parseChapterStructure(body, ruIdx);
+  const result = alignSentences([mkSentence(1, 'anton', 'Нет.')], paras, body); // <24 chars, absent
+  expect(result.aligned[0].spans).toEqual([]);
+});
+```
+
+- [ ] **Step 2: Run — confirm the ё-decomposed and fuzzy tests FAIL, the short-needle test PASSES.**
+
+- [ ] **Step 3: Implement**
+
+At module level in `aligner.ts` add:
+```ts
+const COMBINING_MARK = /\p{Mn}/u;
+const FUZZY_MIN_NEEDLE = 24;
+const FUZZY_ANCHOR_LEN = 16;
+```
+In `buildNormalizedMap`, extend the `else` branch (which already has the ё→е fold):
+```ts
+    } else {
+      out = raw[i].toLowerCase();
+      if (out === 'ё') out = 'е';
+      else if (COMBINING_MARK.test(out)) out = ''; // drop decomposed diacritics (offset-safe)
+    }
+```
+In `alignSentences`, replace the per-sentence match block (lines ~153-162) with the fuzzy-fallback version:
+```ts
+    const needle = normalize(sentence.text);
+    let matchStart = needle.length > 0 ? findMatch(normBody, needle, cursor) : -1;
+    if (matchStart === -1 && needle.length >= FUZZY_MIN_NEEDLE) {
+      // Exact failed (gemma paraphrased/dropped a word). Anchor on the prefix so
+      // the sentence still attaches to its paragraph; approximate the extent.
+      const anchorPos = findMatch(normBody, needle.slice(0, FUZZY_ANCHOR_LEN), cursor);
+      if (anchorPos !== -1) matchStart = anchorPos;
+    }
+
+    if (matchStart === -1) {
+      aligned.push({ sentence, spans: [], lumped: false });
+      continue;
+    }
+
+    const matchEnd = Math.min(matchStart + needle.length, normBody.length);
+    cursor = matchEnd;
+```
+(The `Math.min` is a no-op for exact matches — those never exceed the body — so exact behavior is byte-identical.)
+
+- [ ] **Step 4: Run `cd server && npx vitest run src/analyzer/dialogue-structure/aligner.test.ts` — all pass (new + existing).**
+- [ ] **Step 5: Commit** `fix(server): aligner combining-mark fold + bounded prefix-anchored fuzzy fallback`
+
+---
+
 ### Task 7: Fresh re-analysis of Night Watch on Gemma — acceptance
 
 Prove the compound fix end-to-end on the reproduction book, using the same model, via a FRESH analysis (cache-bypassing).

--- a/docs/superpowers/plans/2026-07-16-analyzer-first-person-narrator-fix.md
+++ b/docs/superpowers/plans/2026-07-16-analyzer-first-person-narrator-fix.md
@@ -4,7 +4,7 @@
 
 **Goal:** Stop the analyzer from scattering a Russian first-person narrator's «я» material across a phantom pronoun character, a mislabeled side-character, and the real protagonist — so re-analyzing Night Watch on the same local model attributes first-person correctly.
 
-**Architecture:** The bug is a compound of two independent root causes, fixed in two subsystems. **RC1 (stage-1 identity):** nothing stops the model from rostering a bare pronoun «Я» as a character or seeding first-person evidence onto the wrong character — fixed by a deterministic roster-dedup guard + a prompt id-rule. **RC2 (structure engine suppressed):** the dialogue-structure correction engine goes `flagOnly` below an 80% per-chapter alignment floor, and Night Watch aligned at only 65.6% because the aligner is an exact-substring match whose normalizer doesn't fold Russian ё↔е — fixed by widening the normalizer + letting the one high-precision narration demote run even below floor. Each fix is deterministic and unit-tested; a final fresh re-analysis proves it end-to-end.
+**Architecture:** The bug is a compound of three root causes. **RC1 (stage-1 identity):** nothing stops the model from rostering a bare pronoun «Я» as a character or seeding first-person evidence onto the wrong character — fixed by a deterministic roster-dedup guard + a prompt id-rule. **RC2 (structure engine suppressed):** the dialogue-structure correction engine goes `flagOnly` below an 80% per-chapter alignment floor, and Night Watch aligned at only 65.6% because the aligner is an exact-substring match whose normalizer doesn't fold Russian ё↔е — fixed by widening the normalizer + letting the one high-precision narration demote run even below floor. **RC3 (stage-2 prompt has no «я» anchor):** the model is handed the roster with no first-person→character mapping, so a model told "egor = Protagonist" routes first-person prose to egor — fixed by surfacing the known first-person-narrator id into the stage-2 prompt (Task 5), plus separator-aware chunking hardening (Task 6). Each code fix is deterministic and unit-tested; a final fresh re-analysis on the same local model proves it end-to-end.
 
 **Tech Stack:** TypeScript (server), Vitest, local Ollama analyzer (`gemma4-e4b-8gb:latest`), the `server/src/analyzer/dialogue-structure/` engine (srv-59).
 
@@ -344,7 +344,161 @@ git commit -m "feat(analyzer): stage-1 prompt id-rule for the single first-perso
 
 ---
 
-### Task 5: Fresh re-analysis of Night Watch on Gemma — acceptance
+### Task 5: Anchor first-person «я» to the narrator id in the stage-2 prompt (RC3-investigation lever)
+
+The stage-2 model prompt passes the roster as `{id,name,role}` with NO «я»→character mapping (analysis.ts:1527, :1592), so a model told "egor = Protagonist" routes first-person prose to egor. The pipeline already computes the first-person narrator (`findFirstPersonCharacter`, analysis.ts:1608) but only feeds it to the structure engine (:1726), never the model. Surface it as an explicit prompt instruction. **This is the most direct lever for the SPEECH-side «я»→Егор lines that RC2's narration demote does not touch** — and the fresh re-analysis is where it takes effect.
+
+**Files:**
+- Modify: `server/src/routes/analysis.ts` — `buildStage2ChapterInbox` (:1491) + `buildStage2ChunkInbox` (:1545): add trailing `firstPersonId: string | null` param and an instruction block; `attributeChapterStage2` (:1654): compute the id once and thread it through `callForBody`. `export` both builders for testing.
+- Test: `server/src/routes/analysis.test.ts` (add a describe block).
+
+**Interfaces:**
+- Consumes: `findFirstPersonCharacter(characters, conv)` (exists, :1608), `conventionsFor(language)`.
+- Produces: `buildStage2ChapterInbox(manuscriptId, title, stage1, chapter, firstPersonId)`; `buildStage2ChunkInbox(manuscriptId, title, stage1, chapter, subBody, precedingContext, firstPersonId)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { buildStage2ChapterInbox } from './analysis.js'; // add to exports in Step 3
+
+describe('stage-2 prompt first-person anchor (RC3)', () => {
+  const stage1 = { characters: [
+    { id: 'антон', name: 'Антон', role: 'Colleague', aliases: ['Антон Городецкий', 'Я'] },
+    { id: 'егор', name: 'Егор', role: 'Protagonist / Observer' },
+  ]} as any;
+  const chapter = { id: 1, title: 'Ch1', body: 'Я кивнул.' };
+
+  it('emits the first-person anchor naming the narrator id when one is provided', () => {
+    const prompt = buildStage2ChapterInbox('m', 'Title', stage1, chapter, 'антон');
+    expect(prompt).toContain('First-person narrator');
+    expect(prompt).toContain('`антон`');
+  });
+
+  it('omits the anchor block when firstPersonId is null', () => {
+    const prompt = buildStage2ChapterInbox('m', 'Title', stage1, chapter, null);
+    expect(prompt).not.toContain('First-person narrator');
+  });
+});
+```
+
+- [ ] **Step 2: Run — verify FAIL**
+
+Run: `cd server && npx vitest run src/routes/analysis.test.ts -t "first-person anchor"`
+Expected: FAIL — `buildStage2ChapterInbox` is not exported / doesn't accept `firstPersonId`.
+
+- [ ] **Step 3: Implement**
+
+`export` both builders. Add the `firstPersonId: string | null` param to each. In each, build the block and insert it right before the body section (`## Chapter …` / `## Section to attribute …`):
+
+```ts
+  const firstPersonBlock = firstPersonId
+    ? `## First-person narrator
+
+This manuscript is narrated in the FIRST PERSON. Every first-person pronoun («я», «меня», «мне», «мной», «мы») refers to character id \`${firstPersonId}\`. Attribute first-person narration and any first-person spoken line to \`${firstPersonId}\` UNLESS a dialogue tag explicitly names a different speaker. Never route a first-person line to another character merely because that character is prominent nearby.
+
+`
+    : '';
+```
+
+Insert `${firstPersonBlock}` immediately before `## Chapter ${chapter.id}` (chapter builder) and before `## Section to attribute` (chunk builder — after `${contextBlock}`).
+
+Then in `attributeChapterStage2` (:1654), compute the id once before `runStage2ChapterChunked` and thread it into both builder calls inside `callForBody`:
+
+```ts
+  const fpConventions = conventionsFor(opts.stageCall.language);
+  const firstPersonId = fpConventions ? findFirstPersonCharacter(opts.stage1.characters, fpConventions) : null;
+```
+
+Update the two `callForBody` builder invocations to pass `firstPersonId` as the final argument.
+
+- [ ] **Step 4: Run — verify PASS**
+
+Run: `cd server && npx vitest run src/routes/analysis.test.ts`
+Expected: PASS (new tests + existing analysis tests green — the extra param is additive; existing callers pass the new arg).
+
+> **Note:** this lever is only as good as `findFirstPersonCharacter` returning the right id, which needs the stage-1 roster to carry «я» in the narrator's aliases — that is exactly what Task 4's prompt rule reinforces. If a fresh run still fragments Антон or omits the «я» alias, the anchor no-ops (null) rather than mis-anchoring — safe by construction.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/routes/analysis.ts server/src/routes/analysis.test.ts
+git commit -m "feat(server): anchor first-person «я» to the narrator id in the stage-2 prompt"
+```
+
+---
+
+### Task 6: Prefer scene-separator boundaries when splitting stage-2 chunks (RC3 hardening)
+
+`splitBodyIntoChunks` splits by size at blank-line boundaries and does NOT prefer scene/section separators (`***`, `* * *`, `⁂`), so a chunk can straddle a scene break. Evidence shows this did NOT cause the Night Watch bug, but a chunk straddling two scenes is a latent attribution-confusion risk. Make a word-free separator paragraph a preferred break point. Only affects over-budget bodies; lossless (`chunks.join('')` still reproduces the body).
+
+**Files:**
+- Modify: `server/src/analyzer/stage2-chunk.ts` — `splitBodyIntoChunks` (:133-155)
+- Test: `server/src/analyzer/stage2-chunk.test.ts`
+
+**Interfaces:**
+- Consumes: `attributableWordCount` (already imported at stage2-chunk.ts:34).
+- Produces: `splitBodyIntoChunks` unchanged signature; a scene-separator unit now forces a chunk boundary.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('(RC3) prefers a scene-separator boundary so no chunk straddles two scenes', () => {
+  const sceneA = 'а'.repeat(60) + '.\n\n';
+  const sep = '***\n\n';
+  const sceneB = 'б'.repeat(60) + '.\n\n';
+  const body = sceneA + sceneA + sep + sceneB + sceneB; // ~260 chars, 4 prose paras + separator
+  const chunks = splitBodyIntoChunks(body, 200); // over budget → must split
+
+  // No chunk contains prose from BOTH scenes.
+  for (const ch of chunks) {
+    expect(ch.includes('а') && ch.includes('б')).toBe(false);
+  }
+  expect(chunks.join('')).toBe(body); // lossless
+});
+```
+
+- [ ] **Step 2: Run — verify FAIL**
+
+Run: `cd server && npx vitest run src/analyzer/stage2-chunk.test.ts -t "scene-separator boundary"`
+Expected: FAIL — without the fix, chunk 1 packs `аа*** б` (194 < 200) so it contains both `а` and `б`.
+
+- [ ] **Step 3: Implement**
+
+In `splitBodyIntoChunks`, add a helper and make a separator unit force a break. Replace the packing loop (currently lines 144-152):
+
+```ts
+  const isSceneSeparatorUnit = (u: string): boolean =>
+    u.trim().length > 0 && attributableWordCount(u) === 0;
+  const chunks: string[] = [];
+  let cur = '';
+  for (const u of units) {
+    // A scene-separator paragraph forces a boundary BEFORE it, so the separator
+    // (and the scene that follows) starts a fresh chunk — no chunk straddles a
+    // scene break. Size overflow breaks too, as before.
+    if (cur && (isSceneSeparatorUnit(u) || cur.length + u.length > charBudget)) {
+      chunks.push(cur);
+      cur = u;
+    } else {
+      cur += u;
+    }
+  }
+```
+
+- [ ] **Step 4: Run — verify PASS**
+
+Run: `cd server && npx vitest run src/analyzer/stage2-chunk.test.ts`
+Expected: PASS (new test + all existing chunk tests green — a word-free separator is not a tiny fragment, so `mergeTinyChunks` is unaffected; a separator-only chunk is skipped at attribution by `hasAttributableContent`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/analyzer/stage2-chunk.ts server/src/analyzer/stage2-chunk.test.ts
+git commit -m "fix(analyzer): prefer scene-separator boundaries when splitting stage-2 chunks"
+```
+
+---
+
+### Task 7: Fresh re-analysis of Night Watch on Gemma — acceptance
 
 Prove the compound fix end-to-end on the reproduction book, using the same model, via a FRESH analysis (cache-bypassing).
 
@@ -386,7 +540,7 @@ jq '.sentences | map(.characterId) | group_by(.) | map({id: .[0], n: length}) | 
 **Acceptance (Gemma is the bar) — calibrated to what the deterministic fixes actually guarantee (review fold, MAJOR 2 & 3):**
 - **Phantom `я` character GONE from cast.json** (hard pass — Task 2 makes this unconditional).
 - **First-person NARRATION off Егор → ~0** (hard pass — `decideNarrationOnly`, now running below floor via Task 3). Егор keeps only his genuine dialogue + any residual first-person *speech*.
-- **First-person SPEECH on Егор: markedly reduced but NOT required to be 0.** Unanchored first-person quotes ("- Я упустил вампиршу") are structurally ambiguous (any speaker says «я») and are left *flagged* by design (#1676). Report the residual count as a bounded number, not a zero. Reattribution of these depends on alignment clearing 80% (so tag-anchored Антон lines auto-correct) + Task 4's prompt — measure, don't assume.
+- **First-person SPEECH on Егор: markedly reduced, target low but not asserted 0.** The primary lever is now Task 5 (the stage-2 «я»→narrator-id prompt anchor) which biases the model to attribute first-person speech to Антон at the source on the fresh run; Task 4 (stage-1 «я» alias) feeds it, and above-floor alignment lets tag-anchored lines auto-correct. Structurally, an unanchored first-person quote remains ambiguous (any speaker says «я»), so a residual is expected — report it as a bounded number, don't assume 0. Measure the before/after Егор count.
 - **`alignedPct` — MEASURED, not asserted.** Record the new book-wide value and the per-chapter `[analysis:structure] aligned=..%` lines vs the 65.6% baseline. If a majority of chapters are still sub-floor, that's the signal to add NFC/fuzzy matching (Task 1 scope note) — a follow-up, not a Task-5 failure.
 - No characterIds in `manuscript-edits.json` absent from `cast.json` (id-drift not reintroduced).
 
@@ -404,7 +558,7 @@ If pass: note it against issue for this fix + update memory (`project_analyzer_f
 
 - **Spec coverage:** RC1 phantom → Task 2; RC1 stage-1 seeding → Task 4 (prompt) + downstream RC2 demote; RC2 low alignment → Task 1; RC2 floor suppression of narration demote → Task 3; same-model fresh re-analysis + Qwen compare → Task 5. All covered.
 - **Deliberately NOT doing:** forcing unanchored first-person QUOTES ("- Я упустил вампиршу") to the narrator — structurally ambiguous (any speaker says «я»); would over-correct. These remain flagged + escalated; Task 4 reduces them at the source. Features (b)/(c) are issue #1676, out of scope.
-- **Ordering:** Tasks 1-4 are independent and unit-tested; do them in any order; Task 5 depends on all. Task 1 is highest-leverage for RC2.
+- **Ordering:** Tasks 1-6 are independent and unit-tested; do them in any order; Task 7 (verify) depends on all. Task 1 is highest-leverage for RC2; Task 5 is highest-leverage for the speech-side «я»→Егор lines (RC3).
 
 ## Independent review folds (2026-07-16, opus adversarial pass)
 
@@ -415,3 +569,10 @@ If pass: note it against issue for this fix + update memory (`project_analyzer_f
 - **MINOR 5 — acknowledged (no code):** `previewFoldForLiveView` (analysis.ts:749) dedups with empty sentences, so the *live* "Cast so far" pill could momentarily show «Я» surviving on roster order; cosmetic only — final cast.json (analysis.ts:726, real sentences) is correct and the frontend snapshot-replaces the roster (per prior live-cast fix).
 - **MINOR 7 — folded:** Task 1 test asserts `spans` membership + alignedPct, not strict array-equality (avoids the tag-span overlap off-by-one).
 - **Confirmed sound by review:** RC1/RC2 diagnosis; Task 1 fold correctness/offset-preservation/symmetry; Task 2 union + survivor-ranking picks Антон, no `isFirstPersonName` false-positive on Яков/Оля/Ян, no circular import, `opts.language` passed by callers.
+
+## RC3 investigation folds (2026-07-16, opus evidence pass)
+
+- **Chunker scene-straddle is NOT the dominant cause (evidence):** misattribution is pervasive, not seam-localized — Антон's own lines are mislabeled `egor` *inside* one unbroken dialogue scene (ch1 bin 600-800); every observable separator landed *at* a chunk boundary, not mid-chunk; a clean single-POV Антон section still dumped 248 lines on `egor` (ch5). Separators survive normalization (`html-utils.ts`: `</p>`→`\n\n`, `\n{3,}`→`\n\n`).
+- **The evidenced miss:** the stage-2 prompt (`analysis.ts:1527/:1592`) passes `{id,name,role}` only — no «я»→id mapping — and `findFirstPersonCharacter` (:1608) is wired only to the structure engine (:1726), never the model. **→ Task 5 (new): surface the first-person-narrator id in the stage-2 prompt.** Highest-leverage lever for the speech-side «я»→Егор lines.
+- **Chunker hardening kept (user-requested):** **→ Task 6 (new): separator-aware `splitBodyIntoChunks`.** Safe + lossless, only-when-over-budget; latent-risk hardening, not the fix for this bug.
+- **Manuscript-view scene separator filed as #1679** (the display counterpart of Task 6); editing-UX (alias re-point + bulk reassign) is #1676. Both out of scope here.

--- a/server/src/analyzer/dialogue-structure/aligner.test.ts
+++ b/server/src/analyzer/dialogue-structure/aligner.test.ts
@@ -158,4 +158,34 @@ describe('alignSentences', () => {
     expect(result.aligned[0].spans).toContain(speechSpan);
     expect(result.alignedPct).toBe(100);
   });
+
+  it('(RC2) aligns across composed vs decomposed ё (combining diaeresis)', () => {
+    const ruIdx = buildNameIndex([{ id: 'anton', name: 'Антон' }], conventionsFor('ru')!);
+    const body = '— Ещё раз, — сказал Антон.'; // composed ё
+    const paras = parseChapterStructure(body, ruIdx);
+    const speechSpan = paras.flatMap((p) => p.spans).find((s) => s.kind === 'speech')!;
+    const decomposed = 'Ещё раз,'.normalize('NFD'); // е + U+0308
+    const result = alignSentences([mkSentence(1, 'anton', decomposed)], paras, body);
+    expect(result.aligned[0].spans).toContain(speechSpan);
+    expect(result.alignedPct).toBe(100);
+  });
+
+  it('(RC2) prefix-anchored fuzzy fallback aligns a paraphrased long sentence to its paragraph', () => {
+    const ruIdx = buildNameIndex([{ id: 'anton', name: 'Антон' }], conventionsFor('ru')!);
+    const body = '— Я упустил вампиршу вчера ночью возле старого парка, — сказал Антон.';
+    const paras = parseChapterStructure(body, ruIdx);
+    const speechSpan = paras.flatMap((p) => p.spans).find((s) => s.kind === 'speech')!;
+    const drifted = 'Я упустил вампиршу вчера возле тёмного парка,'; // middle words changed/dropped
+    const result = alignSentences([mkSentence(1, 'anton', drifted)], paras, body);
+    expect(result.aligned[0].spans).toContain(speechSpan);
+    expect(result.alignedPct).toBe(100);
+  });
+
+  it('(RC2) does NOT fuzzy-match a short needle (avoids false anchors)', () => {
+    const ruIdx = buildNameIndex([{ id: 'anton', name: 'Антон' }], conventionsFor('ru')!);
+    const body = '— Да, конечно, я помню тот давний день очень хорошо, — кивнул Антон.';
+    const paras = parseChapterStructure(body, ruIdx);
+    const result = alignSentences([mkSentence(1, 'anton', 'Нет.')], paras, body); // <24 chars, absent
+    expect(result.aligned[0].spans).toEqual([]);
+  });
 });

--- a/server/src/analyzer/dialogue-structure/aligner.test.ts
+++ b/server/src/analyzer/dialogue-structure/aligner.test.ts
@@ -139,4 +139,23 @@ describe('alignSentences', () => {
     expect(result.aligned[0].spans).toEqual([speechSpan]);
     expect(result.alignedPct).toBe(100);
   });
+
+  it('(RC2) folds ё↔е so a model ё/е swap still aligns', () => {
+    const ruIdx = buildNameIndex([{ id: 'anton', name: 'Антон' }], conventionsFor('ru')!);
+    // Body uses ё in both "Ещё" and "всё".
+    const body = '— Ещё не всё, — сказал Антон.';
+    const paras = parseChapterStructure(body, ruIdx);
+    const speechSpan = paras.flatMap((p) => p.spans).find((s) => s.kind === 'speech')!;
+    expect(body.slice(speechSpan.start, speechSpan.end)).toBe('Ещё не всё,');
+
+    // Model returned the same line with е instead of ё (the classic RU drift).
+    const sentences = [mkSentence(1, 'anton', 'Еще не все,')];
+    const result = alignSentences(sentences, paras, body);
+
+    // Assert on membership + alignedPct, NOT strict array-equality: the overlap
+    // filter (aligner.ts:161) can graze the adjacent tag span depending on the
+    // comma-boundary offset, and that's not what this test is about.
+    expect(result.aligned[0].spans).toContain(speechSpan);
+    expect(result.alignedPct).toBe(100);
+  });
 });

--- a/server/src/analyzer/dialogue-structure/aligner.ts
+++ b/server/src/analyzer/dialogue-structure/aligner.ts
@@ -15,6 +15,9 @@ import type { SentenceOutput } from '../../handoff/schemas.js';
    moves the cursor. */
 
 const WINDOW = 4096;
+const COMBINING_MARK = /\p{Mn}/u;
+const FUZZY_MIN_NEEDLE = 24;
+const FUZZY_ANCHOR_LEN = 16;
 
 export interface AlignedSentence {
   sentence: SentenceOutput;
@@ -72,6 +75,7 @@ function buildNormalizedMap(raw: string): { text: string; rawStart: number[]; ra
       // the 80% alignment floor and suppress ALL structure corrections).
       // 1:1 char replacement — preserves the offset map exactly.
       if (out === 'ё') out = 'е';
+      else if (COMBINING_MARK.test(out)) out = ''; // drop decomposed diacritics (offset-safe)
     }
     const atomStart = i;
     const atomEnd = i + atomLen;
@@ -151,14 +155,20 @@ export function alignSentences(
 
   for (const sentence of sentences) {
     const needle = normalize(sentence.text);
-    const matchStart = needle.length > 0 ? findMatch(normBody, needle, cursor) : -1;
+    let matchStart = needle.length > 0 ? findMatch(normBody, needle, cursor) : -1;
+    if (matchStart === -1 && needle.length >= FUZZY_MIN_NEEDLE) {
+      // Exact failed (gemma paraphrased/dropped a word). Anchor on the prefix so
+      // the sentence still attaches to its paragraph; approximate the extent.
+      const anchorPos = findMatch(normBody, needle.slice(0, FUZZY_ANCHOR_LEN), cursor);
+      if (anchorPos !== -1) matchStart = anchorPos;
+    }
 
     if (matchStart === -1) {
       aligned.push({ sentence, spans: [], lumped: false });
       continue; // do NOT move the cursor — a single bad sentence can't desync the rest
     }
 
-    const matchEnd = matchStart + needle.length;
+    const matchEnd = Math.min(matchStart + needle.length, normBody.length);
     cursor = matchEnd;
 
     const rawMatchStart = rawStart[matchStart];

--- a/server/src/analyzer/dialogue-structure/aligner.ts
+++ b/server/src/analyzer/dialogue-structure/aligner.ts
@@ -67,6 +67,11 @@ function buildNormalizedMap(raw: string): { text: string; rawStart: number[]; ra
       out = '...';
     } else {
       out = raw[i].toLowerCase();
+      // RU: models routinely swap ё↔е. Fold to е so a single ё/е divergence
+      // doesn't orphan the whole sentence (which would drag the chapter under
+      // the 80% alignment floor and suppress ALL structure corrections).
+      // 1:1 char replacement — preserves the offset map exactly.
+      if (out === 'ё') out = 'е';
     }
     const atomStart = i;
     const atomEnd = i + atomLen;

--- a/server/src/analyzer/dialogue-structure/cross-examine.test.ts
+++ b/server/src/analyzer/dialogue-structure/cross-examine.test.ts
@@ -244,19 +244,33 @@ describe('crossExamine — hard invariants', () => {
     expect(result.flags).toEqual([{ index: 0, reason: 'lumped' }]);
   });
 
-  it('INVARIANT: below the alignment floor -> flagOnly, zero corrections, only the unaligned caps applied', () => {
+  it('below the alignment floor -> speech/tag corrections suppressed, but pure-narration still demotes (Wave A parity)', () => {
     const list = [
-      aligned(mkSentence('narrator'), [speechSpan({ characterId: 'anton', source: 'tag-name' })]), // would normally auto-correct
-      aligned(mkSentence('olga', 0.9), [narrationSpan()]), // would normally demote
+      aligned(mkSentence('narrator'), [speechSpan({ characterId: 'anton', source: 'tag-name' })]), // tag-name correction SUPPRESSED below floor
+      aligned(mkSentence('olga', 0.9), [narrationSpan()]), // pure narration STILL demotes to narrator (Wave A parity)
       aligned(mkSentence('anton'), []), // unaligned
     ];
     const result = run(list, 50); // 50% < 80% floor
 
     expect(result.report.flagOnly).toBe(true);
-    expect(result.report.corrected).toBe(0);
-    // model ids pass through completely unchanged, even the tag-name-contradicting one
-    expect(result.sentences.map((s) => s.characterId)).toEqual(['narrator', 'olga', 'anton']);
+    // the tag-name-contradicting speech line is NOT corrected below floor; only the narration demote is
+    expect(result.sentences.map((s) => s.characterId)).toEqual(['narrator', 'narrator', 'anton']);
+    expect(result.report.corrected).toBe(1);
     for (const s of result.sentences) expect(s.confidence).toBeLessThanOrEqual(CONFIDENCE.UNALIGNED_CAP);
+  });
+
+  it('(RC2) below the alignment floor, still demotes pure-narration off a named char to narrator', () => {
+    const as = {
+      sentence: mkSentence('егор'),
+      spans: [{ kind: 'narration', start: 0, end: 12 } as SpanEvidence],
+      lumped: false,
+    };
+    const result = crossExamine(
+      { alignedPct: 60, aligned: [as] } as any,
+      { rosterIds: new Set(['егор', 'narrator']), unknownBucketIds: new Set(), alignmentFloorPct: 80 },
+    );
+    expect(result.sentences[0].characterId).toBe('narrator');
+    expect(result.sentences[0].confidence).toBeLessThanOrEqual(0.5);
   });
 
   it('DEFENSIVE GUARD: an anchored speech span with an unexpected EvidenceSource (neither tag-name, tag-pronoun, nor alternation) keeps the model id and flags it — never auto-corrects to the span speaker', () => {

--- a/server/src/analyzer/dialogue-structure/cross-examine.ts
+++ b/server/src/analyzer/dialogue-structure/cross-examine.ts
@@ -257,6 +257,14 @@ function decideSentence(as: AlignedSentence, opts: CrossExamineOpts, block: { ac
   return decideNarrationOnly(modelId, block);
 }
 
+/** A pure-narration aligned sentence (spans present, no speech, not lumped) is
+    narrator voice on its own structural evidence — so this ONE demote is safe
+    to apply even below the alignment floor, where every other correction is
+    suppressed as unreliable. */
+function isPureNarrationAligned(as: AlignedSentence): boolean {
+  return as.spans.length > 0 && !as.lumped && !as.spans.some((s) => s.kind === 'speech');
+}
+
 /** Cross-examine every aligned sentence against its structural evidence.
     Below the alignment floor, correction is disabled chapter-wide (§5.2) —
     every sentence gets the flag-only pass-through, never a correction. */
@@ -279,7 +287,20 @@ export function crossExamine(alignment: AlignmentResult, opts: CrossExamineOpts)
   const block = { active: false };
 
   alignment.aligned.forEach((as, index) => {
-    const decision = flagOnly ? flagOnlyDecision(as) : decideSentence(as, opts, block);
+    let decision: Decision;
+    if (flagOnly) {
+      // Suppress corrections below the floor EXCEPT the high-precision
+      // pure-narration demote, which doesn't depend on the (unreliable)
+      // window/alternation picture.
+      if (isPureNarrationAligned(as) && as.sentence.characterId !== NARRATOR_ID) {
+        decision = decideNarrationOnly(as.sentence.characterId, block);
+      } else {
+        block.active = false;
+        decision = flagOnlyDecision(as);
+      }
+    } else {
+      decision = decideSentence(as, opts, block);
+    }
     report[decision.bucket] += 1;
     if (decision.flagged) flags.push({ index, reason: decision.reason });
     sentences.push({ ...as.sentence, characterId: decision.characterId, confidence: decision.confidence });

--- a/server/src/analyzer/roster-dedup.test.ts
+++ b/server/src/analyzer/roster-dedup.test.ts
@@ -307,6 +307,18 @@ describe('dedupeRosterByName — first-person pronoun phantom (RC1)', () => {
     expect(r.characters.map((x) => x.id)).toEqual(['антон']);
     expect(r.rewrites['я']).toBe('narrator');
   });
+
+  it('a phantom «Я» with MORE lines than the real protagonist does NOT dissolve the protagonist into narrator', () => {
+    const chars = [
+      c({ id: 'антон', name: 'Антон', gender: 'male', aliases: ['Я'] }),
+      c({ id: 'я', name: 'Я', gender: 'male', aliases: [] }),
+    ];
+    // phantom has FAR more lines than антон — this is what triggers the inversion.
+    const r = dedupeRosterByName(chars as any, [...sent('антон', 20), ...sent('я', 300)], { language: 'ru' });
+    expect(r.characters.map((x) => x.id)).toEqual(['антон']); // real protagonist survives, keeps id антон
+    expect(r.rewrites['я']).toBe('антон');                    // phantom merged INTO антон
+    expect(Object.values(r.rewrites)).not.toContain('narrator'); // антон NOT dissolved to narrator
+  });
 });
 
 describe('dedupeRosterByName Tier-3 (alias coreference — weak suggestions)', () => {

--- a/server/src/analyzer/roster-dedup.test.ts
+++ b/server/src/analyzer/roster-dedup.test.ts
@@ -285,6 +285,30 @@ describe('dedupeRosterByName Tier-3 (alias coreference — strong merge)', () =>
   });
 });
 
+describe('dedupeRosterByName — first-person pronoun phantom (RC1)', () => {
+  it('force-merges a bare «Я» character into the char that lists «Я» as an alias', () => {
+    const chars = [
+      c({ id: 'антон', name: 'Антон', gender: 'male', aliases: ['Антон Городецкий', 'Я'] }),
+      c({ id: 'я', name: 'Я', gender: 'male', aliases: [] }),
+    ];
+    const r = dedupeRosterByName(chars as any, [...sent('антон', 196), ...sent('я', 7)], { language: 'ru' });
+    expect(r.characters.map((x) => x.id)).toEqual(['антон']); // phantom gone, Антон survives (more lines)
+    expect(r.rewrites['я']).toBe('антон');
+  });
+
+  it('routes a bare «Я» to the narrator when NO character claims it as an alias (fallback)', () => {
+    const chars = [
+      c({ id: 'антон', name: 'Антон', gender: 'male', aliases: [] }),
+      c({ id: 'я', name: 'Я', gender: 'male', aliases: [] }),
+    ];
+    const r = dedupeRosterByName(chars as any, [...sent('антон', 196), ...sent('я', 7)], { language: 'ru' });
+    // A bare pronoun is NEVER a real character: with no alias-holder to absorb
+    // it, it routes to the narrator (first-person-with-no-owner = narrator voice).
+    expect(r.characters.map((x) => x.id)).toEqual(['антон']);
+    expect(r.rewrites['я']).toBe('narrator');
+  });
+});
+
 describe('dedupeRosterByName Tier-3 (alias coreference — weak suggestions)', () => {
   it('suggests (does not merge) a one-sided bare-word link on exactly two rows', () => {
     const chars = [

--- a/server/src/analyzer/roster-dedup.ts
+++ b/server/src/analyzer/roster-dedup.ts
@@ -2,6 +2,7 @@ import type { CharacterOutput } from '../handoff/schemas.js';
 import { safeId, normaliseNameKey } from '../util/safe-id.js';
 import { mergeCharacterFields } from './roster-merge-fields.js';
 import { diminutiveCanonical } from './ru-diminutives.js';
+import { conventionsFor } from './dialogue-structure/lang/index.js';
 
 export interface MergeSuggestion { sourceId: string; targetId: string; reason: string }
 
@@ -49,7 +50,7 @@ export function composeRewrites(
 export function dedupeRosterByName(
   characters: CharacterOutput[],
   sentences: ReadonlyArray<{ characterId: string }>,
-  _opts: { language?: string } = {},
+  opts: { language?: string } = {},
 ): { characters: CharacterOutput[]; rewrites: Record<string, string>; suggestions: MergeSuggestion[] } {
   const lines = lineCounts(sentences);
   const rewrites: Record<string, string> = {};
@@ -174,6 +175,16 @@ export function dedupeRosterByName(
   const suggestions: MergeSuggestion[] = [];
 
   const nameKeyOf = (ch: CharacterOutput): string => normaliseNameKey(ch.name);
+
+  // A "character" whose NAME is the language's bare first-person pronoun (the
+  // model rostering «Я»/«I» as its own entity) is never real — it's the
+  // narrator-protagonist's self-reference. Force it to a STRONG edge so it
+  // merges into whichever real character claims that pronoun as an alias,
+  // overriding the single-token weak-link gate that protects role-word minors.
+  const firstPersonRx = conventionsFor(opts.language)?.pronouns.firstPerson ?? null;
+  const isFirstPersonName = (ch: CharacterOutput): boolean =>
+    firstPersonRx !== null && firstPersonRx.test(` ${nameKeyOf(ch)} `);
+
   const aliasKeysOf = (ch: CharacterOutput): Set<string> =>
     new Set((ch.aliases ?? []).map((a) => normaliseNameKey(a)).filter(Boolean));
 
@@ -211,8 +222,8 @@ export function dedupeRosterByName(
       const mutual = linkXY && linkYX;
       const strong =
         mutual ||
-        (linkXY && tokens(x.name).length >= 2) ||
-        (linkYX && tokens(y.name).length >= 2);
+        (linkXY && (tokens(x.name).length >= 2 || isFirstPersonName(x))) ||
+        (linkYX && (tokens(y.name).length >= 2 || isFirstPersonName(y)));
       if (strong) union(x.id, y.id);
     }
   }
@@ -266,6 +277,16 @@ export function dedupeRosterByName(
     }
   }
   roster = roster.filter((ch) => !droppedT3.has(ch.id));
+
+  // Fallback: a bare first-person-pronoun character that STILL stands (no
+  // roster peer aliased it above) is never a real character — route it and its
+  // lines to the narrator rather than leave a pronoun masquerading as a
+  // speaker. Terminal rewrite (→ narrator), so ordering vs the collapse below
+  // is irrelevant. Guarantees "no bare-pronoun row survives" unconditionally.
+  for (const ch of roster) {
+    if (ch.id !== NARRATOR_ID && isFirstPersonName(ch)) rewrites[ch.id] = NARRATOR_ID;
+  }
+  roster = roster.filter((ch) => ch.id === NARRATOR_ID || !isFirstPersonName(ch));
 
   // ── Tier-3 weak suggestions: distinctive overlap on EXACTLY two rows ──────
   // One-sided single-token name links (that failed the mutuality gate) and

--- a/server/src/analyzer/roster-dedup.ts
+++ b/server/src/analyzer/roster-dedup.ts
@@ -263,7 +263,13 @@ export function dedupeRosterByName(
     // token-count tie, so it never changes which real name wins.)
     const ranked = members
       .map((m) => ({ m, idx: roster.indexOf(m), tok: tokens(m.name).length, ln: lines.get(m.id) ?? 0 }))
-      .sort((a, b) => b.tok - a.tok || b.ln - a.ln || a.idx - b.idx);
+      .sort(
+        (a, b) =>
+          (isFirstPersonName(a.m) ? 1 : 0) - (isFirstPersonName(b.m) ? 1 : 0) ||
+          b.tok - a.tok ||
+          b.ln - a.ln ||
+          a.idx - b.idx,
+      );
     const survivor = ranked[0].m;
     // Merge victims in roster order for deterministic field-merge results.
     const victims = ranked

--- a/server/src/analyzer/stage2-chunk.test.ts
+++ b/server/src/analyzer/stage2-chunk.test.ts
@@ -92,6 +92,20 @@ describe('splitBodyIntoChunks', () => {
     expect(chunks.length).toBeGreaterThan(1); // NOT collapsed into one
     expect(chunks.join('')).toBe(body);
   });
+
+  it('(RC3) prefers a scene-separator boundary so no chunk straddles two scenes', () => {
+    const sceneA = 'а'.repeat(60) + '.\n\n';
+    const sep = '***\n\n';
+    const sceneB = 'б'.repeat(60) + '.\n\n';
+    const body = sceneA + sceneA + sep + sceneB + sceneB; // ~260 chars, 4 prose paras + separator
+    const chunks = splitBodyIntoChunks(body, 200); // over budget → must split
+
+    // No chunk contains prose from BOTH scenes.
+    for (const ch of chunks) {
+      expect(ch.includes('а') && ch.includes('б')).toBe(false);
+    }
+    expect(chunks.join('')).toBe(body); // lossless
+  });
 });
 
 describe('splitParagraphIntoSentences', () => {

--- a/server/src/analyzer/stage2-chunk.test.ts
+++ b/server/src/analyzer/stage2-chunk.test.ts
@@ -94,15 +94,15 @@ describe('splitBodyIntoChunks', () => {
   });
 
   it('(RC3) prefers a scene-separator boundary so no chunk straddles two scenes', () => {
-    const sceneA = 'а'.repeat(60) + '.\n\n';
-    const sep = '***\n\n';
-    const sceneB = 'б'.repeat(60) + '.\n\n';
-    const body = sceneA + sceneA + sep + sceneB + sceneB; // ~260 chars, 4 prose paras + separator
-    const chunks = splitBodyIntoChunks(body, 200); // over budget → must split
-
-    // No chunk contains prose from BOTH scenes.
+    const sceneA = 'Первый герой шёл по длинной пыльной улице и думал о своём давнем деле.\n\n';
+    const sep = '* * *\n\n';
+    const sceneB = 'Второй герой молча сидел в тёмной холодной комнате и ждал условного часа.\n\n';
+    const body = sceneA + sceneA + sep + sceneB + sceneB;
+    // Budget forces a split AND is large enough that, without separator-awareness,
+    // the greedy packer would straddle the seam (pack sceneA…sep…sceneB together).
+    const chunks = splitBodyIntoChunks(body, 250);
     for (const ch of chunks) {
-      expect(ch.includes('а') && ch.includes('б')).toBe(false);
+      expect(ch.includes('Первый') && ch.includes('Второй')).toBe(false); // no chunk has both scenes
     }
     expect(chunks.join('')).toBe(body); // lossless
   });

--- a/server/src/analyzer/stage2-chunk.ts
+++ b/server/src/analyzer/stage2-chunk.ts
@@ -104,18 +104,35 @@ function mergeTinyChunks(chunks: string[]): string[] {
     const wc = attributableWordCount(c);
     return wc >= 1 && wc < STAGE2_MIN_EVALUABLE_WORDS;
   };
+  /* A chunk that OPENS with a word-free separator paragraph ("***") is one the
+     packing loop deliberately started a fresh scene on (see splitBodyIntoChunks).
+     A chunk can still be "tiny" by word count (a short scene, or one built almost
+     entirely of the same repeated glyph) without being a fragment in the
+     mergeTinyChunks sense — folding it into its neighbour would silently undo the
+     scene-boundary preference and re-mix two scenes into one chunk. Guard both
+     merge directions on this so the separator boundary the packing loop just
+     created survives this pass. */
+  const startsWithSceneSeparator = (c: string): boolean => {
+    const firstPara = c.split(/\n[ \t]*\n/, 1)[0] ?? '';
+    return firstPara.trim().length > 0 && attributableWordCount(firstPara) === 0;
+  };
   const work = [...chunks];
   const out: string[] = [];
   for (let i = 0; i < work.length; i += 1) {
-    if (isTinyFragment(work[i]) && i + 1 < work.length) {
+    if (isTinyFragment(work[i]) && i + 1 < work.length && !startsWithSceneSeparator(work[i + 1])) {
       work[i + 1] = work[i] + work[i + 1]; // forward-merge into the next chunk
     } else {
       out.push(work[i]);
     }
   }
   // A fragment that was LAST had no following chunk to join — fold it (and any
-  // fragment that merging left trailing) back into the previous chunk instead.
-  while (out.length >= 2 && isTinyFragment(out[out.length - 1])) {
+  // fragment that merging left trailing) back into the previous chunk instead,
+  // unless it is itself a scene that starts with a separator (preserve the break).
+  while (
+    out.length >= 2 &&
+    isTinyFragment(out[out.length - 1]) &&
+    !startsWithSceneSeparator(out[out.length - 1])
+  ) {
     out[out.length - 2] += out.pop()!;
   }
   return out;
@@ -140,10 +157,15 @@ export function splitBodyIntoChunks(body: string, charBudget: number): string[] 
   for (let i = 0; i < parts.length; i += 2) {
     units.push(parts[i] + (parts[i + 1] ?? ''));
   }
+  const isSceneSeparatorUnit = (u: string): boolean =>
+    u.trim().length > 0 && attributableWordCount(u) === 0;
   const chunks: string[] = [];
   let cur = '';
   for (const u of units) {
-    if (cur && cur.length + u.length > charBudget) {
+    // A scene-separator paragraph forces a boundary BEFORE it, so the separator
+    // (and the scene that follows) starts a fresh chunk — no chunk straddles a
+    // scene break. Size overflow breaks too, as before.
+    if (cur && (isSceneSeparatorUnit(u) || cur.length + u.length > charBudget)) {
       chunks.push(cur);
       cur = u;
     } else {

--- a/server/src/analyzer/stage2-chunk.ts
+++ b/server/src/analyzer/stage2-chunk.ts
@@ -104,35 +104,18 @@ function mergeTinyChunks(chunks: string[]): string[] {
     const wc = attributableWordCount(c);
     return wc >= 1 && wc < STAGE2_MIN_EVALUABLE_WORDS;
   };
-  /* A chunk that OPENS with a word-free separator paragraph ("***") is one the
-     packing loop deliberately started a fresh scene on (see splitBodyIntoChunks).
-     A chunk can still be "tiny" by word count (a short scene, or one built almost
-     entirely of the same repeated glyph) without being a fragment in the
-     mergeTinyChunks sense — folding it into its neighbour would silently undo the
-     scene-boundary preference and re-mix two scenes into one chunk. Guard both
-     merge directions on this so the separator boundary the packing loop just
-     created survives this pass. */
-  const startsWithSceneSeparator = (c: string): boolean => {
-    const firstPara = c.split(/\n[ \t]*\n/, 1)[0] ?? '';
-    return firstPara.trim().length > 0 && attributableWordCount(firstPara) === 0;
-  };
   const work = [...chunks];
   const out: string[] = [];
   for (let i = 0; i < work.length; i += 1) {
-    if (isTinyFragment(work[i]) && i + 1 < work.length && !startsWithSceneSeparator(work[i + 1])) {
+    if (isTinyFragment(work[i]) && i + 1 < work.length) {
       work[i + 1] = work[i] + work[i + 1]; // forward-merge into the next chunk
     } else {
       out.push(work[i]);
     }
   }
   // A fragment that was LAST had no following chunk to join — fold it (and any
-  // fragment that merging left trailing) back into the previous chunk instead,
-  // unless it is itself a scene that starts with a separator (preserve the break).
-  while (
-    out.length >= 2 &&
-    isTinyFragment(out[out.length - 1]) &&
-    !startsWithSceneSeparator(out[out.length - 1])
-  ) {
+  // fragment that merging left trailing) back into the previous chunk instead.
+  while (out.length >= 2 && isTinyFragment(out[out.length - 1])) {
     out[out.length - 2] += out.pop()!;
   }
   return out;

--- a/server/src/routes/analysis.structure-engine.test.ts
+++ b/server/src/routes/analysis.structure-engine.test.ts
@@ -126,6 +126,39 @@ describe('attributeChapterStage2 — structure engine wiring (srv-59)', () => {
   });
 });
 
+describe('attributeChapterStage2 — Task 9 roster consolidation before stage-2', () => {
+  it('hands the model a consolidated roster (bare «Я» phantom + fragmented Антон merged) and fires the «я» anchor', async () => {
+    // Raw stage-1 the model would otherwise see: a bare pronoun «Я» char, Антон
+    // split across two ids, and Ольга. `anton` carries «Я» as an alias (the model
+    // volunteered it) so the phantom folds into Антон and the anchor can fire.
+    const rawChars: CharacterOutput[] = [
+      { id: 'anton', name: 'Антон', role: 'lead', color: '#111111', gender: 'male', aliases: ['Я'] },
+      { id: 'anton-gorodetsky', name: 'Антон Городецкий', role: 'lead', color: '#112222', gender: 'male' },
+      { id: 'я', name: 'Я', role: 'char', color: '#113333', gender: 'male' },
+      { id: 'olga', name: 'Ольга', role: 'lead', color: '#222222', gender: 'female' },
+    ];
+    let captured = '';
+    const analyzer: Analyzer = {
+      ...fakeAnalyzer(mockSentences()),
+      runStage2Chapter: (_m: string, _c: number, prompt: string) => {
+        captured = prompt;
+        return Promise.resolve({ sentences: mockSentences() });
+      },
+    };
+    await attributeChapterStage2({
+      ...baseOpts('ru', mockSentences()),
+      analyzer,
+      stage1: { characters: rawChars, chapters: [{ id: 1, title: 'Chapter One' }] },
+    });
+
+    expect(captured).not.toContain('"id": "я"'); // bare pronoun phantom gone from the prompt
+    // Антон is ONE row now (Городецкий fragment merged), not two competing ids.
+    expect(captured.match(/"id": "anton(-gorodetsky)?"/g) ?? []).toHaveLength(1);
+    // …and the «я» prompt-anchor fires because the surviving Антон row carries «Я».
+    expect(captured).toContain('First-person narrator');
+  });
+});
+
 /* srv-59 Task 9b — the escalation WIRING inside attributeChapterStage2:
    reading the `analyzer.structure.escalation` knob, routing 'off'/'local',
    calling escalateFlaggedWindows, and folding `escalated`/`escalationAccepted`

--- a/server/src/routes/analysis.test.ts
+++ b/server/src/routes/analysis.test.ts
@@ -31,6 +31,7 @@ import {
   runMainAnalyzerJob,
   runSubsetAnalyzerJob,
   aggregateStructureReports,
+  buildStage2ChapterInbox,
   type AnalysisJob,
 } from './analysis.js';
 import type { CharacterOutput, SentenceOutput, Stage1ChapterOutput, Stage1Output, Stage2ChapterOutput } from '../handoff/schemas.js';
@@ -3456,4 +3457,25 @@ describe('#1447 third-party front-matter guard — main-route integration', () =
     },
     60_000,
   );
+});
+
+describe('stage-2 prompt first-person anchor (RC3)', () => {
+  const stage1 = {
+    characters: [
+      { id: 'антон', name: 'Антон', role: 'Colleague', aliases: ['Антон Городецкий', 'Я'] },
+      { id: 'егор', name: 'Егор', role: 'Protagonist / Observer' },
+    ],
+  } as any;
+  const chapter = { id: 1, title: 'Ch1', body: 'Я кивнул.' };
+
+  it('emits the first-person anchor naming the narrator id when one is provided', () => {
+    const prompt = buildStage2ChapterInbox('m', 'Title', stage1, chapter, 'антон');
+    expect(prompt).toContain('First-person narrator');
+    expect(prompt).toContain('`антон`');
+  });
+
+  it('omits the anchor block when firstPersonId is null', () => {
+    const prompt = buildStage2ChapterInbox('m', 'Title', stage1, chapter, null);
+    expect(prompt).not.toContain('First-person narrator');
+  });
 });

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -1434,6 +1434,13 @@ true:
    A whole **first-person novel is NOT** such a document — its first-person
    voice is the protagonist/narrator, NOT the book's author; never roster the
    byline author as that voice.
+   The first-person «я» voice is exactly ONE character. NEVER create a
+   character whose name is a bare pronoun (я, I, ich, …) — that is not a
+   character. Attribute first-person NARRATION to \`narrator\`; attribute
+   first-person SPOKEN dialogue to the single protagonist and record «я» in
+   that protagonist's aliases. Do NOT spread first-person lines across
+   several characters, and never attach a first-person line as evidence to a
+   secondary character.
 
 **An explicit \`<Name> <speech-verb>\` dialogue tag is binding** — \`"…,"
 Lessom repeated.\`, \`"Fine," Sela agreed.\`, \`"Where?" Wren asked.\`

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -1704,6 +1704,22 @@ export async function attributeChapterStage2(opts: {
      consulted when `analyzer.structure.escalation === 'cloud'`. */
   escalationAnalyzer?: Analyzer | null;
 }): Promise<Stage2ChunkRunResult> {
+  /* Task 9 — consolidate the roster BEFORE stage-2 so the model sees CLEAN ids.
+     The raw stage-1 roster routinely hands the model a bare first-person-pronoun
+     phantom («Я») and the same character split across several ids (Антон /
+     Антон Городецкий / …). The model then attributes to the pronoun row and
+     spreads one person's lines across the fragments. Merge them up front —
+     exactly as the final cast build merges them — via `dedupeRosterByName` with
+     no sentences (deterministic: name/token structure only, no line counts). The
+     post-stage-2 `dedupAndPrepare` re-runs dedup on the raw roster and remaps any
+     survivor-id difference onto the same final id, so sentence ids stay
+     consistent. This also lets the «я» prompt-anchor below fire whenever a merged
+     row carries «я» as an alias. */
+  const stage1: Stage1Output = {
+    ...opts.stage1,
+    characters: dedupeRosterByName(opts.stage1.characters, [], { language: opts.stageCall.language })
+      .characters,
+  };
   /* RC3 — thread the known first-person narrator id into the stage-2 prompt
      itself (not just the deterministic structure engine below) so the model
      doesn't need to infer «я» from role/prominence alone. Computed once per
@@ -1711,16 +1727,16 @@ export async function attributeChapterStage2(opts: {
      the deterministic engine's own (separate) computation further down. */
   const fpConventions = conventionsFor(opts.stageCall.language);
   const firstPersonId = fpConventions
-    ? findFirstPersonCharacter(opts.stage1.characters, fpConventions)
+    ? findFirstPersonCharacter(stage1.characters, fpConventions)
     : null;
   const callForBody = (subBody: string, preceding: string | null) => {
     const prompt =
       preceding === null && subBody === opts.chapter.body
-        ? buildStage2ChapterInbox(opts.manuscriptId, opts.title, opts.stage1, opts.chapter, firstPersonId)
+        ? buildStage2ChapterInbox(opts.manuscriptId, opts.title, stage1, opts.chapter, firstPersonId)
         : buildStage2ChunkInbox(
             opts.manuscriptId,
             opts.title,
-            opts.stage1,
+            stage1,
             opts.chapter,
             subBody,
             preceding,
@@ -1754,12 +1770,12 @@ export async function attributeChapterStage2(opts: {
     ? conventionsFor(opts.stageCall.language)
     : null;
   if (conventions) {
-    const index = buildNameIndex(opts.stage1.characters, conventions);
+    const index = buildNameIndex(stage1.characters, conventions);
     const paras = parseChapterStructure(opts.chapter.body, index);
-    const firstPersonId = findFirstPersonCharacter(opts.stage1.characters, conventions);
-    resolveWindows(paras, rosterGenderMap(opts.stage1.characters), firstPersonId);
+    const firstPersonId = findFirstPersonCharacter(stage1.characters, conventions);
+    resolveWindows(paras, rosterGenderMap(stage1.characters), firstPersonId);
     const alignment = alignSentences(result.sentences, paras, opts.chapter.body);
-    const rosterIds = new Set(opts.stage1.characters.map((c) => c.id));
+    const rosterIds = new Set(stage1.characters.map((c) => c.id));
     const examined = crossExamine(alignment, {
       rosterIds,
       unknownBucketIds: new Set([MALE_BUCKET_ID, FEMALE_BUCKET_ID]),

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -1495,12 +1495,20 @@ ${chapter.body}
 `;
 }
 
-function buildStage2ChapterInbox(
+export function buildStage2ChapterInbox(
   manuscriptId: string,
   title: string,
   stage1: Stage1Output,
   chapter: { id: number; title: string; body: string },
+  firstPersonId: string | null,
 ): string {
+  const firstPersonBlock = firstPersonId
+    ? `## First-person narrator
+
+This manuscript is narrated in the FIRST PERSON. Every first-person pronoun («я», «меня», «мне», «мной», «мы») refers to character id \`${firstPersonId}\`. Attribute first-person narration and any first-person spoken line to \`${firstPersonId}\` UNLESS a dialogue tag explicitly names a different speaker. Never route a first-person line to another character merely because that character is prominent nearby.
+
+`
+    : '';
   return `---
 manuscriptId: ${manuscriptId}
 stage: 2
@@ -1537,7 +1545,7 @@ ${JSON.stringify(
 )}
 \`\`\`
 
-## Chapter ${chapter.id} — ${chapter.title}
+${firstPersonBlock}## Chapter ${chapter.id} — ${chapter.title}
 
 ${chapter.body}
 `;
@@ -1549,13 +1557,14 @@ ${chapter.body}
    untagged quote keeps its speaker across the seam. The model must attribute
    ONLY the section, not the context. The chunk runner renumbers ids across
    sections, so per-section 1-based numbering is fine. */
-function buildStage2ChunkInbox(
+export function buildStage2ChunkInbox(
   manuscriptId: string,
   title: string,
   stage1: Stage1Output,
   chapter: { id: number; title: string; body: string },
   subBody: string,
   precedingContext: string | null,
+  firstPersonId: string | null,
 ): string {
   const contextBlock = precedingContext
     ? `## Preceding context (already attributed — do NOT include in your output)
@@ -1565,6 +1574,13 @@ ONLY so you can carry a speaker across the boundary (e.g. an untagged quote
 whose speaker was named just before). Do NOT emit any sentences for this text.
 
 ${precedingContext}
+
+`
+    : '';
+  const firstPersonBlock = firstPersonId
+    ? `## First-person narrator
+
+This manuscript is narrated in the FIRST PERSON. Every first-person pronoun («я», «меня», «мне», «мной», «мы») refers to character id \`${firstPersonId}\`. Attribute first-person narration and any first-person spoken line to \`${firstPersonId}\` UNLESS a dialogue tag explicitly names a different speaker. Never route a first-person line to another character merely because that character is prominent nearby.
 
 `
     : '';
@@ -1602,7 +1618,7 @@ ${JSON.stringify(
 )}
 \`\`\`
 
-${contextBlock}## Section to attribute (Chapter ${chapter.id} — ${chapter.title})
+${contextBlock}${firstPersonBlock}## Section to attribute (Chapter ${chapter.id} — ${chapter.title})
 
 ${subBody}
 `;
@@ -1688,10 +1704,19 @@ export async function attributeChapterStage2(opts: {
      consulted when `analyzer.structure.escalation === 'cloud'`. */
   escalationAnalyzer?: Analyzer | null;
 }): Promise<Stage2ChunkRunResult> {
+  /* RC3 — thread the known first-person narrator id into the stage-2 prompt
+     itself (not just the deterministic structure engine below) so the model
+     doesn't need to infer «я» from role/prominence alone. Computed once per
+     chapter, independent of the `analyzer.structure.enabled` gate that guards
+     the deterministic engine's own (separate) computation further down. */
+  const fpConventions = conventionsFor(opts.stageCall.language);
+  const firstPersonId = fpConventions
+    ? findFirstPersonCharacter(opts.stage1.characters, fpConventions)
+    : null;
   const callForBody = (subBody: string, preceding: string | null) => {
     const prompt =
       preceding === null && subBody === opts.chapter.body
-        ? buildStage2ChapterInbox(opts.manuscriptId, opts.title, opts.stage1, opts.chapter)
+        ? buildStage2ChapterInbox(opts.manuscriptId, opts.title, opts.stage1, opts.chapter, firstPersonId)
         : buildStage2ChunkInbox(
             opts.manuscriptId,
             opts.title,
@@ -1699,6 +1724,7 @@ export async function attributeChapterStage2(opts: {
             opts.chapter,
             subBody,
             preceding,
+            firstPersonId,
           );
     return opts.analyzer.runStage2Chapter(
       opts.manuscriptId,

--- a/skills/audiobook-character-detection-per-chapter.md
+++ b/skills/audiobook-character-detection-per-chapter.md
@@ -78,6 +78,13 @@ Registry File`, the surrounding bio block, etc.). The author of
    is the protagonist/narrator, not the book's author. Never roster the book's
    byline author as a character unless they explicitly act or speak in the story
    (e.g. a clearly-framed author's note).
+   The first-person «я» voice is exactly ONE character. NEVER create a
+   character whose name is a bare pronoun (я, I, ich, …) — that is not a
+   character. Attribute first-person NARRATION to `narrator`; attribute
+   first-person SPOKEN dialogue to the single protagonist and record «я» in
+   that protagonist's aliases. Do NOT spread first-person lines across
+   several characters, and never attach a first-person line as evidence to a
+   secondary character.
 
 **Binding rule — an explicit dialogue tag always counts.** If the chapter
 contains a `<Name> <speech-verb>` attribution beat next to a quote — `"…,"


### PR DESCRIPTION
Closes #1680

## What this does

Hardens the analyzer's first-person-narrator handling for Russian (and, where the guards are language-general, other languages). Nine focused, TDD'd changes, each passing the full server suite:

**RC1 — stage-1 identity guards**
- `roster-dedup`: force-merge a bare first-person-pronoun character («Я») into its alias-holder, with a narrator fallback so a bare pronoun **never** survives as a speaker; a pronoun-named row can never be chosen as a merge survivor (review must-fix).
- Stage-1 prompt id-rule: the first-person voice is one character; never roster a bare pronoun.

**RC2 — structure-correction engine reaches more chapters**
- Aligner folds ё↔е and strips combining marks (decomposed diacritics), plus a bounded prefix-anchored fuzzy fallback so a paraphrased sentence still attaches to its paragraph. (Night Watch ch1 alignment 52% → 73%.)
- The high-precision pure-narration→narrator demote now runs even below the alignment floor (restores Wave-A parity the structure engine had regressed).

**RC3 — cleaner stage-2 input**
- The stage-2 model prompt is built from a **consolidated** roster (phantom «Я» removed, fragmented protagonist merged) instead of the raw one, and carries an explicit «я»→narrator anchor when the narrator's id is known.
- Scene-separator-aware chunk splitting so a chunk doesn't straddle two scenes.

## Verification (fresh `gemma4-e4b-8gb` re-analysis of Night Watch)

**Fixed and verified on real data:**
- Phantom «Я» character **gone**; «Я» consolidated onto Антон.
- **id-drift gone** — every `characterId` in the edits exists in the cast.
- Roster consolidation confirmed live in the actual stage-2 prompt (no bare «я» id).
- Below-floor corrections running (ch1 corrected=264, ch2=5 despite being under the floor).

**Honest limitation — not fixed by this PR:** the residual «я»→Егор mis-attribution. On ch1/ch2 the split barely moved (ch1 Егор 170→197, ch2 154→143; Егор still dominates Антон). Root cause is `gemma-4b-e4b` itself judging Егор the protagonist and mis-attributing first-person to him — no deterministic roster/alignment work overrides a model that misreads the protagonist, especially while alignment stays under the 80% floor on dialogue-heavy chapters (ch2 ~31%). Whether a larger model (Qwen-9b / cloud `gemma-4-31b-it`) resolves it is being evaluated separately; #1676 adds the bulk-reassign editing tools for residual cleanup.

## Notes
- Plan + two adversarial reviews (whole-branch + fuzzy path) are in `docs/superpowers/plans/2026-07-16-analyzer-first-person-narrator-fix.md`.
- Follow-ups: #1676 (alias re-point + bulk reassign), #1679 (manuscript-view scene separator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
