### PR TITLE
docs(docs): drop retired weighted-GPU-semaphore knobs from wiki §9 + install guide

### DIFF
--- a/docs/wiki/Advanced-Settings.md
+++ b/docs/wiki/Advanced-Settings.md
@@ -270,15 +270,6 @@ mismatches) — the table's risk column shows each correctly.
 
 | Knob | What it does | Default | Range | Apply | Risk |
 |---|---|---|---|---|---|
-| GPU concurrency | Max concurrent GPU ops (fallback when VRAM budget unset) | 1 | integer, min 1 | restart · app | high |
-| GPU VRAM token budget | Total token budget for the weighted semaphore; 0 disables | 0 | integer, min 0 | restart · app | high |
-| GPU weight: Kokoro | VRAM token cost per Kokoro op | 1 | integer, min 0 | live | high |
-| GPU weight: Qwen | VRAM token cost per Qwen op | 1 | integer, min 0 | live | high |
-| GPU weight: Coqui | VRAM token cost per Coqui op | 3 | integer, min 0 | live | high |
-| GPU weight: Analyzer | VRAM token cost per Ollama op | 4 | integer, min 0 | live | high |
-| GPU weight: ASR (Whisper) | VRAM token cost per Whisper op (cuda only) | 1 | integer, min 0 | live | high |
-| GPU weight: Speaker embed (ECAPA) | VRAM token cost per ECAPA op (cuda only) | 1 | integer, min 0 | live | high |
-| Safe analyzer+TTS coexistence VRAM (MB) | Below this, evict resident Ollama before sidecar TTS load; 0 = always evict | 11000 | integer, min 0 | live | high |
 | Qwen VoiceDesign idle TTL (s) | Idle secs before freeing transient VoiceDesign model (~4-5GB) | 120 | integer, min 0 | restart · sidecar | high |
 | Qwen 1.7B-Base idle TTL (s) | Idle secs before freeing resident 1.7B-Base (~3.4GB) | 120 | integer, min 0 | restart · sidecar | high |
 | ASR (Whisper) idle TTL (s) | Idle secs before freeing Whisper model | 120 | integer, min 0 | restart · sidecar | high |
@@ -295,7 +286,8 @@ mismatches) — the table's risk column shows each correctly.
 an alternate admission path for every heavy GPU op — synthesis, engine loads,
 voice design, ASR transcription, speaker embedding — that reserves each op's
 own **measured VRAM footprint** against a card's actual free memory before
-letting it start, instead of the fixed knobs above. On a multi-GPU box it
+letting it start, rather than capping GPU work at a fixed global concurrency
+limit. On a multi-GPU box it
 steers each op to whichever card has the most free headroom, so moving
 between a single 8 GB card and an 8+16 GB two-card setup needs no settings
 change. Each engine/tier's footprint starts from a seeded cold-start estimate
@@ -307,8 +299,11 @@ pinned to a single worst-case spike forever. The **GPU VRAM reserve cap
 held back on any one card is 5% of *that card's* VRAM, capped at this value —
 sized to the device rather than a flat subtraction that over-provisions a
 small card and under-provisions a large one. While `SEG_CAPACITY_ADMISSION`
-is off, this path is dormant and GPU access falls back to the serialized
-behaviour the rest of this group configures. See
+is off (the default), this path is dormant: heavy GPU work runs one op at a
+time (a simple serialized fallback — the earlier weighted-VRAM-budget and
+per-engine-cost knobs it replaced have been retired), and only the lifecycle
+knobs in the rest of this group still apply — the idle-eviction TTLs and the
+RAM/VRAM recycle-and-restart thresholds. See
 [Troubleshooting](Troubleshooting#gpu-capacity--vram-placement) if an op
 won't place on a card it should fit, or the eGPU drops off the bus.
 

--- a/docs/wiki/Installing-Castwright.md
+++ b/docs/wiki/Installing-Castwright.md
@@ -257,8 +257,10 @@ steps above). All knobs have safe defaults — set only what you need.
 - `WORKSPACE_DIR` — where your per-book library lives (set this to a writable
   folder).
 - `GEN_WORKERS` — how many chapters synthesise at once (default `2`).
-- `GPU_VRAM_BUDGET` — VRAM-weighted GPU budget in GiB (default `8`). Drop to `6`
-  on a 6 GB card.
+- `SEG_CAPACITY_ADMISSION` — `0` (default) runs heavy GPU ops one at a time (a
+  simple serialized fallback); `1` opts into measured-VRAM capacity admission
+  with multi-GPU device steering (see Advanced Settings §9). `GPU_RESERVE_MB`
+  (default `500`) caps the per-card VRAM safety cushion held back from admission.
 - `PRELOAD_COQUI` — `0` (default; Coqui loads on demand) or `1`.
 - `QWEN_BATCH_SIZE` (default `8`) and `QWEN_ATTN_IMPL` (default `sdpa`) — Qwen
   tuning knobs.
@@ -363,7 +365,7 @@ When a compatible build is present (however it got there), activate it via `QWEN
 
 **Switch a book to Qwen3.** Start the app and go to **Account → Defaults for new books → Voice engine** → "Local (free)" → **Voice model** → pick the Qwen3 entry. Save. For an existing book opened under Kokoro / Coqui, use the cast view's "Rebaseline the series" modal to design Qwen voices for the principal cast before regenerating.
 
-**Disk + VRAM.** Qwen Base ~1 GB on disk, Base + VoiceDesign together ~2.5 GB. At runtime Base resides at ~2 GB VRAM during synth and VoiceDesign loads transiently during a design (~4–5 GB on top of Base, freed on idle or at the next synth). The GPU-arbitration semaphore (`GPU_VRAM_BUDGET` in `server/.env`, default 8 GiB) keeps an 8 GB GPU from double-booking against the analyzer.
+**Disk + VRAM.** Qwen Base ~1 GB on disk, Base + VoiceDesign together ~2.5 GB. At runtime Base resides at ~2 GB VRAM during synth and VoiceDesign loads transiently during a design (~4–5 GB on top of Base, freed on idle or at the next synth). By default heavy GPU work runs one op at a time, and the sidecar evicts a resident analyzer before a TTS load, so an 8 GB GPU won't double-book against the analyzer; opt into `SEG_CAPACITY_ADMISSION=1` (Advanced Settings §9) for measured-footprint admission with multi-GPU steering instead.
 
 ## Adding Coqui XTTS v2 (optional add-on)
 


### PR DESCRIPTION
## Summary

Documentation cleanup after the capacity-admission cutover (#1737), which
deleted the weighted `GpuSemaphore` and its knobs and left `gpu.reserveMb`
(`GPU_RESERVE_MB`) as the **only** surviving GPU knob (verified against
`server/src/config/registry.ts` — no `gpu.concurrency`/`gpu.vramBudget`/
`gpu.weight.*`/`gpu.safeCoexist` keys remain). The wiki still documented the
dead ones:

- **`Advanced-Settings.md` §9** — removed the 9 stale rows (GPU concurrency,
  GPU VRAM token budget, six GPU weights, Safe analyzer+TTS coexistence VRAM).
  Also corrected the capacity-placement prose: flag-OFF no longer "falls back
  to the serialized behaviour the rest of this group configures" (those
  arbitration knobs are gone) — it's now a plain one-op-at-a-time serialized
  fallback, and only the lifecycle knobs (idle TTLs, recycle/restart
  thresholds, reserve cap) remain in the group.
- **`Installing-Castwright.md`** — replaced the `GPU_VRAM_BUDGET` env bullet in
  the Generation/TTS list and the Qwen "Disk + VRAM" prose that cited it with
  the current `SEG_CAPACITY_ADMISSION` / `GPU_RESERVE_MB` reality.

Kept rows all map to live registry keys (idle TTLs → `sidecar.*IdleTtl`,
recycle/restart → `sidecar.*Mb`, free floor → `sidecar.vramFreeFloorMb`,
reserve cap → `gpu.reserveMb`). `Troubleshooting.md`'s GPU section was already
clean.

### Residuals (deliberately not in this PR)
- The §9 screenshot (`images/advanced-settings/09-*.png`) still shows the
  deleted knobs — needs a manual UI re-capture.
- `docs/local-llm.md` has two more stale `GPU_VRAM_BUDGET` / `GPU_SAFE_COEXIST_MB`
  references; that file is already edited by #1738, so fixing them there or in a
  follow-up after #1738 merges avoids a cross-branch conflict.

## Test plan

Docs-only (wiki source under `docs/wiki/**`). No code paths touched; verified
the claims against `registry.ts` and the surviving `sidecar.*`/`gpu.reserveMb`
keys. Wiki publishes via `npm run wiki:sync` after merge.

Closes #1740

🤖 Generated with [Claude Code](https://claude.com/claude-code)