### PR TITLE
docs(server): document SEG_CAPACITY_ADMISSION opt-in in .env.example

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -109,6 +109,22 @@ GEMINI_MODEL=gemma-4-31b-it
 # overlap (Kokoro narrator + Qwen dialogue). Restart to apply.
 # GEN_WORKERS=1
 
+# Capacity-aware GPU placement (PR #1719, plan docs/features/264). The opt-in
+# that replaces the retired GPU token budget (GPU_VRAM_BUDGET / GPU_CONCURRENCY /
+# GPU_WEIGHT_* / GPU_SAFE_COEXIST_MB, all now inert) with live per-device VRAM
+# measurement + per-call decode-peak reservation. When 1, the sidecar enforces
+# admission on /synthesize: a no-capacity op gets a 503, Node evicts an idle
+# analyzer or bounded-polls, then surfaces a NoCapacityError toast at the cap
+# (never a hang). 0/unset = dormant (the shipped code default). Read by the
+# sidecar at process start — restart the sidecar to apply. The GPU_RESERVE_MB
+# cushion (generated GPU section below) is the one surviving budget knob.
+#
+# NOTE (#1720): only /synthesize is admitted today. Cold /load, design_voice
+# (VoiceDesign), ASR /transcribe and spk /embed are NOT yet wrapped in the
+# reservation; the LOAD path stays protected in both flag states via the
+# capacity-based evict in server/src/gpu/gpu-load.ts.
+SEG_CAPACITY_ADMISSION=1
+
 # Qwen batching (plans 113/128/136) — throughput vs VRAM, Qwen-only
 # (Coqui/Kokoro/Gemini have no batch API and stay one-per-call). The model runs
 # ONE batched generate_voice_clone forward per decode step instead of N, so a


### PR DESCRIPTION
## Summary

PR #1719 (capacity-aware GPU placement) added `GPU_RESERVE_MB` to the generated GPU section of `server/.env.example`, but left the feature's opt-in flag — `SEG_CAPACITY_ADMISSION` — undocumented there. The flag is a **direct sidecar env read** (`server/tts-sidecar/main.py`), not a registry knob, so `config:sync` never emits it into the managed block.

This adds it to the **hand-written region** of `.env.example` (above the `# >>> BEGIN generated config knobs` marker), set to `1`, with the `#1720` caveat that only `/synthesize` is admitted today. Placing it outside the managed block keeps `config:check` in sync (verified locally: `.env.example in sync ✓`).

No runtime code changes — documentation of an already-shipped flag.

## Test plan

- `npm run config:check` → `.env.example in sync ✓` (the managed block is untouched; the new entry lives in the hand-written region).
- No test surface — `.env.example` is a template, not imported by any code.

Refs #1720

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQcYVw9t2FL8ut8RqyVuyQ
