### PR TITLE
chore(server): wire eval-rate telemetry into subset retry route (srv-61)

### DIFF
--- a/server/src/analyzer/analyzer-eval-stats.test.ts
+++ b/server/src/analyzer/analyzer-eval-stats.test.ts
@@ -6,6 +6,30 @@ import { join } from 'node:path';
 const dir = mkdtempSync(join(tmpdir(), 'aes-'));
 vi.mock('../workspace/paths.js', () => ({ telemetryDir: () => dir }));
 
+/* Count readFile calls so the srv-61 test can prove appendAndTrim no longer
+   re-reads the whole JSONL on every append. Hoisted (vi.mock is hoisted above
+   imports; a plain top-level const would be in the TDZ inside the factory). The
+   mock passes every fs/promises export through untouched — only readFile is
+   wrapped with a counter — so every other test keeps its real IO behaviour. */
+const io = vi.hoisted(() => ({ readFileCalls: 0, failAppendOnce: false }));
+vi.mock('node:fs/promises', async (orig) => {
+  const real = await orig<typeof import('node:fs/promises')>();
+  return {
+    ...real,
+    readFile: (...args: Parameters<typeof real.readFile>) => {
+      io.readFileCalls++;
+      return (real.readFile as (...a: unknown[]) => unknown)(...args);
+    },
+    appendFile: (...args: Parameters<typeof real.appendFile>) => {
+      if (io.failAppendOnce) {
+        io.failAppendOnce = false;
+        return Promise.reject(new Error('disk full'));
+      }
+      return (real.appendFile as (...a: unknown[]) => unknown)(...args);
+    },
+  };
+});
+
 import {
   foldPassTiming, canonicalModel, recordPassEval, withPassEval,
   readAnalyzerEvalRecords, appendAnalyzerEval, analyzerEvalStatsFilePath,
@@ -109,5 +133,52 @@ describe('store IO', () => {
     const recs = await readAnalyzerEvalRecords();
     expect(recs).toHaveLength(ANALYZER_EVAL_MAX_LINES);
     expect(recs[0].chapterId).toBe(9999); // newest kept
+  });
+});
+
+describe('appendAndTrim — in-memory line-count tracking (srv-61)', () => {
+  const rec = (chapterId: number): AnalyzerEvalRecord => ({
+    at: new Date().toISOString(), manuscriptId: 'm', bookTitle: null, model: 'x:latest',
+    stage: 'stage2-ch', chapterId, evalTokS: 1, promptTokS: null, evalCount: 1, loadMs: 0,
+    subCalls: 1, chunkCount: 1, outcome: 'ok',
+  });
+
+  it('does not re-read the whole file on every append (tracks the count in memory)', async () => {
+    // First append establishes the count from disk — exactly ONE read. Asserting
+    // this proves the counter mock is actually intercepting the module's readFile,
+    // so the no-further-reads assertion below can't be a placebo pass.
+    io.readFileCalls = 0;
+    await appendAnalyzerEval(rec(1));
+    const afterFirst = io.readFileCalls;
+    expect(afterFirst).toBeGreaterThanOrEqual(1);
+    // Subsequent below-cap appends must NOT re-read the whole file.
+    await appendAnalyzerEval(rec(2));
+    await appendAnalyzerEval(rec(3));
+    expect(io.readFileCalls).toBe(afterFirst);
+  });
+
+  it('resets the in-memory count on an IO error so the next append re-establishes from disk', async () => {
+    await appendAnalyzerEval(rec(1)); // establishes the count from disk
+    await appendAnalyzerEval(rec(2)); // steady increment — no read
+    io.readFileCalls = 0;
+    io.failAppendOnce = true;
+    await appendAnalyzerEval(rec(3)); // appendFile throws → catch resets count to null
+    expect(io.readFileCalls).toBe(0); // the failed append never reached the read
+    await appendAnalyzerEval(rec(4)); // count was null → MUST re-establish from disk
+    expect(io.readFileCalls).toBe(1);
+    // Store stays consistent: 3 failed to append, 1/2/4 landed.
+    const recs = await readAnalyzerEvalRecords();
+    expect(recs.map((r) => r.chapterId).sort((a, b) => Number(a) - Number(b))).toEqual([1, 2, 4]);
+  });
+
+  it('trims via the in-memory counter as appends cross the cap, keeping newest', async () => {
+    // Pre-fill just under the cap so a handful of real appends cross it and
+    // exercise the establish → increment → trim → post-trim-increment path.
+    const base = Array.from({ length: ANALYZER_EVAL_MAX_LINES - 2 }, (_, i) => JSON.stringify(rec(i))).join('\n') + '\n';
+    writeFileSync(analyzerEvalStatsFilePath(), base);
+    for (let i = 0; i < 5; i++) await appendAnalyzerEval(rec(1000 + i)); // MAX-2+5 = MAX+3
+    const recs = await readAnalyzerEvalRecords();
+    expect(recs).toHaveLength(ANALYZER_EVAL_MAX_LINES);
+    expect(recs[0].chapterId).toBe(1004); // newest kept after repeated trims
   });
 });

--- a/server/src/analyzer/analyzer-eval-stats.ts
+++ b/server/src/analyzer/analyzer-eval-stats.ts
@@ -86,8 +86,23 @@ export function foldPassTiming(acc: RawEvalTiming[]): {
    append and drops lines (N pipelined analysis workers append concurrently). */
 let writeQueue: Promise<void> = Promise.resolve();
 
+/* In-memory line count so the append hot path doesn't re-read the whole JSONL
+   every time just to enforce the cap. `null` = unknown (process start, or after
+   an IO error); the next append establishes it from disk ONCE, then tracks it
+   incrementally. Safe as a module singleton because every append is serialized
+   through `writeQueue` — appendAndTrim never overlaps itself.
+
+   Assumes this process is the sole writer of the file — the same assumption the
+   old read-modify-write trim already relied on (that rewrite was never atomic
+   across processes). A second process sharing telemetryDir (only under the
+   recycle-storm defect — see project_sidecar_recycle_storm_two_supervisors)
+   would go uncounted here until the next trim re-reads; acceptable for
+   best-effort telemetry. Any drift also self-heals whenever a trim re-reads. */
+let cachedLineCount: number | null = null;
+
 export function __resetAnalyzerEvalQueueForTest(): void {
   writeQueue = Promise.resolve();
+  cachedLineCount = null;
 }
 
 export function appendAnalyzerEval(rec: AnalyzerEvalRecord): Promise<void> {
@@ -95,17 +110,34 @@ export function appendAnalyzerEval(rec: AnalyzerEvalRecord): Promise<void> {
   return writeQueue;
 }
 
+/* Trim `lines` (the file's current non-empty lines) down to the cap, writing
+   only when a trim is actually needed. Returns the resulting line count. */
+async function trimToCap(path: string, lines: string[]): Promise<number> {
+  if (lines.length <= ANALYZER_EVAL_MAX_LINES) return lines.length;
+  const kept = lines.slice(lines.length - ANALYZER_EVAL_MAX_LINES);
+  await writeFile(path, `${kept.join('\n')}\n`, 'utf8');
+  return kept.length;
+}
+
 async function appendAndTrim(rec: AnalyzerEvalRecord): Promise<void> {
   const path = analyzerEvalStatsFilePath();
   try {
     await mkdir(telemetryDir(), { recursive: true });
     await appendFile(path, `${JSON.stringify(rec)}\n`, 'utf8');
-    const lines = (await readFile(path, 'utf8')).split('\n').filter((l) => l.trim().length > 0);
-    if (lines.length > ANALYZER_EVAL_MAX_LINES) {
-      await writeFile(path, `${lines.slice(lines.length - ANALYZER_EVAL_MAX_LINES).join('\n')}\n`, 'utf8');
+    /* Steady state: the count is known and this append kept us under the cap —
+       just increment, no read. This is the whole point of the counter. */
+    if (cachedLineCount !== null && cachedLineCount + 1 <= ANALYZER_EVAL_MAX_LINES) {
+      cachedLineCount += 1;
+      return;
     }
+    /* Otherwise the count is unknown (first append this process, or after an
+       error reset) OR this append crosses the cap. Read the file ONCE and reuse
+       that read for the trim — no double read on the first at-cap append. */
+    const lines = (await readFile(path, 'utf8')).split('\n').filter((l) => l.trim().length > 0);
+    cachedLineCount = await trimToCap(path, lines);
   } catch {
     /* observability, not correctness — never break a run */
+    cachedLineCount = null; // truth unknown after a failed write; re-establish next time
   }
 }
 

--- a/server/src/analyzer/ollama.test.ts
+++ b/server/src/analyzer/ollama.test.ts
@@ -819,6 +819,32 @@ describe('OllamaAnalyzer — onEvalTiming sink (analyzer-eval-telemetry)', () =>
 
     expect(timings).toHaveLength(0);
   });
+
+  it('a throwing onEvalTiming sink never fails an otherwise-successful decode (srv-61)', async () => {
+    // The sink is best-effort telemetry on the hot path; a future non-inert sink
+    // must not be able to turn a clean decode into a stage failure.
+    fetchMock.mockResolvedValue(
+      okResponse(
+        ndjsonStreamWithTiming(chunksOf(VALID_RESPONSE, 32), {
+          eval_count: 120,
+          eval_duration: 4_000_000_000,
+          prompt_eval_count: 800,
+          prompt_eval_duration: 2_000_000_000,
+          load_duration: 0,
+        }),
+      ),
+    );
+    const { OllamaAnalyzer } = await import('./ollama.js');
+    const analyzer = new OllamaAnalyzer({ url: 'http://localhost:11434', model: 'qwen3.5:9b' });
+
+    const result = await analyzer.runStage1Chapter('m_ollama_eval_timing_throws', 1, '# prompt', {
+      onEvalTiming: () => {
+        throw new Error('sink boom');
+      },
+    });
+
+    expect(result.characters).toBeDefined();
+  });
 });
 
 /* srv-59 Task 9 — the escalation primitive is deliberately NOT built on

--- a/server/src/analyzer/ollama.ts
+++ b/server/src/analyzer/ollama.ts
@@ -790,9 +790,16 @@ export class OllamaAnalyzer implements Analyzer {
         await sampleAndRecordVram(this.url, this.model, resolveAnalyzerNumCtx());
       }
       /* fs-analyzer-eval-telemetry: best-effort decode-timing capture, gated
-         by the analyzer.evalStats.enabled knob so an operator can disable it. */
+         by the analyzer.evalStats.enabled knob so an operator can disable it.
+         Wrapped so the sink can NEVER turn a clean decode into a stage failure —
+         the sole consumer today is an inert array push, but "never throws on the
+         hot path" must hold by construction for any future sink (srv-61). */
       if (timing && onEvalTiming && configValue<boolean>('analyzer.evalStats.enabled')) {
-        onEvalTiming(timing);
+        try {
+          onEvalTiming(timing);
+        } catch (evalSinkErr) {
+          console.warn('[ollama] onEvalTiming sink threw (ignored, telemetry is best-effort):', evalSinkErr);
+        }
       }
       return buf;
     } finally {

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -5223,56 +5223,73 @@ export async function runSubsetAnalyzerJob(
          the batch. On success we also clear the id from
          cache.failedChapterIds so the analysing view's Retry row
          disappears on reload. */
+      /* srv-61 — lift the per-chapter opts into a named StageCall so the SAME
+         object is handed to both the runner (analyzer.runStage1Chapter) and
+         withPassEval, whose fresh-per-call accumulator attaches to it. Without
+         this a retried chapter's stage-1 chat() sub-calls emit no eval-rate
+         record. Mirrors the main route's castCall wiring. */
+      const stage1Call: StageCall = {
+        signal: abortController.signal,
+        language: bookLanguage,
+        onWaiting: () => emitHeartbeat(0, ch.id),
+        onChunk: (info) => emitHeartbeat(0, ch.id, info),
+        onThrottle: (waitMs, reason) => {
+          send({
+            kind: 'throttle',
+            phaseId: 0,
+            chapterIndex: ch.id,
+            model: subsetModelId,
+            waitMs,
+            reason,
+          });
+        },
+      };
       try {
-        const result = await runStage1Guarded({
-          body: ch.body,
-          runningRoster: Array.from(rebuildRoster().values()),
-          chapterId: ch.id,
-          log,
-          language: bookLanguage,
-          call: () =>
-            runStage1ChapterChunked({
+        const result = await withPassEval(
+          stage1Call,
+          {
+            manuscriptId,
+            bookTitle: record.title ?? null,
+            stage: 'stage1-ch',
+            chapterId: ch.id,
+          },
+          () =>
+            runStage1Guarded({
               body: ch.body,
-              charBudget: resolveStage1ChunkCharBudget(selection.engine, ch.body),
-              mergeRosters: mergeRosterChapter,
-              onChunk: (sec) =>
-                log(
-                  0,
-                  `Chapter ${ch.id} cast — large chapter, section ${sec.index + 1}/${
-                    sec.total
-                  } (${sec.chars.toLocaleString()} chars) to fit the model context…`,
-                ),
-              callForBody: (subBody) =>
-                analyzer.runStage1Chapter(
-                  manuscriptId,
-                  ch.id,
-                  buildStage1ChapterInbox(
-                    manuscriptId,
-                    record.title,
-                    { ...ch, body: subBody },
-                    Array.from(rebuildRoster().values()),
-                    subsetSeriesPrior,
-                    bookAuthor,
-                  ),
-                  {
-                    signal: abortController.signal,
-                    language: bookLanguage,
-                    onWaiting: () => emitHeartbeat(0, ch.id),
-                    onChunk: (info) => emitHeartbeat(0, ch.id, info),
-                    onThrottle: (waitMs, reason) => {
-                      send({
-                        kind: 'throttle',
-                        phaseId: 0,
-                        chapterIndex: ch.id,
-                        model: subsetModelId,
-                        waitMs,
-                        reason,
-                      });
-                    },
-                  },
-                ),
-            }).then((r) => ({ characters: r.characters })),
-        });
+              runningRoster: Array.from(rebuildRoster().values()),
+              chapterId: ch.id,
+              log,
+              language: bookLanguage,
+              call: () =>
+                runStage1ChapterChunked({
+                  body: ch.body,
+                  charBudget: resolveStage1ChunkCharBudget(selection.engine, ch.body),
+                  mergeRosters: mergeRosterChapter,
+                  onChunk: (sec) =>
+                    log(
+                      0,
+                      `Chapter ${ch.id} cast — large chapter, section ${sec.index + 1}/${
+                        sec.total
+                      } (${sec.chars.toLocaleString()} chars) to fit the model context…`,
+                    ),
+                  callForBody: (subBody) =>
+                    analyzer.runStage1Chapter(
+                      manuscriptId,
+                      ch.id,
+                      buildStage1ChapterInbox(
+                        manuscriptId,
+                        record.title,
+                        { ...ch, body: subBody },
+                        Array.from(rebuildRoster().values()),
+                        subsetSeriesPrior,
+                        bookAuthor,
+                      ),
+                      stage1Call,
+                    ),
+                }).then((r) => ({ characters: r.characters })),
+            }),
+          () => null,
+        );
         chapterCast[ch.id] = result.characters;
         cache.chapterCast = chapterCast;
         const wasFailed = clearFailedChapterId(cache, ch.id);
@@ -5479,7 +5496,7 @@ export async function runSubsetAnalyzerJob(
         sentences: chapterSentences,
         chunkCount: subsetChunkCount,
         structureReport: subsetStructureReport,
-      } = await attributeChapterStage2({
+      } = await attributeChapterStage2WithEval({
           analyzer: phase1Analyzer,
           manuscriptId,
           title: record.title,
@@ -5588,10 +5605,23 @@ export async function runSubsetAnalyzerJob(
     const classifyNonStory = analyzer.runNonStoryClassification
       ? async (ch: ThirdPartyGuardChapter): Promise<boolean> => {
           const promptMd = `Title: ${ch.title ?? '(untitled)'}\n\n${ch.body}`;
+          /* srv-61 — wrap the classification chat() sub-calls in withPassEval so a
+             subset retry's nonstory pass emits an eval-rate record too (mirrors the
+             main route). The SAME StageCall is passed to both the runner and
+             withPassEval so its fresh-per-call accumulator attaches to this call. */
+          const nonStoryCall: StageCall = { language: bookLanguage };
           try {
-            const out = await analyzer.runNonStoryClassification!(manuscriptId, ch.id, promptMd, {
-              language: bookLanguage,
-            });
+            const out = await withPassEval(
+              nonStoryCall,
+              {
+                manuscriptId,
+                bookTitle: record.title ?? null,
+                stage: 'nonstory',
+                chapterId: ch.id,
+              },
+              () => analyzer.runNonStoryClassification!(manuscriptId, ch.id, promptMd, nonStoryCall),
+              () => null,
+            );
             return out.nonStory;
           } catch (err) {
             if (err instanceof AnalysisAbortedError) throw err;


### PR DESCRIPTION
Follow-ups from **fs-76** (#1698, shipped in #1699), surfaced by the per-task and whole-branch reviews. All non-blocking (`type:chore`, `moscow:could`). Server-only.

## What changed

**1. Retry-route eval wiring.** The "retry failed chapters" subset route (`runSubsetAnalyzerJob` in `routes/analysis.ts`) re-runs stage-1 cast, stage-2 attribution, and nonstory classification, but emitted **no** eval-rate records for retried chapters. All three sites are now wrapped in `withPassEval`, mirroring the main route exactly:
- stage-1 and nonstory lift their per-chapter opts into a named `StageCall` handed to **both** the runner and `withPassEval` (its fresh-per-call accumulator attaches to the call the chapter actually uses);
- stage-2 swaps `attributeChapterStage2` → `attributeChapterStage2WithEval`.

**2. Sink hardening.** The `onEvalTiming(timing)` call in `analyzer/ollama.ts` is wrapped in try/catch so a future non-inert sink can never turn a clean decode into a stage failure. The sole consumer today is an inert array push, but "never throws on the hot path" now holds by construction.

**3. Line-count in memory.** `analyzer/analyzer-eval-stats.ts` `appendAndTrim` no longer re-reads the whole JSONL on every append just to enforce the 2000-line cap. It tracks the count in memory — established once from disk, incremented in steady state, recomputed on trim, and reset to `null` on IO error so the next append re-establishes. The read is reused for the trim, so the first at-cap append after restart no longer double-reads. Safe as a module singleton because every append is serialized through the existing `writeQueue` mutex. The load-bearing `await` and terminal `.catch` are kept.

## Review

Independent high-effort review (multi-agent workflow) surfaced 3 findings, all in `analyzer-eval-stats.ts`; all addressed:
- cross-process cap drift (PLAUSIBLE) — documented the single-writer assumption (the old read-modify-write trim was never cross-process atomic either; best-effort telemetry);
- redundant double-read on the first at-cap append (CONFIRMED) — fixed via the read-once `trimToCap` helper;
- untested error-reset seam (CONFIRMED) — added a test that forces an `appendFile` failure and asserts the count resets.

## Tests

New coverage: throwing-sink hot path (ollama); in-memory counter — no re-read below cap, cross-cap trim, and the IO-error reset seam. Full pre-commit `test:server` (all server suites) + pre-push `verify:fast:branch` (lint, typecheck, build, sidecar) green.

## Owed

On-box acceptance: drive a real retry-failed-chapters analysis and confirm an eval-rate record appears per retried pass (stage1-ch / stage2-ch / nonstory) — consistent with how fs-76 itself was accepted.

Closes #1700

🤖 Generated with [Claude Code](https://claude.com/claude-code)