### PR TITLE
chore(server): TEMP keep-alive wire probe (diagnostic, revert after)

### DIFF
--- a/server/src/analyzer/ollama.ts
+++ b/server/src/analyzer/ollama.ts
@@ -605,6 +605,19 @@ export class OllamaAnalyzer implements Analyzer {
       },
     };
 
+    /* TEMP DIAGNOSTIC (keep-alive eviction hunt) — logs the EXACT keep_alive on
+       the wire per /api/chat call, plus the model string, the accelerator, the
+       override-map keys, and the cache-key values (num_ctx/num_gpu). Remove once
+       the root cause is confirmed. */
+    console.log(
+      `[keepalive-probe] model=${JSON.stringify(this.model)} ` +
+        `keep_alive=${body.keep_alive} ` +
+        `accel=${getLastKnownVram().accelerator} ` +
+        `resolveKeepAliveSeconds=${resolveKeepAliveSeconds(this.model)} ` +
+        `overrideKeys=${JSON.stringify(Object.keys(getCachedUserSettings().analyzerKeepAliveByModel ?? {}))} ` +
+        `num_ctx=${body.options.num_ctx} num_gpu=${body.options.num_gpu}`,
+    );
+
     /* Short-circuit if the caller has already aborted (e.g. the SSE client
        disconnected while a previous chapter was still running). Saves a
        wasted Ollama round-trip and lets the route loop bail immediately. */

--- a/server/src/routes/ollama-health.ts
+++ b/server/src/routes/ollama-health.ts
@@ -476,6 +476,12 @@ ollamaHealthRouter.post('/load', async (req: Request, res: Response) => {
     `.status` for the HTTP response code). */
 export async function unloadResidentOllama(targets?: string[]): Promise<string[]> {
   const url = getResolvedOllamaUrl();
+  /* TEMP DIAGNOSTIC (keep-alive eviction hunt) — records EVERY explicit evict
+     (keep_alive:0) with its caller stack, so a mid-run eviction is traceable to
+     whatever triggered it. Remove once the root cause is confirmed. */
+  console.log(
+    `[evict-probe] unloadResidentOllama targets=${JSON.stringify(targets ?? null)}\n${new Error('evict call site').stack}`,
+  );
   const list = targets && targets.length > 0 ? targets : (await probeOllamaHealth()).resident ?? [];
   for (const model of list) {
     const result = await callOllamaGenerate(url, { model, prompt: '', keep_alive: 0, stream: false }, PROBE_TIMEOUT_MS);


### PR DESCRIPTION
## Summary

Temporary diagnostic to settle a stubborn analyzer-eviction bug: a local Ollama
model set to a positive per-model keep-alive (e.g. `qwen36-cw-iq3-64k:latest` = 90s)
still evicts/cold-reloads between attribution chunks, yet the Model Manager
display resolves the override correctly. Static code-reading has produced several
contradictory theories; this logs the **actual `keep_alive` on the wire** so we
stop guessing.

Adds two throwaway `console.log`s (no behavior change):

- **`[keepalive-probe]`** in `OllamaAnalyzer.chat` — per `/api/chat` call: the
  model string, the exact `keep_alive` sent, the accelerator,
  `resolveKeepAliveSeconds(model)`, the override-map keys, and `num_ctx`/`num_gpu`
  (the reload cache-key). Tells us whether the runtime sends 90 (idle-timer
  expiry) or 0 (a missed override / evict).
- **`[evict-probe]`** in `unloadResidentOllama` — stack-traces every explicit
  `keep_alive:0` evict, so a mid-run eviction is traceable to its trigger.

Reverted in a follow-up build once the root cause is confirmed.

## Test plan

- No behavior change; existing server suite stays green (cloud verify.yml,
  server-scoped).
- Manual: run one chapter locally, capture `[keepalive-probe]` / `[evict-probe]`
  lines from the server log.

Refs #1709