### PR TITLE
fix(sidecar,server): learn VRAM footprints as windowed p95, reserve per-device

### DIFF
--- a/docs/features/264-vram-aware-gpu-placement.md
+++ b/docs/features/264-vram-aware-gpu-placement.md
@@ -225,7 +225,7 @@ the flag is OFF) should close so admission covers everything the budget did:
   → the learned footprint drifts to the device-wide high-water (over-conservative,
   never an OOM).
 
-  > **CLOSED (#1734).** Fixed on branch `fix/sidecar-footprint-percentile`:
+  > **CLOSED (#1737).** Fixed on branch `fix/sidecar-footprint-percentile`:
   > `PlacementController._reset_peak_mb` calls `torch.cuda.reset_peak_memory_stats`
   > right before each op starts, so the paired `_observed_mb` read at release
   > reflects that op's own peak instead of the process-lifetime high-water mark

--- a/docs/features/264-vram-aware-gpu-placement.md
+++ b/docs/features/264-vram-aware-gpu-placement.md
@@ -224,6 +224,27 @@ the flag is OFF) should close so admission covers everything the budget did:
 - **`_observed_mb` reads `max_memory_allocated` without `reset_peak_memory_stats`**
   → the learned footprint drifts to the device-wide high-water (over-conservative,
   never an OOM).
+
+  > **CLOSED (#1734).** Fixed on branch `fix/sidecar-footprint-percentile`:
+  > `PlacementController._reset_peak_mb` calls `torch.cuda.reset_peak_memory_stats`
+  > right before each op starts, so the paired `_observed_mb` read at release
+  > reflects that op's own peak instead of the process-lifetime high-water mark
+  > (previously a one-off ~9 GB voice-design co-residency spike poisoned every
+  > later reading). `FootprintTable` also no longer ratchets up-only: it now
+  > reserves the **windowed p95** of the last 64 real per-op observations (once
+  > ≥5 samples exist), so a stale outlier ages out of the window instead of
+  > pinning the reservation forever, and the seed is a cold-start prior only
+  > (`qwen` 6144→3072, `qwen.1.7b` 7168→6144, re-grounded on measured real
+  > decode peaks: 0.6B synth ~1952 MB, 1.7B mint ~5654 MB). The VRAM reserve
+  > cushion also moved from a flat `GPU_RESERVE_MB` subtraction to a per-device
+  > one — `min(5% of that card's own VRAM, GPU_RESERVE_MB)`, cap lowered
+  > 768→500. On-box result: the 1.7B Qwen op that the stale high-water estimate
+  > previously refused with `503 noCapacity` on an 8 GB card now admits and
+  > runs, using the measured real peaks above. Regression coverage:
+  > `test_footprints.py` (p95 windowing, seed-as-prior-not-floor, non-positive
+  > observations ignored), `test_placement.py`, `test_design_mint_admission.py`.
+  > The multi-op on-box acceptance walkthrough above is still owed before
+  > `SEG_CAPACITY_ADMISSION` is defaulted ON.
 - **`persona-gpu-plan.ts`'s `unloadResidentSidecar` + `GpuBusyForPersonaError`
   are now dead code** (the reverse-evict was removed); deletion candidates.
 - **`engine-vram-cost.ts` is provably dead** (its registry weights are deleted) —

--- a/docs/local-llm.md
+++ b/docs/local-llm.md
@@ -139,15 +139,20 @@ floated around as `autoPreloadKokoro`: the real var is `PRELOAD_KOKORO`.)
 
 **Peak-under-load footprints (capacity-aware admission).** The resident
 sizes in the table above are steady-state; admission needs the true DECODE
-PEAK, which is higher (e.g. Qwen's ~4 GB resident weight size peaks at
-~5.6 GB during decode). `FootprintTable` in `main.py` seeds these peaks —
-the anchors below are the machine-parseable ground truth a parity test
-(`test_footprints.py`) checks against `SEED_FOOTPRINTS_MB`; an on-box
-observation can only ratchet a seed up, never down.
+PEAK, which is higher than the resident weight size. `FootprintTable` in
+`main.py` seeds these peaks as COLD-START PRIORS — the anchors below are the
+machine-parseable ground truth a parity test (`test_footprints.py`) checks
+against `SEED_FOOTPRINTS_MB`. They're measured real per-op decode peaks
+(0.6B ~1952 MB, 1.7B mint ~5654 MB) rounded up with margin, refined once the
+sidecar has real usage: once an engine/tier has accumulated >= 5 per-op
+observations (each op's own CUDA peak, reset right before the op starts —
+not the process-lifetime high-water mark), the seed is superseded by the
+windowed p95 of the last 64 observations, which tracks real usage up OR
+down instead of ratcheting to a single worst-case spike forever.
 
 <!-- footprint:kokoro=1200 -->
-<!-- footprint:qwen=6144 -->
-<!-- footprint:qwen.1.7b=7168 -->
+<!-- footprint:qwen=3072 -->
+<!-- footprint:qwen.1.7b=6144 -->
 <!-- footprint:coqui=3584 -->
 <!-- footprint:asr=400 -->
 <!-- footprint:spk=200 -->

--- a/docs/release-notes-next.md
+++ b/docs/release-notes-next.md
@@ -184,7 +184,7 @@ Tap any chapter you haven't downloaded and it starts immediately on the home net
   with the default cap lowered 768→500. On-box: measured real per-op peaks
   (0.6B synth ~1952 MB, 1.7B mint ~5654 MB) now admit comfortably on an 8 GB
   card, where the stale high-water estimate previously refused them. Still
-  behind the default-OFF `SEG_CAPACITY_ADMISSION` flag. (#1734)
+  behind the default-OFF `SEG_CAPACITY_ADMISSION` flag. (#1737)
 
 ---
 

--- a/docs/release-notes-next.md
+++ b/docs/release-notes-next.md
@@ -165,6 +165,26 @@ Tap any chapter you haven't downloaded and it starts immediately on the home net
   op on a tight card yields a bounded wait and an actionable no-capacity
   signal instead of an instant busy error. Still shipped OFF while validated
   on real hardware. Refs #1720.
+- **Capacity-aware footprint estimation now self-corrects instead of ratcheting
+  to a one-off spike, and the VRAM reserve is per-device.** `_observed_mb` read
+  `torch.cuda.max_memory_allocated` with no `reset_peak_memory_stats`, so every
+  per-op VRAM sample was the device's PROCESS-LIFETIME high-water mark — one
+  ~9 GB voice-design co-residency spike poisoned every later reading — and
+  `FootprintTable.record` only ever ratcheted that inflated number up, so a
+  1.7B Qwen op was refused with `503 noCapacity` on an 8 GB card it actually
+  fit, and being refused, could never run to self-correct. Fixed: (1)
+  `PlacementController._reset_peak_mb` resets CUDA's peak counter right before
+  each op starts, so `_observed_mb` reflects that op's own peak; (2)
+  `FootprintTable` now reserves the **windowed p95** of the last 64 real
+  per-op observations (once ≥5 samples exist) instead of an up-only max, so
+  the estimate tracks real usage up OR down; (3) the seeds are re-grounded on
+  measured real peaks (`qwen` 6144→3072, `qwen.1.7b` 7168→6144 — cold-start
+  priors only, not floors); (4) the VRAM safety cushion (`GPU_RESERVE_MB`) is
+  now sized **per-device** — `min(5% of that card's VRAM, GPU_RESERVE_MB)` —
+  with the default cap lowered 768→500. On-box: measured real per-op peaks
+  (0.6B synth ~1952 MB, 1.7B mint ~5654 MB) now admit comfortably on an 8 GB
+  card, where the stale high-water estimate previously refused them. Still
+  behind the default-OFF `SEG_CAPACITY_ADMISSION` flag. (#1734)
 
 ---
 

--- a/docs/wiki/Advanced-Settings.md
+++ b/docs/wiki/Advanced-Settings.md
@@ -289,6 +289,28 @@ mismatches) — the table's risk column shows each correctly.
 | Soft VRAM recycle threshold (MB reserved) | Recycle trigger; 0 = auto (90% of device VRAM) | 0 | integer, min 0 | restart · sidecar | high |
 | Hard VRAM restart threshold (MB reserved) | Self-exits to reset CUDA context; 0 = auto (98% of VRAM) | 0 | integer, min 0 | restart · sidecar | high |
 | Per-card VRAM free floor (MB) | Absolute free-VRAM floor before recycle | 1024 | integer, min 0 | restart · sidecar | **medium** |
+| GPU VRAM reserve cap (MB) | Ceiling on the per-device safety cushion held back from every capacity-aware GPU admission (actual cushion = min(5% of that device's own VRAM, this cap)) | 500 | integer, min 0 | restart · sidecar | high |
+
+**Capacity-aware GPU placement** (`SEG_CAPACITY_ADMISSION`, off by default) is
+an alternate admission path for every heavy GPU op — synthesis, engine loads,
+voice design, ASR transcription, speaker embedding — that reserves each op's
+own **measured VRAM footprint** against a card's actual free memory before
+letting it start, instead of the fixed knobs above. On a multi-GPU box it
+steers each op to whichever card has the most free headroom, so moving
+between a single 8 GB card and an 8+16 GB two-card setup needs no settings
+change. Each engine/tier's footprint starts from a seeded cold-start estimate
+and, once a handful of real ops have run, switches to a **self-correcting
+estimate** — the 95th percentile of its last 64 real observations — so an
+early conservative guess relaxes to match actual usage instead of staying
+pinned to a single worst-case spike forever. The **GPU VRAM reserve cap
+(MB)** knob above is a ceiling, not the reserve itself: the cushion actually
+held back on any one card is 5% of *that card's* VRAM, capped at this value —
+sized to the device rather than a flat subtraction that over-provisions a
+small card and under-provisions a large one. While `SEG_CAPACITY_ADMISSION`
+is off, this path is dormant and GPU access falls back to the serialized
+behaviour the rest of this group configures. See
+[Troubleshooting](Troubleshooting#gpu-capacity--vram-placement) if an op
+won't place on a card it should fit, or the eGPU drops off the bus.
 
 ## 10. Gemini rate limits
 

--- a/docs/wiki/Troubleshooting.md
+++ b/docs/wiki/Troubleshooting.md
@@ -160,6 +160,68 @@ The block is deterministic — retrying the same model on the same text fails id
 
 **What to do:** Click Retry on this chapter. If it keeps failing, check the server / voice engine logs for the full error and report it.
 
+## GPU capacity & VRAM placement
+
+Symptoms specific to **capacity-aware GPU placement** (`SEG_CAPACITY_ADMISSION`,
+off by default) — the alternate admission path that reserves each heavy GPU
+op's own measured VRAM footprint against a card's actual free memory. See
+[Advanced Settings → GPU arbitration, memory & lifecycle](Advanced-Settings#9-gpu-arbitration-memory--lifecycle)
+for how it works day to day.
+
+### 503 "no capacity" — an op won't place on a small card that should fit it
+
+**What you saw:** A synth, model load, voice-design, or ASR/embed call
+refuses with a "no capacity" error (or waits and then fails) on a card
+that's otherwise idle and roomy enough for it — e.g. a Higher-quality (1.7B)
+Qwen op refused on an otherwise-empty 8 GB card.
+
+**What to do:** This was an over-conservative footprint bug (an early per-op
+VRAM reading could get poisoned by an unrelated memory spike and then never
+correct itself) and is fixed as of the footprint-percentile update. If you
+still see it: check that **GPU VRAM reserve cap (MB)** in Advanced Settings
+hasn't been pushed unusually high, and give the sidecar a few real ops on
+that engine/tier — the footprint estimate is most conservative right after a
+restart and relaxes to match real usage as it accumulates observations.
+
+### `/capacity`'s reported free VRAM doesn't match nvidia-smi's free
+
+**What you saw:** The sidecar's capacity probe (or the Device panel in Model
+Manager) reports noticeably less free VRAM than `nvidia-smi` shows for the
+same, idle card.
+
+**What to do:** Expected, not a bug. Roughly 1 GB is held by the CUDA
+runtime/context itself and is already excluded from what capacity-aware
+placement treats as free — an idle 8 GB card can show `nvidia-smi` used
+≈114 MB while the driver's own free-memory query reports ≈7068 MB free.
+Placement measures against the latter, so it isn't re-subtracting the
+context a second time; the gap you're seeing is the context, not a leak or a
+double-counted reserve.
+
+### "GPU is lost" / CUDA errors on an eGPU
+
+**What you saw:** The sidecar reports a lost or errored GPU, or wedges
+entirely, on a machine with an external GPU (e.g. over OcuLink).
+
+**What to do:** An OcuLink eGPU is not hot-swappable — adding or removing it
+needs a full reboot, not a cable pull; unplugging it live is a hard crash,
+not a supported operation. If it drops off the CUDA bus on its own mid-run,
+the CUDA context is corrupted process-wide — restart the voice engine to
+recover. If it doesn't come back, reboot with the card connected.
+
+### First concurrent burst of synth + transcribe + embed errors on a cold sidecar
+
+**What you saw:** Firing a `/synthesize`, `/transcribe`, and `/embed` call
+all at once against a **freshly started** sidecar process — before any of
+those three engines has handled a single call yet — can crash one of the
+calls outright.
+
+**What to do:** Known issue, not yet fixed — unrelated to capacity
+placement, it's three heavy engines racing to cold-import their model
+libraries at the same moment. Let each engine warm up with one call on its
+own first (one synth, one transcribe, one embed), then run them
+concurrently; a retry right after the crash also succeeds once the imports
+have settled.
+
 ## Common questions
 
 ### The app won't start

--- a/server/.env.example
+++ b/server/.env.example
@@ -627,8 +627,8 @@ AUDIO_LOUDNORM_LRA=11
 AUDIO_LOUDNORM_TP=-1.5
 
 # ── GPU arbitration, memory & lifecycle ──
-# VRAM safety cushion (MB) held back from every capacity admission. Read by the sidecar (its primary consumer) at process start, so a change needs a sidecar restart to fully take effect. [restart-sidecar · high risk]
-GPU_RESERVE_MB=768
+# Ceiling on the VRAM safety cushion held back from every capacity admission. The actual per-device cushion is min(5% of that device's own VRAM, this cap) — right-sized to the card rather than a flat subtraction. Read by the sidecar (its primary consumer) at process start, so a change needs a sidecar restart to fully take effect. [restart-sidecar · high risk]
+GPU_RESERVE_MB=500
 # Seconds of voice-design inactivity before the watchdog frees the transient Qwen VoiceDesign 1.7B model (reclaiming ~4–5 GB VRAM). Values below 5 fall back to the default (120) to avoid reload thrash. A real /synthesize also frees it immediately. [restart-sidecar · high risk]
 QWEN_DESIGN_IDLE_TTL=120
 # Seconds of inactivity before the watchdog frees the resident Qwen 1.7B-Base model (reclaiming ~3.4 GB VRAM). It stays warm across back-to-back emotion-variant mints and 1.7B (Quality-tier) synths so a full-library re-mint runs in one pass without fragmenting the CUDA allocator (issue #1024); lower this to shrink the warm window on a small card. Values below 5 fall back to the default (120) to avoid reload thrash. [restart-sidecar · high risk]

--- a/server/src/config/registry.test.ts
+++ b/server/src/config/registry.test.ts
@@ -164,7 +164,7 @@ describe('config registry', () => {
     expect(k?.env).toBe('GPU_RESERVE_MB');
     expect(k?.group).toBe('gpu-lifecycle');
     expect(k?.type).toBe('integer');
-    expect(k?.default).toBe(768);
+    expect(k?.default).toBe(500);
     // restart-sidecar, not live: the sidecar (its primary consumer) reads
     // GPU_RESERVE_MB from the environment at process start.
     expect(k?.apply).toBe('restart-sidecar');

--- a/server/src/config/registry.ts
+++ b/server/src/config/registry.ts
@@ -656,10 +656,10 @@ export const KNOBS: ConfigKnob[] = [
     key: 'gpu.reserveMb',
     env: 'GPU_RESERVE_MB',
     group: 'gpu-lifecycle',
-    label: 'GPU VRAM reserve (MB)',
-    help: 'VRAM safety cushion (MB) held back from every capacity admission. Read by the sidecar (its primary consumer) at process start, so a change needs a sidecar restart to fully take effect.',
+    label: 'GPU VRAM reserve cap (MB)',
+    help: 'Ceiling on the VRAM safety cushion held back from every capacity admission. The actual per-device cushion is min(5% of that device\'s own VRAM, this cap) — right-sized to the card rather than a flat subtraction. Read by the sidecar (its primary consumer) at process start, so a change needs a sidecar restart to fully take effect.',
     type: 'integer', min: 0,
-    default: 768,
+    default: 500,
     apply: 'restart-sidecar', risk: 'high',
   },
   {

--- a/server/src/gpu/gpu-load.ts
+++ b/server/src/gpu/gpu-load.ts
@@ -27,8 +27,13 @@ export class GpuBusyError extends Error {
 const HEAVY_TTS_DECODE_FLOOR_MB = 6144;
 
 function reserveMb(): number {
+  // Flat cap for this COARSE load-path check (subtracted from the roomiest
+  // device's free VRAM). The sidecar admission path applies the same
+  // GPU_RESERVE_MB as a PER-DEVICE cap — min(5% of the card, this value) — but
+  // here we only have the roomiest free number, so the flat cap is the right
+  // conservative floor. Fallback matches the sidecar default (500).
   const n = Number(process.env.GPU_RESERVE_MB);
-  return Number.isFinite(n) && n > 0 ? n : 768;
+  return Number.isFinite(n) && n > 0 ? n : 500;
 }
 
 /** Run a sidecar model load safely w.r.t. VRAM.

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -27,6 +27,7 @@ import gc
 import hashlib
 import json
 import logging
+import math
 import os
 import re
 import shutil
@@ -34,6 +35,7 @@ import sys
 import tempfile
 import threading
 import time
+from collections import deque
 from contextlib import contextmanager
 from typing import Any, Callable, Optional
 
@@ -1928,13 +1930,17 @@ def probe_capacity() -> list[dict]:
 
 # Peak-under-load VRAM seeds (MB) per engine/tier — mirrors the maintained
 # table in docs/local-llm.md (parity enforced by test_footprints.py). These
-# are the true DECODE PEAK, not the smaller resident/weight size: e.g. qwen's
-# 6144 is the measured ~5.6 GB decode peak rounded up, not the ~4 GB resident
-# footprint — do not "correct" it down.
+# are COLD-START PRIORS only: once FootprintTable has accumulated
+# >= _FOOTPRINT_MIN_SAMPLES real per-op observations for a key, the learned
+# windowed p95 (see FootprintTable.peak_mb) supersedes the seed entirely —
+# the seed is a starting point, not a floor. Values are measured real per-op
+# decode peaks (0.6B ~1952 MB, 1.7B mint ~5654 MB) rounded up with margin so
+# a cold start still fits the target card (0.6B on a 6 GB card, 1.7B on an
+# 8 GB card).
 SEED_FOOTPRINTS_MB: dict[str, int] = {
     "kokoro": 1200,
-    "qwen": 6144,
-    "qwen.1.7b": 7168,
+    "qwen": 3072,
+    "qwen.1.7b": 6144,
     "coqui": 3584,
     "asr": 400,
     "spk": 200,
@@ -1943,17 +1949,28 @@ SEED_FOOTPRINTS_MB: dict[str, int] = {
 # A wide Qwen batch (large tokenBudget) has a higher true decode peak than the
 # default-config seed above.
 _QWEN_WIDE_TOKEN_BUDGET = 4800
-_QWEN_WIDE_PEAK_MB = 7168
+_QWEN_WIDE_PEAK_MB = 6144
+
+# FootprintTable's learned-estimate tuning: a bounded ring of recent per-op
+# observations per key, and the percentile used to summarize it. p95 (not
+# max) so a single outlier spike ages out of the window instead of pinning
+# the reservation forever; MIN_SAMPLES gates the learned estimate behind
+# enough data to trust over the seed.
+_FOOTPRINT_WINDOW = 64
+_FOOTPRINT_MIN_SAMPLES = 5
+_FOOTPRINT_PERCENTILE = 95
 
 
 class FootprintTable:
     """Per-(engine, model, config) peak-under-load VRAM estimate that
-    capacity-aware admission reserves. `peak_mb` returns `max(seed, learned)`
-    for the key; `record` ratchets the learned estimate up only — a lower
-    on-box observation never lowers what's reserved next time."""
+    capacity-aware admission reserves. `peak_mb` returns the learned p95 of
+    the last `_FOOTPRINT_WINDOW` real per-op observations once at least
+    `_FOOTPRINT_MIN_SAMPLES` have been recorded; below that it falls back to
+    the seed (a cold-start prior only, not a floor — the learned estimate
+    can go below it)."""
 
     def __init__(self) -> None:
-        self._learned: dict[str, int] = {}
+        self._obs: dict[str, deque[int]] = {}
 
     @staticmethod
     def _key(engine: str, model: Optional[str], cfg: Optional[dict]) -> str:
@@ -1971,15 +1988,35 @@ class FootprintTable:
             seed = max(seed, _QWEN_WIDE_PEAK_MB)
         return seed
 
+    def _learned_mb(self, key: str) -> int:
+        dq = self._obs.get(key)
+        if dq is None or len(dq) < _FOOTPRINT_MIN_SAMPLES:
+            return 0
+        s = sorted(dq)
+        idx = min(len(s) - 1, int(math.ceil(_FOOTPRINT_PERCENTILE / 100 * len(s))) - 1)
+        return s[idx]
+
     def peak_mb(self, engine: str, model: Optional[str], cfg: Optional[dict] = None) -> int:
         key = self._key(engine, model, cfg)
-        seed = self._seed_mb(key, engine, cfg)
-        learned = self._learned.get(key, 0)
-        return max(seed, learned)
+        learned = self._learned_mb(key)
+        if learned > 0:
+            return learned
+        return self._seed_mb(key, engine, cfg)
 
     def record(self, engine: str, model: Optional[str], cfg: Optional[dict], observed_mb: int) -> None:
+        if observed_mb <= 0:
+            return
         key = self._key(engine, model, cfg)
-        self._learned[key] = max(self._learned.get(key, 0), observed_mb)
+        self._obs.setdefault(key, deque(maxlen=_FOOTPRINT_WINDOW)).append(int(observed_mb))
+
+
+def _device_reserve_mb(total_mb: int, cap: int) -> int:
+    """The VRAM safety cushion held back on a device with `total_mb` VRAM,
+    given the operator-configured ceiling `cap` (GPU_RESERVE_MB). 5% of the
+    card, capped at `cap` — right-sized to the device instead of a flat
+    number that over-provisions a small card (fragmentation risk there is
+    real but small) and under-provisions a large one relative to its size."""
+    return min(round(0.05 * total_mb), cap)
 
 
 class ReservationLedger:
@@ -2010,26 +2047,32 @@ class ReservationLedger:
         with self._lock:
             self._by_device.get(device_key, {}).pop(token_id, None)
 
-    def _headroom(self, key: str, free_mb: int, total_mb: int, reserve: int) -> int:
+    def _headroom(self, key: str, free_mb: int, total_mb: int, reserve_cap: int) -> int:
         """Available headroom for `key` given its live free/total and the
-        reservations already held on it. Caller MUST hold `self._lock`."""
+        reservations already held on it. The safety cushion subtracted is
+        PER-DEVICE — `_device_reserve_mb(total_mb, reserve_cap)`, i.e. 5% of
+        this device's own VRAM capped at `reserve_cap` — not a flat number
+        applied to every candidate regardless of size. Caller MUST hold
+        `self._lock`."""
         reserved = sum(self._by_device.get(key, {}).values())
-        return min(free_mb, total_mb - reserved) - reserve
+        return min(free_mb, total_mb - reserved) - _device_reserve_mb(total_mb, reserve_cap)
 
     def try_hold(
-        self, candidates: list[tuple[str, int, int]], peak: int, reserve: int
+        self, candidates: list[tuple[str, int, int]], peak: int, reserve_cap: int
     ) -> Optional[tuple[str, int]]:
         """Atomically pick the roomiest candidate that fits `peak` and hold it.
-        `candidates` = [(device_key, freeMb, totalMb), ...]. Returns the token
-        or None if none fit. The fit-check AND the hold happen under a SINGLE
-        lock acquisition, so two concurrent admits can't both pass the check
-        and double-book the same VRAM — the TOCTOU the per-op reservation
-        exists to prevent (decide+hold atomic, per the design)."""
+        `candidates` = [(device_key, freeMb, totalMb), ...]. `reserve_cap` is
+        the GPU_RESERVE_MB ceiling — each candidate's actual reserve is
+        computed per-device from its own totalMb (see `_headroom`). Returns
+        the token or None if none fit. The fit-check AND the hold happen
+        under a SINGLE lock acquisition, so two concurrent admits can't both
+        pass the check and double-book the same VRAM — the TOCTOU the per-op
+        reservation exists to prevent (decide+hold atomic, per the design)."""
         with self._lock:
             best_key: Optional[str] = None
             best_headroom = -1
             for key, free_mb, total_mb in candidates:
-                headroom = self._headroom(key, free_mb, total_mb, reserve)
+                headroom = self._headroom(key, free_mb, total_mb, reserve_cap)
                 if headroom >= peak and headroom > best_headroom:
                     best_key, best_headroom = key, headroom
             if best_key is None:
@@ -2040,17 +2083,18 @@ class ReservationLedger:
             return (best_key, token_id)
 
     def best_fit(
-        self, candidates: list[tuple[str, int, int]], peak: int, reserve: int
+        self, candidates: list[tuple[str, int, int]], peak: int, reserve_cap: int
     ) -> Optional[str]:
         """Read-only twin of `try_hold`: the device_key that would win, or None,
         WITHOUT holding. For the pure `admit()` decision (e.g. /load placement) —
         advisory only; the binding decision is `reservation()`'s atomic
-        `try_hold`."""
+        `try_hold`. `reserve_cap` mirrors `try_hold`'s (per-device reserve,
+        see `_headroom`)."""
         with self._lock:
             best_key: Optional[str] = None
             best_headroom = -1
             for key, free_mb, total_mb in candidates:
-                headroom = self._headroom(key, free_mb, total_mb, reserve)
+                headroom = self._headroom(key, free_mb, total_mb, reserve_cap)
                 if headroom >= peak and headroom > best_headroom:
                     best_key, best_headroom = key, headroom
             return best_key
@@ -2074,7 +2118,10 @@ class PlacementController:
         self.probe = probe
         self.footprints = footprints if footprints is not None else FootprintTable()
         self.ledger = ledger if ledger is not None else ReservationLedger()
-        self.reserve_mb = reserve_mb if reserve_mb is not None else (lambda: int(os.environ.get("GPU_RESERVE_MB", 768)))
+        # `reserve_mb` is the GPU_RESERVE_MB CAP/ceiling, not a flat reserve —
+        # the actual per-device cushion is `_device_reserve_mb(total, cap)`,
+        # min(5% of that device's own VRAM, this cap). See `_device_reserve_mb`.
+        self.reserve_mb = reserve_mb if reserve_mb is not None else (lambda: int(os.environ.get("GPU_RESERVE_MB", 500)))
         self.idle_evict = idle_evict if idle_evict is not None else (lambda device_key: False)
         self.is_resident = is_resident if is_resident is not None else (lambda engine: None)
 
@@ -2105,14 +2152,16 @@ class PlacementController:
         evict is likeliest to cross the threshold. None if the probe shows no
         GPU. (Diverges deliberately from an earlier 'largest shortfall' note:
         max-headroom is the recoverable device, not the least-recoverable one.)"""
-        reserve = self.reserve_mb()
+        reserve_cap = self.reserve_mb()
         best_key: Optional[str] = None
         best_headroom: Optional[int] = None
         for d in devices:
             if d["kind"] == "cpu":
                 continue
             key = self._device_key(d)
-            headroom = min(d["freeMb"], d["totalMb"] - self.ledger.reserved_mb(key)) - reserve
+            headroom = min(d["freeMb"], d["totalMb"] - self.ledger.reserved_mb(key)) - _device_reserve_mb(
+                d["totalMb"], reserve_cap
+            )
             if best_headroom is None or headroom > best_headroom:
                 best_key, best_headroom = key, headroom
         return best_key
@@ -2140,11 +2189,11 @@ class PlacementController:
         peak = self.footprints.peak_mb(engine, model, cfg)
         resident = self.is_resident(engine)
         constraint = resident if resident is not None else pinned
-        reserve = self.reserve_mb()
+        reserve_cap = self.reserve_mb()
         devices = self.probe()
         candidates = self._gpu_candidates(devices, constraint)
 
-        key = self.ledger.best_fit(candidates, peak, reserve)
+        key = self.ledger.best_fit(candidates, peak, reserve_cap)
         if key is not None:
             return {"device": key}
         if cpu_capable and not heavy:
@@ -2154,7 +2203,7 @@ class PlacementController:
         if worst is not None and self.idle_evict(worst):
             devices = self.probe()
             candidates = self._gpu_candidates(devices, constraint)
-            key = self.ledger.best_fit(candidates, peak, reserve)
+            key = self.ledger.best_fit(candidates, peak, reserve_cap)
             if key is not None:
                 return {"device": key}
             worst = self._worst_device_key(devices)
@@ -2181,6 +2230,23 @@ class PlacementController:
         except Exception:
             return 0
 
+    @staticmethod
+    def _reset_peak_mb(device_key: Optional[str]) -> None:
+        """Resets CUDA's peak-allocated counter for `device_key` right before
+        an op starts, so the paired `_observed_mb` read at release reflects
+        THIS op's peak rather than the process-lifetime high-water mark.
+        Guarded like `_observed_mb`: no-op when torch/CUDA isn't available or
+        the device isn't a CUDA one."""
+        if not device_key or not device_key.startswith(("cuda:", "rocm:")):
+            return
+        try:
+            import torch  # type: ignore
+
+            index = int(device_key.split(":", 1)[1])
+            torch.cuda.reset_peak_memory_stats(index)
+        except Exception:
+            pass
+
     @contextmanager
     def reservation(
         self,
@@ -2202,20 +2268,25 @@ class PlacementController:
         peak = self.footprints.peak_mb(engine, model, cfg)
         resident = self.is_resident(engine)
         constraint = resident if resident is not None else pinned
-        reserve = self.reserve_mb()
+        reserve_cap = self.reserve_mb()
         devices = self.probe()
         candidates = self._gpu_candidates(devices, constraint)
 
-        held = self.ledger.try_hold(candidates, peak, reserve)
+        held = self.ledger.try_hold(candidates, peak, reserve_cap)
         if held is None and not (cpu_capable and not heavy):
             worst = self._worst_device_key(devices)
             if worst is not None and self.idle_evict(worst):
                 devices = self.probe()
                 candidates = self._gpu_candidates(devices, constraint)
-                held = self.ledger.try_hold(candidates, peak, reserve)
+                held = self.ledger.try_hold(candidates, peak, reserve_cap)
 
         if held is not None:
             admission: dict = {"device": held[0]}
+            # Device-wide reset, not scoped to this op — a concurrent op on the
+            # same device can truncate the measurement window. Acceptable: it
+            # only ever UNDER-estimates the peak (never over-reserves), and the
+            # reserve cushion + p95 windowing absorb the noise.
+            self._reset_peak_mb(held[0])
         elif cpu_capable and not heavy:
             admission = {"device": "cpu"}
         else:
@@ -2320,7 +2391,7 @@ _placement = PlacementController(
     probe=probe_capacity,
     footprints=FootprintTable(),
     ledger=ReservationLedger(),
-    reserve_mb=lambda: int(os.environ.get("GPU_RESERVE_MB", 768)),
+    reserve_mb=lambda: int(os.environ.get("GPU_RESERVE_MB", 500)),
     idle_evict=_idle_evict,
     is_resident=_is_resident,
 )

--- a/server/tts-sidecar/tests/test_design_mint_admission.py
+++ b/server/tts-sidecar/tests/test_design_mint_admission.py
@@ -3,7 +3,7 @@
 plan). Mirrors test_load_admission.py's fixture shape and the same
 `SEG_CAPACITY_ADMISSION` flag envelope: flag-OFF never probes and calls the
 engine method with no `device` arg (today's behaviour byte-for-byte);
-flag-ON reserves the `qwen.1.7b` footprint (7168 MB — both design and mint
+flag-ON reserves the `qwen.1.7b` footprint (6144 MB — both design and mint
 run on the 1.7B model), steers the admitted device into the engine call, and
 a no-fit probe returns 503 `{noCapacity, neededMb, deviceKey}` before the
 engine is ever asked to design/mint."""
@@ -123,9 +123,9 @@ def test_design_flag_on_favours_roomier_device(monkeypatch, design_client):
     assert args[-1] == "cuda:1"
 
 
-def test_design_nocapacity_returns_503_needed_7168(monkeypatch, design_client):
+def test_design_nocapacity_returns_503_needed_6144(monkeypatch, design_client):
     """Flag ON + a probe that can't fit the 1.7B footprint -> 503 noCapacity
-    with neededMb == 7168 (proves the qwen.1.7b footprint was reserved), and
+    with neededMb == 6144 (proves the qwen.1.7b footprint was reserved), and
     design_voice is never called."""
     monkeypatch.setenv("SEG_CAPACITY_ADMISSION", "1")
     monkeypatch.setattr(
@@ -139,7 +139,7 @@ def test_design_nocapacity_returns_503_needed_7168(monkeypatch, design_client):
     assert r.status_code == 503
     body = r.json()
     assert body["noCapacity"] is True
-    assert body["neededMb"] == 7168
+    assert body["neededMb"] == 6144
     assert body["deviceKey"] == "cuda:0"
     fake = design_client.fake_qwen
     assert fake.design_calls == []
@@ -187,7 +187,7 @@ def test_mint_flag_on_favours_roomier_device(monkeypatch, design_client):
     assert args[-1] == "cuda:1"
 
 
-def test_mint_nocapacity_returns_503_needed_7168(monkeypatch, design_client):
+def test_mint_nocapacity_returns_503_needed_6144(monkeypatch, design_client):
     monkeypatch.setenv("SEG_CAPACITY_ADMISSION", "1")
     monkeypatch.setattr(
         main._placement,
@@ -200,7 +200,7 @@ def test_mint_nocapacity_returns_503_needed_7168(monkeypatch, design_client):
     assert r.status_code == 503
     body = r.json()
     assert body["noCapacity"] is True
-    assert body["neededMb"] == 7168
+    assert body["neededMb"] == 6144
     assert body["deviceKey"] == "cuda:0"
     fake = design_client.fake_qwen
     assert fake.mint_calls == []

--- a/server/tts-sidecar/tests/test_footprints.py
+++ b/server/tts-sidecar/tests/test_footprints.py
@@ -1,7 +1,8 @@
 """Tests for `FootprintTable` — the per-(engine,model,config) peak-under-load
 VRAM estimate that capacity-aware admission reserves (task 2 of the
-vram-aware-placement plan). Seeds mirror the maintained `docs/local-llm.md`;
-on-box observations ratchet the estimate up only, never down."""
+vram-aware-placement plan). Seeds mirror the maintained `docs/local-llm.md`
+and are COLD-START PRIORS only: once enough real per-op observations have
+been recorded, the learned windowed p95 supersedes the seed (up OR down)."""
 from __future__ import annotations
 
 import re
@@ -23,17 +24,54 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 def test_peak_is_above_weight_size():
+    # Cold start (no observations yet): the seed is a realistic per-op decode
+    # peak, not the old grossly-inflated ~6144 value — well below the old
+    # 5600 floor, and equal to the maintained SEED_FOOTPRINTS_MB entry.
     t = main.FootprintTable()
-    assert t.peak_mb("qwen", "qwen-0.6b", {"batch": 32, "tokenBudget": 3600}) >= 5600  # real decode peak, not weight size
+    peak = t.peak_mb("qwen", "qwen-0.6b", {"batch": 32, "tokenBudget": 3600})
+    assert peak < 5600
+    assert peak == main.SEED_FOOTPRINTS_MB["qwen"]
 
 
-def test_ratchets_up_only():
+def test_learned_p95_decays_not_max():
+    # A burst of realistic low observations followed by a single spike (e.g.
+    # a co-residency moment) should NOT pin the reservation at the spike —
+    # the windowed p95 excludes it as a tail outlier once enough samples
+    # exist, unlike the old up-only max ratchet. 50 low + 1 spike gives the
+    # nearest-rank p95 comfortable margin to land inside the low cluster
+    # (a single outlier in 51 samples is well outside the top 5%).
     t = main.FootprintTable()
-    base = t.peak_mb("coqui", None, {})
-    t.record("coqui", None, {}, base + 400)
-    assert t.peak_mb("coqui", None, {}) == base + 400
-    t.record("coqui", None, {}, base - 400)
-    assert t.peak_mb("coqui", None, {}) == base + 400
+    for _ in range(50):
+        t.record("coqui", None, {}, 1900)
+    t.record("coqui", None, {}, 7000)
+    peak = t.peak_mb("coqui", None, {})
+    assert peak < 7000
+    assert peak < 2200  # tracks the low cluster, not the spike
+
+
+def test_seed_used_until_min_samples():
+    t = main.FootprintTable()
+    seed = t.peak_mb("coqui", None, {})
+    assert seed == main.SEED_FOOTPRINTS_MB["coqui"]
+    # Fewer than _FOOTPRINT_MIN_SAMPLES observations: still the seed.
+    for _ in range(main._FOOTPRINT_MIN_SAMPLES - 1):
+        t.record("coqui", None, {}, seed - 500)
+    assert t.peak_mb("coqui", None, {}) == seed
+    # One more observation crosses the min-samples threshold: the learned
+    # p95 (below the seed) takes over — proving the seed is a cold-start
+    # prior, not a floor.
+    t.record("coqui", None, {}, seed - 500)
+    learned = t.peak_mb("coqui", None, {})
+    assert learned == seed - 500
+    assert learned < seed
+
+
+def test_nonpositive_observation_ignored():
+    t = main.FootprintTable()
+    for _ in range(main._FOOTPRINT_MIN_SAMPLES):
+        t.record("coqui", None, {}, 0)
+    # None of those zeros should have entered the window.
+    assert t.peak_mb("coqui", None, {}) == main.SEED_FOOTPRINTS_MB["coqui"]
 
 
 def test_seed_parity_with_local_llm_doc():

--- a/server/tts-sidecar/tests/test_placement.py
+++ b/server/tts-sidecar/tests/test_placement.py
@@ -26,13 +26,34 @@ def dev(kind="cuda", index=0, total=8192, free=8000):
     return {"kind": kind, "index": index, "label": "g", "totalMb": total, "freeMb": free}
 
 
-def make(devices, peak, reserve=768, idle_evict=None, resident=None):
+# --- _device_reserve_mb -----------------------------------------------------
+#
+# The per-device VRAM safety cushion: min(5% of that device's own VRAM, the
+# GPU_RESERVE_MB cap) — right-sizes the reserve to the card instead of
+# subtracting one flat number everywhere (over-provisions a small card,
+# under-provisions a large one relative to its size).
+
+
+@pytest.mark.parametrize(
+    "total_mb,cap,expected",
+    [
+        (8188, 500, 409),  # 5% of an ~8 GB card, under the cap
+        (6144, 500, 307),  # 5% of a 6 GB card, under the cap
+        (16302, 500, 500),  # 5% of a 16 GB card (815) exceeds the cap -> capped
+        (24576, 500, 500),  # 5% of a 24 GB card (1229) exceeds the cap -> capped
+    ],
+)
+def test_device_reserve_mb(total_mb, cap, expected):
+    assert main._device_reserve_mb(total_mb, cap) == expected
+
+
+def make(devices, peak, reserve_cap=768, idle_evict=None, resident=None):
     fp = type("F", (), {"peak_mb": lambda *_: peak, "record": lambda *_: None})()
     return main.PlacementController(
         probe=lambda: devices,
         footprints=fp,
         ledger=main.ReservationLedger(),
-        reserve_mb=lambda: reserve,
+        reserve_mb=lambda: reserve_cap,
         idle_evict=idle_evict or (lambda dk: False),
         is_resident=resident or (lambda e: None),
     )
@@ -43,7 +64,9 @@ def test_reserves_peak_so_second_op_cannot_double_book():
     pc = make(devices, peak=5600)
     with pc.reservation("qwen", "q", {}, cpu_capable=False, heavy=True) as a1:
         assert a1["device"] == "cuda:0"
-        # second op: 8192 - 5600(reserved) - 768 = -176 < 5600 -> no capacity
+        # second op: the per-device reserve on an 8192 MB card is
+        # min(round(0.05*8192), 768) = 410, so headroom = min(8000, 8192 -
+        # 5600(reserved)) - 410 = 2592 - 410 = 2182 < 5600 -> no capacity
         a2 = pc.admit("qwen", "q", {}, cpu_capable=False, heavy=True)
         assert "noCapacity" in a2 and a2["noCapacity"]["neededMb"] == 5600
     # after the first releases, it fits again
@@ -110,9 +133,10 @@ def test_try_hold_is_atomic_under_concurrency():
         t.join()
 
     assert len(granted) == 1, f"expected exactly one atomic grant, got {len(granted)}"
-    # The no-OOM invariant: Σ held ≤ total − reserve.
+    # The no-OOM invariant: Σ held ≤ total − per-device reserve (min(5% of
+    # this 8192 MB card, the 768 cap) = 410).
     assert ledger.reserved_mb("cuda:0") == 5600
-    assert ledger.reserved_mb("cuda:0") <= 8192 - 768
+    assert ledger.reserved_mb("cuda:0") <= 8192 - main._device_reserve_mb(8192, 768)
 
 
 def test_resident_device_still_fit_checked():


### PR DESCRIPTION
## Summary

Capacity-aware admission (`SEG_CAPACITY_ADMISSION`, default OFF) was grossly over-conservative — a 1.7B Qwen op was refused (`503 noCapacity`) on an 8 GB card it actually fits, and being refused could never run to self-correct (deadlock). Two compounding bugs:

1. **`_observed_mb`** read `torch.cuda.max_memory_allocated` with **no `reset_peak_memory_stats`** — every observation was the device's process-lifetime high-water, not the per-op peak (one design co-residency ~9 GB poisoned all later readings).
2. **`FootprintTable`** ratcheted that inflated value **up only** (`max(seed, learned)`), pinning the reservation forever.

**Fix:**
- Per-op measurement: `reset_peak_memory_stats` at reservation-acquire, read `max_memory_allocated` at release.
- **Windowed p95** footprint (last 64 obs, ≥5 samples); the seed is now a cold-start prior, **not a floor** — the learned estimate self-corrects downward.
- Seeds re-grounded on measured peaks (0.6B ~1952 MB, 1.7B mint ~5654 MB): `qwen` 6144→3072, `qwen.1.7b`/wide 7168→6144.
- **Per-device reserve** `min(5% × card, GPU_RESERVE_MB)`, cap default 768→500. A fragmentation probe showed the torch allocator packs to 100% of `mem_get_info` free and coalesces holes, so the reserve is a p95-tail cushion only — not a fragmentation guard.
- Node `gpu-load.ts` coarse-check reserve fallback 768→500 to match.

## Test plan

- New/updated sidecar tests: `test_footprints.py` (p95 decay-not-max, seed-until-min-samples, non-positive ignored, new-seed weight check), `test_placement.py` (`_device_reserve_mb` per-device 8188→409/6144→307/16302→500), `test_design_mint_admission.py` (stale 7168→6144). Seeds parity-tested against `docs/local-llm.md`.
- Full sidecar suite green; full server suite green (pre-commit, 4965 passed).
- **On-box (dual-GPU box, flag ON):** a 1.7B mint is now admitted to and completes on the 8 GB card (peak within budget, no OOM) — previously `503 noCapacity`. The fragmentation probe confirmed 100%-of-free packing.

Docs: wiki (Advanced-Settings §9 + a Troubleshooting GPU/VRAM section), plan 264 marks the `_observed_mb` follow-up CLOSED, technical release-notes entry. User-facing `RELEASE_NOTES.md` line intentionally skipped — flag is default-OFF, no user-visible delta.

Refs #1720
Closes #1736

🤖 Generated with [Claude Code](https://claude.com/claude-code)