### PR TITLE
fix(server): pin the local analyzer resident for the duration of a run

### DIFF
--- a/server/src/analyzer/ollama.test.ts
+++ b/server/src/analyzer/ollama.test.ts
@@ -290,6 +290,29 @@ describe('OllamaAnalyzer — keep_alive policy (per-model seconds)', () => {
     expect(keepAliveFor('qwen3.5:9b', 'unknown')).toBe(900);
     expect(keepAliveFor('qwen3.5:4b', 'cpu')).toBe(30); // small model → fallback, unaffected by CPU clamp
   });
+
+  it('PINS the model (-1) while an analysis run is in flight, overriding fallback / override / CPU-clamp', async () => {
+    const { keepAliveFor } = await import('./ollama.js');
+    const { markAnalysisBusy, clearAnalysisBusy } = await import('../tts/design-lock.js');
+    _setUserSettingsCacheForTest({
+      ...DEFAULT_USER_SETTINGS,
+      analyzerKeepAliveByModel: { 'qwen3.5:4b': 120 }, // a positive override…
+    });
+    markAnalysisBusy('/book/pinned');
+    try {
+      // …is superseded by the run-scoped pin. Calls land minutes apart, so any
+      // finite TTL would let Ollama evict between them mid-run.
+      expect(keepAliveFor('qwen36-cw-iq4-32k:latest')).toBe(-1); // uncurated fallback → pinned
+      expect(keepAliveFor('qwen3.5:4b')).toBe(-1); // override → pinned
+      expect(keepAliveFor('qwen3.5:9b', 'cpu')).toBe(-1); // RAM-heavy CPU clamp → pinned
+    } finally {
+      clearAnalysisBusy('/book/pinned');
+    }
+    // Run over → normal resolution resumes (teardown issues the keep_alive:0 evict).
+    expect(keepAliveFor('qwen36-cw-iq4-32k:latest')).toBe(30);
+    expect(keepAliveFor('qwen3.5:4b')).toBe(120);
+    expect(keepAliveFor('qwen3.5:9b', 'cpu')).toBe(0);
+  });
 });
 
 describe('OllamaAnalyzer — schema-constrained `format`', () => {

--- a/server/src/analyzer/ollama.ts
+++ b/server/src/analyzer/ollama.ts
@@ -18,6 +18,7 @@ import { costForEngine } from '../tts/engine-vram-cost.js';
 import { acquireAnalyzerSlot, describeAnalyzerConcurrency } from './analyzer-concurrency.js';
 import { getLastKnownAnalyzerDevice } from '../gpu/analyzer-device-state.js';
 import { getResolvedOllamaUrl, getCachedUserSettings } from '../workspace/user-settings.js';
+import { isAnyAnalysisBusy } from '../tts/design-lock.js';
 import { configValue } from '../config/resolver.js';
 import type { Accelerator } from '../gpu/vram-state.js';
 import { getLastKnownVram } from '../gpu/vram-state.js';
@@ -168,9 +169,21 @@ export function hasKeepAliveOverride(model: string): boolean {
   return map[model] !== undefined || map[normalizeModelTag(model)] !== undefined;
 }
 
-/** `keep_alive` (integer seconds) for an Ollama /api/chat call. Per-model via
-    resolveKeepAliveSeconds; RAM-heavy models clamp to 0 on CPU. */
+/** `keep_alive` (integer seconds, or -1 to pin) for an Ollama analyzer call.
+    While ANY analysis run is in flight the model is PINNED (-1); otherwise
+    per-model via resolveKeepAliveSeconds, with RAM-heavy models clamped to 0
+    on CPU. */
 export function keepAliveFor(model: string, accelerator: Accelerator = 'unknown'): number {
+  /* Pin the analyzer resident for the whole run. Attribution calls land minutes
+     apart — measured 120–200 s gaps between /api/chat calls on a 100k-word book
+     — so ANY finite idle TTL (even the 30 s fallback, or a user's 90) lets
+     Ollama evict the model between calls and cold-reload on the next. That
+     thrash both slows the run and opens a window where a transient
+     unreachable-during-reload trips the cloud (Gemini) fallback into a hard
+     failure. The run's teardown (routes/analysis.ts endJob) issues the matching
+     keep_alive:0 evict once no run remains, so the pin is strictly run-scoped
+     and the per-model value keeps its meaning as the POST-run idle retention. */
+  if (isAnyAnalysisBusy()) return -1;
   if (RAM_HEAVY_MODELS.has(model) && accelerator === 'cpu') return 0;
   return resolveKeepAliveSeconds(model);
 }
@@ -823,7 +836,9 @@ export async function generatePersonaViaOllama(
     messages: [{ role: 'user' as const, content: prompt }],
     stream: false,
     think: false,
-    keep_alive: opts.keepAlive ?? 0,
+    /* Pin during an active analysis run (same rationale as keepAliveFor); the
+       caller-supplied keepAlive is the post-run idle window otherwise. */
+    keep_alive: isAnyAnalysisBusy() ? -1 : (opts.keepAlive ?? 0),
     options: {
       temperature: resolveOllamaTemperature(),
       ...(onCpu ? { num_gpu: 0 } : {}),

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -26,7 +26,7 @@ import {
   type PhaseWatermark,
 } from '../analyzer/phase-watermark.js';
 import { AnalysisAbortedError } from '../analyzer/ollama.js';
-import { detectOllamaDevice } from './ollama-health.js';
+import { detectOllamaDevice, unloadResidentOllama } from './ollama-health.js';
 import { setLastKnownAnalyzerDevice } from '../gpu/analyzer-device-state.js';
 import { foldMinorCast } from '../analyzer/fold-minor-cast.js';
 import {
@@ -115,7 +115,7 @@ import {
 import { stampStateSchema } from '../workspace/state-migrate.js';
 import type { BookStateJson, AnalysisProvenanceReport } from '../workspace/scan.js';
 import { findBookByManuscriptId, bookStateLanguage } from '../workspace/scan.js';
-import { markAnalysisBusy, clearAnalysisBusy, isDesignBusy } from '../tts/design-lock.js';
+import { markAnalysisBusy, clearAnalysisBusy, isDesignBusy, isAnyAnalysisBusy } from '../tts/design-lock.js';
 import { scanSeriesCharactersForBookId } from '../workspace/series-cast-scan.js';
 import { dedupSeriesPrior } from '../workspace/series-prior-dedup.js';
 import { linkSeriesReuseAtAnalysis, pruneStaleReuseLinks } from '../workspace/series-reuse-link.js';
@@ -2296,6 +2296,20 @@ function endJob(job: AnalysisJob, finalEv?: unknown): void {
      start once analysis is done (mutual exclusion — re-analysis rewrites the
      whole cast). Ref-counted, so a sibling main/subset job keeps it held. */
   if (job.bookDir) clearAnalysisBusy(job.bookDir);
+  /* Release the run-scoped analyzer PIN. keepAliveFor() returned -1 for every
+     Ollama call while a run was in flight (see analyzer/ollama.ts) so the model
+     couldn't idle out between the minutes-apart attribution calls. Now that this
+     run is over, issue the matching keep_alive:0 evict so the pinned model
+     doesn't sit resident forever. Guarded: only a local Ollama run loaded a
+     model, and only when NO sibling analysis (main+subset, ref-counted via
+     isAnyAnalysisBusy) is still running — otherwise we'd evict a model that
+     run still needs. Best-effort and fire-and-forget: a failed evict just means
+     the model idles per its own keep_alive, and the next run re-warms it. */
+  if (job.engine === 'local' && !isAnyAnalysisBusy()) {
+    void unloadResidentOllama().catch(() => {
+      /* Ollama unreachable / already evicted — nothing to release. */
+    });
+  }
 }
 
 analysisRouter.post('/:id/analysis', async (req: Request, res: Response) => {


### PR DESCRIPTION
## Summary

On a local Ollama run, attribution calls land **120–200s apart** (measured — each
section streams 1–3 min before the next call). Any finite `keep_alive` (the 30s
fallback, or a user's 90) expires in those gaps → Ollama evicts the model between
calls and cold-reloads on the next → `ollama ps` shows `Stopping…` and the run
thrashes. A transient unreachable-during-reload then trips the **Gemini fallback**
into a hard RECITATION failure on copyrighted text.

**Fix:** while any analysis run is in flight (`isAnyAnalysisBusy`), `keepAliveFor()`
returns **-1** (pin) — no idle timer, no eviction regardless of gap. One place
covers every analyzer Ollama path (runtime chat + warm/Load) plus the persona
one-shot. `endJob` issues the matching **keep_alive:0** evict once no run remains
(ref-counted main+subset, guarded to local runs), so the pin is run-scoped and
the per-model keep-alive keeps its meaning as post-run idle retention.

Completes the keep-alive trilogy: #1711 (fallback 30 not 0), #1713 (persistence),
and this (pin during a run so the value never has to out-run the inter-call gap).

## Test plan

- `ollama.test.ts`: `keepAliveFor` returns -1 while a book is marked busy —
  overriding the fallback, a positive override, and the RAM-heavy CPU clamp —
  and reverts when cleared. 37 pass.
- Manual: `[keepalive-probe]` shows `keep_alive=-1` during a run; `ollama ps`
  holds resident (no `Stopping…`); `[evict-probe]` fires once at run end.

Closes #1714