### PR TITLE
fix(server): pin the analyzer during script-review runs too, not just analysis

### DIFF
--- a/server/src/analyzer/ollama.test.ts
+++ b/server/src/analyzer/ollama.test.ts
@@ -291,24 +291,32 @@ describe('OllamaAnalyzer — keep_alive policy (per-model seconds)', () => {
     expect(keepAliveFor('qwen3.5:4b', 'cpu')).toBe(30); // small model → fallback, unaffected by CPU clamp
   });
 
-  it('PINS the model (-1) while an analysis run is in flight, overriding fallback / override / CPU-clamp', async () => {
+  it('PINS the model (-1) while an analysis OR review run is in flight, overriding fallback / override / CPU-clamp', async () => {
     const { keepAliveFor } = await import('./ollama.js');
-    const { markAnalysisBusy, clearAnalysisBusy } = await import('../tts/design-lock.js');
+    const { markAnalysisBusy, clearAnalysisBusy, markReviewBusy, clearReviewBusy } = await import(
+      '../tts/design-lock.js'
+    );
     _setUserSettingsCacheForTest({
       ...DEFAULT_USER_SETTINGS,
       analyzerKeepAliveByModel: { 'qwen3.5:4b': 120 }, // a positive override…
     });
-    markAnalysisBusy('/book/pinned');
-    try {
-      // …is superseded by the run-scoped pin. Calls land minutes apart, so any
-      // finite TTL would let Ollama evict between them mid-run.
-      expect(keepAliveFor('qwen36-cw-iq4-32k:latest')).toBe(-1); // uncurated fallback → pinned
-      expect(keepAliveFor('qwen3.5:4b')).toBe(-1); // override → pinned
-      expect(keepAliveFor('qwen3.5:9b', 'cpu')).toBe(-1); // RAM-heavy CPU clamp → pinned
-    } finally {
-      clearAnalysisBusy('/book/pinned');
+    // …is superseded by the run-scoped pin. Calls land minutes apart, so any
+    // finite TTL would let Ollama evict between them mid-run. Both a main
+    // analysis run and a script-review run pin the model.
+    for (const [mark, clear] of [
+      [markAnalysisBusy, clearAnalysisBusy],
+      [markReviewBusy, clearReviewBusy],
+    ] as const) {
+      mark('/book/pinned');
+      try {
+        expect(keepAliveFor('qwen36-cw-iq4-32k:latest')).toBe(-1); // uncurated fallback → pinned
+        expect(keepAliveFor('qwen3.5:4b')).toBe(-1); // override → pinned
+        expect(keepAliveFor('qwen3.5:9b', 'cpu')).toBe(-1); // RAM-heavy CPU clamp → pinned
+      } finally {
+        clear('/book/pinned');
+      }
     }
-    // Run over → normal resolution resumes (teardown issues the keep_alive:0 evict).
+    // Both runs over → normal resolution resumes (teardown issues the keep_alive:0 evict).
     expect(keepAliveFor('qwen36-cw-iq4-32k:latest')).toBe(30);
     expect(keepAliveFor('qwen3.5:4b')).toBe(120);
     expect(keepAliveFor('qwen3.5:9b', 'cpu')).toBe(0);

--- a/server/src/analyzer/ollama.ts
+++ b/server/src/analyzer/ollama.ts
@@ -18,7 +18,7 @@ import { costForEngine } from '../tts/engine-vram-cost.js';
 import { acquireAnalyzerSlot, describeAnalyzerConcurrency } from './analyzer-concurrency.js';
 import { getLastKnownAnalyzerDevice } from '../gpu/analyzer-device-state.js';
 import { getResolvedOllamaUrl, getCachedUserSettings } from '../workspace/user-settings.js';
-import { isAnyAnalysisBusy } from '../tts/design-lock.js';
+import { isAnyAnalyzerRunBusy } from '../tts/design-lock.js';
 import { configValue } from '../config/resolver.js';
 import type { Accelerator } from '../gpu/vram-state.js';
 import { getLastKnownVram } from '../gpu/vram-state.js';
@@ -170,7 +170,7 @@ export function hasKeepAliveOverride(model: string): boolean {
 }
 
 /** `keep_alive` (integer seconds, or -1 to pin) for an Ollama analyzer call.
-    While ANY analysis run is in flight the model is PINNED (-1); otherwise
+    While ANY analyzer run (analysis OR script review) is in flight the model is PINNED (-1); otherwise
     per-model via resolveKeepAliveSeconds, with RAM-heavy models clamped to 0
     on CPU. */
 export function keepAliveFor(model: string, accelerator: Accelerator = 'unknown'): number {
@@ -183,7 +183,7 @@ export function keepAliveFor(model: string, accelerator: Accelerator = 'unknown'
      failure. The run's teardown (routes/analysis.ts endJob) issues the matching
      keep_alive:0 evict once no run remains, so the pin is strictly run-scoped
      and the per-model value keeps its meaning as the POST-run idle retention. */
-  if (isAnyAnalysisBusy()) return -1;
+  if (isAnyAnalyzerRunBusy()) return -1;
   if (RAM_HEAVY_MODELS.has(model) && accelerator === 'cpu') return 0;
   return resolveKeepAliveSeconds(model);
 }
@@ -838,7 +838,7 @@ export async function generatePersonaViaOllama(
     think: false,
     /* Pin during an active analysis run (same rationale as keepAliveFor); the
        caller-supplied keepAlive is the post-run idle window otherwise. */
-    keep_alive: isAnyAnalysisBusy() ? -1 : (opts.keepAlive ?? 0),
+    keep_alive: isAnyAnalyzerRunBusy() ? -1 : (opts.keepAlive ?? 0),
     options: {
       temperature: resolveOllamaTemperature(),
       ...(onCpu ? { num_gpu: 0 } : {}),

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -115,7 +115,7 @@ import {
 import { stampStateSchema } from '../workspace/state-migrate.js';
 import type { BookStateJson, AnalysisProvenanceReport } from '../workspace/scan.js';
 import { findBookByManuscriptId, bookStateLanguage } from '../workspace/scan.js';
-import { markAnalysisBusy, clearAnalysisBusy, isDesignBusy, isAnyAnalysisBusy } from '../tts/design-lock.js';
+import { markAnalysisBusy, clearAnalysisBusy, isDesignBusy, isAnyAnalyzerRunBusy } from '../tts/design-lock.js';
 import { scanSeriesCharactersForBookId } from '../workspace/series-cast-scan.js';
 import { dedupSeriesPrior } from '../workspace/series-prior-dedup.js';
 import { linkSeriesReuseAtAnalysis, pruneStaleReuseLinks } from '../workspace/series-reuse-link.js';
@@ -2305,7 +2305,7 @@ function endJob(job: AnalysisJob, finalEv?: unknown): void {
      isAnyAnalysisBusy) is still running — otherwise we'd evict a model that
      run still needs. Best-effort and fire-and-forget: a failed evict just means
      the model idles per its own keep_alive, and the next run re-warms it. */
-  if (job.engine === 'local' && !isAnyAnalysisBusy()) {
+  if (job.engine === 'local' && !isAnyAnalyzerRunBusy()) {
     void unloadResidentOllama().catch(() => {
       /* Ollama unreachable / already evicted — nothing to release. */
     });

--- a/server/src/routes/script-review.ts
+++ b/server/src/routes/script-review.ts
@@ -30,6 +30,8 @@ import { readJson } from '../workspace/state-io.js';
 import { loadPostFoldSentencesByChapter } from '../store/post-fold-sentences.js';
 import { selectAnalyzerForPhase } from '../analyzer/select-analyzer.js';
 import { selectAnalyzer, type StageCall } from '../analyzer/index.js';
+import { markReviewBusy, clearReviewBusy, isAnyAnalyzerRunBusy } from '../tts/design-lock.js';
+import { unloadResidentOllama } from './ollama-health.js';
 import { withPassEval } from '../analyzer/analyzer-eval-stats.js';
 import { getResolvedGeminiApiKey, getResolvedAllowCloudFallback } from '../workspace/user-settings.js';
 import { makeThrottledHeartbeat } from './analysis-heartbeat.js';
@@ -766,7 +768,16 @@ async function runScriptReviewJob(
   const record = structureEnabled ? await getOrHydrateManuscript(manuscriptId) : undefined;
   const bodyByChapter = new Map<number, string>((record?.chapterHints ?? []).map((h) => [h.id, h.body]));
   const reviewLanguage = bookStateLanguage(located.state);
+  /* Pin the local analyzer resident for the whole review run. Review calls land
+     minutes apart per chapter — the same cadence as attribution — so a finite
+     keep-alive would let Ollama evict the model between chapters and cold-reload
+     on the next (keepAliveFor pins while isAnyReviewBusy, via isAnyAnalyzerRunBusy).
+     Only a local run loads a model; balanced by the clearReviewBusy + evict in
+     the finally below. Marked INSIDE the try so a warm-step early-return can't
+     leak the ref. */
+  const pinnedLocal = selection.engine === 'local';
   try {
+    if (pinnedLocal) markReviewBusy(located.bookDir);
     for (let i = 0; i < chapterIds.length; i += 1) {
       if (job.controller.signal.aborted) break;
       const chapterId = chapterIds[i];
@@ -962,6 +973,18 @@ async function runScriptReviewJob(
     }
   } finally {
     for (const sub of job.subscribers) clearInterval(sub.keepAlive);
+    /* Release the run-scoped analyzer pin: clear this run's busy ref and, once
+       no analysis/other review still needs the model (ref-counted), evict it
+       (keep_alive:0) so the pinned model doesn't sit resident forever.
+       Best-effort — a failed evict just leaves it to idle per its own value. */
+    if (pinnedLocal) {
+      clearReviewBusy(located.bookDir);
+      if (!isAnyAnalyzerRunBusy()) {
+        void unloadResidentOllama().catch(() => {
+          /* Ollama unreachable / already evicted — nothing to release. */
+        });
+      }
+    }
   }
   if (job.controller.signal.aborted) {
     send({ kind: 'error', code: 'cancelled', message: 'Review cancelled.' });

--- a/server/src/tts/design-lock.ts
+++ b/server/src/tts/design-lock.ts
@@ -49,6 +49,7 @@ export async function withDesignLock<T>(bookDir: string, fn: () => Promise<T>): 
 /* ── Cross-operation busy registry (mutual exclusion) ───────────────────── */
 
 const analysisBusy = new Map<string, number>(); // bookDir → ref count (main + subset)
+const reviewBusy = new Map<string, number>(); // bookDir → ref count (script-review runs)
 const designBusy = new Set<string>(); // bookDir of an active bulk-design job
 
 export function markAnalysisBusy(bookDir: string): void {
@@ -90,4 +91,28 @@ export function isOtherBookDesignBusy(bookDir: string): boolean {
 /** True when ANY book has an analysis job in flight (main or subset). */
 export function isAnyAnalysisBusy(): boolean {
   return analysisBusy.size > 0;
+}
+
+/* ── Script-review runs (separate from analysisBusy so a review does NOT trip
+      the analysis↔design mutual exclusion, but DOES drive the analyzer
+      keep-alive pin — a review re-runs the local analyzer per chapter with the
+      same minutes-apart call cadence as analysis). ─────────────────────────── */
+export function markReviewBusy(bookDir: string): void {
+  reviewBusy.set(bookDir, (reviewBusy.get(bookDir) ?? 0) + 1);
+}
+export function clearReviewBusy(bookDir: string): void {
+  const n = (reviewBusy.get(bookDir) ?? 0) - 1;
+  if (n <= 0) reviewBusy.delete(bookDir);
+  else reviewBusy.set(bookDir, n);
+}
+export function isAnyReviewBusy(): boolean {
+  return reviewBusy.size > 0;
+}
+
+/** True while ANY local-analyzer run — main/subset analysis OR script review —
+    is in flight. Drives the analyzer keep-alive pin (analyzer/ollama.ts
+    keepAliveFor): both send /api/chat calls minutes apart, so any finite idle
+    TTL lets Ollama evict the model between calls and cold-reload on the next. */
+export function isAnyAnalyzerRunBusy(): boolean {
+  return analysisBusy.size > 0 || reviewBusy.size > 0;
 }


### PR DESCRIPTION
## Summary

Follow-up to #1715. The run pin keyed off `isAnyAnalysisBusy`, so it only covered
the main analysis run. **Script/chapter review** runs the same local analyzer per
chapter with the same minutes-apart `/api/chat` cadence, but never marked
`analysisBusy` — so `keepAliveFor` fell back to the finite per-model value and the
model thrashed (evict/reload) between review chapters exactly as analysis did
before #1715.

**Fix:** a dedicated `reviewBusy` ref-count (kept separate from `analysisBusy` so a
review does **not** trip the analysis↔design mutual exclusion) plus a combined
`isAnyAnalyzerRunBusy()` = analysis || review. `keepAliveFor` (and the persona
path) now pin on that. `runScriptReviewJob` marks `reviewBusy` for a local run and,
in its `finally`, clears it and evicts the model (`keep_alive:0`) once no
analysis/other review still needs it — mirroring analysis `endJob`. The analysis
`endJob` evict guard is widened to `isAnyAnalyzerRunBusy` too, so an analysis
finishing mid-review can't yank a model the review is still using.

## Test plan

- `ollama.test.ts`: `keepAliveFor` returns -1 while EITHER a `markAnalysisBusy` or a
  `markReviewBusy` ref is held, and reverts when both clear. 37 pass.
- `script-review.test.ts`: 81 pass (one tinypool worker-exit flake on first run,
  green on retry — known infra flake, not an assertion failure).

Refs #1714