### PR TITLE
fix(server): analyzer keep-alive falls back to 30s, not evict-per-call

### DIFF
--- a/server/src/analyzer/ollama.test.ts
+++ b/server/src/analyzer/ollama.test.ts
@@ -193,9 +193,10 @@ describe('OllamaAnalyzer — happy path streaming', () => {
      * the string sentinel. */
     expect(body.format).not.toBe('json');
     expect(typeof body.format).toBe('object');
-    /* qwen3.5:9b resolves to its coded default keep-alive (300 s) — see
-       DEFAULT_KEEP_ALIVE_SECONDS in ollama.ts; unknown tags get 0. */
-    expect(body.keep_alive).toBe(300);
+    /* qwen3.5:9b has no override, so it resolves to the flat 30s fallback
+       (DEFAULT_ANALYZER_KEEP_ALIVE_SECONDS) — the curated per-model map was
+       removed. accel is 'unknown' here so the RAM-heavy CPU clamp doesn't fire. */
+    expect(body.keep_alive).toBe(30);
     expect(body.options.num_ctx).toBe(32768);
     /* Pin all layers to GPU — see ANALYZER_NUM_GPU in ollama.ts. 999 is
        the standard "all layers" idiom; without this, Ollama auto-splits
@@ -253,14 +254,18 @@ describe('OllamaAnalyzer — analyzer slot (limiter + model lease)', () => {
 describe('OllamaAnalyzer — keep_alive policy (per-model seconds)', () => {
   afterEach(() => _resetUserSettingsCache());
 
-  it('returns the coded default (300) for supported models, 0 for unknown', async () => {
+  it('returns the flat 30s fallback for ANY model without an override (curated map removed)', async () => {
     const { keepAliveFor } = await import('./ollama.js');
-    expect(keepAliveFor('qwen3.5:4b')).toBe(300);
-    expect(keepAliveFor('llama3.1:8b')).toBe(300);
-    expect(keepAliveFor('qwen3.5:9b')).toBe(300);
-    expect(keepAliveFor('gemma4-e4b-8gb')).toBe(300);
-    expect(keepAliveFor('gemma4-e4b-8gb:latest')).toBe(300); // normalized to bare
-    expect(keepAliveFor('placeholder:test-7b')).toBe(0);
+    // Formerly-curated tags no longer get a special 300 — they share the fallback.
+    expect(keepAliveFor('qwen3.5:4b')).toBe(30);
+    expect(keepAliveFor('llama3.1:8b')).toBe(30);
+    expect(keepAliveFor('qwen3.5:9b')).toBe(30);
+    expect(keepAliveFor('gemma4-e4b-8gb')).toBe(30);
+    expect(keepAliveFor('gemma4-e4b-8gb:latest')).toBe(30); // normalized to bare
+    // The regression that started this: an uncurated fine-tune used to fall to 0
+    // (evict-per-call). It now gets the 30s fallback so a run stays resident.
+    expect(keepAliveFor('qwen36-cw-iq4-32k:latest')).toBe(30);
+    expect(keepAliveFor('placeholder:test-7b')).toBe(30);
   });
 
   it('lets a user override win, including -1 (pin) and 0 (evict)', async () => {
@@ -270,7 +275,7 @@ describe('OllamaAnalyzer — keep_alive policy (per-model seconds)', () => {
       analyzerKeepAliveByModel: { 'qwen36-castwright:latest': 600, 'qwen3.5:4b': 0, 'llama3.1:8b': -1 },
     });
     expect(keepAliveFor('qwen36-castwright:latest')).toBe(600);
-    expect(keepAliveFor('qwen3.5:4b')).toBe(0); // override beats the 300 default
+    expect(keepAliveFor('qwen3.5:4b')).toBe(0); // override beats the 30s fallback
     expect(keepAliveFor('llama3.1:8b')).toBe(-1);
   });
 
@@ -283,7 +288,7 @@ describe('OllamaAnalyzer — keep_alive policy (per-model seconds)', () => {
     expect(keepAliveFor('qwen3.5:9b', 'cuda')).toBe(900);
     expect(keepAliveFor('qwen3.5:9b', 'cpu')).toBe(0);
     expect(keepAliveFor('qwen3.5:9b', 'unknown')).toBe(900);
-    expect(keepAliveFor('qwen3.5:4b', 'cpu')).toBe(300); // small model unaffected
+    expect(keepAliveFor('qwen3.5:4b', 'cpu')).toBe(30); // small model → fallback, unaffected by CPU clamp
   });
 });
 

--- a/server/src/analyzer/ollama.ts
+++ b/server/src/analyzer/ollama.ts
@@ -127,17 +127,18 @@ export function resolveOllamaRetryTemperature(): number {
   return configValue<number>('analyzer.ollama.retryTemperature');
 }
 
-/* Coded keep-alive defaults (seconds) for the analyzer models Castwright
-   supports out of the box. Keyed on the NORMALIZED (bare, no ':latest') tag.
-   User overrides in userSettings.analyzerKeepAliveByModel win; anything not
-   listed and not overridden falls to 0 (unload immediately). 300 = the former
-   global '5m' the retired RESIDENT_MODELS allowlist applied. */
-const DEFAULT_KEEP_ALIVE_SECONDS: Record<string, number> = {
-  'qwen3.5:4b': 300,
-  'qwen3.5:9b': 300,
-  'llama3.1:8b': 300,
-  'gemma4-e4b-8gb': 300,
-};
+/* Fallback keep-alive (seconds) for any analyzer model WITHOUT an explicit
+   per-model override in userSettings.analyzerKeepAliveByModel. Deliberately a
+   single flat value — the previous per-model curated map (qwen3.5:4b→300 etc.)
+   was removed: it left every UNCURATED tag (a Castwright fine-tune like
+   qwen36-cw-iq4-32k, any pulled community model) falling through to 0, which is
+   Ollama's EVICT-IMMEDIATELY idiom — so the analyzer unloaded after every
+   /api/chat call and cold-reloaded on the next, thrashing a whole run. 30s
+   comfortably bridges the gap between back-to-back attribution calls (which
+   refresh the timer) so the model stays resident through a run, while still
+   idling out ~30s after the run ends. Raise per-model in Model Manager for a
+   longer hold; 0 (evict) / -1 (pin) remain available as explicit overrides. */
+const DEFAULT_ANALYZER_KEEP_ALIVE_SECONDS = 30;
 
 /* Models unsafe to keep resident on CPU (would pin ~6.4 GB system RAM for the
    whole window). Clamped to 0 on a CPU-only box regardless of the configured
@@ -151,14 +152,14 @@ export function normalizeModelTag(tag: string): string {
 }
 
 /** Resolved keep-alive (seconds) for `model`: user override (raw or normalized
-    key) → coded default (normalized) → 0. Reads the settings cache synchronously
-    so it is safe at the request-body build site. */
+    key) → flat DEFAULT_ANALYZER_KEEP_ALIVE_SECONDS (30). Reads the settings
+    cache synchronously so it is safe at the request-body build site. */
 export function resolveKeepAliveSeconds(model: string): number {
   const map = getCachedUserSettings().analyzerKeepAliveByModel ?? {};
   const norm = normalizeModelTag(model);
   const override = map[model] ?? map[norm];
   if (override !== undefined) return override;
-  return DEFAULT_KEEP_ALIVE_SECONDS[norm] ?? 0;
+  return DEFAULT_ANALYZER_KEEP_ALIVE_SECONDS;
 }
 
 /** True when the user has an explicit override for `model` (either key form). */
@@ -573,9 +574,9 @@ export class OllamaAnalyzer implements Analyzer {
          extra fields. The existing validation-retry loop below still guards
          against semantic violations the schema can't express. */
       format: responseFormat,
-      /* Per-model keep_alive — see keepAliveFor + DEFAULT_KEEP_ALIVE_SECONDS
-         above; a user override in analyzerKeepAliveByModel wins over the
-         coded default. */
+      /* Per-model keep_alive — see keepAliveFor + resolveKeepAliveSeconds
+         above; a user override in analyzerKeepAliveByModel wins over the flat
+         DEFAULT_ANALYZER_KEEP_ALIVE_SECONDS fallback. */
       keep_alive: keepAliveFor(this.model, getLastKnownVram().accelerator),
       /* Suppress qwen3.5's thinking tokens — they'd appear as
          `<think>…</think>` ahead of the JSON and break the parser. Ollama

--- a/server/src/routes/models-inventory.test.ts
+++ b/server/src/routes/models-inventory.test.ts
@@ -372,7 +372,7 @@ describe('buildModelInventory', () => {
     const supported = res.items.find((i) => i.id === 'ollama:qwen3.5:4b');
     expect(custom?.keepAliveSeconds).toBe(300);
     expect(custom?.keepAliveIsOverride).toBe(true);
-    expect(supported?.keepAliveSeconds).toBe(300); // coded default
+    expect(supported?.keepAliveSeconds).toBe(30); // flat fallback (no override)
     expect(supported?.keepAliveIsOverride).toBe(false);
   });
 });

--- a/server/src/routes/ollama-health.test.ts
+++ b/server/src/routes/ollama-health.test.ts
@@ -272,9 +272,9 @@ describe('warmOllamaModel (Part 2 — patient warm)', () => {
     expect(res.ok).toBe(true);
     const body = generateCallBody();
     expect(body?.model).toBe('qwen3.5:9b');
-    // 300 = the coded DEFAULT_KEEP_ALIVE_SECONDS for qwen3.5:9b (analyzer/ollama.ts),
-    // resolved via resolveKeepAliveSeconds — no longer a hardcoded '5m'.
-    expect(body?.keep_alive).toBe(300);
+    // 30 = the flat fallback (no override) resolved via resolveKeepAliveSeconds
+    // — no longer a hardcoded '5m'.
+    expect(body?.keep_alive).toBe(30);
     expect(body?.prompt).toBe('');
     expect((body?.options as { num_ctx?: number })?.num_ctx).toBe(32768);
     expect((body?.options as { num_gpu?: number })?.num_gpu).toBe(999);
@@ -347,14 +347,14 @@ describe('warmOllamaModel (Part 2 — patient warm)', () => {
     expect(body?.keep_alive).toBe(1800);
   });
 
-  it('floors a custom local tag\'s warm keep_alive to 30s when it resolves to 0 (Load must HOLD, not evict)', async () => {
-    /* Regression: qwen36-cw-* is a custom local tag — not in
-       DEFAULT_KEEP_ALIVE_SECONDS and with no user override, so
-       resolveKeepAliveSeconds() returns 0. But 0 is Ollama's EVICT-now idiom
-       (see the /unload route), so the per-model warm change (7b87221f) made the
-       Load button load-then-immediately-unload: the pill snapped back to
-       "Analyzer idle" and analysis never started. An explicit Load means "hold
-       it resident" — the warm floor turns a resolved 0 into 30s. */
+  it('warms a custom local tag with the 30s fallback (no override, curated map removed → Load HOLDS, not evicts)', async () => {
+    /* Regression that drove the whole keep-alive saga: qwen36-cw-* is a custom
+       local tag with no user override. It used to fall through the (now-removed)
+       curated map to 0 — Ollama's EVICT-now idiom — so the runtime chat path
+       unloaded the model after every call and the Load button loaded-then-
+       immediately-unloaded. resolveKeepAliveSeconds now returns the flat 30s
+       fallback for any uncurated tag, so warm (and every runtime call) sends 30
+       and the model stays resident through a run. */
     fetchMock.mockResolvedValue(new Response('', { status: 200 }));
     await warmOllamaModel('qwen36-cw-iq3-64k:latest');
     const body = generateCallBody();
@@ -363,7 +363,7 @@ describe('warmOllamaModel (Part 2 — patient warm)', () => {
 
   it('floors a RAM-heavy model\'s warm keep_alive to 30s on CPU too — explicit Load overrides the runtime CPU clamp', async () => {
     /* The RAM_HEAVY-on-CPU clamp (keepAliveFor → 0) is a runtime-chat safety
-       rail so a big model isn't pinned in system RAM for the whole 300s window.
+       rail so a big model isn't pinned in system RAM for the whole hold window.
        On an EXPLICIT Load the user is asking to hold it, so the warm floor
        still applies (30s, not the runtime-chat 0) — a short, deliberate hold
        rather than a no-op Load. */
@@ -378,13 +378,13 @@ describe('warmOllamaModel (Part 2 — patient warm)', () => {
     }
   });
 
-  it('does NOT clamp a RAM-heavy model\'s warm keep_alive on cuda/unknown (stays 300)', async () => {
+  it('does NOT clamp a RAM-heavy model\'s warm keep_alive on cuda/unknown (stays at the 30s fallback)', async () => {
     setLastKnownVram({ totalMb: 8188 }); // -> accelerator: 'cuda'
     try {
       fetchMock.mockResolvedValue(new Response('', { status: 200 }));
       await warmOllamaModel('qwen3.5:9b');
       const body = generateCallBody();
-      expect(body?.keep_alive).toBe(300);
+      expect(body?.keep_alive).toBe(30);
     } finally {
       setLastKnownVram(null); // reset to 'unknown'
     }
@@ -404,9 +404,9 @@ describe('POST /api/ollama/load', () => {
     const body = generateCallBody();
     expect(body?.prompt).toBe('');
     expect(body?.stream).toBe(false);
-    // 300 = the coded DEFAULT_KEEP_ALIVE_SECONDS for the default analysis
-    // model qwen3.5:4b (analyzer/ollama.ts), resolved via resolveKeepAliveSeconds.
-    expect(body?.keep_alive).toBe(300);
+    // 30 = the flat DEFAULT_ANALYZER_KEEP_ALIVE_SECONDS fallback for the default
+    // analysis model qwen3.5:4b (no override), resolved via resolveKeepAliveSeconds.
+    expect(body?.keep_alive).toBe(30);
     /* CRITICAL: warming must use the same num_ctx AND num_gpu the
        analyzer's runStage path passes (ANALYZER_NUM_CTX, ANALYZER_NUM_GPU
        in server/src/analyzer/ollama.ts). Either drifting triggers a
@@ -449,8 +449,8 @@ describe('POST /api/ollama/load', () => {
     expect(res.status).toBe(200);
     const body = generateCallBody();
     expect(body?.model).toBe('llama3.1:8b');
-    // 300 = the coded DEFAULT_KEEP_ALIVE_SECONDS for llama3.1:8b (analyzer/ollama.ts).
-    expect(body?.keep_alive).toBe(300);
+    // 30 = the flat fallback (no override) for llama3.1:8b, via resolveKeepAliveSeconds.
+    expect(body?.keep_alive).toBe(30);
     expect((body?.options as { num_ctx?: number })?.num_ctx).toBe(32768);
     expect((body?.options as { num_gpu?: number })?.num_gpu).toBe(999);
   });

--- a/server/src/routes/ollama-health.ts
+++ b/server/src/routes/ollama-health.ts
@@ -421,7 +421,7 @@ export async function warmOllamaModel(
         prompt: '',
         /* An explicit Load means "hold this model resident" — so warm with the
            model's configured keep-alive, but FLOOR a resolved 0 up to 30s.
-           keepAliveFor() returns 0 for any tag not in DEFAULT_KEEP_ALIVE_SECONDS
+           keepAliveFor() returns 0 only for a RAM-heavy model on CPU or an explicit 0 override
            without a user override (e.g. a custom `qwen36-cw-*` quant), and 0 is
            Ollama's evict-immediately idiom — warming with it loaded the model and
            dropped it in the same call, so the Load button looked dead and the

--- a/server/src/workspace/user-settings.ts
+++ b/server/src/workspace/user-settings.ts
@@ -243,8 +243,8 @@ export const userSettingsSchema = z.object({
   tourCompletedAt: z.string().nullable().optional(),
   /* Per-model Ollama analyzer keep-alive (seconds). Sparse override map:
      model tag → seconds (0 = unload immediately, -1 = pin, N = resident N s).
-     Absent tags fall through to DEFAULT_KEEP_ALIVE_SECONDS in analyzer/ollama.ts
-     and then to 0. NOT in FORBIDDEN_KEYS — the general Account/Model-Manager
+     Absent tags fall through to the flat DEFAULT_ANALYZER_KEEP_ALIVE_SECONDS
+     (30s) in analyzer/ollama.ts. NOT in FORBIDDEN_KEYS — the general Account/Model-Manager
      PUT is the sanctioned write path (mirrors configOverrides). Read
      synchronously by resolveKeepAliveSeconds. Optional-with-default so legacy
      files load unchanged. */
@@ -328,7 +328,7 @@ export const DEFAULT_USER_SETTINGS: UserSettings = {
   /* config-override store — empty by default; populated by writeConfigOverride. */
   configOverrides: {},
   /* Per-model analyzer keep-alive — empty by default; every model falls
-     through to its coded default (see DEFAULT_KEEP_ALIVE_SECONDS). */
+     through to the flat DEFAULT_ANALYZER_KEEP_ALIVE_SECONDS (30s). */
   analyzerKeepAliveByModel: {},
   /* srv-2 — auto-backup ON by default (disaster recovery without manual
      intervention), daily, keep the last 14 snapshots. Flip in lockstep with


### PR DESCRIPTION
## Summary

The analyzer's runtime `/api/chat` sent **`keep_alive: 0`** for any Ollama tag
without an explicit per-model override that also wasn't one of the four stock
tags in the curated `DEFAULT_KEEP_ALIVE_SECONDS` map. That covers **every
Castwright fine-tune** (`qwen36-cw-*`, `gemma4-cw-*`) and any pulled community
model. `0` is Ollama's evict-immediately idiom, so the analyzer **unloaded after
every call and cold-reloaded on the next** — the mid-analysis reload storm
(`ollama ps` flipping to `Stopping…`, repeated `load_model: initializing`).

Confirmed on the wire via the `[keepalive-probe]` diagnostic (#1710):
```
model="qwen36-cw-iq4-32k:latest" keep_alive=0 resolveKeepAliveSeconds=0 overrideKeys=[]
```

**Fix:** removed the curated per-model map (a hidden special-case covering only
4 stock tags) and resolve any tag without an override to a flat
`DEFAULT_ANALYZER_KEEP_ALIVE_SECONDS = 30`. 30s bridges back-to-back attribution
calls (which refresh the timer) so the model stays resident through a run.
Admin per-model overrides still win; the RAM-heavy-on-CPU clamp is untouched.

Note: a *separate* bug (per-model keep-alive values set in Model Manager not
persisting to disk) is tracked/fixed separately — this PR makes the analyzer
stop evicting regardless of whether an explicit override sticks.

## Test plan

- `server/src/analyzer/ollama.test.ts`, `ollama-health.test.ts`,
  `models-inventory.test.ts` updated for the 30s fallback (was 300/0); 117 pass.
- Manual: `[keepalive-probe]` now logs `keep_alive=30` for uncurated tags;
  `ollama ps` holds a refreshing countdown through a run instead of `Stopping…`.

Refs #1709