### PR TITLE
fix(server): targeted settings save no longer wipes default-carrying fields

### DIFF
--- a/server/src/workspace/user-settings.test.ts
+++ b/server/src/workspace/user-settings.test.ts
@@ -743,4 +743,30 @@ describe('analyzerKeepAliveByModel', () => {
   it('is present in DEFAULT_USER_SETTINGS', () => {
     expect(DEFAULT_USER_SETTINGS.analyzerKeepAliveByModel).toEqual({});
   });
+
+  it('survives a targeted save of an UNRELATED field (partial-patch default-clobber regression)', async () => {
+    const mod = await import('./user-settings.js');
+    mod._resetUserSettingsCache();
+    try {
+      // 1. Save a per-model keep-alive override.
+      await mod.writeUserSettings({
+        analyzerKeepAliveByModel: { 'qwen36-cw-iq4-32k:latest': 90 },
+      });
+      // 2. Save an UNRELATED field with NO keep-alive key — mirrors the
+      //    analysing-screen phase-model dropdown (saves just analyzerPhase0Model).
+      //    Before the fix, patchSchema (userSettingsSchema.partial()) applied
+      //    analyzerKeepAliveByModel's `.default({})` and the wholesale merge
+      //    wiped the saved 90 back to {}.
+      const after = await mod.writeUserSettings({ analyzerPhase0Model: 'qwen3.5:4b' });
+      expect(after.analyzerKeepAliveByModel).toEqual({ 'qwen36-cw-iq4-32k:latest': 90 });
+      expect(after.analyzerPhase0Model).toBe('qwen3.5:4b');
+      // 3. And it survives a reload from disk (not just the in-memory cache).
+      mod._resetUserSettingsCache();
+      const reread = await mod.readUserSettings();
+      expect(reread.analyzerKeepAliveByModel).toEqual({ 'qwen36-cw-iq4-32k:latest': 90 });
+    } finally {
+      await mod.writeUserSettings({ analyzerKeepAliveByModel: {}, analyzerPhase0Model: null });
+      mod._resetUserSettingsCache();
+    }
+  });
 });

--- a/server/src/workspace/user-settings.ts
+++ b/server/src/workspace/user-settings.ts
@@ -384,14 +384,31 @@ const patchSchema = userSettingsSchema.partial();
 export async function writeUserSettings(patch: unknown): Promise<UserSettings> {
   const sanitised = stripForbiddenKeys(patch);
   const validated = patchSchema.parse(sanitised);
+  /* Merge ONLY the keys the caller actually sent. `patchSchema`
+     (userSettingsSchema.partial()) still applies every field's `.default()` for
+     keys the PUT OMITTED — Zod fires defaults even under `.partial()`, so the
+     parsed object carries e.g. `analyzerKeepAliveByModel: {}`,
+     `configOverrides: {}`, `analysisEngine: 'local'` even when the request never
+     mentioned them. The old `{ ...current, ...validated }` therefore RESET every
+     default-carrying field on any targeted save — the analysing-screen
+     phase-model dropdown sends just `analyzerPhase0Model`, which silently wiped
+     the user's per-model keep-alive map and registry overrides on disk. Keying
+     the merge off the sanitised INPUT keys makes an omitted field mean
+     "leave as-is", matching the mock save path (mockPutUserSettings). */
+  const sentKeys = Object.keys(sanitised as Record<string, unknown>);
+  const validatedRecord = validated as Record<string, unknown>;
   const next = writeChain.then(async () => {
     const current = await readUserSettings();
-    const merged: UserSettings = { ...current, ...validated };
+    const merged: UserSettings = { ...current };
+    for (const key of sentKeys) {
+      if (key in validatedRecord) (merged as Record<string, unknown>)[key] = validatedRecord[key];
+    }
     /* A genuine change to the default TTS model is an explicit user choice —
        latch the sentinel so getResolvedTtsModelKey honours it instead of
        preferring Qwen. (GET returns the STORED key, so a no-op round-trip
        sends the same value back and never trips this.) */
     if (
+      sentKeys.includes('defaultTtsModelKey') &&
       validated.defaultTtsModelKey !== undefined &&
       validated.defaultTtsModelKey !== current.defaultTtsModelKey
     ) {


### PR DESCRIPTION
## Summary

Per-model analyzer keep-alive set in Model Manager never persisted — the runtime
always read an empty map (`overrideKeys=[]`, confirmed on the wire) and sent
`keep_alive: 0`. Root cause: `writeUserSettings` merged the full parsed patch,
but `userSettingsSchema.partial()` still applies each field's `.default()` for
OMITTED keys. So parsing a patch that omits a field injects its default
(`analyzerKeepAliveByModel: {}`, `configOverrides: {}`, `analysisEngine: 'local'`,
`allowCloudFallback: true`), and `{ ...current, ...validated }` reset all of them
on any targeted save. The analysing-screen phase-model dropdown saves just
`analyzerPhase0Model` — each save wiped the keep-alive map to `{}` on disk.

**Fix:** merge only the keys the caller actually sent (`Object.keys` of the
sanitised input), so an omitted field means "leave as-is" — matching the mock
save path (`mockPutUserSettings`, which already filtered to defined keys).

This is the companion to #1711 (which stopped the runtime evicting on a 0/empty
map). Together: analysis stays resident, AND an explicit per-model keep-alive
now sticks.

## Test plan

- New regression in `user-settings.test.ts`: saving `analyzerPhase0Model`
  preserves a previously-saved keep-alive map, across a disk reload. 74 pass.
- Also protects `configOverrides` / `analysisEngine` / `allowCloudFallback`
  from the same clobber.

Closes #1712