### PR TITLE
fix(sidecar): keep every heavy-GPU op's device on its admitted card (#1730)

### DIFF
--- a/docs/features/264-vram-aware-gpu-placement.md
+++ b/docs/features/264-vram-aware-gpu-placement.md
@@ -231,6 +231,18 @@ the flag is OFF) should close so admission covers everything the budget did:
 The three flag-ON stale-`self._device` items above (Qwen forward, ASR/SPK
 cold-load, Coqui load-steer) are tracked together in **#1730**.
 
+> **CLOSED (#1730).** All three are fixed: the Qwen 1.7B forward now moves its
+> ref_code onto the resident wrapper's own `self._base17.device` (published with
+> the model at load, immune to a shared-field clobber); `/transcribe` + `/embed`
+> thread the admitted card into `transcribe`/`_ensure_loaded` / `ensure_loaded`
+> as a parameter (applied under the load lock, no pre-mutation across the
+> unlocked gap); and Coqui's `_ensure_loaded` keeps `self._device` in step with
+> the card the model is actually on (restored to the requested pref on
+> `unload()`). Regression coverage: `test_design_mint_admission.py`,
+> `test_transcribe_embed_admission.py`, `test_coqui_device.py`. On-box 2-card
+> acceptance (with `SEG_CAPACITY_ADMISSION=1`) still owed before the
+> concurrent-multi-card flag flip.
+
 ## Ship notes
 
 (Filled when status flips to `stable` after the on-box acceptance above passes and

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -1141,6 +1141,12 @@ class CoquiEngine(Engine):
         self._tts = tts
         self._torch = torch
         self._resolved_device = device
+        # Keep the shared `self._device` in step with the card the model is
+        # ACTUALLY on (#1730 gap 3): an admitted `device` override resolves here
+        # but previously left `self._device` stale at the env pref, so any reader
+        # of `self._device` saw a card the model wasn't on. `unload()` restores
+        # the requested pref so a later flag-off reload still re-resolves cleanly.
+        self._device = device
         self._use_half = bool(want_half and _parse_device(device)[0] == "cuda")
         if self._use_half:
             log.info("fp16 autocast enabled for /synthesize.")
@@ -1178,6 +1184,10 @@ class CoquiEngine(Engine):
         self._torch = None
         self._speakers = []
         self._resolved_device = "cpu"
+        # Restore the env pref (#1730 gap 3): `_ensure_loaded` overwrote
+        # `self._device` with the resolved card, so a later flag-off reload must
+        # re-resolve from the ORIGINAL request (e.g. 'auto'), not the last card.
+        self._device = self._requested_device
         self._use_half = False
         # Break the dropped model's reference cycles NOW (see
         # _reclaim_host_and_vram) — nn.Module graphs aren't refcount-freed, and
@@ -3798,7 +3808,13 @@ class QwenEngine(Engine):
             with self._synth_lock:
                 self._ensure_base17_for_mint(device=device)
                 rc = base_item.ref_code
-                rc = rc.to(self._device) if hasattr(rc, "to") else rc
+                # Move onto the card the resident 1.7B is ACTUALLY on, read off
+                # the wrapper itself (published atomically with the model at load
+                # — the same value it feeds its own `input_ids.to(...)`). NOT the
+                # shared engine-wide `self._device`, which a concurrent
+                # design/mint admitted to another card can clobber in the
+                # unlocked gap between load and this forward (#1730 gap 1).
+                rc = rc.to(self._base17.device) if hasattr(rc, "to") else rc
                 _t = time.perf_counter()
                 _phase("anchoring")
                 ref_wavs, ref_sr = self._base17.model.speech_tokenizer.decode(
@@ -3997,8 +4013,11 @@ class QwenEngine(Engine):
 
         # Decode ref_code through the 1.7B speech_tokenizer to get a waveform,
         # then re-derive a 1.7B-native clone prompt (mirrors mint_variant ~1831-1836).
+        # Move onto the resident 1.7B's OWN card (read off the wrapper, immune to
+        # a concurrent clobber of the shared `self._device` — #1730 gap 1; see
+        # mint_variant's matching forward for the full rationale).
         rc = base_item.ref_code
-        rc = rc.to(self._device) if hasattr(rc, "to") else rc
+        rc = rc.to(self._base17.device) if hasattr(rc, "to") else rc
         ref_wavs, ref_sr = self._base17.model.speech_tokenizer.decode(
             [{"audio_codes": rc}]
         )
@@ -4415,16 +4434,25 @@ class WhisperEngine:
         self._requested_device = self._device  # preserved for /health fell_back detection
         self._model_name = (os.environ.get("ASR_MODEL", "base").strip() or "base")
 
-    def _compute_type(self) -> str:
+    def _compute_type(self, device: Optional[str] = None) -> str:
         """int8 on CPU (fast, tiny); int8_float16 on GPU (small VRAM, fast).
-        Override via ASR_COMPUTE_TYPE for a roomier card."""
-        family, _ = _parse_device(self._device)
+        Override via ASR_COMPUTE_TYPE for a roomier card. `device` (#1730 gap 2)
+        computes the type off the load's threaded card rather than the shared
+        `self._device`; `None` falls back to it (the pre-admission behaviour)."""
+        family, _ = _parse_device(device if device is not None else self._device)
         default = "int8_float16" if family == "cuda" else "int8"
         return (os.environ.get("ASR_COMPUTE_TYPE", default).strip() or default)
 
-    def _ensure_loaded(self) -> None:
+    def _ensure_loaded(self, device: Optional[str] = None) -> None:
         if self._model is not None:
             return
+        # Capacity-aware placement (#1730 gap 2): the admitted card threads in as
+        # a PARAMETER and drives THIS cold load — mirroring the /load path —
+        # rather than the route pre-mutating the shared `self._device` before an
+        # unlocked load, where a concurrent multi-GPU first cold-load admitted to
+        # another card could clobber it. `None` keeps the env-derived default
+        # byte-for-byte.
+        dev = device if device is not None else self._device
         try:
             from faster_whisper import WhisperModel  # type: ignore
         except ImportError as e:
@@ -4435,10 +4463,12 @@ class WhisperEngine:
             ) from e
         log.info(
             "Loading Whisper ASR model=%s device=%s compute=%s ...",
-            self._model_name, self._device, self._compute_type(),
+            self._model_name, dev, self._compute_type(dev),
         )
-        self._model = WhisperModel(self._model_name, **_ct2_kwargs(self._device, self._compute_type()))
-        log.info("Whisper ASR loaded (model=%s device=%s).", self._model_name, self._device)
+        self._model = WhisperModel(self._model_name, **_ct2_kwargs(dev, self._compute_type(dev)))
+        # Reflect the resolved card for /health fell_back detection once loaded.
+        self._device = dev
+        log.info("Whisper ASR loaded (model=%s device=%s).", self._model_name, dev)
 
     @staticmethod
     def _pcm_to_float32_16k(pcm: bytes, sample_rate: int) -> Any:
@@ -4457,7 +4487,7 @@ class WhisperEngine:
 
     def transcribe(
         self, pcm: bytes, sample_rate: int, language: Optional[str] = None,
-        word_timestamps: bool = False,
+        word_timestamps: bool = False, device: Optional[str] = None,
     ) -> dict[str, Any]:
         """Transcribe one clip's PCM. Returns the text plus Whisper's
         intrinsic signals — `avg_logprob` (lower = less confident),
@@ -4474,8 +4504,12 @@ class WhisperEngine:
         wants no cross-sentence hallucination carryover on an isolated clip.
         The two call sites never overlap (only the caption export path ever
         sets word_timestamps), so this is additive, not a behaviour change
-        for the existing QA caller."""
-        self._ensure_loaded()
+        for the existing QA caller.
+
+        `device` (#1730 gap 2) threads an admitted card straight into the cold
+        load, so nothing reads the shared `self._device` across the unlocked
+        route→load gap; `None` is the pre-admission path."""
+        self._ensure_loaded(device=device)
         assert self._model is not None
         audio = self._pcm_to_float32_16k(pcm, sample_rate)
         with self._infer_lock:
@@ -4560,12 +4594,18 @@ class SpeakerEngine:
             run_opts={"device": device},
         )
 
-    async def ensure_loaded(self):
+    async def ensure_loaded(self, device: Optional[str] = None):
         if self._model is not None:
             return
         async with self._load_lock:
             if self._model is not None:
                 return
+            # Capacity-aware placement (#1730 gap 2): apply the admitted card
+            # UNDER the load lock, threaded in as a parameter — not mutated by
+            # the route before the lock, where a concurrent multi-GPU first
+            # cold-load could clobber it. `None` keeps the env-derived default.
+            if device is not None:
+                self.device = device
             # srv-47: a requested cuda device that isn't actually present
             # degrades to cpu rather than crashing.  Use _parse_device so an
             # indexed pin (cuda:1) is treated the same as plain 'cuda'.
@@ -7034,9 +7074,12 @@ async def transcribe(req: Request) -> Response:
             ) as adm:
                 if "noCapacity" in adm:
                     return _no_capacity(adm)
-                ASR._device = adm["device"]  # steer the (possibly cold) load
+                # Thread the admitted card as a param (#1730 gap 2) — the load
+                # honours it under the lock; nothing pre-mutates the shared
+                # ASR._device across the unlocked gap.
                 result = await asyncio.to_thread(
-                    ASR.transcribe, pcm, sample_rate, language, word_timestamps
+                    ASR.transcribe, pcm, sample_rate, language, word_timestamps,
+                    adm["device"],
                 )
         else:
             result = await asyncio.to_thread(
@@ -7106,8 +7149,9 @@ async def embed(req: Request) -> Response:
             ) as adm:
                 if "noCapacity" in adm:
                     return _no_capacity(adm)
-                SPK.device = adm["device"]  # steer the (possibly cold) load
-                await SPK.ensure_loaded()  # srv-47 R2-B: a cuda LOAD poison must be fenced too
+                # Thread the admitted card as a param (#1730 gap 2) — applied
+                # under ensure_loaded()'s load lock, not pre-mutated outside it.
+                await SPK.ensure_loaded(adm["device"])  # srv-47 R2-B: a cuda LOAD poison must be fenced too
                 embedding = await asyncio.to_thread(SPK.embed, pcm, int(sample_rate))
         else:
             await SPK.ensure_loaded()  # srv-47 R2-B: a cuda LOAD poison must be fenced too

--- a/server/tts-sidecar/tests/test_coqui_device.py
+++ b/server/tts-sidecar/tests/test_coqui_device.py
@@ -153,3 +153,58 @@ def test_auto_cuda_available_now_resolves_to_indexed_cuda_zero(monkeypatch):
     assert opts["device"] == "cuda:0"
     assert opts["half"] is True
     assert opts["deepspeed"] is True
+
+
+# ── admitted-device consistency: self._device tracks the resolved card while
+#    resident, and is restored to the pref on unload (#1730 gap 3) ────────────
+
+
+def _stub_coqui_load(monkeypatch) -> dict:
+    """Neutralise the heavy XTTS load so `_ensure_loaded` can run headless, and
+    return a dict the fake TTS records the `.to(device)` target into."""
+    moved: dict = {}
+    monkeypatch.setattr(main, "_apply_torch_perf_flags", lambda t: None)
+    monkeypatch.setattr(main, "_validate_cuda_index", lambda d, t: None)
+
+    class _FakeTTS:
+        synthesizer = types.SimpleNamespace(
+            tts_model=types.SimpleNamespace(
+                gpt=types.SimpleNamespace(init_gpt_for_inference=lambda **k: None),
+                speaker_manager=types.SimpleNamespace(name_to_id={"speaker": 0}),
+            )
+        )
+
+        def __init__(self, model_id):
+            self.model_id = model_id
+
+        def to(self, device):
+            moved["device"] = device
+
+    fake_pkg = types.ModuleType("TTS")
+    fake_api = types.ModuleType("TTS.api")
+    fake_api.TTS = _FakeTTS
+    monkeypatch.setitem(sys.modules, "TTS", fake_pkg)
+    monkeypatch.setitem(sys.modules, "TTS.api", fake_api)
+    monkeypatch.setitem(sys.modules, "torch", _torch_stub())
+    return moved
+
+
+def test_admitted_device_updates_self_device_and_unload_restores(monkeypatch):
+    """An admitted `device` override drives the load AND leaves `self._device`
+    reflecting the resolved card — not stale at the env pref — so nothing that
+    reads `self._device` sees a card the model isn't on (#1730 gap 3). Pre-fix
+    `self._device` stayed 'auto' while the model sat on cuda:1. `unload()`
+    restores the requested pref so a later flag-off reload re-resolves cleanly."""
+    monkeypatch.setenv("COQUI_DEVICE", "auto")  # env pref, unresolved
+    eng = main.CoquiEngine()
+    assert eng._device == "auto" and eng._requested_device == "auto"
+
+    moved = _stub_coqui_load(monkeypatch)
+    eng._ensure_loaded("xtts_v2", device="cuda:1")
+
+    assert moved["device"] == "cuda:1"       # model loaded on the admitted card
+    assert eng._resolved_device == "cuda:1"  # concrete truth
+    assert eng._device == "cuda:1"           # no longer stale at 'auto' (the fix)
+
+    eng.unload()
+    assert eng._device == "auto"             # pref restored for re-resolution

--- a/server/tts-sidecar/tests/test_design_mint_admission.py
+++ b/server/tts-sidecar/tests/test_design_mint_admission.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import sys
 import threading
 import time
+import types
 from pathlib import Path
 from typing import Optional
 
@@ -330,3 +331,71 @@ def test_device_none_leaves_device_pref_untouched(monkeypatch, _stub_codec):
     pref_before2 = eng2._device_pref
     eng2._ensure_base17_for_mint()  # device=None
     assert eng2._device_pref == pref_before2
+
+
+# --- forward-clobber: the 1.7B FORWARD must target the resident model's OWN
+#     card, not the shared engine-wide `self._device` (#1730 gap 1) ------------
+#
+# The load-atomicity tests above prove the two cold loads don't clobber each
+# other's `self._device` DURING the load (under `_cold_load_lock`). But the
+# later FORWARD (`rc.to(...)` before the 1.7B speech_tokenizer decode) runs
+# outside that lock, so on a genuine multi-card box a concurrent design/mint
+# admitted to a different card can overwrite the single `self._device` field in
+# the gap between load and forward. The fix reads the device off the resident
+# 1.7B wrapper (`self._base17.device`, published atomically with the model at
+# load and the same value the wrapper feeds its own `input_ids.to(...)`), which
+# travels WITH that model and is immune to the shared-field clobber.
+
+
+class _RecordingRefCode:
+    """A ref_code stand-in that records the device its `.to(...)` was moved to
+    and returns itself (so the downstream decode still gets a codes object)."""
+
+    def __init__(self) -> None:
+        self.moved_to: Optional[str] = None
+
+    def to(self, device):  # noqa: D401 — test double
+        self.moved_to = device
+        return self
+
+
+def _fake_base17_on(device: str):
+    """A minimal 1.7B wrapper stand-in resident on `device`, exposing the two
+    attributes `_load_voice_prompt_17b`'s forward touches: `.device` and
+    `.model.speech_tokenizer.decode` + `.create_voice_clone_prompt`."""
+    speech_tokenizer = types.SimpleNamespace(decode=lambda payload: ([object()], 24000))
+    return types.SimpleNamespace(
+        device=device,
+        model=types.SimpleNamespace(speech_tokenizer=speech_tokenizer),
+        create_voice_clone_prompt=lambda **kwargs: object(),
+    )
+
+
+def test_load_voice_prompt_17b_forward_targets_resident_card_not_clobbered_device(
+    monkeypatch, tmp_path
+):
+    """THE forward-clobber regression: the 1.7B ref_code forward must move onto
+    the card the resident 1.7B is ACTUALLY on, even if a concurrent op has since
+    overwritten the shared `self._device`. Resident 1.7B lives on cuda:0; a
+    concurrent design clobbered `self._device` to cuda:1 — the forward must still
+    target cuda:0. (Pre-fix `rc.to(self._device)` moved it to the wrong card.)"""
+    eng = main.QwenEngine()
+    eng._voices_dir = str(tmp_path)
+    eng._base17 = _fake_base17_on("cuda:0")
+    eng._device = "cuda:1"  # simulate the concurrent clobber
+
+    rc = _RecordingRefCode()
+    base_item = types.SimpleNamespace(ref_code=rc, ref_text="calibration line")
+    monkeypatch.setattr(eng, "_load_voice_prompt", lambda voice: ([base_item], "en", False))
+
+    # `import torch` inside the method is function-local, so inject via sys.modules;
+    # only `torch.save` is exercised on the re-derive path (persist step).
+    fake_torch = types.SimpleNamespace(save=lambda obj, path: Path(path).write_bytes(b""))
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    eng._load_voice_prompt_17b("qwen-voice")
+
+    assert rc.moved_to == "cuda:0", (
+        "1.7B forward must target the resident model's card (cuda:0), not the "
+        f"clobbered engine-wide self._device (cuda:1); got {rc.moved_to!r}"
+    )

--- a/server/tts-sidecar/tests/test_design_progress.py
+++ b/server/tts-sidecar/tests/test_design_progress.py
@@ -67,6 +67,10 @@ def test_mint_variant_reports_phases_in_order(monkeypatch):
 
     class _FakeBase17:
         model = _Model()
+        # The real Qwen3TTSModel wrapper caches its device at `.device`; the
+        # mint forward now moves ref_code onto it (#1730 gap 1), so the double
+        # exposes it too.
+        device = "cpu"
 
         def create_voice_clone_prompt(self, ref_audio, ref_text):
             return {"prompt": True}

--- a/server/tts-sidecar/tests/test_transcribe_embed_admission.py
+++ b/server/tts-sidecar/tests/test_transcribe_embed_admission.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import sys
 import types
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 import numpy as np
 import pytest
@@ -126,25 +126,26 @@ def test_transcribe_gpu_no_fit_returns_503(monkeypatch, asr_client) -> None:
 
 def test_transcribe_gpu_steers_to_roomier_device(monkeypatch, asr_client) -> None:
     """ASR_DEVICE=cuda (unindexed, so unpinned) + flag ON + a probe favouring
-    cuda:1 -> the reservation admits onto cuda:1 and ASR._device is steered
-    there BEFORE the transcribe call runs."""
+    cuda:1 -> the reservation admits onto cuda:1 and that card is threaded into
+    the cold load as a `device` PARAMETER (#1730 gap 2), not pre-mutated onto
+    the shared ASR._device. Post-load ASR._device reflects it for /health."""
     _swap_asr(monkeypatch, "cuda")
     monkeypatch.setenv("SEG_CAPACITY_ADMISSION", "1")
     monkeypatch.setattr(main._placement, "probe", lambda: ROOMY_PROBE)
-    seen_device: dict[str, str] = {}
-    orig_transcribe = main.WhisperEngine.transcribe
+    seen_device: dict[str, Optional[str]] = {}
+    orig_ensure = main.WhisperEngine._ensure_loaded
 
-    def _spy_transcribe(self, *a, **k):
-        seen_device["device"] = self._device
-        return orig_transcribe(self, *a, **k)
+    def _spy_ensure(self, device=None):
+        seen_device["device"] = device
+        return orig_ensure(self, device)
 
-    monkeypatch.setattr(main.WhisperEngine, "transcribe", _spy_transcribe)
+    monkeypatch.setattr(main.WhisperEngine, "_ensure_loaded", _spy_ensure)
 
     r = asr_client.post("/transcribe", content=_pcm(), headers={"X-Sample-Rate": "24000"})
 
     assert r.status_code == 200
-    assert seen_device["device"] == "cuda:1"
-    assert main.ASR._device == "cuda:1"
+    assert seen_device["device"] == "cuda:1"  # admitted card arrives as a PARAM
+    assert main.ASR._device == "cuda:1"        # load reflected it for /health
 
 
 # ── /embed ───────────────────────────────────────────────────────────────
@@ -233,19 +234,20 @@ def test_embed_gpu_no_fit_returns_503(monkeypatch, embed_client) -> None:
 
 def test_embed_gpu_steers_to_roomier_device(monkeypatch, embed_client) -> None:
     """SPK_DEVICE=cuda (unindexed, so unpinned) + flag ON + a probe favouring
-    cuda:1 -> the reservation admits onto cuda:1 and SPK.device is steered
-    there BEFORE ensure_loaded()/embed run."""
+    cuda:1 -> the reservation admits onto cuda:1 and that card is threaded into
+    ensure_loaded() as a `device` PARAMETER (#1730 gap 2), applied under its
+    load lock rather than pre-mutated onto the shared SPK.device."""
     _install_speechbrain_stub(monkeypatch)
     _stub_torch_cuda(monkeypatch)
     _swap_spk(monkeypatch, "cuda")
     monkeypatch.setenv("SEG_CAPACITY_ADMISSION", "1")
     monkeypatch.setattr(main._placement, "probe", lambda: ROOMY_PROBE)
-    seen_device: dict[str, str] = {}
+    seen_device: dict[str, Optional[str]] = {}
     orig_ensure_loaded = main.SpeakerEngine.ensure_loaded
 
-    async def _spy_ensure_loaded(self):
-        seen_device["device"] = self.device
-        return await orig_ensure_loaded(self)
+    async def _spy_ensure_loaded(self, device=None):
+        seen_device["device"] = device
+        return await orig_ensure_loaded(self, device)
 
     monkeypatch.setattr(main.SpeakerEngine, "ensure_loaded", _spy_ensure_loaded)
     monkeypatch.setattr(main.SpeakerEngine, "embed", lambda self, pcm, sr: [0.0] * 192)
@@ -253,5 +255,68 @@ def test_embed_gpu_steers_to_roomier_device(monkeypatch, embed_client) -> None:
     r = embed_client.post("/embed", content=_pcm(seconds=0.5, sample_rate=16000), headers={"X-Sample-Rate": "16000"})
 
     assert r.status_code == 200
-    assert seen_device["device"] == "cuda:1"
+    assert seen_device["device"] == "cuda:1"  # admitted card arrives as a PARAM
     assert main.SPK.device == "cuda:1"
+
+
+# ── device-steer atomicity: the load honours the threaded `device` param, not a
+#    stale shared `self._device`/`self.device` (#1730 gap 2) ─────────────────
+#
+# The route no longer mutates the engine's device attr before an unlocked cold
+# load; it threads the admitted card in as a call PARAMETER (mirroring the
+# `/load` path). These prove the load derives its card from that param even when
+# the shared attr has been left stale by a concurrent op — so a concurrent
+# multi-GPU FIRST cold-load can't land on the wrong card.
+
+
+def test_asr_ensure_loaded_uses_device_param_not_stale_self_device(
+    monkeypatch, fake_whisper_module
+) -> None:
+    """ASR: `_ensure_loaded(device="cuda:1")` must build the CT2 model from the
+    cuda:1 PARAM even though `self._device` is a stale cuda:0 (as if a concurrent
+    first cold-load clobbered it in the gap). Pre-fix `_ensure_loaded` took no
+    device and read `self._device`, landing the load on the wrong card."""
+    monkeypatch.setenv("ASR_DEVICE", "cuda:0")
+    eng = main.WhisperEngine()
+    eng._device = "cuda:0"  # stale shared attr
+
+    seen: dict[str, str] = {}
+    orig_ct2 = main._ct2_kwargs
+
+    def _spy_ct2(device: str, compute_type: str) -> dict:
+        seen["device"] = device
+        return orig_ct2(device, compute_type)
+
+    monkeypatch.setattr(main, "_ct2_kwargs", _spy_ct2)
+
+    eng._ensure_loaded(device="cuda:1")
+
+    assert seen["device"] == "cuda:1"  # load derived from the PARAM, not self._device
+    assert eng._device == "cuda:1"     # reflected post-load for /health fell_back
+
+
+def test_spk_ensure_loaded_uses_device_param_not_stale_self_device(monkeypatch) -> None:
+    """SPK: `ensure_loaded(device="cuda:1")` must load ECAPA on the cuda:1 PARAM
+    under the load lock even though `self.device` is a stale cuda:0. Pre-fix
+    `ensure_loaded` took no device and the route pre-mutated `self.device`
+    outside the lock, so a concurrent first cold-load could clobber it."""
+    import asyncio
+
+    _install_speechbrain_stub(monkeypatch)
+    _stub_torch_cuda(monkeypatch)
+    monkeypatch.setenv("SPK_DEVICE", "cuda:0")
+    eng = main.SpeakerEngine()
+    eng.device = "cuda:0"  # stale shared attr
+
+    captured: dict[str, str] = {}
+
+    def _spy_load_on(self, device: str):
+        captured["device"] = device
+        return _FakeSpkModel()
+
+    monkeypatch.setattr(main.SpeakerEngine, "_load_on", _spy_load_on)
+
+    asyncio.run(eng.ensure_loaded(device="cuda:1"))
+
+    assert captured["device"] == "cuda:1"  # _load_on got the PARAM's card
+    assert eng.device == "cuda:1"


### PR DESCRIPTION
## Summary

Closes the three flag-ON, multi-GPU-only device-steer atomicity gaps the #1720 whole-branch review surfaced (plan [264](docs/features/264-vram-aware-gpu-placement.md) "Out of scope (flag-on-readiness follow-ups)"). All three are the same defect class: a resolved device is written to a **shared mutable engine attr** and read back across an **unlocked gap**, so a concurrent op admitted to another card can clobber it. The `/load` path already avoids this by threading `device=` as a call parameter — this makes the other heavy ops match.

- **Qwen 1.7B forward-clobber** — `mint_variant` / `_load_voice_prompt_17b` now move `ref_code` onto the resident wrapper's own `self._base17.device` (published atomically with the model at load, the same value the wrapper feeds its own `input_ids.to(...)`) instead of the shared `self._device`. Immune by construction to a concurrent `design_voice`/`mint` clobber.
- **ASR/SPK cold-load steer unlocked** — `/transcribe` + `/embed` thread the admitted card into `transcribe`/`_ensure_loaded` (ASR) and `ensure_loaded` (SPK) as a **parameter**, applied under the engine load lock, instead of pre-mutating `ASR._device`/`SPK.device` outside it.
- **Coqui load-steer stale** — `_ensure_loaded` keeps `self._device` in step with the card the model actually loaded on; `unload()` restores the requested pref so a later flag-off reload re-resolves cleanly.

All three are **flag-OFF-safe and single-GPU-safe** — no behaviour change on any current shipping configuration (`SEG_CAPACITY_ADMISSION` defaults OFF, and even ON they only matter on a genuine 2-card box). No release-notes delta for that reason.

## Test plan

- New regression tests, each **fails pre-fix, passes after**:
  - `test_design_mint_admission.py::test_load_voice_prompt_17b_forward_targets_resident_card_not_clobbered_device` — forward targets the resident 1.7B's card even when `self._device` is concurrently clobbered.
  - `test_transcribe_embed_admission.py::test_{asr,spk}_ensure_loaded_uses_device_param_not_stale_self_device` — the load honours the threaded param over a stale shared attr; the two existing route steer tests updated to the new param contract.
  - `test_coqui_device.py::test_admitted_device_updates_self_device_and_unload_restores`.
- `test_design_progress.py` double gains the `.device` the real Qwen wrapper carries.
- Full `npm run test:sidecar` suite green (`-m "not golden"`, exit 0).
- **On-box 2-card acceptance (`SEG_CAPACITY_ADMISSION=1`) still owed** before the concurrent-multi-card flag flip — can't be exercised on a single-GPU box; pytest regressions are the lock.

Refs #1720
Closes #1730

🤖 Generated with [Claude Code](https://claude.com/claude-code)