### PR TITLE
fix(frontend): keep-alive field saves on Enter + Saved confirmation

### DIFF
--- a/docs/release-notes-next.md
+++ b/docs/release-notes-next.md
@@ -118,6 +118,15 @@ Tap any chapter you haven't downloaded and it starts immediately on the home net
 - Per-model Ollama analyzer keep-alive (seconds) in the Model Manager; retired
   the hardcoded `RESIDENT_MODELS` allowlist and the `analyzer.ollama.keepAlive`
   knob (#1696).
+- **Fix (keep-alive, pre-release): the per-model keep-alive field now saves on
+  Enter and confirms with a "Saved" flash.** The field was a `blur`-only
+  autosave with no Save button of its own — typing a value and pressing Enter
+  (or reloading) without first tabbing/clicking away silently discarded it, so
+  the value "reverted to 0 on reload." `onKeyDown` Enter now routes through the
+  same commit path as blur, and every save (field + reset pill) flashes a
+  transient "Saved" so the autosave is no longer invisible. Regression tests in
+  `src/views/model-manager.test.tsx` pin both the Enter-save and the Saved
+  affordance.
 - **Analyzer: local Ollama analysis can now run K chapters/chunks concurrently
   for ~2–3× overnight-batch throughput — safe on 6/8 GB cards and decoupled
   from TTS.** A new width-K limiter (`analyzer.ollama.concurrency` /

--- a/src/views/model-manager.test.tsx
+++ b/src/views/model-manager.test.tsx
@@ -640,6 +640,53 @@ describe('ModelManagerView — per-model keep-alive control', () => {
       }),
     );
   });
+
+  /* Regression: the field is a silent autosave with no Save button of its
+     own. Pressing Enter — the natural "commit" gesture — must save without
+     first tabbing/clicking away, or the typed value is lost on reload. */
+  it('saves on Enter without an explicit blur', async () => {
+    mockInventory.mockResolvedValue({
+      ...INVENTORY,
+      items: [
+        ...INVENTORY.items,
+        { ...ANALYZER_ITEM_FIXTURE, keepAliveSeconds: 0, keepAliveIsOverride: false },
+      ],
+    });
+    putUserSettings.mockResolvedValue(SETTINGS_FIXTURE);
+    renderManager({ analyzerKeepAliveByModel: { 'qwen3.5:4b': 120 } });
+
+    const field = (await screen.findByTestId(
+      'keepalive-ollama:qwen36-castwright:latest',
+    )) as HTMLInputElement;
+    fireEvent.change(field, { target: { value: '90' } });
+    fireEvent.keyDown(field, { key: 'Enter' });
+
+    await waitFor(() =>
+      expect(putUserSettings).toHaveBeenCalledWith({
+        analyzerKeepAliveByModel: { 'qwen3.5:4b': 120, 'qwen36-castwright:latest': 90 },
+      }),
+    );
+  });
+
+  it('flashes a Saved confirmation after a keep-alive save', async () => {
+    mockInventory.mockResolvedValue({
+      ...INVENTORY,
+      items: [
+        ...INVENTORY.items,
+        { ...ANALYZER_ITEM_FIXTURE, keepAliveSeconds: 0, keepAliveIsOverride: false },
+      ],
+    });
+    putUserSettings.mockResolvedValue(SETTINGS_FIXTURE);
+    renderManager();
+
+    const field = await screen.findByTestId('keepalive-ollama:qwen36-castwright:latest');
+    fireEvent.change(field, { target: { value: '90' } });
+    fireEvent.blur(field);
+
+    expect(
+      await screen.findByTestId('keepalive-saved-ollama:qwen36-castwright:latest'),
+    ).toBeInTheDocument();
+  });
 });
 
 describe('ModelManagerView — back-to-Admin breadcrumb', () => {

--- a/src/views/model-manager.tsx
+++ b/src/views/model-manager.tsx
@@ -484,6 +484,7 @@ function ModelRow({
 }) {
   const dispatch = useAppDispatch();
   const [installerOpen, setInstallerOpen] = useState(false);
+  const [keepAliveSaved, setKeepAliveSaved] = useState(false);
   const hasInstaller = INSTALLER_IDS.has(item.id);
   const engine = TTS_ENGINE_BY_ID[item.id];
   const loadModel = TTS_LOAD_MODEL_BY_ID[item.id];
@@ -514,6 +515,27 @@ function ModelRow({
   /* Ollama tags contain colons (ollama:qwen3.5:4b) — slice the prefix, never
      split(':'). Mirrors performRemoval in models-inventory.ts. */
   const analyzerModel = isAnalyzer ? item.id.slice('ollama:'.length) : undefined;
+
+  /* Persist the keep-alive map and flash a 'Saved' confirmation. The field is
+     a silent per-row autosave with no Save button of its own, so the number
+     input (blur / Enter) and the reset pill all route through here — otherwise
+     a save gives no visible signal at all. */
+  const saveKeepAlive = (next: Record<string, number>) => {
+    void dispatch(saveAccountSettings({ analyzerKeepAliveByModel: next })).then(() => {
+      setKeepAliveSaved(true);
+      window.setTimeout(() => setKeepAliveSaved(false), 2000);
+      onChanged();
+    });
+  };
+  /* Commit the typed value. Called on blur AND on Enter — Enter is the natural
+     "commit" gesture, and without it a typed value is silently lost on the
+     next reload (the input never blurred, so nothing saved). */
+  const commitKeepAlive = (raw: string) => {
+    if (!analyzerModel) return;
+    const secs = Math.trunc(Number(raw));
+    if (!Number.isFinite(secs)) return;
+    saveKeepAlive({ ...keepAliveMap, [analyzerModel]: secs });
+  };
   const doLoad = () =>
     onAction(() =>
       engine
@@ -580,11 +602,9 @@ function ModelRow({
                 type="number"
                 data-testid={`keepalive-${item.id}`}
                 defaultValue={item.keepAliveSeconds ?? 0}
-                onBlur={(e) => {
-                  const secs = Math.trunc(Number(e.currentTarget.value));
-                  if (!Number.isFinite(secs)) return;
-                  const next = { ...keepAliveMap, [analyzerModel]: secs };
-                  void dispatch(saveAccountSettings({ analyzerKeepAliveByModel: next })).then(onChanged);
+                onBlur={(e) => commitKeepAlive(e.currentTarget.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') commitKeepAlive(e.currentTarget.value);
                 }}
                 className="w-16 min-h-[44px] fine-pointer:min-h-0 rounded-md border border-ink/15 bg-white px-2 text-right text-ink"
                 aria-label={`Keep-alive seconds for ${item.label}`}
@@ -597,13 +617,21 @@ function ModelRow({
                   onClick={() => {
                     const next = { ...keepAliveMap };
                     delete next[analyzerModel];
-                    void dispatch(saveAccountSettings({ analyzerKeepAliveByModel: next })).then(onChanged);
+                    saveKeepAlive(next);
                   }}
                   className="min-h-[44px] fine-pointer:min-h-0 min-w-[44px] fine-pointer:min-w-0 flex items-center justify-center text-ink/45 hover:text-ink"
                   aria-label="Reset to default"
                 >
                   ↺
                 </button>
+              )}
+              {keepAliveSaved && (
+                <span
+                  data-testid={`keepalive-saved-${item.id}`}
+                  className="text-[10px] font-semibold text-magenta"
+                >
+                  Saved
+                </span>
               )}
             </label>
           )}


### PR DESCRIPTION
## Summary

The per-model analyzer **keep-alive** field in the Model Manager was a `blur`-only autosave with no Save button of its own. Typing a value and pressing **Enter** — or reloading — without first tabbing/clicking away never fired `onBlur`, so the value was silently discarded and "reverted to 0 on reload." There was also no confirmation a save happened.

Diagnosed end-to-end against the running server: `PUT /api/user/settings` persists the keep-alive map correctly (200, written to disk); tabbing out saved; pressing Enter fired no request. The backend was never at fault — the gap was purely the missing Enter commit.

### Changes
- `onKeyDown` Enter now routes through one `commitKeepAlive` path shared with blur → Enter saves.
- Every keep-alive save (number field + reset ↺ pill) flashes a transient **"Saved"** so the otherwise-invisible autosave gives visible feedback.

## Test plan
- New regression tests in `src/views/model-manager.test.tsx`: (a) saves on Enter without an explicit blur, (b) flashes a "Saved" confirmation after a save. Both fail before the fix, pass after.
- Full frontend suite green (4016 tests) via pre-commit; pre-push `verify:fast:branch` (lint, typecheck, build) green.
- Manually verified in the running app: Enter now fires the `PUT`; value persists across reload.

Closes #1703

🤖 Generated with [Claude Code](https://claude.com/claude-code)