### PR TITLE
chore(server): finalize srv-62 keep-alive — revert wire probes, refresh docs

### DIFF
--- a/docs/features/263-per-model-keepalive.md
+++ b/docs/features/263-per-model-keepalive.md
@@ -17,6 +17,31 @@ owner: null
 > `keepAliveSeconds`/`keepAliveIsOverride`); `POST /api/ollama/load` (unchanged
 > shape, changed behavior)
 
+> **Update — srv-62 / #1709 (runtime-path fallback + pin-during-run).** Two
+> changes landed after the original plan that supersede the runtime keep-alive
+> resolution described in **Invariants 1 & 2** below; they are corrected inline,
+> but read this first:
+> - **Curated map removed → flat 30s fallback (#1711).** The coded
+>   `DEFAULT_KEEP_ALIVE_SECONDS` map (four tags @ `300`, `0` for everything else)
+>   is deleted. `resolveKeepAliveSeconds` now returns the user override or a flat
+>   `DEFAULT_ANALYZER_KEEP_ALIVE_SECONDS = 30`. Every uncurated fine-tune (e.g.
+>   `qwen36-cw-iq3-64k:latest`) used to fall to `0` = evict-per-call, cold-loading
+>   the model on every attribution chunk; it now holds 30s and stays resident
+>   across a run. This is the runtime-path sibling of the #1706 warm-path floor
+>   (Invariant 8).
+> - **Pin the analyzer for the whole run (#1715, extended to review runs #1718).**
+>   Attribution `/api/chat` calls land 120–200 s apart, so *any* finite idle TTL
+>   (even 30, even a user's 90) lets Ollama evict between calls and cold-reload —
+>   thrash that also opens a reload window where a transient unreachable trips the
+>   cloud (Gemini) fallback into a hard failure. `keepAliveFor` therefore returns
+>   `-1` (pin) while **any** analyzer run — analysis, subset-retry, or script
+>   review — is in flight; the run's teardown (`routes/analysis.ts` `endJob`)
+>   issues the matching `keep_alive:0` evict. **Net effect:** the per-model
+>   seconds value now governs the *post-run* idle hold only; mid-run eviction can
+>   no longer happen regardless of the value. This makes the exact fallback (30
+>   vs a longer bridge) largely cosmetic — the reload-per-call tax srv-62 targeted
+>   is eliminated by the pin.
+
 ## Benefit / Rationale
 
 - **User:** any analyzer model — including a custom/renamed Ollama tag like
@@ -27,12 +52,13 @@ owner: null
   use across chapter boundaries.
 - **Technical:** deletes a hardcoded per-box allowlist (`RESIDENT_MODELS`) and
   the registry knob that fed it (`analyzer.ollama.keepAlive` / `ANALYZER_KEEP_ALIVE`),
-  replacing both with a data-driven `override ?? default ?? 0` resolver that
-  works for any model tag, not just the four the codebase happened to name.
+  replacing both with a data-driven `override ?? default` resolver (the default a
+  flat `30`s since srv-62/#1709) that works for any model tag, not just the four
+  the codebase happened to name.
 - **Architectural:** locks in the "server resolves, client only displays"
   pattern for a value the client can't compute itself — the Model Manager reads
   `item.keepAliveSeconds`/`item.keepAliveIsOverride` off the inventory payload
-  rather than mirroring `DEFAULT_KEEP_ALIVE_SECONDS`/`normalizeModelTag` into
+  rather than mirroring `DEFAULT_ANALYZER_KEEP_ALIVE_SECONDS`/`normalizeModelTag` into
   `src/`, so server and client can never drift on what a given tag's keep-alive
   actually resolves to. Also locks in that a sparse per-model settings map (like
   `analyzerKeepAliveByModel`) must always be edited via full-map merge-then-PUT,
@@ -58,10 +84,10 @@ owner: null
   is untouched — this plan only changes *how long* a model stays resident once
   loaded, not *whether* it gets evicted for a TTS/voice-design load.
 - **Migration story:** none needed. `analyzerKeepAliveByModel` is additive with
-  `.default({})`; an existing installation with no overrides gets exactly
-  today's effective behavior for the four supported models (all default to
-  `300`) and `0` for any unlisted tag (same as the old allowlist's fallthrough).
-  No `state.json`/`cast.json` shape changes.
+  `.default({})`; an existing installation with no overrides gets the flat `30`s
+  fallback for every tag (srv-62/#1709; originally this was `300` for four
+  supported models and `0` for anything unlisted). No `state.json`/`cast.json`
+  shape changes.
 - **Reversibility:** an operator can restore per-call behavior for any model by
   setting its keep-alive to `0` in the Model Manager — no code revert needed.
   Reverting the whole feature (re-adding `RESIDENT_MODELS`) is a code revert of
@@ -70,25 +96,34 @@ owner: null
 
 ## Invariants to preserve
 
-1. `keepAliveFor(model, accelerator)` (`server/src/analyzer/ollama.ts:166`) =
+1. `keepAliveFor(model, accelerator)` (`server/src/analyzer/ollama.ts`) —
+   **updated by srv-62/#1709.** Order: if **any** analyzer run is in flight
+   (`isAnyAnalyzerRunBusy()` = analysis OR script review) it returns `-1` (pin)
+   regardless of model/override/clamp; otherwise
    `RAM_HEAVY_MODELS.has(model) && accelerator === 'cpu' ? 0 : resolveKeepAliveSeconds(model)`.
-   Returns an **integer number of seconds**, not a duration string — Ollama's
-   `keep_alive` accepts an integer natively.
-2. `resolveKeepAliveSeconds(model)` (`ollama.ts:150`) = the first defined of:
-   the user's raw-key override (`map[model]`), the user's normalized-key
-   override (`map[normalizeModelTag(model)]`), the coded default
-   (`DEFAULT_KEEP_ALIVE_SECONDS[normalizeModelTag(model)]`), or `0`.
-   `DEFAULT_KEEP_ALIVE_SECONDS` (`ollama.ts:129`) seeds exactly the four models
-   the old allowlist covered, all at `300`: `qwen3.5:4b`, `qwen3.5:9b`,
-   `llama3.1:8b`, `gemma4-e4b-8gb`. Any tag not in that map and not overridden
-   resolves to `0` (unload immediately) — today's behavior for a
-   non-allowlisted model, unchanged.
+   Returns an **integer number of seconds** (`-1` = pin), not a duration string —
+   Ollama's `keep_alive` accepts an integer natively. The run-scoped pin is the
+   durable fix for mid-run eviction; run teardown (`routes/analysis.ts` `endJob`,
+   plus the script-review job's `finally`) issues the matching `keep_alive:0`
+   evict, so the pin is strictly run-scoped and the per-model value keeps its
+   meaning as the *post-run* idle retention.
+2. `resolveKeepAliveSeconds(model)` (`ollama.ts`) — **updated by srv-62/#1709.**
+   = the first defined of: the user's raw-key override (`map[model]`), the user's
+   normalized-key override (`map[normalizeModelTag(model)]`), or the flat
+   `DEFAULT_ANALYZER_KEEP_ALIVE_SECONDS` (`30`). The old curated
+   `DEFAULT_KEEP_ALIVE_SECONDS` map (four tags @ `300`, `0`-fallthrough for
+   everything else) was **deleted (#1711)**: an uncurated fine-tune with no
+   override no longer falls to `0` (evict-per-call) but to `30`, a short bridge
+   that survives back-to-back attribution calls. A user override still wins; `-1`
+   still means pin forever.
 3. `normalizeModelTag(tag)` (`ollama.ts:143`) strips a trailing `:latest` only
    — `gemma4-e4b-8gb:latest` → `gemma4-e4b-8gb`; `qwen3.5:9b` is untouched
    (`9b` is a real tag component, not the literal `latest`).
-4. Seconds semantics are Ollama-native: `0` = unload immediately (the default
-   for an unconfigured custom tag), a positive integer = seconds resident,
-   `-1` = pin forever. The Model Manager's helper copy documents all three.
+4. Seconds semantics are Ollama-native: `0` = unload immediately, a positive
+   integer = seconds resident, `-1` = pin forever. An unconfigured custom tag now
+   defaults to `30` (srv-62/#1709), not `0`. The Model Manager's helper copy (the
+   keep-alive field's `title` tooltip) documents the default, all three explicit
+   values, the run-scoped pin, and the CPU RAM-heavy clamp.
 5. **Full-map merge, never partial PUT.** `writeUserSettings`
    (`server/src/workspace/user-settings.ts`) shallow-merges
    `{ ...current, ...validated }` at the top level, so a PUT carrying a
@@ -116,20 +151,23 @@ owner: null
    intent, not the CPU-clamped runtime value) and
    `keepAliveIsOverride: hasKeepAliveOverride(m.name)` (`:320`). The frontend
    reads these two fields directly and contains **no** mirror of
-   `DEFAULT_KEEP_ALIVE_SECONDS` or `normalizeModelTag` under `src/` — the
+   `DEFAULT_ANALYZER_KEEP_ALIVE_SECONDS` or `normalizeModelTag` under `src/` — the
    server is the only place that resolver logic lives.
 8. `POST /api/ollama/load` (`server/src/routes/ollama-health.ts`,
    `warmOllamaModel`) warms with `keep_alive:
    floorWarmKeepAlive(keepAliveFor(model, getLastKnownVram().accelerator))` — not
    a hardcoded `'5m'`. An **explicit Load means "hold it resident"**, so a
-   resolved keep-alive of `0` (a custom tag with no override, OR the
-   `RAM_HEAVY_MODELS` CPU clamp) is **floored up to `WARM_MIN_KEEP_ALIVE_SECONDS`
-   (30)** rather than warming-and-evicting in the same call. A positive per-model
-   value is honored as-is; a negative keep-forever (`-1`) override passes through
-   untouched (floor fires only on exactly `0`). This is the ONE place the warm
-   path diverges from the analyzer chat path (Invariant 1), which still sends the
-   unfloored, CPU-clamped value — the clamp's RAM-safety concern is about a model
-   pinned across a long analysis loop, not a single 30s manual warm.
+   resolved keep-alive of `0` is **floored up to `WARM_MIN_KEEP_ALIVE_SECONDS`
+   (30)** rather than warming-and-evicting in the same call. Since srv-62/#1709
+   made the runtime fallback a flat `30`, the only way a warm now resolves `0`
+   (and thus hits the floor) is the `RAM_HEAVY_MODELS` CPU clamp — a custom tag
+   with no override already resolves `30`. A positive per-model value is honored
+   as-is; a negative keep-forever (`-1`) override passes through untouched (floor
+   fires only on exactly `0`). This is the ONE place the warm path diverges from
+   the analyzer chat path (Invariant 1), which during a run pins at `-1` and
+   otherwise sends the unfloored, CPU-clamped value — the clamp's RAM-safety
+   concern is about a model pinned across a long analysis loop, not a single 30s
+   manual warm.
    **Supersedes this plan's original intent** that a `0`-keep-alive model "warms
    once and does not persist": warming with `keep_alive: 0` is Ollama's
    evict-immediately idiom, so it loaded the model and dropped it in the same
@@ -148,16 +186,18 @@ owner: null
 
 ### Automated coverage
 
-- Vitest server (`server/src/analyzer/ollama.test.ts`) — rewritten
-  `keepAliveFor`/`resolveKeepAliveSeconds` block: a supported model with no
-  override resolves `300` (integer, not `'5m'`); a `:latest`-suffixed tag
-  normalizes to the same default; a user override wins over the coded default;
-  an unconfigured custom tag resolves `0`; `-1` passes through unclamped;
-  `RAM_HEAVY_MODELS` on `accelerator: 'cpu'` clamps to `0` even with a positive
-  override; `cuda`/`unknown` honor the override. Both wire-level assertions
-  that `body.keep_alive` reaches `/api/chat` as an integer (`300`, not `'5m'`)
-  are updated, including the one inside the happy-path streaming describe
-  block that used to reference the old `RESIDENT_MODELS` set.
+- Vitest server (`server/src/analyzer/ollama.test.ts`) — `keepAliveFor`/
+  `resolveKeepAliveSeconds` block (**updated by srv-62/#1709**): ANY model with
+  no override — formerly-curated (`qwen3.5:4b`, `llama3.1:8b`, `qwen3.5:9b`,
+  `gemma4-e4b-8gb`) and uncurated (`qwen36-cw-iq4-32k:latest`,
+  `placeholder:test-7b`) alike — resolves the flat `30` fallback (integer, not
+  `'5m'`); a `:latest`-suffixed tag normalizes; a user override wins (`600`,
+  `0`, `-1`); `RAM_HEAVY_MODELS` on `accelerator: 'cpu'` clamps to `0` even with
+  a positive override while `cuda`/`unknown` honor it; and — the pin — while an
+  analysis OR review run is in flight `keepAliveFor` returns `-1` for every case
+  (uncurated fallback, override, and the CPU clamp), reverting to normal
+  resolution once both runs end. The happy-path streaming block asserts at the
+  wire level that `body.keep_alive` reaches `/api/chat` as the integer `30`.
 - Vitest server (`server/src/workspace/user-settings.test.ts`) —
   `analyzerKeepAliveByModel` accepts a sparse integer map, rejects
   non-integers, round-trips through `writeUserSettings`; a cold-cache read
@@ -170,16 +210,16 @@ owner: null
   GPU plan resolves `keepAlive: 300` via the fixed `PERSONA_KEEP_ALIVE_SECONDS`
   constant, independent of any configured `analyzerKeepAliveByModel` override.
 - Vitest server (`server/src/routes/models-inventory.test.ts`) — an analyzer
-  inventory item carries `keepAliveSeconds` (override, coded default, or `0`)
-  and `keepAliveIsOverride` (`true` only when a user override exists for that
-  tag).
+  inventory item carries `keepAliveSeconds` (the user override, else the flat
+  `30` fallback) and `keepAliveIsOverride` (`true` only when a user override
+  exists for that tag).
 - Vitest server (`server/src/routes/ollama-health.test.ts`) — the `/load`
   warm route sends `floorWarmKeepAlive(keepAliveFor(model, accelerator))`, not
-  a hardcoded `'5m'`: a supported model stays at its coded `300`; a **custom tag
-  with no override is floored from `0` to `30`** (the regression test — Load must
-  hold, not evict); a RAM-heavy model (`qwen3.5:9b`) is also floored to `30` on a
-  `cpu` accelerator (explicit Load overrides the runtime clamp) while its
-  `cuda`/`unknown` warm stays at the coded `300`.
+  a hardcoded `'5m'`: with no override every tag warms at the flat `30` fallback
+  (the test asserts `keep_alive === 30` for `qwen3.5:9b`); a RAM-heavy model on a
+  `cpu` accelerator resolves `0` and is floored back to `30` (explicit Load
+  overrides the runtime clamp — Load must hold, not evict), while its
+  `cuda`/`unknown` warm is the un-clamped `30`.
 - Vitest server (`server/src/routes/user-settings.test.ts`) — the settings PUT
   route round-trips `analyzerKeepAliveByModel`.
 - Vitest frontend (`src/views/model-manager.test.tsx`) — an analyzer row
@@ -207,10 +247,12 @@ is a convenient real analysis to drive while observing `ollama ps`).
 
 1. **Open `#/admin` → Model Manager**, with `server` running against a real
    Ollama daemon. Each Ollama-backed analyzer row shows a **keep-alive
-   (seconds)** number field next to its Load/Unload control. A model from
-   `DEFAULT_KEEP_ALIVE_SECONDS` (e.g. `qwen3.5:4b`) shows `300`; a
-   custom/pulled tag not in that map (e.g. `qwen36-castwright:latest`) shows
-   `0`.
+   (seconds)** number field next to its Load/Unload control. With no override,
+   every tag — curated or a custom/pulled fine-tune (e.g.
+   `qwen36-castwright:latest`) — shows the flat `30` default (srv-62/#1709; the
+   old per-tag `300`/`0` split is gone). Hovering the field shows the helper
+   tooltip documenting the default, the `0`/positive/`-1` semantics, the
+   run-scoped pin, and the CPU RAM-heavy clamp.
 2. **Set `qwen36-castwright:latest`'s keep-alive field to `300`** and blur the
    field (tab or click away). Expect a `PUT /api/user/settings` carrying the
    full `analyzerKeepAliveByModel` map with `{ "qwen36-castwright:latest": 300,
@@ -223,31 +265,34 @@ is a convenient real analysis to drive while observing `ollama ps`).
    normalization. Every previously-configured model's entry stays present
    unchanged. A ↺ reset button now appears next to the field (since
    `keepAliveIsOverride` is now `true` for this tag).
-3. **Run an analysis** (or the manual "Load" pill) against that model, then in
-   PowerShell run `ollama ps` repeatedly across a chapter boundary or two.
-   Expect the model's `UNTIL` column to show a real countdown (e.g.
-   `4 minutes from now`) that keeps refreshing on each new call, **not** an
-   immediate `Stopping…` between requests — the behavior the old
-   `RESIDENT_MODELS` allowlist could never grant to a non-listed tag.
-4. **Set the same field to `0`** and blur. Expect the next **analysis** call's
-   `keep_alive` to be `0` and `ollama ps` to show the model evicting immediately
-   after the call completes — reproducing the pre-configured-tag behavior on
-   demand. **But an explicit "Load" pill on the Analysing screen still warms it:**
-   clicking Load warms with `keep_alive: 30` (the floor, Invariant 8), so
-   `ollama ps` shows the model resident with an ~30s `UNTIL` countdown and the
-   pill goes green — Load never load-then-evicts. This is the regression fix:
-   before the floor, a `0`-resolving tag (default for any custom quant) made the
-   Load button appear to do nothing.
+3. **Run an analysis** against that model, then in PowerShell run `ollama ps`
+   repeatedly across a chapter boundary or two. Because the analyzer is **pinned
+   for the duration of the run** (srv-62/#1709, Invariant 1), expect `UNTIL` to
+   read `Forever` (or refresh with no `Stopping…`) across every attribution
+   chunk — no cold reload between calls. When the run **ends**, teardown evicts
+   and the field's configured seconds (default `30`) govern the idle hold. (A
+   manual "Load" pill outside a run still warms with the floored keep-alive per
+   Invariant 8.)
+4. **Set the same field to `0`** and blur. **During an analysis run this is
+   overridden by the pin** (`/api/chat` sends `-1`, Invariant 1) — the `0` only
+   takes effect as the *post-run* idle, so once the run ends the model evicts
+   immediately rather than lingering. **An explicit "Load" pill outside a run
+   still warms it:** clicking Load warms with `keep_alive: 30` (the floor,
+   Invariant 8), so `ollama ps` shows the model resident with an ~30s `UNTIL`
+   countdown and the pill goes green — Load never load-then-evicts. This is the
+   regression fix: before the floor, a `0`-resolving tag (default for any custom
+   quant) made the Load button appear to do nothing.
 5. **Set the field to `-1`.** Expect the model to stay resident indefinitely
    (`ollama ps` shows no eviction countdown) until manually unloaded.
 6. **Click ↺ (reset)** on an overridden row. Expect the field to fall back to
-   displaying the coded default (`300` for a supported model, `0` for a
-   custom tag) and the reset button to disappear; the PUT carries the map
-   with that tag's key removed, every other override intact.
-7. **On a CPU-only box** (no CUDA), configure `qwen3.5:9b`'s keep-alive to a
-   positive value. Expect the actual `keep_alive` sent on `/api/chat` to still
-   be `0` (the `RAM_HEAVY_MODELS` CPU clamp overrides the configured value) —
-   the UI's helper copy notes this caveat next to the field.
+   displaying the flat `30` default (srv-62/#1709 — same for every tag now) and
+   the reset button to disappear; the PUT carries the map with that tag's key
+   removed, every other override intact.
+7. **On a CPU-only box** (no CUDA, and with no analysis run in flight — the pin
+   would otherwise send `-1`), configure `qwen3.5:9b`'s keep-alive to a positive
+   value. Expect the resolved post-run `keep_alive` to still be `0` (the
+   `RAM_HEAVY_MODELS` CPU clamp overrides the configured value) — the UI's helper
+   tooltip notes this caveat next to the field.
 8. **Design a voice** (cast-review) with a custom analyzer model configured
    and no override set. Expect the persona/voice-design keep-alive to still
    behave as `300` (unchanged) — confirming persona never regressed to `0`

--- a/server/src/analyzer/ollama.ts
+++ b/server/src/analyzer/ollama.ts
@@ -617,19 +617,6 @@ export class OllamaAnalyzer implements Analyzer {
       },
     };
 
-    /* TEMP DIAGNOSTIC (keep-alive eviction hunt) — logs the EXACT keep_alive on
-       the wire per /api/chat call, plus the model string, the accelerator, the
-       override-map keys, and the cache-key values (num_ctx/num_gpu). Remove once
-       the root cause is confirmed. */
-    console.log(
-      `[keepalive-probe] model=${JSON.stringify(this.model)} ` +
-        `keep_alive=${body.keep_alive} ` +
-        `accel=${getLastKnownVram().accelerator} ` +
-        `resolveKeepAliveSeconds=${resolveKeepAliveSeconds(this.model)} ` +
-        `overrideKeys=${JSON.stringify(Object.keys(getCachedUserSettings().analyzerKeepAliveByModel ?? {}))} ` +
-        `num_ctx=${body.options.num_ctx} num_gpu=${body.options.num_gpu}`,
-    );
-
     /* Short-circuit if the caller has already aborted (e.g. the SSE client
        disconnected while a previous chapter was still running). Saves a
        wasted Ollama round-trip and lets the route loop bail immediately. */

--- a/server/src/routes/ollama-health.ts
+++ b/server/src/routes/ollama-health.ts
@@ -476,12 +476,6 @@ ollamaHealthRouter.post('/load', async (req: Request, res: Response) => {
     `.status` for the HTTP response code). */
 export async function unloadResidentOllama(targets?: string[]): Promise<string[]> {
   const url = getResolvedOllamaUrl();
-  /* TEMP DIAGNOSTIC (keep-alive eviction hunt) — records EVERY explicit evict
-     (keep_alive:0) with its caller stack, so a mid-run eviction is traceable to
-     whatever triggered it. Remove once the root cause is confirmed. */
-  console.log(
-    `[evict-probe] unloadResidentOllama targets=${JSON.stringify(targets ?? null)}\n${new Error('evict call site').stack}`,
-  );
   const list = targets && targets.length > 0 ? targets : (await probeOllamaHealth()).resident ?? [];
   for (const model of list) {
     const result = await callOllamaGenerate(url, { model, prompt: '', keep_alive: 0, stream: false }, PROBE_TIMEOUT_MS);

--- a/src/views/model-manager.tsx
+++ b/src/views/model-manager.tsx
@@ -595,7 +595,17 @@ function ModelRow({
             />
           )}
           {isAnalyzer && analyzerModel && (
-            <label className="flex items-center gap-1 text-[11px] text-ink/60">
+            <label
+              className="flex items-center gap-1 text-[11px] text-ink/60"
+              title={
+                'Seconds the model stays resident after a call. Defaults to 30 if unset — ' +
+                'enough to bridge back-to-back analysis calls so the model is not cold-loaded ' +
+                'per chunk. 0 = evict immediately, -1 = pin forever. During an analysis or ' +
+                'script-review run the model is pinned regardless, so this value governs only ' +
+                'the post-run idle hold. On a CPU-only box, RAM-heavy models (qwen3.5:9b) are ' +
+                'clamped to 0.'
+              }
+            >
               keep-alive
               <input
                 key={`keepalive-${item.id}-${item.keepAliveSeconds ?? 0}`}


### PR DESCRIPTION
## What

Finalizes **srv-62 / #1709**. The runtime-path work the issue tracked already shipped — uncurated Ollama analyzer tags fall back to a flat `DEFAULT_ANALYZER_KEEP_ALIVE_SECONDS = 30` (#1711) and the analyzer is pinned (`-1`) for the whole run (#1715, extended to review runs in #1718), so mid-run eviction can no longer happen regardless of the configured value. This PR is the clean-up-and-document half:

- **Revert the two temporary diagnostic probes from the eviction hunt (#1710):** the `[keepalive-probe]` `console.log` in `OllamaAnalyzer.chat` and the `[evict-probe]` in `unloadResidentOllama`. Pure debug-logging removal — no behavior change.
- **Refresh plan 263** (`docs/features/263-per-model-keepalive.md`) to match shipped reality. The stale curated `DEFAULT_KEEP_ALIVE_SECONDS` map (four tags @ `300`, `0`-fallthrough) is gone; Invariants 1, 2, 4, 8, the test-plan bullets, and the acceptance walkthrough now describe the flat-30 fallback and the run-scoped pin. A header note summarizes the two changes that superseded the original design.
- **Document the default in the Model Manager helper copy** — a `title` tooltip on the keep-alive field covering the default (30), the `0` = evict / `-1` = pin semantics, the run-scoped pin, and the CPU RAM-heavy clamp.

## Why

The probes were shipped deliberately temporary (see #1710) and the plan doc had drifted from the code after #1711/#1715/#1718. This lands the doc + helper-copy acceptance items the issue called for and removes the debug logging now that the root cause is confirmed and fixed.

## Verification

- Root + server `tsc --noEmit` — clean
- ESLint on the three changed files (`--max-warnings 0`) — clean
- `server/src/analyzer/ollama.test.ts` + `server/src/routes/ollama-health.test.ts` — 88 passed
- `src/views/model-manager.test.tsx` — 50 passed
- Pre-commit `verify:fast:scoped` + pre-push `verify:fast:branch` — passed

## Not in this PR

On-box `ollama ps` acceptance (steady, no `Stopping…` across chunks on an analysis **and** a review run) is owed and remains the trigger to close #1709 — hence `Refs`, not `Closes`.

Refs #1709