### PR TITLE
fix(server): surface Gemini content-block errors + show the effective analyzer model

### DIFF
--- a/server/src/analyzer/errors.ts
+++ b/server/src/analyzer/errors.ts
@@ -36,3 +36,42 @@ export class AnalyzerTruncatedError extends Error {
     this.name = 'AnalyzerTruncatedError';
   }
 }
+
+/* Thrown by GeminiAnalyzer when the stream finishes with ZERO text — the
+   signature of a content-filter block. On a `gemini-*` model the usual cause is
+   RECITATION (Google refuses memorised/copyrighted source) or SAFETY; the model
+   returns a candidate carrying only the stop reason, or rejects the prompt via
+   promptFeedback.blockReason.
+
+   This is a DETERMINISTIC, WHOLE-BOOK-FATAL condition: the same filter blocks
+   every chapter identically, so retrying or splitting is futile. The run-level
+   consumers key off this TYPE to fail fast with one actionable terminal error
+   instead of grinding chapter-by-chapter:
+     - analysis.ts rethrows it from the per-chapter catch to its terminal handler,
+     - script-review.ts breaks the chunk loop and emits a terminal error,
+     - failure-taxonomy.ts matches it by `name` → `analyzer-content-blocked`.
+
+   The message reproduces the pre-typed-error string VERBATIM (same reason suffix
+   + remediation hint) so existing log-greps and the taxonomy regex still match.
+   Mirrors the sentinel shape of `AnalyzerTruncatedError` above. */
+export class GeminiContentBlockedError extends Error {
+  readonly code = 'GEMINI_CONTENT_BLOCKED';
+  constructor(
+    /** The Gemini model id that returned the empty/blocked response. */
+    public readonly model: string,
+    /** The stop/block reason (RECITATION / SAFETY / PROHIBITED_CONTENT), or
+        undefined when the stream ended empty without one. */
+    public readonly reason?: string,
+  ) {
+    const named =
+      reason && reason !== 'FINISH_REASON_UNSPECIFIED' ? ` (reason=${reason})` : '';
+    const hint =
+      reason && reason !== 'FINISH_REASON_UNSPECIFIED'
+        ? ' A content filter blocked the text — gemini-* models block copyrighted' +
+          ' source via RECITATION. Switch GEMINI_MODEL to a gemma-* model or set' +
+          ' ANALYZER=local (Ollama).'
+        : '';
+    super(`Gemini ${model} returned an empty response${named}.${hint}`);
+    this.name = 'GeminiContentBlockedError';
+  }
+}

--- a/server/src/analyzer/gemini.test.ts
+++ b/server/src/analyzer/gemini.test.ts
@@ -11,6 +11,7 @@ import { mkdir, rm } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { geminiRateLimiter } from './rate-limit.js';
+import { GeminiContentBlockedError } from './errors.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const HANDOFF_ROOT = resolve(__dirname, '..', '..', 'handoff');
@@ -164,6 +165,13 @@ describe('GeminiAnalyzer.runStage1 — streaming chunk feedback', () => {
     );
     expect(err?.message).toMatch(/empty response/); // back-compat with the generic branch
     expect(err?.message).toMatch(/RECITATION/); // the actionable reason
+    /* Typed sentinel — the run-level consumers (analysis + script-review) key
+       off the type to fast-fail the whole run instead of grinding chapter by
+       chapter, and the taxonomy matches it by name. Survives message rewording. */
+    expect(err).toBeInstanceOf(GeminiContentBlockedError);
+    expect((err as GeminiContentBlockedError).name).toBe('GeminiContentBlockedError');
+    expect((err as GeminiContentBlockedError).model).toBe('gemini-3.1-flash-lite');
+    expect((err as GeminiContentBlockedError).reason).toBe('RECITATION');
   });
 
   it('surfaces a prompt-level blockReason (SAFETY) on an empty response', async () => {

--- a/server/src/analyzer/gemini.ts
+++ b/server/src/analyzer/gemini.ts
@@ -37,7 +37,7 @@ import type { Analyzer, StageCall, StageChunkInfo } from './index.js';
 import { isNonEnglish, normaliseBookLanguage } from '../tts/language.js';
 import { getLanguageEntry } from '../tts/language-registry.js';
 import { AnalysisAbortedError } from './ollama.js';
-import { AnalyzerTruncatedError } from './errors.js';
+import { AnalyzerTruncatedError, GeminiContentBlockedError } from './errors.js';
 import { geminiRateLimiter, DailyQuotaExhaustedError } from './rate-limit.js';
 import { countCjkChars } from '../util/cjk.js';
 import {
@@ -781,16 +781,13 @@ export class GeminiAnalyzer implements Analyzer {
            (no retry, no chunk-split) and NAME the reason so the operator can
            act. Reordered ahead of nothing — historically this branch threw a
            bare "empty response" and discarded the reason captured below. */
+        /* Typed sentinel — carries the model + reason so the run-level consumers
+           (analysis, script-review) fast-fail the whole run and the taxonomy
+           matches by name. The message text is built inside the error VERBATIM
+           (same reason suffix + remediation hint), so log-greps and the taxonomy
+           regex still match. */
         const stopReason = finishReason ?? blockReason;
-        const named =
-          stopReason && stopReason !== 'FINISH_REASON_UNSPECIFIED' ? ` (reason=${stopReason})` : '';
-        const hint =
-          stopReason && stopReason !== 'FINISH_REASON_UNSPECIFIED'
-            ? ' A content filter blocked the text — gemini-* models block copyrighted' +
-              ' source via RECITATION. Switch GEMINI_MODEL to a gemma-* model or set' +
-              ' ANALYZER=local (Ollama).'
-            : '';
-        throw new Error(`Gemini ${this.model} returned an empty response${named}.${hint}`);
+        throw new GeminiContentBlockedError(this.model, stopReason);
       }
       /* Truncation gate (#528): the stream completed but the model stopped
          because it hit the output cap (or a safety/recitation block), not

--- a/server/src/analyzer/index.ts
+++ b/server/src/analyzer/index.ts
@@ -273,6 +273,10 @@ export class FallbackAnalyzer implements Analyzer {
     } catch (err) {
       if (err instanceof AnalysisAbortedError) throw err;
       if (err instanceof LocalUnreachableError) {
+        /* Announce the switch so the route re-labels the pill with the effective
+           Gemini model (mirrors runScriptReviewChapter) — otherwise the UI keeps
+           naming the local model that isn't running. */
+        call.onFallback?.({ reason: 'Ollama unreachable' });
         return await this.fallback.runStage1Chapter(manuscriptId, chapterId, promptMd, call);
       }
       throw err;
@@ -290,6 +294,8 @@ export class FallbackAnalyzer implements Analyzer {
     } catch (err) {
       if (err instanceof AnalysisAbortedError) throw err;
       if (err instanceof LocalUnreachableError) {
+        /* Announce the switch so the route re-labels the pill (see runStage1Chapter). */
+        call.onFallback?.({ reason: 'Ollama unreachable' });
         return await this.fallback.runStage2Chapter(manuscriptId, chapterId, promptMd, call);
       }
       throw err;

--- a/server/src/routes/analysis.phase-model.test.ts
+++ b/server/src/routes/analysis.phase-model.test.ts
@@ -16,6 +16,9 @@ import type { Analyzer, AnalyzerSelection, StageCall } from '../analyzer/index.j
 import type { Stage1ChapterOutput, Stage1Output, Stage2ChapterOutput } from '../handoff/schemas.js';
 import type { ChapterHint } from '../store/manuscripts.js';
 import { putManuscript, removeManuscript } from '../store/manuscripts.js';
+import { GeminiContentBlockedError } from '../analyzer/errors.js';
+import { LocalUnreachableError } from '../analyzer/ollama.js';
+import { FallbackAnalyzer } from '../analyzer/index.js';
 
 /* ── spy analyzer / selection helpers (mirrors analysis-pipelining.test.ts) */
 
@@ -272,6 +275,115 @@ describe('phase events carry the resolved model id', () => {
       for (const ev of phase1Events) {
         expect(ev.model, `phase-1 event missing model: ${JSON.stringify(ev)}`).toBe(PHASE1_MODEL);
       }
+    } finally {
+      removeManuscript(manuscriptId);
+      await clearAnalysisCache(manuscriptId);
+      process.env.STAGE2_COVERAGE_RETRIES = origCovRetries;
+    }
+  }, 60_000);
+});
+
+/* ── Suite: a Gemini content-block fails fast with a terminal error ────── */
+
+function buildContentBlockedPhase0Analyzer(model: string): Analyzer {
+  return {
+    ...buildSpyPhase0Analyzer(),
+    async runStage1Chapter(): Promise<Stage1ChapterOutput> {
+      /* Deterministic, whole-book-fatal filter block — must NOT be swallowed
+         into a per-chapter chapter-failed + empty roster (the "0%, no error"
+         symptom). It must reach the route's terminal error handler. */
+      throw new GeminiContentBlockedError(model, 'RECITATION');
+    },
+  };
+}
+
+describe('a Gemini content-block surfaces a terminal error', () => {
+  it('phase-0 per-chapter content-block → terminal analyzer-content-blocked error, not a silent empty roster', async () => {
+    const MODEL = 'gemini-3.1-flash-lite';
+    const manuscriptId = `test-content-blocked-${Date.now()}`;
+    registerStubManuscript(manuscriptId, 2);
+    const origCovRetries = process.env.STAGE2_COVERAGE_RETRIES;
+    process.env.STAGE2_COVERAGE_RETRIES = '0';
+
+    const phase0Selection = buildSelection(buildContentBlockedPhase0Analyzer(MODEL), MODEL);
+    const job = buildStubJob(manuscriptId);
+    const events = attachEventCapture(job);
+
+    try {
+      const { getManuscript } = await import('../store/manuscripts.js');
+      const recordRef = getManuscript(manuscriptId);
+      if (!recordRef) throw new Error('stub manuscript not found');
+
+      await runMainAnalyzerJob(job, recordRef as never, phase0Selection, {
+        requestedFresh: true,
+        allowStage1Shrink: true,
+        requestedModel: undefined,
+      });
+
+      const errorEvent = events.find((e) => e.kind === 'error') as
+        | (CapturedEvent & { code?: string; message?: string })
+        | undefined;
+      expect(errorEvent, 'a terminal error event must be emitted, not a silent all-chapters-failed run').toBeDefined();
+      expect(errorEvent?.code).toBe('analyzer-content-blocked');
+    } finally {
+      removeManuscript(manuscriptId);
+      await clearAnalysisCache(manuscriptId);
+      process.env.STAGE2_COVERAGE_RETRIES = origCovRetries;
+    }
+  }, 60_000);
+});
+
+/* ── Suite: the pill shows the EFFECTIVE model after a local→gemini fallback ── */
+
+describe('phase events name the effective model after a silent local→gemini fallback (Bug 2)', () => {
+  it('phase-0 events switch from the dead local primary to the Gemini fallback model', async () => {
+    const LOCAL_MODEL = 'qwen-local-test';
+    const FALLBACK_MODEL = 'gemini-3.1-flash-lite';
+    const manuscriptId = `test-fallback-model-${Date.now()}`;
+    registerStubManuscript(manuscriptId, 2);
+    const origCovRetries = process.env.STAGE2_COVERAGE_RETRIES;
+    process.env.STAGE2_COVERAGE_RETRIES = '0';
+
+    /* Primary (local) is unreachable on every chapter; the Gemini fallback works.
+       The FallbackAnalyzer must ANNOUNCE the switch (call.onFallback) so the route
+       re-labels the pill — otherwise it keeps naming the local model that isn't
+       running (the "wrong model in the pill" bug). */
+    const primary: Analyzer = {
+      ...buildSpyPhase0Analyzer(),
+      async runStage1Chapter(): Promise<Stage1ChapterOutput> {
+        throw new LocalUnreachableError('Ollama down');
+      },
+    };
+    const selection: AnalyzerSelection = {
+      analyzer: new FallbackAnalyzer(primary, buildSpyPhase0Analyzer()),
+      engine: 'local',
+      model: LOCAL_MODEL,
+      fallbackModel: FALLBACK_MODEL,
+    };
+    /* phase-1 uses a plain working spy so the test never touches a real backend. */
+    setPhase1Selection(buildSelection(buildSpyPhase1Analyzer(), 'phase1-test-model'));
+
+    const job = buildStubJob(manuscriptId);
+    const events = attachEventCapture(job);
+    try {
+      const { getManuscript } = await import('../store/manuscripts.js');
+      const recordRef = getManuscript(manuscriptId);
+      if (!recordRef) throw new Error('stub manuscript not found');
+
+      await runMainAnalyzerJob(job, recordRef as never, selection, {
+        requestedFresh: true,
+        allowStage1Shrink: true,
+        requestedModel: undefined,
+      });
+
+      const phase0Models = (
+        events.filter((e) => e.kind === 'phase' && e.phaseId === 0) as Array<
+          CapturedEvent & { model?: string }
+        >
+      ).map((e) => e.model);
+      expect(phase0Models, 'phase-0 events must name the effective Gemini fallback model').toContain(
+        FALLBACK_MODEL,
+      );
     } finally {
       removeManuscript(manuscriptId);
       await clearAnalysisCache(manuscriptId);

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -26,6 +26,7 @@ import {
   type PhaseWatermark,
 } from '../analyzer/phase-watermark.js';
 import { AnalysisAbortedError } from '../analyzer/ollama.js';
+import { GeminiContentBlockedError } from '../analyzer/errors.js';
 import { detectOllamaDevice, unloadResidentOllama } from './ollama-health.js';
 import { setLastKnownAnalyzerDevice } from '../gpu/analyzer-device-state.js';
 import { foldMinorCast } from '../analyzer/fold-minor-cast.js';
@@ -2561,7 +2562,10 @@ export async function runMainAnalyzerJob(
   const abortController = job.controller;
   const analyzer = selection.analyzer;
   const recordRef = record;
-  const activeModelId = selection.model;
+  /* Mutable — a local→Gemini fallback (announced via StageCall.onFallback below)
+     reassigns this to the effective Gemini model so subsequent phase events name
+     the model that's actually running, not the dead local primary. */
+  let activeModelId = selection.model;
   const analyzerLabel = engineLabel(selection.engine, activeModelId);
   /* Read-once user-settings snapshot — the handler passes one in; legacy
      callers / tests fall back to the in-process cache. Drives both the
@@ -2593,7 +2597,9 @@ export async function runMainAnalyzerJob(
     userSettings,
   });
   const phase1Analyzer = phase1Selection.analyzer;
-  const phase1ModelId = phase1Selection.model;
+  /* Mutable for the same reason as activeModelId — Phase 1's stage2Call.onFallback
+     reassigns it to the effective Gemini model on a local→Gemini switch. */
+  let phase1ModelId = phase1Selection.model;
   const phase1AnalyzerLabel = engineLabel(phase1Selection.engine, phase1ModelId);
   /* srv-59 Task 9b — ONE escalation-window budget shared across every
      chapter's attributeChapterStage2 call below, so the cap is per-BOOK
@@ -3262,6 +3268,20 @@ export async function runMainAnalyzerJob(
               reason,
             });
           },
+          /* Local analyzer went unreachable → the FallbackAnalyzer switched to
+             Gemini. Re-label so the pill names the model actually running (all
+             later phase-0 events read the reassigned `activeModelId`). */
+          onFallback: () => {
+            activeModelId = selection.fallbackModel ?? activeModelId;
+            send({
+              kind: 'phase',
+              phaseId: 0,
+              progress: phase0Progress(),
+              label: PHASES[0].label,
+              model: activeModelId,
+              engine: 'gemini',
+            });
+          },
         };
         try {
           result = await withPassEval(
@@ -3323,6 +3343,12 @@ export async function runMainAnalyzerJob(
           /* Client disconnect propagates up — let the route's outer catch
              land us back at res.end() without a "failed" SSE event. */
           if (chErr instanceof AnalysisAbortedError) throw chErr;
+          /* A gemini-* content-filter block (RECITATION/SAFETY) is deterministic
+             and whole-book-fatal — the same filter blocks every chapter. Rethrow
+             to the route's terminal handler (classifies as analyzer-content-blocked
+             with remediation) instead of swallowing it into a per-chapter
+             chapter-failed that grinds on and ends in an empty roster. */
+          if (chErr instanceof GeminiContentBlockedError) throw chErr;
           /* Per-chapter failure (malformed JSON after retry, validation
              miss, model truncation, …) is NON-FATAL for the run. The
              chapter is dropped from cast detection; the rest of the
@@ -4048,6 +4074,13 @@ export async function runMainAnalyzerJob(
         signal: abortController.signal,
         language: bookLanguage,
         onWaiting: () => tickOverall(),
+        /* Local analyzer unreachable → switched to Gemini. Re-label so the pill
+           names the effective model (later phase-1 events read the reassigned
+           `phase1ModelId`; tickOverall re-emits now for immediate feedback). */
+        onFallback: () => {
+          phase1ModelId = phase1Selection.fallbackModel ?? phase1ModelId;
+          tickOverall();
+        },
         /* Per-chunk heartbeat so the user sees evidence of model output
            on each chapter. Stage 2's existing wall-clock heartbeat log
            lines already cover the silence-watchdog purpose. */
@@ -5278,6 +5311,10 @@ export async function runSubsetAnalyzerJob(
         emitCastUpdate();
       } catch (chErr) {
         if (chErr instanceof AnalysisAbortedError) throw chErr;
+        /* Whole-book-fatal content-filter block — rethrow to the terminal
+           handler rather than grinding chapter-by-chapter (see the main-loop
+           sibling above). */
+        if (chErr instanceof GeminiContentBlockedError) throw chErr;
         chapterCast[ch.id] = [];
         cache.chapterCast = chapterCast;
         const classified = classifyAnalysisFailure(chErr, analyzerLabel);

--- a/server/src/routes/failure-taxonomy.test.ts
+++ b/server/src/routes/failure-taxonomy.test.ts
@@ -11,7 +11,7 @@ import { describe, it, expect } from 'vitest';
 import { classifyFailure, classifyAnalysisError, classifyAnalysisFailure } from './failure-taxonomy.js';
 import { FAILURE_REMEDIATIONS } from './failure-remediations.js';
 import { DailyQuotaExhaustedError } from '../analyzer/rate-limit.js';
-import { AnalyzerTruncatedError } from '../analyzer/errors.js';
+import { AnalyzerTruncatedError, GeminiContentBlockedError } from '../analyzer/errors.js';
 
 /* No copy should leak raw stack/jargon at the user — assert the message reads
    like a sentence (starts uppercase, ends with punctuation, no "Traceback"
@@ -294,6 +294,21 @@ describe('analysis-side codes (spec A2)', () => {
     expect(classifyAnalysisFailure(err, 'Gemini (gemini-3.1-flash-lite)').code).toBe(
       'analyzer-content-blocked',
     );
+  });
+  it('classifies a real GeminiContentBlockedError instance as analyzer-content-blocked', () => {
+    const err = new GeminiContentBlockedError('gemini-3.1-flash-lite', 'RECITATION');
+    expect(classifyAnalysisError(err).code).toBe('analyzer-content-blocked');
+    expect(classifyAnalysisFailure(err, 'Gemini (gemini-3.1-flash-lite)').code).toBe(
+      'analyzer-content-blocked',
+    );
+  });
+  it('classifies GeminiContentBlockedError by name even if the message is reworded', () => {
+    /* Name-driven match survives a future message reword — the regex is the
+       fallback, the typed name is the primary matcher (mirrors AnalyzerTruncatedError). */
+    const err = Object.assign(new Error('totally different future wording'), {
+      name: 'GeminiContentBlockedError',
+    });
+    expect(classifyAnalysisError(err).code).toBe('analyzer-content-blocked');
   });
   it("does NOT blame Ollama's same-worded empty response on the recitation filter", () => {
     const err = new Error('Ollama qwen3.5:4b returned an empty response.');

--- a/server/src/routes/failure-taxonomy.ts
+++ b/server/src/routes/failure-taxonomy.ts
@@ -140,6 +140,9 @@ export const FAILURE_SIGNATURES: FailureSignature[] = [
     code: 'analyzer-content-blocked',
     fatal: true,
     source: 'analysis',
+    /* Typed-error match first (survives message rewording), regex as fallback
+       for any bare Error carrying the same wording. */
+    matchName: 'GeminiContentBlockedError',
     match: (raw) => /Gemini\b.*\breturned an empty response\b/i.test(raw),
   },
   {

--- a/server/src/routes/script-review.test.ts
+++ b/server/src/routes/script-review.test.ts
@@ -336,6 +336,33 @@ describe('POST /api/books/:bookId/script-review', () => {
     expect(events.some((e) => e.kind === 'result')).toBe(false);
   });
 
+  it('a Gemini content-block (RECITATION) fast-fails the whole pass with content_blocked — no per-chapter grind', async () => {
+    /* A gemini-* content-filter block is deterministic and whole-book-fatal:
+       the same filter blocks every chapter identically. So the FIRST block must
+       stop the run with one actionable terminal error, NOT emit a chapter-failed
+       for chapter 1 and grind on to chapter 2 (the "frozen at 0%, no error"
+       symptom this fixes). */
+    writeBook(SENTENCES);
+    const { GeminiContentBlockedError } = await import('../analyzer/errors.js');
+    runReview.mockImplementation((): Promise<ScriptReviewOutput> =>
+      Promise.reject(new GeminiContentBlockedError('gemini-3.1-flash-lite', 'RECITATION')),
+    );
+
+    const res = await request(app).post(`/api/books/${bookId}/script-review`).send({});
+    const events = parseSse(res.text);
+
+    const err = events.find((e) => e.kind === 'error') as
+      | { code?: string; message?: string; model?: string; remediation?: string }
+      | undefined;
+    expect(err?.code).toBe('content_blocked');
+    expect(err?.message).toMatch(/RECITATION/); // the actionable reason
+    expect(err?.model).toBe('gemini-3.1-flash-lite'); // the model that actually ran
+    // No success result, and — crucially — no chapter-failed grind: it stopped at
+    // the first block, so chapter 2 was never even attempted.
+    expect(events.some((e) => e.kind === 'result')).toBe(false);
+    expect(events.some((e) => e.kind === 'chapter-failed')).toBe(false);
+  });
+
   /* Round-3 review Important Finding 5 — the detached job launch
      (`void runScriptReviewJob(...).finally(...)`) had no `.catch`, so a
      SYNCHRONOUS throw inside runScriptReviewJob (e.g. selectAnalyzerForPhase

--- a/server/src/routes/script-review.ts
+++ b/server/src/routes/script-review.ts
@@ -35,8 +35,9 @@ import { getResolvedGeminiApiKey, getResolvedAllowCloudFallback } from '../works
 import { makeThrottledHeartbeat } from './analysis-heartbeat.js';
 import { warmOllamaModel } from './ollama-health.js';
 import { AnalysisAbortedError } from '../analyzer/ollama.js';
-import { AnalyzerTruncatedError } from '../analyzer/errors.js';
+import { AnalyzerTruncatedError, GeminiContentBlockedError } from '../analyzer/errors.js';
 import { DailyQuotaExhaustedError } from '../analyzer/rate-limit.js';
+import { FAILURE_REMEDIATIONS } from './failure-remediations.js';
 import { upsertChapterEntry, readLedger, discardChapters, resolveOps, patchSelection } from '../workspace/script-review-ledger.js';
 import {
   chunkSentencesByBudget,
@@ -874,6 +875,11 @@ async function runScriptReviewJob(
       // exact same spot the original early-return left off (before this
       // chapter's pacing/checkpoint bookkeeping).
       let quotaErr: DailyQuotaExhaustedError | null = null;
+      /* A gemini-* content-filter block (RECITATION/SAFETY) is deterministic and
+         whole-book-fatal — the same filter blocks every chapter. Capture it and
+         fail the whole pass fast (mirrors quotaErr) instead of emitting a
+         chapter-failed and grinding through the remaining chapters. */
+      let blockedErr: GeminiContentBlockedError | null = null;
       await withPassEval(
         reviewCall,
         {
@@ -899,6 +905,10 @@ async function runScriptReviewJob(
                 quotaErr = err;
                 break;
               }
+              if (err instanceof GeminiContentBlockedError) {
+                blockedErr = err;
+                break;
+              }
               send({ kind: 'chapter-failed', chapterId, message: (err as Error).message });
             }
             // Intra-chapter creep: only advances the bar for multi-chunk (local)
@@ -917,6 +927,22 @@ async function runScriptReviewJob(
         },
         () => null,
       );
+      if (blockedErr) {
+        /* Terminal, actionable error. The message already names the model +
+           reason + remediation ("switch GEMINI_MODEL to a gemma-* model or set
+           ANALYZER=local"); `model` drives the status pill, `remediation` the
+           panel copy. Renders generically in the frontend else-branch toast (no
+           Retry — retrying the same model is futile). */
+        send({
+          kind: 'error',
+          code: 'content_blocked',
+          message: (blockedErr as GeminiContentBlockedError).message,
+          model: (blockedErr as GeminiContentBlockedError).model,
+          remediation: FAILURE_REMEDIATIONS['analyzer-content-blocked'].remediation,
+        });
+        for (const sub of job.subscribers) sub.res.end();
+        return;
+      }
       if (quotaErr) {
         send({ kind: 'error', code: 'quota_exhausted', message: 'Daily analyzer quota exhausted. Already-reviewed chapters are streamed — re-run to finish.', resetAt: (quotaErr as DailyQuotaExhaustedError).resetAt instanceof Date ? (quotaErr as DailyQuotaExhaustedError).resetAt.toISOString() : undefined });
         for (const sub of job.subscribers) sub.res.end();


### PR DESCRIPTION
## What & why

Running the analyzer or script review on a copyrighted book left the UI **frozen at 0% "doing nothing"** with no error, while the status pill named a model that wasn't the one actually running.

**Bug 1 — the content-block error never surfaced.** A `gemini-*` model fed copyrighted source hits Google's RECITATION filter and returns an empty candidate — a deterministic, whole-book-fatal condition. The taxonomy already knows this (`analyzer-content-blocked`, `fatal: true`), but the per-chapter handlers ignored the fatal flag: analysis emitted a non-terminal `chapter-failed` and continued (ending in a vague `cast_incomplete` / empty roster); script-review did the same generically (terminal error only after all N chapters of doomed calls). So the run ground through every chapter with no actionable error.

**Bug 2 — the pill showed the selected/primary model, not the effective one.** On a local→Gemini fallback, `FallbackAnalyzer.runStage1Chapter`/`runStage2Chapter` switched to Gemini **silently** (unlike `runScriptReviewChapter`). Analysis captured the model id once from the primary selection, so the pill kept naming the local model while the real call went to `process.env.GEMINI_MODEL` (e.g. `gemini-3.1-flash-lite`).

## Changes (server-only)

- **Typed `GeminiContentBlockedError`** (name-matchable, carries `model` + `reason`) thrown at the Gemini empty-response site. Message is built verbatim inside the error, so existing log-greps and the taxonomy regex still match.
- **Taxonomy** matches `analyzer-content-blocked` by name first (regex kept as fallback).
- **Analysis** rethrows it from the Phase-0 per-chapter catches → the existing terminal handler surfaces one `analyzer-content-blocked` error with remediation ("switch GEMINI_MODEL to a gemma-* model or set ANALYZER=local"), instead of a silent empty roster. (Stage-2 already propagated to the terminal handler.)
- **Script-review** detects it in the chunk loop, breaks, and emits a terminal `content_blocked` error on the first hit — mirrors the daily-quota fast-fail.
- **`FallbackAnalyzer`** announces the local→Gemini switch for stage-1/stage-2; analysis re-labels the pill with the effective model.

Frontend needs no change: `analyzer-content-blocked` is already in the Help taxonomy, `content_blocked` renders in the generic toast, and the pill is driven purely by the SSE `phase.model`.

## Tests

Regression tests added for: the typed throw (preserving message text), the taxonomy name-match, script-review fast-fail (one `content_blocked`, no per-chapter grind), and the analysis terminal-error + effective-model-on-fallback paths. Verified: typecheck clean, ESLint clean, 512 tests passing across all affected suites (analysis, script-review, taxonomy, gemini, fallback-analyzer, select-analyzer).

Closes #1716

🤖 Generated with [Claude Code](https://claude.com/claude-code)