### PR TITLE
chore(server): replace unreachable computeTpmWait 60000 fallback with an invariant tripwire

### DIFF
--- a/server/src/analyzer/rate-limit.test.ts
+++ b/server/src/analyzer/rate-limit.test.ts
@@ -4,7 +4,7 @@
    doesn't actually take 60 s. */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { GeminiRateLimiter, DailyQuotaExhaustedError } from './rate-limit.js';
+import { GeminiRateLimiter, DailyQuotaExhaustedError, computeTpmWait } from './rate-limit.js';
 import { AnalysisAbortedError } from './ollama.js';
 
 describe('GeminiRateLimiter', () => {
@@ -211,5 +211,47 @@ describe('GeminiRateLimiter', () => {
       code: 'REQUEST_EXCEEDS_TPM',
     });
     expect(Date.now() - start).toBeLessThan(1000); // did NOT wait 60s
+  });
+});
+
+describe('computeTpmWait', () => {
+  const state = (entries: Array<{ ts: number; tokens: number }>) => ({
+    rpmWindow: [],
+    tpmWindow: entries.map((e) => ({ ...e, pending: false })),
+    rpdCount: 0,
+    rpdDayKey: '2026-05-16',
+    blockUntil: 0,
+  });
+
+  it('returns the wait until the oldest entry frees enough headroom', () => {
+    /* cap 250K, needed 30K, window 240K (two 120K entries). surplus = 20K,
+       freed by the first (oldest) entry, which expires 60 s after its ts. */
+    const now = 1_000_000;
+    const wait = computeTpmWait(
+      state([
+        { ts: now - 40_000, tokens: 120_000 },
+        { ts: now - 20_000, tokens: 120_000 },
+      ]),
+      now,
+      30_000,
+      250_000,
+    );
+    // oldest entry expires at (now - 40_000) + 60_000 = now + 20_000.
+    expect(wait).toBe(20_000);
+  });
+
+  it('returns 0 when the request already fits (no surplus)', () => {
+    const now = 1_000_000;
+    expect(computeTpmWait(state([{ ts: now, tokens: 10_000 }]), now, 30_000, 250_000)).toBe(0);
+  });
+
+  it('throws the invariant tripwire if reached with needed > cap (guard bypassed)', () => {
+    /* acquire's RC5 guard makes this unreachable in production; assert the
+       tripwire fires so a future caller that bypasses it fails loudly
+       instead of silently soft-capping. */
+    const now = 1_000_000;
+    expect(() =>
+      computeTpmWait(state([{ ts: now, tokens: 10_000 }]), now, 300_000, 250_000),
+    ).toThrow(/invariant violated/);
   });
 });

--- a/server/src/analyzer/rate-limit.ts
+++ b/server/src/analyzer/rate-limit.ts
@@ -311,11 +311,14 @@ export class GeminiRateLimiter {
    `needed`. Walks entries from oldest to newest summing freed tokens;
    returns the wait until the entry whose expiry frees enough.
 
-   Edge case: if `needed` exceeds the model's TPM cap entirely (e.g. a
-   400K-token prompt against a 250K cap), no wait will ever free enough.
-   We return 60_000 in that case as a soft cap — the retry loop will hit
-   its own ceiling and give up cleanly. */
-function computeTpmWait(s: ModelState, now: number, needed: number, cap: number): number {
+   Invariant (upheld by acquire's RC5 fail-fast guard): `needed <= cap`.
+   So `surplus = current + needed - cap <= current`, and the running
+   `freed` sum reaches `current` — hence `surplus` — before the window is
+   exhausted; the in-loop return always fires. Falling out of the loop
+   means a caller reached here with `needed > cap` (an unsatisfiable
+   request that bypassed the guard); throw as a tripwire rather than
+   masking it as a soft-capped wait. Exported for that invariant test. */
+export function computeTpmWait(s: ModelState, now: number, needed: number, cap: number): number {
   const current = s.tpmWindow.reduce((sum, e) => sum + e.tokens, 0);
   const surplus = current + needed - cap;
   if (surplus <= 0) return 0; // shouldn't happen — caller already checked
@@ -327,7 +330,10 @@ function computeTpmWait(s: ModelState, now: number, needed: number, cap: number)
       return Math.max(0, expiresAt - now);
     }
   }
-  return 60_000;
+  throw new Error(
+    `computeTpmWait invariant violated: needed ${needed} exceeds cap ${cap} — ` +
+      `acquire's fail-fast guard should have rejected this request before the wait loop.`,
+  );
 }
 
 /** Module-level singleton. RPM/TPM/RPD are global per process — sharing


### PR DESCRIPTION
## Summary

`computeTpmWait()`'s trailing `return 60_000` "request exceeds the model's TPM cap entirely" branch became **unreachable** once #1682 (merged via #1693) added the fail-fast guard at the top of `acquire()` that throws `RequestExceedsTpmError` when `Number.isFinite(limits.tpm) && estimatedTokens > limits.tpm`.

By the time `computeTpmWait()` runs, `needed <= cap` always holds, so `surplus = current + needed - cap <= current`. The running `freed` sum reaches `current` (hence `surplus`) before the window is exhausted, so the in-loop `return` always fires — the trailing `return 60_000` is dead code, and its "soft cap" comment is now false.

`strict` control-flow analysis can't prove the loop always returns, so simply deleting the trailing `return` breaks the build. Rather than keep a misleading soft-cap, this converts it to an **explicit invariant tripwire** (issue #1689's second acceptance option): it throws if a future caller ever reaches it with `needed > cap` (i.e. bypassed the guard), and the comment is rewritten to state the invariant instead of the old false claim.

## Changes

- `server/src/analyzer/rate-limit.ts` — replace the unreachable `return 60_000` with an invariant-violation `throw`; rewrite the stale comment; `export` `computeTpmWait` so the invariant is directly testable.
- `server/src/analyzer/rate-limit.test.ts` — new `describe('computeTpmWait')` with three unit tests: the reachable wait computation, the no-surplus fast path, and the tripwire throw.

## Test plan

- `npx vitest run src/analyzer/rate-limit.test.ts` → 15/15 green (12 existing + 3 new).
- `tsc --noEmit` clean (confirms the `throw` satisfies strict control-flow where the deleted `return` did).
- No production behaviour change — the removed branch was unreachable; the fail-fast guard's own test (`fails fast when a single request exceeds a finite TPM`) already covers the guarded path.

No release-notes / regression-plan entry: internal dead-code removal with no user- or operator-visible effect. `06-analyzer-gemini.md` documents the rate-limit *table*, not this control-flow detail.

Closes #1689

🤖 Generated with [Claude Code](https://claude.com/claude-code)