### PR TITLE
feat(server): chunk-safe stage-2 attribution rules

### DIFF
--- a/docs/features/265-attribution-eval-tuning.md
+++ b/docs/features/265-attribution-eval-tuning.md
@@ -248,3 +248,33 @@ its baseline min on Qwen, and flat-or-better on cloud Flash-lite/Gemma (ch44 was
 chunk-safe rules variant (to get the block into the chunk path without the boundary misfire), RU/DE
 eval fixtures, and pinning the cloud decoding temperature (the unpinned ~1.0 default drove the wide
 ch45 raw band on cloud vs the tight band on temp-0.2 Qwen).
+
+### Chunk-safe rules variant — hybrid-C (#1758 / srv-63, 2026-07-22)
+
+The chunk-safe follow-up above. Branch `feat/server-chunk-safe-attribution-rules` under its own
+spec/plan (`docs/superpowers/{specs,plans}/2026-07-22-chunk-safe-attribution-rules*`). Adds a
+second rules constant `STAGE2_ATTRIBUTION_RULES_CHUNK` (rules 1/2/4/5 byte-identical to the chapter
+block — a drift-guard test pins that — with only rule #3 rewritten to scope continuation/alternation
+*within the section*), rendered in `buildStage2ChunkInbox` alongside a deterministic "last-speaker
+seed" threaded through the sequential chunk driver (last non-`narrator` id of each chunk's raw
+returned attributions, carried across all-narration chunks). The chapter builder is byte-identical.
+
+**On-box eval (English, `--runs 3`, `qwen36-cw-iq4-32k`) — floor-only, no lift.** The baseline was
+**reused** from the 2026-07-21 capture (not re-run): the chunk path — `stage2-chunk.ts`, stage-1,
+and `buildStage2ChunkInbox` — is unchanged from that baseline commit (`36f127ae`, an ancestor of
+`main`) through current `main` (#1761 touched only the *chapter* builder), so the ch44 baseline is
+byte-identical, on the same corpus (ch44 n=328). ch44 raw: **hybrid-C 81.8% [81.4–82.0]** vs
+**baseline 82.5% [80.5–83.5]** vs the rejected both-builders **80.0%**. So hybrid-C clears the
+no-regression floor (≥ baseline min 80.5) and beats both-builders by **+1.8** — the cross-boundary
+misfire is gone — but sits −0.7 below the baseline mean (inside the baseline's own band): a **flat,
+floor-only** result, not a lift. Family split explains the wash: rules 1/2 lifted `tag` (+1.1) and
+`pronoun` (+3.2), but `unanchored` (−4.6) and `unaligned` (−19.5, wide-CI/seg-drift-heavy) fell —
+i.e. the seed + rule-#3 rewrite did **not** pay off on the continuation cases they targeted. Every
+other fixture flat (chapter path untouched: ch43 80.3=80.3 exact, ch45/46/Coalfall within noise);
+`det`/`final` ticked down ~1pt.
+
+**Shipped as floor-only** (user decision, 2026-07-22): no regression, strictly better than
+both-builders, and it closes the "chunk path carries zero attribution rules" gap — but with **no
+measured quality benefit**, so **no release-notes entry** (no user-visible delta). The seed/rule-#3
+machinery earned no lift here; whether to keep or drop it is folded into the deferred
+deterministic-first phase-2 / ch44-residual work, not re-litigated now.

--- a/docs/superpowers/plans/2026-07-22-chunk-safe-attribution-rules.md
+++ b/docs/superpowers/plans/2026-07-22-chunk-safe-attribution-rules.md
@@ -1,0 +1,565 @@
+# Chunk-safe stage-2 attribution rules (#1758 / srv-63) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Get the stage-2 attribution rules block into the *chunk* prompt builder — with a boundary-safe rewrite of rule #3 and a deterministic last-speaker seed — so large chunked chapters (ch44) get the same attribution rules the single-call chapters already do, without re-introducing the cross-boundary parity regression Target C hit.
+
+**Architecture:** Add a second rules constant `STAGE2_ATTRIBUTION_RULES_CHUNK` (rules 1/2/4/5 byte-identical to the shipped chapter block, only rule #3 rewritten to scope continuation/alternation *within the section*). Render it plus a "Speaker at section start" seed inside `buildStage2ChunkInbox`. Thread a `lastSpeakerId: string | null` through the sequential chunk driver (`runStage2ChapterChunked`), computed after each chunk as the last non-`narrator` `characterId` in that chunk's returned attributions (falling back to the incoming value on an all-narration chunk). The whole-chapter builder path is untouched.
+
+**Tech Stack:** TypeScript, Node, Vitest (server harness, `cd server && npm run test`). No new deps.
+
+## Global Constraints
+
+- **Every changed line traces to #1758.** The whole-chapter builder (`buildStage2ChapterInbox`) and its shipped `STAGE2_ATTRIBUTION_RULES` block MUST stay byte-identical — no reordering, no rewording. (Surgical-changes rule, CLAUDE.md.)
+- **No new env var / knob** in this work — pure prompt + driver plumbing. (If one were needed it would have to be a registry knob + `.env.example`; it isn't.)
+- **Deciding metric for acceptance is `raw` recall** (pre-crossExamine), local target `qwen36-cw-iq4-32k`, `--runs 3`. On-box eval only — NOT a CI gate.
+- **Seed source is the RAW model output**, i.e. the `SentenceOutput[]` returned by `attributeSpan` *before* crossExamine runs (crossExamine runs later, on the stitched result, in `analysis.ts`). So the only non-speaker id that appears is the literal `'narrator'` — unknown gender buckets are added by a later pass and never seen here.
+- **Never `--no-verify`.** Pre-commit runs scope-filtered `verify:fast:scoped`; a server-src change runs the server suite. Keep each task green.
+- Commit subjects: `<type>(<scope>): <subject>`, ≤100 chars. Scope is `server`.
+
+## File Structure
+
+- **`server/src/routes/analysis.ts`** — `export` the existing `STAGE2_ATTRIBUTION_RULES`; add `STAGE2_ATTRIBUTION_RULES_CHUNK`; add the seed block + `lastSpeakerId` param to `buildStage2ChunkInbox`; forward `lastSpeakerId` from the `callForBody` closure in `attributeChapterStage2`.
+- **`server/src/analyzer/stage2-chunk.ts`** — widen `Stage2ChunkRunOptions.callForBody` to a 3-arg signature; compute + thread `lastSpeakerId` through `runChunks` and the `attributeSpan` adaptive-re-split recursion; add a module-private `lastSpokenSpeaker` helper.
+- **`server/src/routes/analysis.test.ts`** — flip the existing "chunk builder omits the rules block" test to assert the chunk-variant block IS present + seed rendering + ordering; add the drift-guard test.
+- **`server/src/analyzer/stage2-chunk.test.ts`** — add the driver test that `lastSpeakerId` is computed and threaded (incl. all-narration carry-through and adaptive re-split).
+
+---
+
+### Task 1: Chunk-variant rules constant + drift-guard test
+
+Adds the second rules constant with only rule #3 rewritten, exports both constants, and locks rules 1/2/4/5 identical between them with a test. No behaviour wiring yet — this task is self-contained and compiles on its own.
+
+**Files:**
+- Modify: `server/src/routes/analysis.ts:1532` (export existing constant; add new one after it, ~line 1553)
+- Test: `server/src/routes/analysis.test.ts` (new `describe` block, append near the existing "stage-2 attribution rules block (Target C)" suite ~line 3535)
+
+**Interfaces:**
+- Produces: `export const STAGE2_ATTRIBUTION_RULES: string` (now exported), `export const STAGE2_ATTRIBUTION_RULES_CHUNK: string` — both begin with the `## Attribution rules` header; rules 1, 2, 4, 5 are textually identical; rule 3 differs.
+
+- [ ] **Step 1: Write the failing drift-guard + shape test**
+
+Append to `server/src/routes/analysis.test.ts`. Import both constants (add to the existing import from `./analysis.js` — check the top-of-file import list and extend it):
+
+```ts
+import {
+  STAGE2_ATTRIBUTION_RULES,
+  STAGE2_ATTRIBUTION_RULES_CHUNK,
+} from './analysis.js';
+
+describe('chunk-variant attribution rules (#1758)', () => {
+  // Extract the numbered rule bodies "N. …" up to the next "\nN. " boundary.
+  function rule(block: string, n: number): string {
+    const m = block.match(new RegExp(`\\n${n}\\. [\\s\\S]*?(?=\\n\\d\\. |$)`));
+    return (m?.[0] ?? '').trim();
+  }
+
+  it('shares rules 1, 2, 4, 5 byte-for-byte with the chapter block', () => {
+    for (const n of [1, 2, 4, 5]) {
+      expect(rule(STAGE2_ATTRIBUTION_RULES_CHUNK, n)).toBe(rule(STAGE2_ATTRIBUTION_RULES, n));
+      expect(rule(STAGE2_ATTRIBUTION_RULES_CHUNK, n)).not.toBe(''); // guard: regex actually matched
+    }
+  });
+
+  it('rewrites rule 3 to scope continuation/alternation within the section', () => {
+    const chunk3 = rule(STAGE2_ATTRIBUTION_RULES_CHUNK, 3);
+    expect(chunk3).not.toBe(rule(STAGE2_ATTRIBUTION_RULES, 3));
+    expect(chunk3).toContain('within this section');
+    // No unqualified claim that alternation carries in from before the section.
+    expect(chunk3).toContain('Do NOT assume');
+  });
+
+  it('both blocks start with the same header', () => {
+    expect(STAGE2_ATTRIBUTION_RULES_CHUNK.startsWith('## Attribution rules')).toBe(true);
+    expect(STAGE2_ATTRIBUTION_RULES.startsWith('## Attribution rules')).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run it — expect a compile/failing test**
+
+Run: `cd server && npx vitest run src/routes/analysis.test.ts -t "chunk-variant attribution rules"`
+Expected: FAIL — `STAGE2_ATTRIBUTION_RULES_CHUNK` is not exported (and `STAGE2_ATTRIBUTION_RULES` isn't either yet), so the import errors.
+
+- [ ] **Step 3: Export the existing constant and add the chunk variant**
+
+In `server/src/routes/analysis.ts`, change the declaration at line 1532 from `const STAGE2_ATTRIBUTION_RULES = ` to `export const STAGE2_ATTRIBUTION_RULES = ` (leave the block body and the preceding comment untouched).
+
+Immediately after the closing `` `; `` of `STAGE2_ATTRIBUTION_RULES` (currently ~line 1553), insert:
+
+```ts
+/* #1758 — the chunk-path variant of the attribution rules. Rules 1, 2, 4, 5 are
+   byte-identical to STAGE2_ATTRIBUTION_RULES (all boundary-safe: explicit tag,
+   same-paragraph action beat, narration, addressee). Only rule 3 is rewritten to
+   scope continuation/alternation WITHIN the section — a chunk that opens
+   mid-conversation has no in-band anchor for two-hander alternation parity, so
+   telling the model to alternate across the seam flipped the whole run (the ch44
+   both-builders regression). The "Speaker at section start" seed (buildStage2ChunkInbox)
+   powers only rule 3's continuation clause; alternation is disclaimed across the seam.
+   A drift-guard unit test pins rules 1/2/4/5 identical between the two constants. */
+export const STAGE2_ATTRIBUTION_RULES_CHUNK = `## Attribution rules
+
+Apply these when assigning each sentence's speaker. They hold whatever
+quotation marks the text uses — \`"…"\`, \`«…»\`, \`„…"\`, \`“…”\` — and in any
+language:
+
+1. A dialogue tag is decisive. When a quote carries an explicit speech tag —
+   \`"…," said X\` / \`"…," X asked\` / \`"…," whispered X\` — the speaker is X,
+   whatever the surrounding lines suggest.
+2. An action beat names the speaker. A quote sharing a paragraph with a
+   character's action belongs to that character: \`X folded her arms. "Get
+   out."\` and \`"Get out." X turned away.\` are both spoken by X.
+3. Untagged quotes continue, and two-handers alternate — within this section. An
+   untagged quote keeps the last speaker established here (or the "Speaker at
+   section start" named below, for the first quote). Do NOT assume a two-hander's
+   alternation carries in from before this section's start; near the start, rely
+   on dialogue tags and action beats rather than alternation parity.
+4. Narration is the narrator. Non-dialogue prose — description, action,
+   scene-setting — is \`narrator\`, even between two characters' lines. Only words
+   inside quote marks belong to a character (unless the whole chapter is a
+   first-person document).
+5. The addressee is not the speaker. A name spoken to someone ("Careful,
+   Anton.") marks who is addressed, not who speaks — never attribute the line to
+   the person being addressed.`;
+```
+
+Copy rules 1, 2, 4, 5 (and the lead-in paragraph + header) **verbatim** from `STAGE2_ATTRIBUTION_RULES` — the drift-guard test enforces this. Only rule 3's text differs.
+
+- [ ] **Step 4: Run the test — expect PASS**
+
+Run: `cd server && npx vitest run src/routes/analysis.test.ts -t "chunk-variant attribution rules"`
+Expected: PASS (all three cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/routes/analysis.ts server/src/routes/analysis.test.ts
+git commit -m "feat(server): add chunk-variant STAGE2_ATTRIBUTION_RULES_CHUNK + drift guard (#1758)"
+```
+
+---
+
+### Task 2: Render the chunk rules block + last-speaker seed in `buildStage2ChunkInbox`
+
+Adds a `lastSpeakerId: string | null` parameter to the chunk builder, renders the chunk-variant rules block (Task 1) and the "Speaker at section start" seed, and flips the existing test that asserted the chunk builder omits the rules block. The one existing caller (`callForBody` in `analysis.ts`) is updated to pass `null` here — the real value arrives in Task 3.
+
+**Files:**
+- Modify: `server/src/routes/analysis.ts:1620-1685` (`buildStage2ChunkInbox` signature + body), and `analysis.ts:1806-1814` (the `buildStage2ChunkInbox` call inside `callForBody` — pass `null` for now)
+- Test: `server/src/routes/analysis.test.ts:3507` (flip the "does NOT render" case) + the ordering/seed assertions
+
+**Interfaces:**
+- Consumes: `STAGE2_ATTRIBUTION_RULES_CHUNK` (Task 1).
+- Produces: `buildStage2ChunkInbox(manuscriptId, title, stage1, chapter, subBody, precedingContext, firstPersonId, lastSpeakerId)` — the new 8th positional param `lastSpeakerId: string | null`. Prompt section order: roster → `## Attribution rules` → preceding-context → `## Speaker at section start` (only when `lastSpeakerId` non-null) → first-person → section body.
+
+- [ ] **Step 1: Flip / extend the builder test**
+
+In `server/src/routes/analysis.test.ts`, replace the existing case at line 3507 ("does NOT render the rules block in the chunk builder…") with the following, and note the `buildStage2ChunkInbox` call now passes an 8th arg:
+
+```ts
+  it('renders the chunk-variant rules block in the chunk builder (#1758)', () => {
+    const prompt = buildStage2ChunkInbox(
+      'm', 'Title', stage1, chapter, 'section text', 'prior tail', null, null,
+    );
+    expect(prompt).toContain('## Attribution rules');
+    expect(prompt).toContain('within this section'); // the rule-3 rewrite marker
+    // Order: roster → rules → preceding-context → section.
+    const characters = prompt.indexOf('## Characters (from stage 1)');
+    const rules = prompt.indexOf('## Attribution rules');
+    const context = prompt.indexOf('## Preceding context');
+    const section = prompt.indexOf('## Section to attribute');
+    expect(rules).toBeGreaterThan(characters);
+    expect(context).toBeGreaterThan(rules);
+    expect(section).toBeGreaterThan(context);
+  });
+
+  it('renders the last-speaker seed only when lastSpeakerId is provided (#1758)', () => {
+    const seeded = buildStage2ChunkInbox(
+      'm', 'Title', stage1, chapter, 'section text', 'prior tail', null, 'egor',
+    );
+    expect(seeded).toContain('## Speaker at section start');
+    expect(seeded).toContain('`egor`');
+    // Seed sits after preceding-context and before the section body.
+    expect(seeded.indexOf('## Speaker at section start')).toBeGreaterThan(
+      seeded.indexOf('## Preceding context'),
+    );
+    expect(seeded.indexOf('## Section to attribute')).toBeGreaterThan(
+      seeded.indexOf('## Speaker at section start'),
+    );
+
+    const unseeded = buildStage2ChunkInbox(
+      'm', 'Title', stage1, chapter, 'section text', 'prior tail', null, null,
+    );
+    expect(unseeded).not.toContain('## Speaker at section start');
+  });
+
+  it('renders the first-person block after the seed when both apply (#1758)', () => {
+    const prompt = buildStage2ChunkInbox(
+      'm', 'Title', stage1, chapter, 'section text', 'prior tail', 'anton', 'egor',
+    );
+    const seed = prompt.indexOf('## Speaker at section start');
+    const firstPerson = prompt.indexOf('## First-person narrator');
+    expect(seed).toBeGreaterThan(0);
+    expect(firstPerson).toBeGreaterThan(seed);
+  });
+```
+
+- [ ] **Step 2: Run it — expect FAIL**
+
+Run: `cd server && npx vitest run src/routes/analysis.test.ts -t "chunk"`
+Expected: FAIL — `buildStage2ChunkInbox` takes 7 args (TS arity error on the 8th) and renders neither the rules block nor the seed.
+
+- [ ] **Step 3: Add the param + render the block and seed**
+
+In `server/src/routes/analysis.ts`, change the `buildStage2ChunkInbox` signature (line 1620-1628) to append the new param:
+
+```ts
+export function buildStage2ChunkInbox(
+  manuscriptId: string,
+  title: string,
+  stage1: Stage1Output,
+  chapter: { id: number; title: string; body: string },
+  subBody: string,
+  precedingContext: string | null,
+  firstPersonId: string | null,
+  lastSpeakerId: string | null,
+): string {
+```
+
+Immediately after the `contextBlock` const (ends line 1639), add the seed block:
+
+```ts
+  const seedBlock = lastSpeakerId
+    ? `## Speaker at section start
+
+The last character to speak before this section was \`${lastSpeakerId}\`. Treat the
+first untagged quote in this section as continuing \`${lastSpeakerId}\`, unless a
+dialogue tag or action beat names a different speaker.
+
+`
+    : '';
+```
+
+Update the `## Characters` json block's trailing region and the return template so the rules block renders after the roster and the seed renders between preceding-context and first-person. The tail of the template (currently line 1680-1683) becomes:
+
+```ts
+\`\`\`
+
+${STAGE2_ATTRIBUTION_RULES_CHUNK}
+
+${contextBlock}${seedBlock}${firstPersonBlock}## Section to attribute (Chapter ${chapter.id} — ${chapter.title})
+
+${subBody}
+`;
+```
+
+(The `` ``` `` closing the characters json is already there — insert `${STAGE2_ATTRIBUTION_RULES_CHUNK}` on its own paragraph after it, mirroring how `buildStage2ChapterInbox` places `${STAGE2_ATTRIBUTION_RULES}` at line 1605.)
+
+Also update the stale comment above the function (line 1613-1619): it currently says "but NOT the attribution rules block — chapter-only". Change that clause to note the chunk builder now renders `STAGE2_ATTRIBUTION_RULES_CHUNK` + the last-speaker seed (#1758).
+
+- [ ] **Step 4: Update the one existing caller to pass `null`**
+
+In `attributeChapterStage2`'s `callForBody` closure (`analysis.ts:1806-1814`), the `buildStage2ChunkInbox(...)` call currently ends `..., preceding, firstPersonId)`. Append `, null` as the 8th arg for now (Task 3 replaces it with the real `lastSpeakerId`):
+
+```ts
+        : buildStage2ChunkInbox(
+            opts.manuscriptId,
+            opts.title,
+            stage1,
+            opts.chapter,
+            subBody,
+            preceding,
+            firstPersonId,
+            null,
+          );
+```
+
+- [ ] **Step 5: Run the builder tests + the drift guard — expect PASS**
+
+Run: `cd server && npx vitest run src/routes/analysis.test.ts -t "chunk"`
+Expected: PASS. Then confirm the untouched chapter-builder cases still pass:
+Run: `cd server && npx vitest run src/routes/analysis.test.ts -t "attribution rules block (Target C)"`
+Expected: PASS (chapter-builder order/content unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/routes/analysis.ts server/src/routes/analysis.test.ts
+git commit -m "feat(server): render chunk rules block + last-speaker seed in chunk inbox (#1758)"
+```
+
+---
+
+### Task 3: Thread `lastSpeakerId` through the chunk driver
+
+Widens the `callForBody` contract to a 3-arg signature, computes the last-established speaker after each chunk (last non-`narrator` id in that chunk's returned attributions, falling back to the incoming value on an all-narration chunk), threads it through both the top-level chunk loop and the adaptive re-split recursion, and forwards it from `analysis.ts`'s `callForBody` into `buildStage2ChunkInbox`. This is the task that makes the seed live.
+
+**Files:**
+- Modify: `server/src/analyzer/stage2-chunk.ts:264-267` (`callForBody` type), `:302-338` (`attributeSpan` recursion), `:345-358` (`runChunks` loop); add a `lastSpokenSpeaker` helper near `tailParagraphs` (~line 241)
+- Modify: `server/src/routes/analysis.ts:1802-1821` (`callForBody` closure signature + forward)
+- Test: `server/src/analyzer/stage2-chunk.test.ts` (new driver cases)
+
+**Interfaces:**
+- Consumes: `buildStage2ChunkInbox(..., lastSpeakerId)` (Task 2).
+- Produces: `Stage2ChunkRunOptions.callForBody: (subBody: string, precedingContext: string | null, lastSpeakerId: string | null) => Promise<{ sentences: SentenceOutput[] }>`. Helper `lastSpokenSpeaker(sentences: SentenceOutput[], incoming: string | null): string | null` — last `characterId !== 'narrator'`, else `incoming`.
+
+- [ ] **Step 1: Write the failing driver test**
+
+Append to `server/src/analyzer/stage2-chunk.test.ts`. Use a fake whose attribution depends on `subBody` so chunks yield distinct speakers, and capture the 3rd arg:
+
+```ts
+describe('lastSpeakerId threading (#1758)', () => {
+  /* Fake model: each paragraph "SPK:<id> …" is attributed to <id>; a paragraph
+     with no SPK prefix is narrator. Lets a test script who "spoke last" per chunk. */
+  function speakerAttribute(subBody: string): { sentences: SentenceOutput[] } {
+    const paras = subBody.split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
+    return {
+      sentences: paras.map((text, i) => ({
+        id: i + 1,
+        chapterId: 1,
+        characterId: text.startsWith('SPK:') ? text.slice(4).split(' ')[0] : 'narrator',
+        text,
+      })),
+    };
+  }
+
+  it('seeds chunk 2 with the last non-narrator speaker of chunk 1', async () => {
+    // Two paragraphs per chunk, budget forces a 2-chunk split.
+    const body = ['SPK:egor line one here', 'narration here between', 'SPK:anton line two here', 'more narration text']
+      .join('\n\n');
+    const seen: Array<string | null> = [];
+    const call = vi.fn(async (subBody: string, _p: string | null, seed: string | null) => {
+      seen.push(seed);
+      return speakerAttribute(subBody);
+    });
+    await runStage2ChapterChunked({ body, charBudget: 40, coverageRetries: 1, callForBody: call });
+    expect(seen[0]).toBeNull();          // first chunk: no seed
+    expect(seen[1]).toBe('egor');        // chunk 1's last spoken id
+  });
+
+  it('carries the prior speaker through an all-narration chunk', async () => {
+    const body = ['SPK:egor first spoken line', 'pure narration paragraph one', 'pure narration paragraph two']
+      .join('\n\n');
+    const seen: Array<string | null> = [];
+    const call = vi.fn(async (subBody: string, _p: string | null, seed: string | null) => {
+      seen.push(seed);
+      return speakerAttribute(subBody);
+    });
+    await runStage2ChapterChunked({ body, charBudget: 30, coverageRetries: 1, callForBody: call });
+    // Whatever chunk boundaries fall out, once egor has spoken every later chunk is seeded egor.
+    const afterEgor = seen.slice(1);
+    expect(afterEgor.every((s) => s === 'egor')).toBe(true);
+  });
+});
+```
+
+Extend the existing `import` from `./stage2-chunk.js` if `runStage2ChapterChunked` isn't already imported (it is, per the file head).
+
+- [ ] **Step 2: Run it — expect FAIL**
+
+Run: `cd server && npx vitest run src/analyzer/stage2-chunk.test.ts -t "lastSpeakerId threading"`
+Expected: FAIL — `call` receives only 2 args, so `seed` is `undefined` and `seen[1]` is `undefined`, not `'egor'`.
+
+- [ ] **Step 3: Add the helper and widen the `callForBody` type**
+
+In `server/src/analyzer/stage2-chunk.ts`, after `tailParagraphs` (line 241), add:
+
+```ts
+/** #1758 — the last non-`narrator` speaker in a chunk's returned attributions,
+    used to seed the next chunk's first untagged quote. Falls back to `incoming`
+    when the chunk added no spoken line, so a speaker established earlier carries
+    across an all-narration chunk. Reads the RAW model output (pre-crossExamine),
+    where the only non-speaker id is the literal 'narrator'. */
+export function lastSpokenSpeaker(
+  sentences: SentenceOutput[],
+  incoming: string | null,
+): string | null {
+  for (let i = sentences.length - 1; i >= 0; i -= 1) {
+    if (sentences[i].characterId !== 'narrator') return sentences[i].characterId;
+  }
+  return incoming;
+}
+```
+
+Widen the `callForBody` type (line 264-267):
+
+```ts
+  callForBody: (
+    subBody: string,
+    precedingContext: string | null,
+    lastSpeakerId: string | null,
+  ) => Promise<{ sentences: SentenceOutput[] }>;
+```
+
+- [ ] **Step 4: Thread the seed through `attributeSpan` and `runChunks`**
+
+`attributeSpan` (line 303) gains a `lastSpeakerId` param and forwards it; the recursion updates it from the sub-call's **returned** sentences (NOT from `tailParagraphs` — that derives from input text; the seed derives from output attributions):
+
+```ts
+  const attributeSpan = async (
+    span: string,
+    depth: number,
+    preceding: string | null,
+    lastSpeakerId: string | null,
+  ): Promise<SentenceOutput[]> => {
+    if (!hasAttributableContent(span)) return [];
+    try {
+      const { result } = await runStage2WithCoverageGuard({
+        body: span,
+        maxRetries: opts.coverageRetries,
+        call: () => opts.callForBody(span, preceding, lastSpeakerId),
+        thresholds: opts.coverageThresholds,
+        onRetry: opts.onRetry,
+      });
+      return result.sentences;
+    } catch (err) {
+      if (err instanceof AnalyzerTruncatedError && depth < maxSplitDepth) {
+        const sub = splitSpanForRetry(span);
+        if (sub.length > 1) {
+          const out: SentenceOutput[] = [];
+          let prev = preceding;
+          let seed = lastSpeakerId;
+          for (const s of sub) {
+            const part = await attributeSpan(s, depth + 1, prev, seed);
+            out.push(...part);
+            prev = tailParagraphs(s, contextParagraphs);
+            seed = lastSpokenSpeaker(part, seed);
+          }
+          return out;
+        }
+      }
+      throw err;
+    }
+  };
+```
+
+`runChunks` (line 345-358) threads the seed across chunks:
+
+```ts
+  const runChunks = async (chunks: string[]): Promise<Stage2ChunkRunResult> => {
+    const all: SentenceOutput[] = [];
+    let preceding: string | null = null;
+    let lastSpeakerId: string | null = null;
+    for (let i = 0; i < chunks.length; i += 1) {
+      opts.onChunk?.({ index: i, total: chunks.length, chars: chunks[i].length });
+      const sectionSentences = await attributeSpan(chunks[i], 0, preceding, lastSpeakerId);
+      opts.onSectionDone?.(i, sectionSentences.length);
+      all.push(...sectionSentences);
+      preceding = tailParagraphs(chunks[i], contextParagraphs);
+      lastSpeakerId = lastSpokenSpeaker(sectionSentences, lastSpeakerId);
+    }
+    const sentences = all.map((s, i) => ({ ...s, id: i + 1 }));
+    const coverage = validateStage2Coverage(opts.body, sentences, opts.coverageThresholds);
+    return { sentences, coverage, chunkCount: chunks.length };
+  };
+```
+
+The two single-call sites that pass `null` preceding also pass `null` seed:
+- Line 318 inside `attributeSpan` is already updated above.
+- The under-budget single-call path (line 377): `call: () => opts.callForBody(opts.body, null, null),`.
+
+- [ ] **Step 5: Forward the real seed from `analysis.ts`**
+
+In `attributeChapterStage2`'s `callForBody` closure (`analysis.ts:1802`), widen the closure signature and forward the seed to the chunk builder (replacing the `null` placeholder from Task 2):
+
+```ts
+  const callForBody = (subBody: string, preceding: string | null, lastSpeakerId: string | null) => {
+    const prompt =
+      preceding === null && subBody === opts.chapter.body
+        ? buildStage2ChapterInbox(opts.manuscriptId, opts.title, stage1, opts.chapter, firstPersonId)
+        : buildStage2ChunkInbox(
+            opts.manuscriptId,
+            opts.title,
+            stage1,
+            opts.chapter,
+            subBody,
+            preceding,
+            firstPersonId,
+            lastSpeakerId,
+          );
+    return opts.analyzer.runStage2Chapter(
+      opts.manuscriptId,
+      opts.chapter.id,
+      prompt,
+      opts.stageCall,
+    );
+  };
+```
+
+(The chapter-builder branch ignores `lastSpeakerId` — it only fires on the single-call path where the seed is `null` anyway.)
+
+- [ ] **Step 6: Run the driver tests + the full stage2-chunk + analysis suites**
+
+Run: `cd server && npx vitest run src/analyzer/stage2-chunk.test.ts src/routes/analysis.test.ts`
+Expected: PASS — the new threading cases plus all existing chunk/coverage/re-split cases (the added `callForBody` arg is optional-at-call for the existing 2-arg fakes because TS allows calling a 3-param function type only when the fakes match; the existing test fakes declare `(subBody, _preceding)` — verify they still satisfy the widened type, which they do since extra params are contravariantly ignorable for a value assigned to the wider type). If any existing fake is rejected by TS, add a `_seed?: string | null` param to it.
+
+- [ ] **Step 7: Typecheck the whole server**
+
+Run: `cd server && npm run typecheck` (or root `npm run typecheck`)
+Expected: clean — the `callForBody` signature change is internally consistent across `stage2-chunk.ts` and `analysis.ts`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add server/src/analyzer/stage2-chunk.ts server/src/analyzer/stage2-chunk.test.ts server/src/routes/analysis.ts
+git commit -m "feat(server): thread last-speaker seed through the stage-2 chunk driver (#1758)"
+```
+
+---
+
+### Task 4: On-box ch44 eval acceptance + docs
+
+Not a code task — the empirical gate the whole design turns on. Runs the attribution eval on the corpus box (corpus is local-only, absent on the general dev box) and records the numbers, then updates the regression plan + release notes. Per the spec's Measurement plan.
+
+**Files:**
+- Modify: `docs/features/265-attribution-eval-tuning.md` (append the #1758 cycle + captured ch44 numbers)
+- Modify: `docs/release-notes-next.md` + `RELEASE_NOTES.md` (gated on a measurable ch44 raw lift — append only if the win materialises)
+
+- [ ] **Step 1: Confirm the fixture set (spec step 0)**
+
+On the corpus-present box, confirm **ch44 is the sole chunked fixture** and note ch43's margin under the 9000-char budget (spec §Measurement caveat). If a second fixture now chunks, widen the gate to cover it before trusting "flat by construction".
+
+- [ ] **Step 2: Re-baseline on `main`**
+
+From a checkout on `main` (post-#1761) with the corpus present and Ollama up, run the eval `--runs 3` against `qwen36-cw-iq4-32k`; record per-fixture + ch44 `raw.byFamily`.
+
+- [ ] **Step 3: Run the treatment (this branch)**
+
+Same command on `feat/server-chunk-safe-attribution-rules`. Compare per the gate:
+- **ch44:** treatment mean `raw` ≥ baseline min (floor, no regression); ≥ baseline max = the win. Collapsed speaker-inference families hold at/above baseline min.
+- **Every other fixture:** flat within run-to-run noise (any real movement = an accidental chapter-builder change → bug, blocks ship).
+- **Secondary:** ch44 `det`/`final` do not regress vs post-#1761 baseline.
+
+- [ ] **Step 4: Bisect ONLY on failure**
+
+If hybrid-C does **not** recover ch44, run the one diagnostic config — **rules 1/2/4/5 in chunks, no rule #3, no seed** — to isolate whether the residual is rule-#3 parity (seed/wording needs work) or another rule misfiring on fragments (different fix). Do NOT run this up front.
+
+- [ ] **Step 5: Record + docs**
+
+Record the numbers in `docs/features/265-attribution-eval-tuning.md` (the #1758 cycle). If ch44 raw lifted measurably, append the user-facing release-notes line (large chunked chapters now get the same attribution rules as single-call ones) to `docs/release-notes-next.md` + `RELEASE_NOTES.md`. If the result is floor-only (no regression, no lift), say so and skip the release-notes entry (no user-visible delta).
+
+- [ ] **Step 6: Commit docs**
+
+```bash
+git add docs/features/265-attribution-eval-tuning.md docs/release-notes-next.md RELEASE_NOTES.md
+git commit -m "docs(server): record #1758 chunk-safe rules ch44 eval + release note"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 chunk-variant rules block → Task 1. ✓
+- §2 last-speaker seed → Task 2 (render) + Task 3 (compute). ✓
+- §3 plumbing (callForBody 3-arg, runChunks loop, re-split recursion nuance = derive from returned sentences not input text) → Task 3, Step 4 (explicit `lastSpokenSpeaker(part, seed)` in the recursion, distinct from `prev = tailParagraphs(...)`). ✓
+- §4 rules structure (separate constant + drift guard) → Task 1. ✓
+- Testing: builder test flip → Task 2 Step 1; drift guard → Task 1; driver test (incl. all-narration carry + re-split) → Task 3; chapter-builder regression guard → Task 2 Step 5 (existing Target C cases re-run). ✓
+- Measurement plan + isolation bisect → Task 4. ✓
+- Export requirement for drift guard → Task 1 Step 3 (both constants exported). ✓
+- Positional-arg shift caveat → Task 2 (append as 8th arg; test call sites updated). ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows the actual code. Task 4 is intentionally an on-box acceptance (live model) — its "numbers" are recorded at run time, which is the nature of the eval gate, not a placeholder.
+
+**Type consistency:** `lastSpeakerId: string | null` used identically in `buildStage2ChunkInbox`, the `callForBody` closure, the `Stage2ChunkRunOptions.callForBody` type, `attributeSpan`, and `runChunks`. Helper `lastSpokenSpeaker(sentences, incoming)` name matches across its definition (Task 3 Step 3) and both call sites (Step 4). `STAGE2_ATTRIBUTION_RULES_CHUNK` spelled identically in Task 1 (def) and Task 2 (render).
+
+**One risk to watch during execution (Task 3 Step 6):** the existing chunk-runner test fakes are typed `(subBody, _preceding)`. Assigning a 2-param function to a 3-param function *type* is legal in TS (fewer params is assignable), so they should compile unchanged; the note in Step 6 covers the fallback if not.

--- a/docs/superpowers/plans/2026-07-22-chunk-safe-attribution-rules.md
+++ b/docs/superpowers/plans/2026-07-22-chunk-safe-attribution-rules.md
@@ -39,14 +39,9 @@ Adds the second rules constant with only rule #3 rewritten, exports both constan
 
 - [ ] **Step 1: Write the failing drift-guard + shape test**
 
-Append to `server/src/routes/analysis.test.ts`. Import both constants (add to the existing import from `./analysis.js` — check the top-of-file import list and extend it):
+Append to `server/src/routes/analysis.test.ts`. `buildStage2ChapterInbox` / `buildStage2ChunkInbox` are already named-imported from `./analysis.js` (~lines 34-36) — **fold** `STAGE2_ATTRIBUTION_RULES` and `STAGE2_ATTRIBUTION_RULES_CHUNK` into that existing import block; do NOT add a second `import … from './analysis.js'` statement. Then append the suite:
 
 ```ts
-import {
-  STAGE2_ATTRIBUTION_RULES,
-  STAGE2_ATTRIBUTION_RULES_CHUNK,
-} from './analysis.js';
-
 describe('chunk-variant attribution rules (#1758)', () => {
   // Extract the numbered rule bodies "N. …" up to the next "\nN. " boundary.
   function rule(block: string, n: number): string {
@@ -294,7 +289,7 @@ git commit -m "feat(server): render chunk rules block + last-speaker seed in chu
 Widens the `callForBody` contract to a 3-arg signature, computes the last-established speaker after each chunk (last non-`narrator` id in that chunk's returned attributions, falling back to the incoming value on an all-narration chunk), threads it through both the top-level chunk loop and the adaptive re-split recursion, and forwards it from `analysis.ts`'s `callForBody` into `buildStage2ChunkInbox`. This is the task that makes the seed live.
 
 **Files:**
-- Modify: `server/src/analyzer/stage2-chunk.ts:264-267` (`callForBody` type), `:302-338` (`attributeSpan` recursion), `:345-358` (`runChunks` loop); add a `lastSpokenSpeaker` helper near `tailParagraphs` (~line 241)
+- Modify: `server/src/analyzer/stage2-chunk.ts:264-267` (`callForBody` type), `:303-338` (`attributeSpan` recursion), `:345-358` (`runChunks` loop); add a `lastSpokenSpeaker` helper near `tailParagraphs` (~line 241)
 - Modify: `server/src/routes/analysis.ts:1802-1821` (`callForBody` closure signature + forward)
 - Test: `server/src/analyzer/stage2-chunk.test.ts` (new driver cases)
 

--- a/docs/superpowers/specs/2026-07-22-chunk-safe-attribution-rules-design.md
+++ b/docs/superpowers/specs/2026-07-22-chunk-safe-attribution-rules-design.md
@@ -1,0 +1,226 @@
+# Chunk-safe stage-2 attribution rules (#1758 / srv-63) — Design
+
+**Status:** draft (awaiting user approval → writing-plans → SDD)
+**Date:** 2026-07-22
+**Author:** design thread (follow-up to PR #1761 Target C)
+**Related:** [[project_attribution_eval_qwen_baseline]], issue #1758 (srv-63),
+Target C spec `docs/superpowers/specs/2026-07-21-target-c-stage2-attribution-prompt-design.md`,
+regression plan `docs/features/265-attribution-eval-tuning.md`
+
+## Goal
+
+Get the stage-2 `STAGE2_ATTRIBUTION_RULES` block — which Target C (#1761) ships
+into the whole-chapter builder only — into the **chunk** builder as well,
+**without** re-introducing the cross-boundary regression that forced Target C to
+narrow to chapter-only. The win is confined to chapters large enough to chunk;
+in the eval corpus that is **ch44 alone**, so this raises ch44's `raw`
+attribution toward the chapter-only fixtures' gains while leaving every
+single-call fixture untouched.
+
+## Background — why the block is chapter-only today
+
+Target C's on-box eval (`--runs 3`, targets `qwen36-cw-iq4-32k`,
+`gemma-4-31b-it`, `gemini-3.1-flash-lite`) found that injecting the rules block
+into **both** stage-2 builders lifted the single-call chapters (Qwen raw ch45
++3.5, ch46 +0.8) but **regressed ch44 −2.5** — the only chunked fixture — with a
+**broad drop across every speaker-inference family** (narration held). Root
+cause: **rule #3**, "untagged quotes continue, and two-handers alternate."
+
+`buildStage2ChunkInbox` sends the model one *section* of a large chapter at a
+time. Rule #3 tells the model to alternate a sustained two-hander, but a chunk
+that opens mid-conversation has no in-band anchor for the alternation **parity**
+(who spoke last). The model re-derives parity from scratch and, when it guesses
+the offset wrong, flips the speaker for the *entire* run of alternating lines in
+that chunk — hence the broad-family collapse. Target C shipped the block
+chapter-only (ch44 recovered to baseline 82.6) and filed #1758 to design a
+chunk-safe variant.
+
+## The enabling fact — chunks are dispatched sequentially
+
+`runStage2ChapterChunked` (`server/src/analyzer/stage2-chunk.ts:347–353`)
+processes chunks **in order**, carrying the prior chunk's tail forward:
+
+```ts
+let preceding: string | null = null;
+for (let i = 0; i < chunks.length; i += 1) {
+  const sectionSentences = await attributeSpan(chunks[i], 0, preceding);
+  // …accumulate…
+  preceding = tailParagraphs(chunks[i], contextParagraphs);
+}
+```
+
+Two consequences the design leans on:
+
+1. By the time chunk *i+1*'s prompt is built, chunk *i*'s **attributions**
+   (`sectionSentences`, `SentenceOutput[]` with `characterId`) already exist —
+   the last-established speaker is deterministically in hand.
+2. The prompt already carries a `precedingContext` **text** block
+   (`buildStage2ChunkInbox`, `analysis.ts:1629`) — the prior chunk's tail
+   paragraphs — "provided ONLY so you can carry a speaker across the boundary."
+   But it hands the model the tail *prose*, not the *fact* of who last spoke; the
+   model still has to re-infer it. The seed closes exactly that gap.
+
+The eval observed the both-builders ch44 regression **through this same driver**,
+so a change here is exercised by the eval automatically — no separate harness
+wiring for the chunk path.
+
+## Design (hybrid: boundary-safe rule #3 + last-speaker seed)
+
+### 1. Chunk-variant rules block
+
+A `STAGE2_ATTRIBUTION_RULES_CHUNK` constant, module-level in `analysis.ts`
+beside `STAGE2_ATTRIBUTION_RULES`. Rules **1, 2, 4, 5 are byte-identical** to the
+shipped chapter block — all four are boundary-safe (explicit tag, action beat,
+narration, addressee) and are the high-value rules the chapter-only ship
+currently denies chunks. Only **rule #3** is rewritten to scope
+continuation/alternation *within the section*:
+
+```
+3. Untagged quotes continue, and two-handers alternate — within this section.
+   An untagged quote keeps the last speaker established here (or the "Speaker at
+   section start" named below, for the first quote). Do NOT assume a two-hander's
+   alternation carries in from before this section's start; near the start, rely
+   on dialogue tags and action beats rather than alternation parity.
+```
+
+The failure mode (cross-boundary parity flip) is designed out by wording, not
+merely mitigated: the model is told the alternation does not carry across the
+seam.
+
+### 2. Last-speaker seed
+
+When a preceding chunk exists **and** it produced a spoken line, inject a small
+block (rendered only when a seed id is present):
+
+```
+## Speaker at section start
+
+The last character to speak before this section was `X`. Treat the first
+untagged quote in this section as continuing `X`, unless a dialogue tag or
+action beat names a different speaker.
+```
+
+- **Computed as:** the `characterId` of the **last non-`narrator` sentence** in
+  the immediately-preceding chunk's attributions. `null` (block omitted) when the
+  prior chunk was pure narration or this is the first chunk. Rule #1 ("a tag is
+  decisive") overrides the seed, so a stale/wrong seed only affects genuinely
+  untagged lines right at the boundary — a deliberately small blast radius.
+- **Deliberately no parity seed.** Seeding two-hander alternation parity is the
+  fragile part of the rejected approach B; a wrong parity seed flips a whole run.
+  The last-speaker seed only powers rule #3's *continuation* clause, not its
+  alternation clause. Alternation, cross-boundary, is simply disclaimed.
+
+### 3. Plumbing
+
+Thread a `lastSpeakerId: string | null` alongside the existing `preceding` text,
+mirroring how `preceding` is already carried and updated:
+
+- **`stage2-chunk.ts`** — extend `RunStage2ChunkedOpts.callForBody` to
+  `(subBody, precedingContext, lastSpeakerId) => …`. In the driver loop, after
+  each chunk, compute `lastSpeakerId` = last non-`narrator` `characterId` in that
+  chunk's `sectionSentences`, **falling back to the incoming value** when the
+  chunk added no spoken line (so a speaker established two chunks back still
+  carries across an all-narration chunk). Pass it into the next
+  `attributeSpan(...)`. Thread it through the **adaptive re-split recursion**
+  (`attributeSpan`, `stage2-chunk.ts:328–331`) the same way `prev` is updated per
+  sub-section, so a split chunk seeds its sub-sections correctly.
+- **`analysis.ts`** — `callForBody` passes `lastSpeakerId` into
+  `buildStage2ChunkInbox`; the builder gains a `lastSpeakerId: string | null`
+  parameter and renders the seed block (§2) and the chunk-variant rules block
+  (§1). `buildStage2ChapterInbox` is **untouched** — it never chunks, so it keeps
+  the shipped chapter rules block.
+
+No change to the JSON output contract, the roster, or the chapter-builder path.
+
+### 4. Rules-block structure (implementation detail)
+
+Lean choice: a **separate `STAGE2_ATTRIBUTION_RULES_CHUNK` constant** plus a unit
+test asserting rules 1/2/4/5 are textually identical across the two constants
+(drift guard). The alternative — factoring rule #3 out as a parameter of a shared
+builder — is also fine; the drift-guard test makes the small duplication safe
+either way. Settled in the plan, not a design fork.
+
+## Measurement plan
+
+Deciding metric: **`raw`** recall (pre-crossExamine), `--runs 3`, same harness
+and gate shape as Target C. This change is **structurally confined to ch44**: the
+chunk builder only runs on bodies over the ~9000-char budget, and ch44 (~18.4k)
+is the sole such fixture (ch43 8.85k, ch45 3.1k, ch46 4.6k, Coalfall 3.4k are all
+single-call — see Target C spec "Chunking"). So the gate is unusually tight:
+
+- **ch44 (the target):** treatment mean `raw` **≥ shipped chapter-only baseline
+  min** is the floor (no regression); the goal is to recover the chunk share of
+  the both-builders ch45/ch46-style gains — treatment mean `raw` **≥ baseline
+  max** counts as the win. The per-family split (Target C's `raw.byFamily`, now
+  populated) must show the speaker-inference families that collapsed under
+  both-builders **holding at or above their baseline min** — that is the exact
+  regression signature this design targets.
+- **Every other fixture (ch43/45/46/Coalfall):** **flat by construction** — their
+  prompt is the untouched chapter builder. Any movement beyond run-to-run noise
+  is a bug (an accidental chapter-builder change) and blocks ship.
+- **Secondary:** `det`/`final` on ch44 do not regress vs the post-#1761 baseline
+  (same band rule).
+- **Targets:** local `qwen36-cw-iq4-32k` is the primary decision gate (ch44's
+  regression was Qwen-only; cloud was flat there). Cloud `gemma-4-31b-it` /
+  `gemini-3.1-flash-lite` are confirmatory — run if the free-tier budget/time
+  allows, but a Qwen-green result ships (cloud was already flat on ch44 under
+  both-builders, so it has little to say here).
+
+Baseline = current `main` (chapter-only, post-#1761). Treatment = this branch.
+Re-baseline fresh in-session (seed/quant drift). Run from a checkout with the
+corpus present (`server/src/analyzer/attribution-eval/corpus/`) and Ollama up.
+
+## Testing
+
+- **`buildStage2ChunkInbox` unit test (rewrite the existing one).** The current
+  test asserts the rules block is *absent* from the chunk builder (Target C's
+  chapter-only invariant). Flip it: assert (a) the chunk-variant block **is**
+  present; (b) rule #3 uses the within-section wording (no unqualified
+  "alternation carries"); (c) the "Speaker at section start" block renders with
+  `X` when `lastSpeakerId` is given and is **omitted** when `null`; (d) the
+  first-person block still renders alongside the seed when both apply; (e)
+  ordering (roster → rules → preceding-context → seed → first-person → body).
+- **Drift-guard unit test.** Rules 1/2/4/5 are textually identical between
+  `STAGE2_ATTRIBUTION_RULES` and `STAGE2_ATTRIBUTION_RULES_CHUNK`.
+- **`stage2-chunk.ts` driver unit test.** With a stubbed `callForBody` capturing
+  its args: across a two-chunk body, chunk 2 receives `lastSpeakerId` = the last
+  non-narrator id of chunk 1; an all-narration middle chunk carries the prior
+  speaker through; the value threads into an adaptive re-split's sub-sections.
+- **Chapter-builder regression guard.** A test (or reuse of Target C's) pinning
+  that `buildStage2ChapterInbox` output is unchanged by this work.
+- **On-box acceptance (not CI):** the ch44 `raw --runs 3` eval above — live model,
+  manual/on-box gate, recorded in the plan and `docs/features/265`.
+
+## Risks
+
+- **Seed error propagation** — a wrong last-speaker id seeds the next chunk's
+  first untagged quote. Bounded: rule #1 overrides it, and it touches only
+  genuinely-untagged boundary lines. The eval's ch44 per-family gate is the guard.
+- **Chunk-variant drift** — two rules constants can diverge silently. Mitigated by
+  the drift-guard test on rules 1/2/4/5.
+- **Thin chunk-path coverage** — ch44 is the *only* chunked fixture, so the gate
+  rests on one chapter. Accepted (same limitation Target C shipped under); the
+  RU/DE follow-up (#1759) and any future large fixtures widen it later. If ch44
+  proves too thin to call, the plan may lower the eval chunk budget so ch43 also
+  chunks (Target C's noted option) — a measurement tweak, not a design change.
+- **Prompt length on the iq4 quant** — the chunk block + seed add ~18 lines ×
+  chunk count. Negligible vs body; the no-regression gate catches a net loss.
+
+## Rollout
+
+Single `feat/server-chunk-safe-attribution-rules` branch off latest `main`
+(already cut), SDD implementation (chunk-variant constant + seed block + the
+`lastSpeakerId` threading through `stage2-chunk.ts`/`analysis.ts` + the tests
+above), on-box ch44 eval as acceptance, PR with `Closes #1758`, mandatory
+code-review gate, merge. Update `docs/features/265-attribution-eval-tuning.md`
+with the #1758 cycle and captured ch44 numbers; release-notes entry gated on a
+measurable user-visible delta (a ch44 raw-attribution lift qualifies — large
+chunked chapters now get the same rules the single-call ones already do).
+
+## Out of scope
+
+- **Two-hander parity seed** (rejected approach B's fragile half) — revisit only
+  as a measured follow-up if ch44 still leaves alternation gains after this.
+- **Deterministic-first phase-2 / crossExamine strong-tag softening** — the
+  separately-sequenced next item, not this work.
+- **RU/DE fixtures (#1759)** — the language axis; tracked separately.

--- a/docs/superpowers/specs/2026-07-22-chunk-safe-attribution-rules-design.md
+++ b/docs/superpowers/specs/2026-07-22-chunk-safe-attribution-rules-design.md
@@ -35,6 +35,20 @@ that chunk — hence the broad-family collapse. Target C shipped the block
 chapter-only (ch44 recovered to baseline 82.6) and filed #1758 to design a
 chunk-safe variant.
 
+**The rule-#3 attribution is inferred, not experimentally isolated
+(assumption-check, IMPORTANT).** Target C's eval compared the *whole* block
+(both-builders) against *no* block (chapter-only); it never ran "rules 1/2/4/5
+in chunks but not #3," so "rule #3 specifically" is a structural inference, not
+a measured result. The inference is well-grounded: of the five rules, #3 is the
+**only** one with cross-boundary/stateful semantics ("keeps the last established
+speaker", "alternate") — rules 1 (tag), 2 (same-paragraph action beat), 4
+(narration), 5 (addressee) are all locally decidable within a fragment. But the
+design's core bet (keep 1/2/4/5 verbatim, rewrite only #3) rests on that
+inference. The mitigation is empirical, not argumentative: **the ch44 per-family
+`raw` gate is the real hypothesis test** — if hybrid-C recovers ch44 and the
+previously-collapsed families hold, the inference is confirmed; if it does not,
+the Measurement plan's isolation bisect locates the true culprit before ship.
+
 ## The enabling fact — chunks are dispatched sequentially
 
 `runStage2ChapterChunked` (`server/src/analyzer/stage2-chunk.ts:347–353`)
@@ -122,8 +136,13 @@ mirroring how `preceding` is already carried and updated:
   chunk added no spoken line (so a speaker established two chunks back still
   carries across an all-narration chunk). Pass it into the next
   `attributeSpan(...)`. Thread it through the **adaptive re-split recursion**
-  (`attributeSpan`, `stage2-chunk.ts:328–331`) the same way `prev` is updated per
-  sub-section, so a split chunk seeds its sub-sections correctly.
+  (`attributeSpan`, `stage2-chunk.ts:327–332`) so a split chunk seeds its
+  sub-sections correctly. **Nuance (assumption-check):** unlike `prev`, the
+  updated `lastSpeakerId` is *not* a byte-mirror of the input helper — `prev =
+  tailParagraphs(s, …)` derives from the sub-section's input *text*, whereas
+  `lastSpeakerId` must derive from that sub-call's **returned** attributed
+  sentences (last non-`narrator` `characterId` of the returned slice, falling
+  back to the incoming value). Don't copy the `prev` update line verbatim.
 - **`analysis.ts`** — `callForBody` passes `lastSpeakerId` into
   `buildStage2ChunkInbox`; the builder gains a `lastSpeakerId: string | null`
   parameter and renders the seed block (§2) and the chunk-variant rules block
@@ -157,7 +176,14 @@ single-call — see Target C spec "Chunking"). So the gate is unusually tight:
   regression signature this design targets.
 - **Every other fixture (ch43/45/46/Coalfall):** **flat by construction** — their
   prompt is the untouched chapter builder. Any movement beyond run-to-run noise
-  is a bug (an accidental chapter-builder change) and blocks ship.
+  is a bug (an accidental chapter-builder change) and blocks ship. **Caveat
+  (assumption-check):** "flat by construction" holds only while each stays under
+  the 9000-char budget. ch43 (~8.85k) sits only ~150 chars under it — a config
+  drift (`numCtx`, `localInputFraction`) or a larger ch43 tips it into chunking.
+  **Fixture char counts are UNVERIFIABLE off-corpus** (the corpus dir is
+  local-only, absent on this box); re-confirm ch44-is-sole-chunked — and ch43's
+  margin — on the corpus-present box as step 0 of the eval, before trusting the
+  gate.
 - **Secondary:** `det`/`final` on ch44 do not regress vs the post-#1761 baseline
   (same band rule).
 - **Targets:** local `qwen36-cw-iq4-32k` is the primary decision gate (ch44's
@@ -165,6 +191,16 @@ single-call — see Target C spec "Chunking"). So the gate is unusually tight:
   `gemini-3.1-flash-lite` are confirmatory — run if the free-tier budget/time
   allows, but a Qwen-green result ships (cloud was already flat on ch44 under
   both-builders, so it has little to say here).
+
+- **Ship logic + isolation bisect (assumption-check).** Hybrid-C green on ch44
+  (mean `raw` ≥ baseline min, collapsed families recovered) → **ship**; the
+  rule-#3 root cause is thereby confirmed and no isolation run is needed. Hybrid-C
+  **fails** to recover ch44 → run one cheap local-Qwen diagnostic config,
+  **rules 1/2/4/5 in chunks with no rule #3 and no seed**, to isolate whether the
+  residual is rule-#3 parity (→ the seed/wording needs more work) or one of the
+  other four rules misfiring on fragments (→ a different fix). This is a
+  bisect-only-on-failure step, mirroring Target C's "bisect to per-lever only if
+  the block regresses" — not run up front.
 
 Baseline = current `main` (chapter-only, post-#1761). Treatment = this branch.
 Re-baseline fresh in-session (seed/quant drift). Run from a checkout with the
@@ -180,8 +216,17 @@ corpus present (`server/src/analyzer/attribution-eval/corpus/`) and Ollama up.
   `X` when `lastSpeakerId` is given and is **omitted** when `null`; (d) the
   first-person block still renders alongside the seed when both apply; (e)
   ordering (roster → rules → preceding-context → seed → first-person → body).
+  **Note (assumption-check):** `buildStage2ChunkInbox` is called *positionally*
+  (7 args today at `analysis.test.ts:3514`); adding `lastSpeakerId` shifts the
+  signature — choose the insertion point deliberately (append is safest) and
+  update that call. Keep the `## Attribution rules` header identical so the
+  flipped `.toContain(...)` assertion needs only its polarity changed.
 - **Drift-guard unit test.** Rules 1/2/4/5 are textually identical between
-  `STAGE2_ATTRIBUTION_RULES` and `STAGE2_ATTRIBUTION_RULES_CHUNK`.
+  `STAGE2_ATTRIBUTION_RULES` and `STAGE2_ATTRIBUTION_RULES_CHUNK`. **Requires an
+  export:** `STAGE2_ATTRIBUTION_RULES` is currently module-private
+  (`analysis.ts:1532`) — export both constants for a direct text-equality
+  assertion, or assert equality via the two *rendered* prompts (no new export).
+  Plan picks one.
 - **`stage2-chunk.ts` driver unit test.** With a stubbed `callForBody` capturing
   its args: across a two-chunk body, chunk 2 receives `lastSpeakerId` = the last
   non-narrator id of chunk 1; an all-narration middle chunk carries the prior

--- a/server/src/analyzer/stage2-chunk.test.ts
+++ b/server/src/analyzer/stage2-chunk.test.ts
@@ -15,6 +15,7 @@ import {
   resolveStage2ChunkCharBudget,
   tailParagraphs,
   runStage2ChapterChunked,
+  lastSpokenSpeaker,
 } from './stage2-chunk.js';
 
 /* A fake "model": one sentence per paragraph, text copied verbatim so the
@@ -512,17 +513,65 @@ describe('lastSpeakerId threading (#1758)', () => {
     expect(seen[1]).toBe('egor');        // chunk 1's last spoken id
   });
 
-  it('carries the prior speaker through an all-narration chunk', async () => {
-    const body = ['SPK:egor first spoken line', 'pure narration paragraph one', 'pure narration paragraph two']
-      .join('\n\n');
+  it('carries the prior speaker through an all-narration MIDDLE chunk', async () => {
+    /* Empirically verified (chunk-boundary probe via splitBodyIntoChunks, see
+       the #1758 fix report) that this body splits into exactly 3 chunks at
+       charBudget=150 — [spoken, all-narration, narration] — with the middle
+       chunk PURELY narration and long enough (>= STAGE2_MIN_EVALUABLE_WORDS
+       attributable words) to survive mergeTinyChunks as its OWN isolated
+       chunk rather than being folded into a neighbour. That makes seen[2]
+       (chunk 2's seed) genuinely exercise lastSpokenSpeaker's `return
+       incoming` fallback branch — chunk 1 contributes no spoken line, so
+       chunk 2 must be seeded from what chunk 0 established, not from chunk 1. */
+    const body = [
+      'SPK:egor Egor turned toward the door and said something important before leaving the room quietly tonight.',
+      'The hallway stretched long and silent, dust motes drifting through a single shaft of pale evening light that fell across the worn floorboards near the far wall.',
+      'Somewhere below a clock ticked steadily, marking each second as the old house settled into its familiar nighttime creaks and quiet groaning timbers.',
+    ].join('\n\n');
     const seen: Array<string | null> = [];
     const call = vi.fn(async (subBody: string, _p: string | null, seed: string | null) => {
       seen.push(seed);
       return speakerAttribute(subBody);
     });
-    await runStage2ChapterChunked({ body, charBudget: 30, coverageRetries: 1, callForBody: call });
-    // Whatever chunk boundaries fall out, once egor has spoken every later chunk is seeded egor.
-    const afterEgor = seen.slice(1);
-    expect(afterEgor.every((s) => s === 'egor')).toBe(true);
+    const result = await runStage2ChapterChunked({
+      body,
+      charBudget: 150,
+      coverageRetries: 1,
+      callForBody: call,
+    });
+    expect(result.chunkCount).toBe(3); // pins the 3-chunk split the fallback branch needs
+    // seen[2] is the fallback assertion: chunk 1 (all-narration) added no spoken
+    // line, so chunk 2 must still be seeded 'egor' — carried through, not reset.
+    expect(seen).toEqual([null, 'egor', 'egor']);
+  });
+});
+
+describe('lastSpokenSpeaker (#1758)', () => {
+  function mkSentence(id: number, characterId: string): SentenceOutput {
+    return { id, chapterId: 1, characterId, text: `sentence ${id}` };
+  }
+
+  it('returns the last non-narrator speaker id', () => {
+    const sentences = [
+      mkSentence(1, 'egor'),
+      mkSentence(2, 'narrator'),
+      mkSentence(3, 'anton'),
+      mkSentence(4, 'narrator'),
+    ];
+    expect(lastSpokenSpeaker(sentences, null)).toBe('anton');
+  });
+
+  it('falls back to incoming when the chunk is all-narration', () => {
+    const sentences = [mkSentence(1, 'narrator'), mkSentence(2, 'narrator')];
+    expect(lastSpokenSpeaker(sentences, 'egor')).toBe('egor');
+  });
+
+  it('falls back to incoming on an empty sentence list', () => {
+    expect(lastSpokenSpeaker([], 'egor')).toBe('egor');
+  });
+
+  it('returns null when all-narration and incoming is null', () => {
+    const sentences = [mkSentence(1, 'narrator')];
+    expect(lastSpokenSpeaker(sentences, null)).toBeNull();
   });
 });

--- a/server/src/analyzer/stage2-chunk.test.ts
+++ b/server/src/analyzer/stage2-chunk.test.ts
@@ -482,3 +482,47 @@ describe('onSectionDone', () => {
     expect(calls).toEqual([[0, 2]]);
   });
 });
+
+describe('lastSpeakerId threading (#1758)', () => {
+  /* Fake model: each paragraph "SPK:<id> …" is attributed to <id>; a paragraph
+     with no SPK prefix is narrator. Lets a test script who "spoke last" per chunk. */
+  function speakerAttribute(subBody: string): { sentences: SentenceOutput[] } {
+    const paras = subBody.split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
+    return {
+      sentences: paras.map((text, i) => ({
+        id: i + 1,
+        chapterId: 1,
+        characterId: text.startsWith('SPK:') ? text.slice(4).split(' ')[0] : 'narrator',
+        text,
+      })),
+    };
+  }
+
+  it('seeds chunk 2 with the last non-narrator speaker of chunk 1', async () => {
+    // Two paragraphs per chunk, budget forces a 2-chunk split.
+    const body = ['SPK:egor line one here', 'narration here between', 'SPK:anton line two here', 'more narration text']
+      .join('\n\n');
+    const seen: Array<string | null> = [];
+    const call = vi.fn(async (subBody: string, _p: string | null, seed: string | null) => {
+      seen.push(seed);
+      return speakerAttribute(subBody);
+    });
+    await runStage2ChapterChunked({ body, charBudget: 40, coverageRetries: 1, callForBody: call });
+    expect(seen[0]).toBeNull();          // first chunk: no seed
+    expect(seen[1]).toBe('egor');        // chunk 1's last spoken id
+  });
+
+  it('carries the prior speaker through an all-narration chunk', async () => {
+    const body = ['SPK:egor first spoken line', 'pure narration paragraph one', 'pure narration paragraph two']
+      .join('\n\n');
+    const seen: Array<string | null> = [];
+    const call = vi.fn(async (subBody: string, _p: string | null, seed: string | null) => {
+      seen.push(seed);
+      return speakerAttribute(subBody);
+    });
+    await runStage2ChapterChunked({ body, charBudget: 30, coverageRetries: 1, callForBody: call });
+    // Whatever chunk boundaries fall out, once egor has spoken every later chunk is seeded egor.
+    const afterEgor = seen.slice(1);
+    expect(afterEgor.every((s) => s === 'egor')).toBe(true);
+  });
+});

--- a/server/src/analyzer/stage2-chunk.ts
+++ b/server/src/analyzer/stage2-chunk.ts
@@ -240,6 +240,21 @@ export function tailParagraphs(text: string, n: number): string {
   return paras.slice(-Math.max(0, n)).join('\n\n');
 }
 
+/** #1758 — the last non-`narrator` speaker in a chunk's returned attributions,
+    used to seed the next chunk's first untagged quote. Falls back to `incoming`
+    when the chunk added no spoken line, so a speaker established earlier carries
+    across an all-narration chunk. Reads the RAW model output (pre-crossExamine),
+    where the only non-speaker id is the literal 'narrator'. */
+export function lastSpokenSpeaker(
+  sentences: SentenceOutput[],
+  incoming: string | null,
+): string | null {
+  for (let i = sentences.length - 1; i >= 0; i -= 1) {
+    if (sentences[i].characterId !== 'narrator') return sentences[i].characterId;
+  }
+  return incoming;
+}
+
 export interface Stage2ChunkRunResult {
   sentences: SentenceOutput[];
   /** Combined coverage verdict against the FULL chapter body. */
@@ -264,6 +279,7 @@ export interface Stage2ChunkRunOptions {
   callForBody: (
     subBody: string,
     precedingContext: string | null,
+    lastSpeakerId: string | null,
   ) => Promise<{ sentences: SentenceOutput[] }>;
   /** Preceding-context paragraph count. Default 2. */
   contextParagraphs?: number;
@@ -304,6 +320,7 @@ export async function runStage2ChapterChunked(
     span: string,
     depth: number,
     preceding: string | null,
+    lastSpeakerId: string | null,
   ): Promise<SentenceOutput[]> => {
     /* A span with no attributable words (a lone "***" scene break isolated
        between two over-budget paragraphs) has nothing to attribute. Skip it:
@@ -315,7 +332,7 @@ export async function runStage2ChapterChunked(
       const { result } = await runStage2WithCoverageGuard({
         body: span,
         maxRetries: opts.coverageRetries,
-        call: () => opts.callForBody(span, preceding),
+        call: () => opts.callForBody(span, preceding, lastSpeakerId),
         thresholds: opts.coverageThresholds,
         onRetry: opts.onRetry,
       });
@@ -326,9 +343,12 @@ export async function runStage2ChapterChunked(
         if (sub.length > 1) {
           const out: SentenceOutput[] = [];
           let prev = preceding;
+          let seed = lastSpeakerId;
           for (const s of sub) {
-            out.push(...(await attributeSpan(s, depth + 1, prev)));
+            const part = await attributeSpan(s, depth + 1, prev, seed);
+            out.push(...part);
             prev = tailParagraphs(s, contextParagraphs);
+            seed = lastSpokenSpeaker(part, seed);
           }
           return out;
         }
@@ -345,12 +365,14 @@ export async function runStage2ChapterChunked(
   const runChunks = async (chunks: string[]): Promise<Stage2ChunkRunResult> => {
     const all: SentenceOutput[] = [];
     let preceding: string | null = null;
+    let lastSpeakerId: string | null = null;
     for (let i = 0; i < chunks.length; i += 1) {
       opts.onChunk?.({ index: i, total: chunks.length, chars: chunks[i].length });
-      const sectionSentences = await attributeSpan(chunks[i], 0, preceding);
+      const sectionSentences = await attributeSpan(chunks[i], 0, preceding, lastSpeakerId);
       opts.onSectionDone?.(i, sectionSentences.length);
       all.push(...sectionSentences);
       preceding = tailParagraphs(chunks[i], contextParagraphs);
+      lastSpeakerId = lastSpokenSpeaker(sectionSentences, lastSpeakerId);
     }
     const sentences = all.map((s, i) => ({ ...s, id: i + 1 }));
     const coverage = validateStage2Coverage(opts.body, sentences, opts.coverageThresholds);
@@ -374,7 +396,7 @@ export async function runStage2ChapterChunked(
       const { result, coverage } = await runStage2WithCoverageGuard({
         body: opts.body,
         maxRetries: opts.coverageRetries,
-        call: () => opts.callForBody(opts.body, null),
+        call: () => opts.callForBody(opts.body, null, null),
         thresholds: opts.coverageThresholds,
         onRetry: opts.onRetry,
       });

--- a/server/src/routes/analysis.test.ts
+++ b/server/src/routes/analysis.test.ts
@@ -3506,24 +3506,50 @@ describe('stage-2 attribution rules block (Target C)', () => {
     expect(body).toBeGreaterThan(rules);
   });
 
-  it('does NOT render the rules block in the chunk builder — chunks deliberately omit it (chapter-only)', () => {
-    // The rules block is injected ONLY into the whole-chapter builder. The chunk
-    // builder omits it by design: the untagged-continuation / two-hander rules
-    // misfire across chunk boundaries on multi-speaker chapters — the on-box eval
-    // showed a ch44 raw regression (the sole chunked fixture) that this omission
-    // recovers, while every single-call chapter keeps the win. See the Target C
-    // ship note in docs/features/265-attribution-eval-tuning.md.
+  it('renders the chunk-variant rules block in the chunk builder (#1758)', () => {
     const prompt = buildStage2ChunkInbox(
-      'm', 'Title', stage1, chapter, 'section text', 'prior tail', null,
+      'm', 'Title', stage1, chapter, 'section text', 'prior tail', null, null,
     );
-    expect(prompt).not.toContain('## Attribution rules');
-    // The rest of the chunk prompt still renders in order.
+    expect(prompt).toContain('## Attribution rules');
+    expect(prompt).toContain('within this section'); // the rule-3 rewrite marker
+    // Order: roster → rules → preceding-context → section.
     const characters = prompt.indexOf('## Characters (from stage 1)');
+    const rules = prompt.indexOf('## Attribution rules');
     const context = prompt.indexOf('## Preceding context');
     const section = prompt.indexOf('## Section to attribute');
-    expect(characters).toBeGreaterThanOrEqual(0);
-    expect(context).toBeGreaterThan(characters);
+    expect(rules).toBeGreaterThan(characters);
+    expect(context).toBeGreaterThan(rules);
     expect(section).toBeGreaterThan(context);
+  });
+
+  it('renders the last-speaker seed only when lastSpeakerId is provided (#1758)', () => {
+    const seeded = buildStage2ChunkInbox(
+      'm', 'Title', stage1, chapter, 'section text', 'prior tail', null, 'egor',
+    );
+    expect(seeded).toContain('## Speaker at section start');
+    expect(seeded).toContain('`egor`');
+    // Seed sits after preceding-context and before the section body.
+    expect(seeded.indexOf('## Speaker at section start')).toBeGreaterThan(
+      seeded.indexOf('## Preceding context'),
+    );
+    expect(seeded.indexOf('## Section to attribute')).toBeGreaterThan(
+      seeded.indexOf('## Speaker at section start'),
+    );
+
+    const unseeded = buildStage2ChunkInbox(
+      'm', 'Title', stage1, chapter, 'section text', 'prior tail', null, null,
+    );
+    expect(unseeded).not.toContain('## Speaker at section start');
+  });
+
+  it('renders the first-person block after the seed when both apply (#1758)', () => {
+    const prompt = buildStage2ChunkInbox(
+      'm', 'Title', stage1, chapter, 'section text', 'prior tail', 'anton', 'egor',
+    );
+    const seed = prompt.indexOf('## Speaker at section start');
+    const firstPerson = prompt.indexOf('## First-person narrator');
+    expect(seed).toBeGreaterThan(0);
+    expect(firstPerson).toBeGreaterThan(seed);
   });
 
   it('still renders the first-person block after the rules block when a first-person id is present', () => {

--- a/server/src/routes/analysis.test.ts
+++ b/server/src/routes/analysis.test.ts
@@ -3558,8 +3558,13 @@ describe('chunk-variant attribution rules (#1758)', () => {
     expect(chunk3).toContain('Do NOT assume');
   });
 
-  it('both blocks start with the same header', () => {
+  it('both blocks start with the same header, and the full header + lead-in span is byte-identical', () => {
     expect(STAGE2_ATTRIBUTION_RULES_CHUNK.startsWith('## Attribution rules')).toBe(true);
     expect(STAGE2_ATTRIBUTION_RULES.startsWith('## Attribution rules')).toBe(true);
+
+    // The entire span before rule 1 (header + lead-in paragraph) must be
+    // byte-identical between the two constants — not just share a prefix.
+    const leadIn = (block: string) => block.slice(0, block.indexOf('\n1. '));
+    expect(leadIn(STAGE2_ATTRIBUTION_RULES_CHUNK)).toBe(leadIn(STAGE2_ATTRIBUTION_RULES));
   });
 });

--- a/server/src/routes/analysis.test.ts
+++ b/server/src/routes/analysis.test.ts
@@ -33,6 +33,8 @@ import {
   aggregateStructureReports,
   buildStage2ChapterInbox,
   buildStage2ChunkInbox,
+  STAGE2_ATTRIBUTION_RULES,
+  STAGE2_ATTRIBUTION_RULES_CHUNK,
   type AnalysisJob,
 } from './analysis.js';
 import type { CharacterOutput, SentenceOutput, Stage1ChapterOutput, Stage1Output, Stage2ChapterOutput } from '../handoff/schemas.js';
@@ -3531,5 +3533,33 @@ describe('stage-2 attribution rules block (Target C)', () => {
     expect(rules).toBeGreaterThan(0);
     expect(firstPerson).toBeGreaterThan(rules);
     expect(prompt).toContain('`anton`');
+  });
+});
+
+describe('chunk-variant attribution rules (#1758)', () => {
+  // Extract the numbered rule bodies "N. …" up to the next "\nN. " boundary.
+  function rule(block: string, n: number): string {
+    const m = block.match(new RegExp(`\\n${n}\\. [\\s\\S]*?(?=\\n\\d\\. |$)`));
+    return (m?.[0] ?? '').trim();
+  }
+
+  it('shares rules 1, 2, 4, 5 byte-for-byte with the chapter block', () => {
+    for (const n of [1, 2, 4, 5]) {
+      expect(rule(STAGE2_ATTRIBUTION_RULES_CHUNK, n)).toBe(rule(STAGE2_ATTRIBUTION_RULES, n));
+      expect(rule(STAGE2_ATTRIBUTION_RULES_CHUNK, n)).not.toBe(''); // guard: regex actually matched
+    }
+  });
+
+  it('rewrites rule 3 to scope continuation/alternation within the section', () => {
+    const chunk3 = rule(STAGE2_ATTRIBUTION_RULES_CHUNK, 3);
+    expect(chunk3).not.toBe(rule(STAGE2_ATTRIBUTION_RULES, 3));
+    expect(chunk3).toContain('within this section');
+    // No unqualified claim that alternation carries in from before the section.
+    expect(chunk3).toContain('Do NOT assume');
+  });
+
+  it('both blocks start with the same header', () => {
+    expect(STAGE2_ATTRIBUTION_RULES_CHUNK.startsWith('## Attribution rules')).toBe(true);
+    expect(STAGE2_ATTRIBUTION_RULES.startsWith('## Attribution rules')).toBe(true);
   });
 });

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -1645,12 +1645,13 @@ ${chapter.body}
 }
 
 /* Stage-2 inbox for ONE SECTION of a large chapter (#528 chunking). Same roster
-   as buildStage2ChapterInbox (but NOT the attribution rules block — chapter-only,
-   see STAGE2_ATTRIBUTION_RULES), the body is a sub-section and an
-   optional "preceding context" block carries the prior section's tail so an
-   untagged quote keeps its speaker across the seam. The model must attribute
-   ONLY the section, not the context. The chunk runner renumbers ids across
-   sections, so per-section 1-based numbering is fine. */
+   as buildStage2ChapterInbox, plus the chunk-variant attribution rules block
+   (STAGE2_ATTRIBUTION_RULES_CHUNK, #1758) and an optional last-speaker seed —
+   the body is a sub-section and an optional "preceding context" block carries
+   the prior section's tail so an untagged quote keeps its speaker across the
+   seam. The model must attribute ONLY the section, not the context. The chunk
+   runner renumbers ids across sections, so per-section 1-based numbering is
+   fine. */
 export function buildStage2ChunkInbox(
   manuscriptId: string,
   title: string,
@@ -1659,6 +1660,7 @@ export function buildStage2ChunkInbox(
   subBody: string,
   precedingContext: string | null,
   firstPersonId: string | null,
+  lastSpeakerId: string | null,
 ): string {
   const contextBlock = precedingContext
     ? `## Preceding context (already attributed — do NOT include in your output)
@@ -1668,6 +1670,15 @@ ONLY so you can carry a speaker across the boundary (e.g. an untagged quote
 whose speaker was named just before). Do NOT emit any sentences for this text.
 
 ${precedingContext}
+
+`
+    : '';
+  const seedBlock = lastSpeakerId
+    ? `## Speaker at section start
+
+The last character to speak before this section was \`${lastSpeakerId}\`. Treat the
+first untagged quote in this section as continuing \`${lastSpeakerId}\`, unless a
+dialogue tag or action beat names a different speaker.
 
 `
     : '';
@@ -1712,7 +1723,9 @@ ${JSON.stringify(
 )}
 \`\`\`
 
-${contextBlock}${firstPersonBlock}## Section to attribute (Chapter ${chapter.id} — ${chapter.title})
+${STAGE2_ATTRIBUTION_RULES_CHUNK}
+
+${contextBlock}${seedBlock}${firstPersonBlock}## Section to attribute (Chapter ${chapter.id} — ${chapter.title})
 
 ${subBody}
 `;
@@ -1845,6 +1858,7 @@ export async function attributeChapterStage2(opts: {
             subBody,
             preceding,
             firstPersonId,
+            null,
           );
     return opts.analyzer.runStage2Chapter(
       opts.manuscriptId,

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -1529,7 +1529,7 @@ ${chapter.body}
    regression). Language-/quote-agnostic by construction (see the lead line) so
    it does not misfire on «…» / „…" or non-English text. Kept deliberately
    short — every rule earns its tokens. */
-const STAGE2_ATTRIBUTION_RULES = `## Attribution rules
+export const STAGE2_ATTRIBUTION_RULES = `## Attribution rules
 
 Apply these when assigning each sentence's speaker. They hold whatever
 quotation marks the text uses — \`"…"\`, \`«…»\`, \`„…"\`, \`“…”\` — and in any
@@ -1544,6 +1544,40 @@ language:
 3. Untagged quotes continue, and two-handers alternate. An untagged quote keeps
    the last established speaker. In a sustained back-and-forth between exactly
    two characters, untagged quotes alternate between them.
+4. Narration is the narrator. Non-dialogue prose — description, action,
+   scene-setting — is \`narrator\`, even between two characters' lines. Only words
+   inside quote marks belong to a character (unless the whole chapter is a
+   first-person document).
+5. The addressee is not the speaker. A name spoken to someone ("Careful,
+   Anton.") marks who is addressed, not who speaks — never attribute the line to
+   the person being addressed.`;
+
+/* #1758 — the chunk-path variant of the attribution rules. Rules 1, 2, 4, 5 are
+   byte-identical to STAGE2_ATTRIBUTION_RULES (all boundary-safe: explicit tag,
+   same-paragraph action beat, narration, addressee). Only rule 3 is rewritten to
+   scope continuation/alternation WITHIN the section — a chunk that opens
+   mid-conversation has no in-band anchor for two-hander alternation parity, so
+   telling the model to alternate across the seam flipped the whole run (the ch44
+   both-builders regression). The "Speaker at section start" seed (buildStage2ChunkInbox)
+   powers only rule 3's continuation clause; alternation is disclaimed across the seam.
+   A drift-guard unit test pins rules 1/2/4/5 identical between the two constants. */
+export const STAGE2_ATTRIBUTION_RULES_CHUNK = `## Attribution rules
+
+Apply these when assigning each sentence's speaker. They hold whatever
+quotation marks the text uses — \`"…"\`, \`«…»\`, \`„…"\`, \`"…"\` — and in any
+language:
+
+1. A dialogue tag is decisive. When a quote carries an explicit speech tag —
+   \`"…," said X\` / \`"…," X asked\` / \`"…," whispered X\` — the speaker is X,
+   whatever the surrounding lines suggest.
+2. An action beat names the speaker. A quote sharing a paragraph with a
+   character's action belongs to that character: \`X folded her arms. "Get
+   out."\` and \`"Get out." X turned away.\` are both spoken by X.
+3. Untagged quotes continue, and two-handers alternate — within this section. An
+   untagged quote keeps the last speaker established here (or the "Speaker at
+   section start" named below, for the first quote). Do NOT assume a two-hander's
+   alternation carries in from before this section's start; near the start, rely
+   on dialogue tags and action beats rather than alternation parity.
 4. Narration is the narrator. Non-dialogue prose — description, action,
    scene-setting — is \`narrator\`, even between two characters' lines. Only words
    inside quote marks belong to a character (unless the whole chapter is a

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -1564,7 +1564,7 @@ language:
 export const STAGE2_ATTRIBUTION_RULES_CHUNK = `## Attribution rules
 
 Apply these when assigning each sentence's speaker. They hold whatever
-quotation marks the text uses — \`"…"\`, \`«…»\`, \`„…"\`, \`"…"\` — and in any
+quotation marks the text uses — \`"…"\`, \`«…»\`, \`„…"\`, \`“…”\` — and in any
 language:
 
 1. A dialogue tag is decisive. When a quote carries an explicit speech tag —

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -1846,7 +1846,7 @@ export async function attributeChapterStage2(opts: {
   const firstPersonId = fpConventions
     ? findFirstPersonCharacter(stage1.characters, fpConventions)
     : null;
-  const callForBody = (subBody: string, preceding: string | null) => {
+  const callForBody = (subBody: string, preceding: string | null, lastSpeakerId: string | null) => {
     const prompt =
       preceding === null && subBody === opts.chapter.body
         ? buildStage2ChapterInbox(opts.manuscriptId, opts.title, stage1, opts.chapter, firstPersonId)
@@ -1858,7 +1858,7 @@ export async function attributeChapterStage2(opts: {
             subBody,
             preceding,
             firstPersonId,
-            null,
+            lastSpeakerId,
           );
     return opts.analyzer.runStage2Chapter(
       opts.manuscriptId,


### PR DESCRIPTION
## Summary

Gets the stage-2 attribution rules block into the **chunked-chapter** prompt path, safely. Adds a second constant `STAGE2_ATTRIBUTION_RULES_CHUNK` — rules 1/2/4/5 byte-identical to the shipped chapter block (a drift-guard test pins that), with only rule #3 rewritten to scope untagged-continuation / two-hander alternation *within the section* — rendered in `buildStage2ChunkInbox` alongside a deterministic **last-speaker seed** threaded through the sequential chunk driver (last non-`narrator` id of each chunk's raw returned attributions, carried across all-narration chunks). The whole-chapter builder (`buildStage2ChapterInbox` + `STAGE2_ATTRIBUTION_RULES`) is byte-identical — no change to single-call chapters.

This closes the "chunk path carries zero attribution rules" gap without the cross-boundary parity misfire that regressed ch44 when the block was injected into *both* builders (#1761 shipped chapter-builder-only for exactly that reason).

## Eval (on-box, English, `--runs 3`, `qwen36-cw-iq4-32k`) — floor-only, no regression

- **ch44** (sole chunked fixture, n=328): hybrid-C **81.8%** [81.4–82.0] raw vs **baseline 82.5%** [80.5–83.5] vs rejected both-builders **80.0%**. Clears the no-regression floor (≥ baseline min 80.5) and beats both-builders by **+1.8** — the cross-boundary misfire is gone — but flat vs the baseline mean (no lift). Family split nets to a wash: `tag` +1.1 / `pronoun` +3.2, but `unanchored` −4.6 / `unaligned` −19.5 (wide-CI, seg-drift-heavy).
- **Every other fixture flat** (chapter path untouched: ch43 80.3=80.3 exact, ch45/46/Coalfall within noise).
- Baseline **reused** from the 2026-07-21 capture (validated: the chunk path — `stage2-chunk.ts`, stage-1, `buildStage2ChunkInbox` — is byte-identical from that baseline commit `36f127ae`, an ancestor of `main`, through current `main`; same corpus n=328).
- **Shipped floor-only:** no regression, strictly better than both-builders, closes the gap — but **no measured quality delta**, so **no release-notes entry**.

## Test plan

- Drift-guard: `STAGE2_ATTRIBUTION_RULES_CHUNK` rules 1/2/4/5 + header/lead-in byte-identical to the chapter block; rule #3 rewritten (`analysis.test.ts`).
- Chunk builder renders the chunk rules block + conditional last-speaker seed in the correct section order (`analysis.test.ts`).
- Driver threads the seed: chunk 2 seeded from chunk 1's last spoken id; all-narration carry-through via a forced 3-chunk split; direct `lastSpokenSpeaker` unit tests for all branches (`stage2-chunk.test.ts`).
- Full server suite green (5026 passed, 8 skipped); `npm run typecheck` clean; `verify:fast:branch` green.
- Final whole-branch review (Opus): ready to merge, no Critical/Important findings.

Plan: `docs/superpowers/plans/2026-07-22-chunk-safe-attribution-rules.md`
Regression: `docs/features/265-attribution-eval-tuning.md`

Closes #1758

🤖 Generated with [Claude Code](https://claude.com/claude-code)
