### PR TITLE
feat(server): script-review QA eval harness (char-level, opt-in)

### DIFF
--- a/docs/features/265-attribution-eval-tuning.md
+++ b/docs/features/265-attribution-eval-tuning.md
@@ -394,6 +394,14 @@ version of chunk 0 than production ever runs. This task's silver capture path
 done here — until then, treat any gold `reviewed`-stage opening-line result as a conservative
 (harder-than-production) floor.
 
+**Fidelity note — roster has no per-character `role`.** The `reviewed` stage's roster
+(`reviewRoster`, `run-eval.ts`) carries `gender`/`aliases` but, like production's stringified
+cast, no per-character `role` — `RosterSnapshot` has no such field, and `runReviewOverChapter`'s
+roster param types it optional — so the gemini chunk budget's `JSON.stringify(roster).length`
+approximates, rather than exactly matches, production's chunk boundaries. The internal
+`final`→`reviewed` comparison is unaffected either way, since both sides of that comparison share
+the same roster within a run.
+
 **The char metric is a regression guard, not a lift target.** On an attribution baseline that's
 already good (post the deterministic-first tuning cycles above), the *expected* good outcome on the
 `reviewed` stage is **helped ≈ harmed ≈ 0** — there's little left for review to correctly fix, and a

--- a/docs/features/265-attribution-eval-tuning.md
+++ b/docs/features/265-attribution-eval-tuning.md
@@ -52,7 +52,11 @@ owner: null
     coarsening.
   - Two new npm scripts: `eval:attribution` (runner, via
     `scripts/run-attribution-eval.mjs`) and `eval:attribution:capture`
-    (capture CLI, via `tsx`).
+    (capture CLI, via `tsx`). Silver capture (Task 8) rides the same
+    `eval:attribution:capture` script with an extra `--silver` flag
+    (`capture-cli.ts`'s `parseArgs`) rather than a third npm entry — the
+    existing script already forwards argv through `tsx`, so a flag was
+    sufficient.
 - **Invariants preserved:** the opt-in/gated-tooling posture established by
   `golden-audio` (185) — no model-touching command in `test:all`/`verify`;
   SKIP + exit 0 when a gate is missing. No production runtime behaviour
@@ -115,10 +119,16 @@ owner: null
 - Vitest server (`server/src/analyzer/attribution-eval/capture.test.ts`) —
   pure transforms: `buildLabelledChapter` filters to chapter/orders by
   id/maps `characterId`→`speakerId`; `buildRosterSnapshot` keeps
-  id/name/gender/aliases with name→id fallback.
+  id/name/gender/aliases with name→id fallback; `buildSilverSkeleton` (Task
+  8) schema-parses, seeds `lines` from current attribution, and attaches
+  `priorExchange` only when the supplied prior-chapter sentences resolve to
+  a two-speaker exchange (reusing `priorChapterBoundaryExchange`).
 - Vitest server (`server/src/analyzer/attribution-eval/capture-cli.test.ts`)
   — `captureCorpus` end-to-end against a temp workspace: writes the labelled
   fixture(s) + roster snapshot, reproduces the upstream boilerplate strip.
+  `captureSilverCorpus` (Task 8) — writes the `.silver.labelled.json`
+  skeleton with the prior chapter's captured boundary exchange attached, and
+  omits it for a chapter with no preceding chapter.
 - Vitest server (`server/src/analyzer/attribution-eval/buckets.test.ts`) —
   `evidenceFamily` reason→bucket coarsening for every prefix
   (`tag-*`, `pronoun-*`, `alt-*`, `unanchored*`, `narration*`, `lumped`,
@@ -167,6 +177,13 @@ and/or a `GEMINI_API_KEY`.
    (`server/src/analyzer/attribution-eval/corpus/<slug>.roster.json`). No
    model calls; pure file transform. `git status` shows nothing new tracked
    (corpus dir is git-ignored).
+1a. **Capture a silver skeleton (Task 8):**
+    `npm run eval:attribution:capture -- --book <bookId> --chapters <N> --silver`
+    → writes `<slug>-ch<NN>.<lang>.silver.labelled.json`, `lines` seeded from
+    that chapter's current attribution and, when a preceding chapter exists,
+    a `priorExchange` captured from its final two-speaker exchange. No model
+    calls; the corrected `speakerId`s are authored afterward by a human
+    labelling pass over this skeleton, not by the CLI.
 2. **Run the eval against Qwen local:**
    `npm run eval:attribution -- --engine qwen` → prints a per-fixture,
    per-stage scorecard (`raw → det → final` recall %, `n=`, `seg-drift`) plus
@@ -340,3 +357,49 @@ gained `"canonicalId": "unknown-male"` (entry kept, not deleted); nine ch44 cont
 (5 diagnostic-confirmed from the plan table + 4 same-run siblings — `[309]`, `[317]`, `[318]`,
 `[319]` — added under the plan's own uninterrupted-run rule; label changes shift baseline and
 treatment scores equally and cannot distort the ③ delta).
+
+### Script-review eval (char-level), silver capture + prior-exchange (2026-07-22)
+
+This closes out the harness's own build (spec §3, Tasks 1–8): the `reviewed` stage measures the
+**net effect of the LLM script-review pass** (`--review`) on attribution quality — did the pass that
+runs *after* stage-2 + deterministic attribution make the transcript more or less correct, char for
+char. It reuses the char-level, **segmentation-invariant** projection (`char-project.ts`'s
+`CharProjection`, built for exactly this reason: scoring by chapter-text character position rather
+than by matching normalised line text means a `reviewed`-stage split/extract/reattribute op registers
+as an honest recall change instead of looking like a truth line "vanished"). `char-score.ts`'s
+`diffHelpedHarmed` compares the pre-review (`final`) and post-review (`reviewed`) char-by-char
+correctness against truth and buckets every truth-attributed character into **helped** (was wrong,
+review fixed it), **harmed** (was right, review broke it), or **churn** (still wrong, but changed) —
+reported per fixture via `formatReviewLine` (`run-eval-cli.ts`) alongside the reviewed stage's
+per-op-class volumes and an illustrative op-dump of un-scored/off-roster ops.
+
+**Gold-only gate.** Only the gold tier — the four hand-corrected PwF fixtures (ch43–46) plus the
+committed Coalfall guardrail — gates anything. Silver fixtures (the `.silver.labelled.json` tag,
+`FIXTURE_RE` in `run-eval-cli.ts`) are reported in their own `--- silver (directional, not gating)
+---` block and never factor into a pass/fail decision (`partitionByTier`). This is deliberate: silver
+skeletons are seeded from the book's *current* (possibly still-wrong) attribution rather than a full
+independent human labelling pass, so they're directional signal for spotting a class of review
+mistake early, not a number to hold a merge gate on.
+
+**Prior-exchange v1 limitation.** The `reviewed` stage's first chunk of a chapter is fed the prior
+chapter's final two-speaker exchange (`priorExchange`, fs-64's `priorChapterBoundaryExchange`) in
+production, so it can resolve a tagless chapter-opening line via turn-taking — exactly the same
+context the real route gives it. The v1 gold fixtures (ch43–46) were captured **before** this field
+existed and carry no `priorExchange`, so a chunk-0 review run over them under-measures any
+opening-line correction that depends on that context — the eval sees a harder, context-starved
+version of chunk 0 than production ever runs. This task's silver capture path
+(`buildSilverSkeleton`, `capture.ts` / `captureSilverCorpus`, `capture-cli.ts`) captures
+`priorExchange` from the start, by reusing (not reimplementing) the route's own
+`priorChapterBoundaryExchange`; re-capturing the gold fixtures with it is a tracked follow-up, not
+done here — until then, treat any gold `reviewed`-stage opening-line result as a conservative
+(harder-than-production) floor.
+
+**The char metric is a regression guard, not a lift target.** On an attribution baseline that's
+already good (post the deterministic-first tuning cycles above), the *expected* good outcome on the
+`reviewed` stage is **helped ≈ harmed ≈ 0** — there's little left for review to correctly fix, and a
+well-behaved review pass shouldn't be breaking correct lines either. A large **positive** Δ
+(reviewed noticeably better than final) is not a signal that script-review is earning its keep; it's
+a signal to go check whether attribution *upstream* of review regressed — a bug that pushed more
+lines wrong right before the review stage would show up as a big charitable "helped" swing here, as
+review happens to patch over some of the damage. Read this stage as "did review avoid making a good
+baseline worse", not "how much did review improve things."

--- a/docs/superpowers/plans/2026-07-22-script-review-eval.md
+++ b/docs/superpowers/plans/2026-07-22-script-review-eval.md
@@ -1,0 +1,534 @@
+# Script-review eval harness (char-level metric) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the attribution-eval harness with a segmentation-invariant **char-level**
+`reviewed` stage that runs the real script-review pass on the pipeline's final attributed
+sentences, scores its net effect on attribution against the golden fixtures, and dumps the
+un-scoreable ops — then capture the baseline (gold + silver, both engines) as the gate for the
+sequenced tuning follow-up.
+
+**Architecture:** A new char-projection metric (`projectToChars` onto `chapterText` via the
+position-preserving `normalizeForMatch`) scores attribution per chapter-body character, so
+`split`/`extract`/`reattribute` are scored soundly and the `final→reviewed` diff is a direct
+char-array comparison. The pass is run faithfully to production by reusing the already-pure chunker
+functions + a **server-side port** of `planApply` acceptance (the server tsconfig can't import root
+`src/`), re-implementing only the thin non-streaming force-split loop. No production runtime change.
+
+**Tech Stack:** TypeScript (server, `NodeNext` ESM), Vitest (node env), the existing
+`attribution-eval` harness (`run-eval.ts`, `scorer.ts`, `schema.ts`), the script-review route's
+exported builders (`buildScriptReviewChapterInbox`, `buildReviewSentencesInput`) and the pure
+chunker (`chapter-chunker.ts`).
+
+## Global Constraints
+
+Every task's requirements implicitly include these.
+
+- **Gold-only gate.** The hard no-regression gate is gold ch43–46 + committed Coalfall (char
+  metric). **Silver fixtures never block**; reported in a separate block, labelled directional.
+- **No production-route behaviour change.** Reuse the *pure* functions
+  (`chunkSentencesByBudget`, `ownsOp`, `primarySentenceId`, `chapterChunkBudget`,
+  `buildScriptReviewChapterInbox`, `buildReviewSentencesInput` — all already exported). Do **not**
+  extract `reviewCore`/SSE/ledger from `script-review.ts`.
+- **`planApply` is PORTED server-side, not imported from `src/`.** Server `tsconfig.json` has
+  `rootDir: ./src` + `include: ["src/**/*"]` and imports nothing from root `src/`. Port
+  `normalizeForMatch` / `resolveAnchorOffset` / `planApply` into a server module; pin no-drift with
+  a **shared JSON test vector** both the frontend test and the server test read via `fs`.
+- **Char projection uses `normalizeForMatch` (position-preserving), NEVER the scorer's
+  `normalise()`** (which collapses whitespace / strips brackets / drops apostrophes → no positional
+  correspondence to `chapterText`).
+- **`reviewedSpeakerByChar` is a copy of `finalSpeakerByChar` mutated in place** by accepted ops —
+  never a re-projection of post-op sentences (would shift spans, break the equal-length diff).
+- **Line-level `raw`/`det`/`final` recall is unchanged** (backward-compatible with the shipped
+  attribution baselines). The char track is additive.
+- **No `byFamily` breakdown on the `reviewed` stage** (the `reasons` array indexes the `final` line
+  stream; resegmentation breaks the 1:1 map).
+- **Off-roster `reattribute` (carrying `proposed`) is dumped, not char-scored** in v1.
+- **Opt-in, triple-gated.** `runEval` returns `{ skipped }` (never throws) on no-corpus /
+  engine-down / no-key, review stage included. Never wired into `test:all` / `verify`.
+- **Corpus local-only.** Silver fixtures are copyrighted → git-ignored corpus dir. Only Coalfall
+  committed.
+- Every new server env knob (none expected here) MUST be a registry knob + `.env.example`.
+
+## File Structure
+
+**New (server, all under `server/src/analyzer/attribution-eval/`):**
+- `review-apply-core.ts` — ported pure `normalizeForMatch` / `resolveAnchorOffset` / `planApply`
+  (keyed on `ScriptReviewOp`). One responsibility: decide the accepted op set + resolve anchors.
+- `char-project.ts` — `projectToChars(chapterText, units)` → `{ speakerByChar, spans }`.
+- `char-score.ts` — `charRecall` (raw + per-line-averaged), `diffHelpedHarmed`.
+- `apply-ops-chars.ts` — `applyOpsToCharArray` (reattribute/split/extract → mutated char array).
+- `review-run.ts` — `runReviewOverChapter` (thin faithful chunk loop → owned `ScriptReviewOp[]`).
+- `__fixtures__/review-apply-vectors.json` — shared no-drift vector (committed; synthetic ops, no
+  book text).
+- Test files colocated: `review-apply-core.test.ts`, `char-project.test.ts`, `char-score.test.ts`,
+  `apply-ops-chars.test.ts`, `review-run.test.ts`.
+
+**Modified:**
+- `run-eval.ts` — `review?` opt on `evalFixture`; `ReviewScore`/`FixtureResult.reviewed`;
+  aggregation.
+- `run-eval-cli.ts` — `--review` flag, char scorecard, op-dump, silver partition, silver regex.
+- `src/lib/script-review-apply.test.ts` — also assert the shared vector (drift guard, frontend
+  side).
+- `capture-cli.ts` (+ `capture.ts`) — silver capture path + optional prior-exchange field.
+- `schema.ts` — optional `priorExchange` on `LabelledChapter` (additive).
+- `docs/features/265-attribution-eval-tuning.md` — ship note (this rides plan 265's harness).
+
+---
+
+### Task 1: Port the apply/match core server-side + shared no-drift vector
+
+**Files:**
+- Create: `server/src/analyzer/attribution-eval/review-apply-core.ts`
+- Create: `server/src/analyzer/attribution-eval/__fixtures__/review-apply-vectors.json`
+- Test: `server/src/analyzer/attribution-eval/review-apply-core.test.ts`
+- Modify: `src/lib/script-review-apply.test.ts` (add the shared-vector assertion, frontend side)
+
+**Interfaces:**
+- Produces: `normalizeForMatch(text: string): string`,
+  `resolveAnchorOffset(text: string, anchor: string): number | null`,
+  `planApply(ops: ScriptReviewOp[], live: LiveSentence[], roster: Set<string>): { appliable: ScriptReviewOp[]; unappliable: Array<{ op: ScriptReviewOp; reason: string }> }`
+  where `LiveSentence = { id: number; chapterId: number; text: string; characterId: string; instruct?: string; vocalization?: boolean }`.
+- Consumes: `ScriptReviewOp` from `../../handoff/schemas.js`.
+
+**Porting source:** `src/lib/script-review-apply.ts` — `REVIEW_EMOTIONS` (**line 4** — `planApply`
+uses it at line 171 for `fix_emotion` validation, so it MUST be ported too) plus `normChar` /
+`normalizeForMatch` / `resolveAnchorOffset` / `planApply` (lines 72-224). Port verbatim, retyped to
+`ScriptReviewOp`, dropping the Redux import. The frontend `ReviewOp` and server `ScriptReviewOp` are
+already parallel types across the boundary — this continues that pattern; the shared vector guards
+drift.
+
+**Vector-authoring note:** `planApply` checks `anchor` before `anchorEnd` for `extract_dialogue`
+(lines 144-145), so the "anchorEnd absent" case MUST give a *resolvable* `anchor`, or it fails with
+`anchor not found or not unique` instead of the intended `extract anchorEnd not found or not unique`.
+
+- [ ] **Step 1: Write the shared vector fixture** — `review-apply-vectors.json`: an array of
+  `{ name, ops, live, roster, expected: { appliableOpIndexes: number[], unappliable: [{ opIndex, reason }] } }`
+  cases covering: a clean `reattribute` (on-roster) accepted; a `reattribute` to a non-roster id →
+  `reattribute characterId not in roster`; a `split` with a resolvable anchor accepted; a `split`
+  with an anchor absent → `anchor not found or not unique`; two structural ops on the same id →
+  second `second structural op on the same id`; a valid adjacent same-speaker `merge`; a
+  non-adjacent `merge` → `merge members not adjacent / same character / same chapter`; an
+  `extract_dialogue` with `anchorEnd` absent. **Synthetic text only — no book content.**
+
+- [ ] **Step 2: Write `review-apply-core.test.ts` (fails — module absent)** — load the vector via
+  `fs.readFileSync(new URL('./__fixtures__/review-apply-vectors.json', import.meta.url))`, and for
+  each case assert `planApply(ops, live, new Set(roster))` yields exactly the expected appliable
+  indexes and unappliable {index, reason}. Add direct unit cases for `resolveAnchorOffset`
+  (unique-match end offset; null on absent; null on non-unique) and `normalizeForMatch`
+  (smart-quote/dash/ellipsis folds; NO whitespace collapse — `"a  b"` stays two spaces).
+
+- [ ] **Step 3: Run it — FAIL** (`cd server && npm run test -- review-apply-core`). Expected:
+  module-not-found.
+
+- [ ] **Step 4: Create `review-apply-core.ts`** — port the four functions. Signature of `planApply`
+  exactly as Interfaces above. Keep the arity/`Array.isArray(mergeIds)` guards verbatim (they
+  prevent the mid-hydration throw documented at `script-review-apply.ts:118-137`).
+
+- [ ] **Step 5: Run it — PASS.**
+
+- [ ] **Step 6: Add the frontend-side drift assertion** — in `src/lib/script-review-apply.test.ts`,
+  load the SAME `review-apply-vectors.json` (relative `fs` path to the server fixture) and assert
+  the frontend `planApply` produces the identical appliable/unappliable result. This is the
+  no-drift lock: one vector, two implementations.
+
+- [ ] **Step 7: Run both suites — PASS** (`npm run test -- script-review-apply` and
+  `cd server && npm run test -- review-apply-core`).
+
+- [ ] **Step 8: Commit** — `test(server): port script-review apply/match core for the eval + shared no-drift vector`.
+
+---
+
+### Task 2: `projectToChars` — char-position speaker projection
+
+**Files:**
+- Create: `server/src/analyzer/attribution-eval/char-project.ts`
+- Test: `server/src/analyzer/attribution-eval/char-project.test.ts`
+
+**Interfaces:**
+- Consumes: `normalizeForMatch` from `./review-apply-core.js`.
+- Produces:
+  ```ts
+  export interface CharProjection {
+    speakerByChar: Array<string | null>; // length === chapterText.length
+    spans: Array<{ start: number; end: number; speakerId: string }>; // [start,end) in chapterText
+    dropped: number; // units whose text was NOT located at/after the cursor (skipped, chars stay null)
+  }
+  export function projectToChars(
+    chapterText: string,
+    units: Array<{ text: string; speakerId: string }>,
+  ): CharProjection;
+  ```
+  `dropped` is surfaced (not just "recorded") so a caller can print how many predicted/truth units
+  failed to locate — a high `dropped` on the PREDICTED side means the char metric is silently
+  under-covering and the number is suspect (assumption-checker Important-4).
+
+**Method:** Build the normalized chapterText + its `origEndForNormLen` index map ONCE (same
+construction as `resolveAnchorOffset`, but retained for the whole text). Walk `units` in order,
+maintaining a normalized-cursor; for each unit, `indexOf(normalizeForMatch(unit.text))` from the
+cursor; map the normalized `[matchStart, matchEnd)` back to original offsets via the index map →
+`{start, end}`; fill `speakerByChar[start..end) = speakerId`; advance the cursor to `matchEnd`. A
+unit not found at/after the cursor is **skipped** (its chars stay `null`) — recorded so callers can
+count drops (O-4: skip, never fuzzy-mis-assign).
+
+- [ ] **Step 1: Write `char-project.test.ts` (fails)** — cases:
+  (a) two contiguous units over a plain `chapterText` → correct spans + `speakerByChar`;
+  (b) smart-quote/spacing difference between unit text and chapterText (unit `"Hi,"` vs body
+  `“Hi,”`) still locates the span (proves `normalizeForMatch` path + index map);
+  (c) a unit whose text is absent → skipped, its chars stay `null`, others unaffected, and
+  `dropped === 1`;
+  (d) two identical-text units by different speakers → the cursor advances so the SECOND resolves
+  to the second occurrence (not the first again);
+  (e) `speakerByChar.length === chapterText.length`.
+
+- [ ] **Step 2: Run — FAIL** (module absent).
+
+- [ ] **Step 3: Implement `projectToChars`** per Method.
+
+- [ ] **Step 4: Run — PASS.**
+
+- [ ] **Step 5: Commit** — `feat(server): projectToChars — char-position speaker projection for the review eval`.
+
+---
+
+### Task 3: Char scorer — `charRecall` + helped/harmed
+
+**Files:**
+- Create: `server/src/analyzer/attribution-eval/char-score.ts`
+- Test: `server/src/analyzer/attribution-eval/char-score.test.ts`
+
+**Interfaces:**
+- Consumes: `CharProjection` (Task 2); an optional `aliasMap: Map<string,string>` (the existing
+  `rosterAliasMap` seam).
+- Produces:
+  ```ts
+  export interface CharScore {
+    charRecall: number;      // char-weighted: correctChars / truthChars
+    lineRecall: number;      // per-truth-line-averaged char-correctness (perceived-quality headline)
+    truthChars: number;
+  }
+  export function scoreCharRecall(
+    truth: CharProjection, predicted: CharProjection, aliasMap?: Map<string,string>,
+  ): CharScore;
+  export function diffHelpedHarmed(
+    finalByChar: Array<string|null>, reviewedByChar: Array<string|null>,
+    truthByChar: Array<string|null>, aliasMap?: Map<string,string>,
+  ): { helped: number; harmed: number; churn: number }; // char counts
+  ```
+
+**Denominator:** only chars where `truth.speakerByChar[i] !== null` count. `charRecall` = fraction
+of those where resolved predicted == resolved truth. `lineRecall` = average over `truth.spans` of
+each span's own char-correctness (so a long narration span and a short dialogue line weigh equally).
+`diffHelpedHarmed`: over truth-attributed chars, helped = wrong-in-final & right-in-reviewed;
+harmed = right-in-final & wrong-in-reviewed; churn = wrong→different-wrong.
+
+- [ ] **Step 1: Write `char-score.test.ts` (fails)** — hand-built projections:
+  (a) all chars correct → `charRecall === 1`, `lineRecall === 1`;
+  (b) **the split-lift case**: `final` attributes one 2-speaker span entirely to speaker A (half
+  wrong); `reviewed` splits it so the second half is speaker B (matching truth) → `charRecall` and
+  `helped` both rise, `harmed === 0` (this is exactly what the old line scorer scored as a
+  regression);
+  (c) a `harmed` case: `reviewed` overturns a correct span → `harmed > 0`;
+  (d) aliasMap resolves `the_torment → unknown-male` so an aliased match scores correct;
+  (e) `lineRecall` weights a long narration span and a short dialogue line equally (a mis-attributed
+  short line drops `lineRecall` more than its char share).
+
+- [ ] **Step 2: Run — FAIL.**
+- [ ] **Step 3: Implement `char-score.ts`.**
+- [ ] **Step 4: Run — PASS.**
+- [ ] **Step 5: Commit** — `feat(server): char-level recall + helped/harmed for the review eval`.
+
+---
+
+### Task 4: Char-array applier (reattribute / split / extract)
+
+**Files:**
+- Create: `server/src/analyzer/attribution-eval/apply-ops-chars.ts`
+- Test: `server/src/analyzer/attribution-eval/apply-ops-chars.test.ts`
+
+**Interfaces:**
+- Consumes: `resolveAnchorOffset` (Task 1), `CharProjection.spans` (Task 2), `ScriptReviewOp`.
+- Produces:
+  ```ts
+  export function applyOpsToCharArray(
+    finalByChar: Array<string|null>,
+    finalSentences: Array<{ id: number; text: string; characterId: string }>,
+    finalSpans: Array<{ id: number; start: number; end: number }>, // per-sentence chapter span
+    acceptedOps: ScriptReviewOp[],
+  ): Array<string|null>; // reviewedByChar (a COPY of finalByChar, mutated)
+  ```
+
+**Rule (Global Constraint):** copy `finalByChar`, then for each accepted op mutate the copy in
+place. Only three op classes act:
+- `reattribute` (on-roster `characterId` only): set the target sentence's whole span `[start,end)`
+  to `characterId`. (Off-roster `proposed` → skip here; dumped by the CLI, Task 7.)
+- `split`: `off = resolveAnchorOffset(sentence.text, op.anchor)` (sentence-local) → chapter offset
+  `start + off`; assign `[start, start+off) = pieceCharacterIds[0]`, `[start+off, end) =
+  pieceCharacterIds[1]`. Same-speaker default (`pieceCharacterIds` absent) → no-op.
+- `extract_dialogue`: local `start`/`end` offsets via `resolveAnchorOffset(anchor/anchorEnd)` →
+  chapter offsets; middle sub-span → `pieceCharacterIds[1]`, flanks keep the sentence's speaker.
+
+`finalSpans` gives each sentence's chapter-char `{start,end}`; the applier resolves the op's
+sentence-local anchor offset and adds `start`. Ops here are already `planApply`-accepted (Task 5),
+so anchors resolve; still guard `null`/`end<=start` as no-ops (defensive).
+
+- [ ] **Step 1: Write `apply-ops-chars.test.ts` (fails)** — per op: a `reattribute` recolors the
+  whole span; a `split` recolors only the second piece; an `extract_dialogue` recolors only the
+  middle; a same-speaker split (no `pieceCharacterIds`) is a no-op; an op whose anchor doesn't
+  resolve is a no-op; `finalByChar` is NOT mutated (returned array is a distinct copy).
+
+- [ ] **Step 2: Run — FAIL.**
+- [ ] **Step 3: Implement `apply-ops-chars.ts`.**
+- [ ] **Step 4: Run — PASS.**
+- [ ] **Step 5: Commit** — `feat(server): char-array applier for reattribute/split/extract`.
+
+---
+
+### Task 5: Thin faithful review-core loop + route-parity drift test
+
+**Files:**
+- Create: `server/src/analyzer/attribution-eval/review-run.ts`
+- Test: `server/src/analyzer/attribution-eval/review-run.test.ts`
+
+**Interfaces:**
+- Consumes: `chunkSentencesByBudget`, `ownsOp`, `primarySentenceId`, `chapterChunkBudget`,
+  `OUTPUT_HEAVY_CLOUD_RESERVED_TOKENS` (`../chapter-chunker.js`);
+  `buildScriptReviewChapterInbox`, `buildReviewSentencesInput`, `type PriorExchange`
+  (`../../routes/script-review.js`); `planApply` (Task 1); an `Analyzer` with
+  `runScriptReviewChapter`. **Route import is safe** — `run-eval.ts` already imports from
+  `routes/analysis.js`; loading `routes/script-review.js` runs only `Router()` + map init, no
+  `listen`/side-effect (established precedent, not a concern).
+- Produces:
+  ```ts
+  export async function runReviewOverChapter(opts: {
+    analyzer: Analyzer;
+    engine: 'local' | 'gemini';                  // chunk-budget vocabulary; caller maps qwen→local, gemma→gemini
+    manuscriptId: string; chapterId: number;
+    sentences: SentenceOutput[];                 // the pipeline's FINAL attributed sentences
+    roster: Array<{ id: string; name: string; role?: string }>; // slim — for the inbox
+    priorExchange?: PriorExchange;               // fed into chunk 0 only (index === 0), route-faithful
+    evidence?: Map<number, string>;              // built by the caller (Task 6) via buildStructureEvidence
+    call: StageCall;
+  }): Promise<{ ops: ScriptReviewOp[]; accepted: ScriptReviewOp[] }>; // owned+deduped, and planApply-accepted
+  ```
+
+**Method (mirror `script-review.ts:810-875`, minus streaming/ledger/fallback):** chunk via
+`chunkSentencesByBudget` with `chapterChunkBudget(engine, JSON.stringify(roster).length+800,
+sampleText, OUTPUT_HEAVY_CLOUD_RESERVED_TOKENS)` and the same `serialize` (per-sentence
+`buildReviewSentencesInput`); for each chunk call `analyzer.runScriptReviewChapter` over
+`buildScriptReviewChapterInbox(...contextBefore, core, contextAfter...)`, filter by
+`ownsOp(coreIds, primarySentenceId(op))`; halve-and-retry the core on `AnalyzerTruncatedError`
+(depth ≤ 3, the `MAX_FORCE_SPLIT_DEPTH`/`CHUNK_OVERLAP` constants — redeclare locally = 3). Then
+`accepted = planApply(ops, live, rosterSet).appliable` where `live` maps each sentence to
+`{ id, chapterId, text, characterId }`. (Prior-exchange is passed in by the caller when present —
+Task 6.)
+
+- [ ] **Step 1: Write `review-run.test.ts` (fails)** — a STUB analyzer whose
+  `runScriptReviewChapter` returns a fixed op set keyed off the prompt's chunk (so a multi-chunk
+  chapter exercises `ownsOp` de-dup). Assert: (a) an op whose primary sentence lands in a chunk's
+  CONTEXT (not core) is emitted once, by the owning chunk only; (b) the owned op set equals a
+  reference single-pass ownership over the same chunks — a *consistency* guard (the route's
+  `reviewCore` is a closure inside `runScriptReviewJob`, not importable, so this pins the harness
+  loop against its own ownership reference built on the SAME shared pure
+  `ownsOp`/`primarySentenceId`/`chunkSentencesByBudget` production uses; catches internal drift, not
+  divergence from the route's exact loop — acceptable under the no-extract stance);
+  (c) `accepted` excludes an op `planApply` rejects (bad anchor).
+
+- [ ] **Step 2: Run — FAIL.**
+- [ ] **Step 3: Implement `runReviewOverChapter`.**
+- [ ] **Step 4: Run — PASS.**
+- [ ] **Step 5: Commit** — `feat(server): faithful thin review-core loop for the eval (route-parity)`.
+
+---
+
+### Task 6: Wire the `reviewed` stage into `evalFixture`
+
+**Files:**
+- Modify: `server/src/analyzer/attribution-eval/run-eval.ts` (evalFixture + aggregateFixture/aggStage)
+- Modify: `server/src/analyzer/attribution-eval/schema.ts` (optional `priorExchange`)
+- Test: `server/src/analyzer/attribution-eval/run-eval.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: Tasks 2–5. Reuses the existing `rosterAliasMap` (run-eval.ts:77) and `rosterToStage1`.
+- Produces: `FixtureResult.reviewed?: ReviewScore` and an **aggregated** `FixtureAgg.reviewed?:
+  ReviewAgg` (§Aggregation below).
+  ```ts
+  export interface ReviewScore {                     // per-run
+    charFinal: number; charReviewed: number;         // charRecall (char-weighted)
+    lineFinal: number; lineReviewed: number;         // per-truth-line-averaged
+    helped: number; harmed: number; churn: number;   // char counts
+    predictedDropped: number; truthDropped: number;  // projectToChars misses (coverage-health, Important-4)
+    opsByClass: Record<string, number>;
+    dump: Array<{ id: number; op: string; rationale: string; anchor?: string }>; // un-scored ops
+  }
+  ```
+  `evalFixture`'s opts gain `review?: boolean` (default false) **and `engine?: 'qwen' | 'gemma'`**
+  (optional — required only when `review:true`; already known to `runEval`'s caller loop). Keeping
+  it optional means the existing non-review callers + `run-eval.test.ts` cases compile unchanged.
+
+**Engine mapping (Critical-1):** `runReviewOverChapter` needs `'local' | 'gemini'`, but the eval
+speaks `'qwen' | 'gemma'`. Add a one-liner in run-eval.ts:
+`const chunkEngine = opts.engine === 'qwen' ? 'local' : 'gemini';` (matches `buildAnalyzer`:
+qwen→Ollama/local, gemma→Gemini/gemini). Pass `chunkEngine` to `runReviewOverChapter`.
+
+**Method** (when `review`), after the existing `attributeChapterStage2` call:
+1. `finalSentences = result.sentences` (each is `SentenceOutput` with `chapterId` present —
+   schemas.ts:120 — so Task 5's `live` mapping is sound).
+2. **Evidence — eval-native (Important-3), NOT `getOrHydrateManuscript`** (which has no
+   `chapterHints` body for the synthetic eval manuscript): call
+   `buildStructureEvidence(truth.chapterText, finalSentences, fullRoster, opts.truth-language)`
+   directly, gated on `configValue('analyzer.structure.enabled')`, where `fullRoster` is the
+   `RosterSnapshot.characters` (carries `gender`/`aliases` — the evidence builder needs them, not
+   the slim `{id,name,role}`). The slim roster still goes to the inbox.
+3. `priorExchange` = the fixture's optional `priorExchange` (Task 8 capture), passed to
+   `runReviewOverChapter`.
+4. `runReviewOverChapter({ analyzer, engine: chunkEngine, manuscriptId, chapterId, sentences:
+   finalSentences, roster: slimRoster, priorExchange, evidence, call })` → `{ ops, accepted }`.
+5. `truthProj = projectToChars(truth.chapterText, truth.lines)`;
+   `finalProj = projectToChars(truth.chapterText, finalSentences.map(s => ({ text: s.text,
+   speakerId: s.characterId })))` — **the `characterId → speakerId` adapter is required** (Task 2
+   takes `speakerId`; precedent `toPredicted`, run-eval.ts:69).
+6. `reviewedByChar = applyOpsToCharArray(finalProj.speakerByChar, finalSentences,
+   finalProj.spans-as-{id,start,end}, accepted-attribution-ops)` (copy+mutate; Task 4).
+7. Score: `scoreCharRecall(truthProj, finalProj, aliasMap)` and `…(truthProj, reviewedProj,
+   aliasMap)` for the two char/line recalls; `diffHelpedHarmed(finalProj.speakerByChar,
+   reviewedByChar, truthProj.speakerByChar, aliasMap)`; `predictedDropped = finalProj.dropped`,
+   `truthDropped = truthProj.dropped`. `opsByClass`/`dump` from ALL ops (applied-scored + un-scored
+   classes + off-roster reattributes). **No `byFamily` on reviewed.**
+
+Omitting `review` leaves the existing `raw`/`det`/`final` result byte-identical.
+
+**Aggregation over `--runs N` (Critical-2):** `aggregateFixture` averages the per-run `reviewed`
+into `FixtureAgg.reviewed?: ReviewAgg`:
+```ts
+export interface ReviewAgg {
+  charFinal: Stat; charReviewed: Stat; lineFinal: Stat; lineReviewed: Stat; // reuse stat() → mean/min/max
+  helped: Stat; harmed: Stat; churn: Stat;                                   // per-run char counts
+  predictedDropped: Stat; truthDropped: Stat;
+  opsByClass: Record<string, number>;   // mean count per class across runs
+  dump: ReviewScore['dump'];            // representative: run-0's dump (dumps are illustrative, not aggregated)
+}
+```
+`aggStage` is untouched (it's for the line stages); add a sibling `aggReview(scores: ReviewScore[])`.
+When no run has `reviewed` (review off), `FixtureAgg.reviewed` is `undefined`.
+
+- [ ] **Step 1: Extend `run-eval.test.ts` (fails)** — mocked analyzer whose
+  `runScriptReviewChapter` returns one on-roster `reattribute`: assert `evalFixture({review:true,
+  engine:'qwen'})` populates `reviewed` (char/line + helped/harmed + predictedDropped + opsByClass),
+  the `characterId→speakerId` adapter works (a fixture whose final `characterId` matches truth
+  scores `charFinal>0`), and `review:false` (default) yields the exact same `raw/det/final` object as
+  today (snapshot the non-review shape). Add an **aggregation** case: two `FixtureResult`s with
+  `reviewed` → `aggregateFixture` produces `ReviewAgg` with `helped`/`harmed` as `Stat`
+  (mean/min/max) and `dump` from run-0.
+
+- [ ] **Step 2: Run — FAIL.**
+- [ ] **Step 3: Implement** the `reviewed` branch + `chunkEngine` map in `evalFixture`;
+  `aggReview` + `FixtureAgg.reviewed` in `aggregateFixture`; add optional `priorExchange` to
+  `LabelledChapterSchema` pinned as `z.object({ turns: z.array(z.object({ speakerId: z.string(),
+  speakerName: z.string(), text: z.string() })) }).optional()` (matches route `PriorExchange`), and
+  thread it into `runReviewOverChapter` when present.
+- [ ] **Step 4: Run — PASS.** Also run the full `attribution-eval` suite (no regression to existing
+  stages).
+- [ ] **Step 5: Commit** — `feat(server): reviewed char-stage + run-aggregation in evalFixture (opt-in)`.
+
+---
+
+### Task 7: CLI `--review` — scorecard, op-dump, silver partition
+
+**Files:**
+- Modify: `server/src/analyzer/attribution-eval/run-eval-cli.ts`
+- Test: `server/src/analyzer/attribution-eval/run-eval-cli.test.ts` (extend; pure helpers)
+
+**Interfaces:**
+- Consumes: `FixtureAgg.reviewed?: ReviewAgg` (the **aggregated** shape from Task 6, not per-run
+  `ReviewScore`). Threads `review` **and `engine`** through `runEval` → `evalFixture` (the existing
+  `runEval` loop at run-eval-cli.ts:88-100 must add `review` and `engine` to the `evalFixture(...)`
+  call — `engine` is the loop var already in scope).
+
+**Method:** add `--review` (and env `EVAL_REVIEW`) → `review:true`, threaded to `evalFixture`.
+Extend the fixture regex to tag silver:
+`/^(.+)-ch(\d+)\.([a-z]{2})(\.silver)?\.labelled\.json$/`, tagging each `CorpusItem` with
+`tier: 'gold' | 'silver'` (the `loadDir`/`FIXTURE_RE` at run-eval-cli.ts:15). `printScorecard`:
+after the existing `raw→det→final` line, when `reviewed` present print a char line from the
+`ReviewAgg` Stats — `final(char) X% → reviewed(char) Y% (Δ … | line Xl%→Yl% | helped H harmed M
+churn C)` with `--runs>1` ranges from the `Stat`s — plus a **coverage-health note when
+`predictedDropped.mean > 0`** ("⚠ N predicted units unlocated — char coverage incomplete",
+Important-4), a by-class op count, then an **op-dump** block for the un-scored ops. Print **gold
+fixtures and the Coalfall guardrail first, then a separate `--- silver (directional, not gating)
+---` block**; silver rows carry a `directional` marker.
+
+- [ ] **Step 1: Extend `run-eval-cli.test.ts` (fails)** — unit-test the pure helpers: the silver
+  regex tags `foo-ch12.en.silver.labelled.json` as silver and `foo-ch12.en.labelled.json` as gold;
+  a `formatReviewLine(ReviewAgg, runs)` renders the Δ + helped/harmed (+ range when runs>1) + the
+  drop warning when `predictedDropped.mean>0`; the partition helper splits gold+Coalfall from
+  silver.
+
+- [ ] **Step 2: Run — FAIL.**
+- [ ] **Step 3: Implement** the flag, regex, `tier`, formatting, partition, op-dump. Keep
+  `main()`'s SKIP/exit-0 posture.
+- [ ] **Step 4: Run — PASS.**
+- [ ] **Step 5: Commit** — `feat(server): eval --review scorecard, op-dump, silver partition`.
+
+---
+
+### Task 8: Silver capture path + prior-exchange + regression doc
+
+**Files:**
+- Modify: `server/src/analyzer/attribution-eval/capture.ts`, `capture-cli.ts`
+- Test: `server/src/analyzer/attribution-eval/capture.test.ts` (extend)
+- Modify: `docs/features/265-attribution-eval-tuning.md` (ship note)
+- Modify: `package.json` (a `eval:attribution:capture-silver` script if a distinct entry is needed)
+
+**Interfaces:** a capture that writes a **silver skeleton** for an untuned chapter — `chapterText`
+(stripped body) + `lines` seeded from the book's current attribution + an optional captured
+`priorExchange` — under `<slug>-chNN.<lang>.silver.labelled.json`. The **label content**
+(corrected `speakerId`s) is authored by the strong-model labelling pass at capture time (an
+activity, not code); the CLI only produces the skeleton + prior-exchange and marks the file silver.
+
+**Prior-exchange:** capture the prior chapter's final two-speaker exchange (reuse the route's
+`priorChapterBoundaryExchange` logic — export it or mirror its pure core) into the fixture's
+optional `priorExchange`, so Task 6 feeds chunk 0 production-faithfully. For gold fixtures this is a
+follow-up re-capture; v1 gold fixtures without it state the limitation (opening-line corrections
+under-measured) in the ship note.
+
+- [ ] **Step 1: Extend `capture.test.ts` (fails)** — `buildSilverSkeleton(chapterBody, sentences,
+  roster, priorExchange?)` produces a valid `LabelledChapter` (schema-parses) with the silver naming
+  and the `priorExchange` field when supplied.
+- [ ] **Step 2: Run — FAIL.**
+- [ ] **Step 3: Implement** the skeleton writer + prior-exchange capture; wire the CLI entry.
+- [ ] **Step 4: Run — PASS.**
+- [ ] **Step 5: Update `docs/features/265-attribution-eval-tuning.md`** — a "Script-review eval
+  (char-level)" ship note: what the `reviewed` stage measures, the gold-only gate, silver
+  directional posture, the prior-exchange v1 limitation, and that the char metric is a
+  **regression guard** (helped≈harmed≈0 is the expected good outcome on a good baseline).
+- [ ] **Step 6: Commit** — `feat(server): silver capture skeleton + prior-exchange; 265 ship note`.
+
+---
+
+## Baseline capture (post-implementation activity — not a code task)
+
+After Task 8 merges, on the dev box: scan the untuned PwF chapters → recommend a silver set → user
+confirms → label them (strong independent full-chapter pass) → run
+`npm run eval:attribution -- --review --runs 3` (qwen local, then cloud). Record the baseline
+scorecard (gold char metric + silver directional + op-dump volumes) in the 265 ship note + a memory.
+That number gates the sequenced tuning follow-up (spec §7).
+
+## Notes for the implementer
+
+- **No release-notes entry.** This is opt-in dev tooling with no user- or operator-visible runtime
+  delta (same posture as the attribution-eval harness in plan 265) — the before-shipping
+  release-notes step is legitimately N/A; say so in the PR.
+- **Gating stays intact.** Never add any `eval:attribution` invocation to `test:all` / `verify`.
+- **The PR needs a linked issue** (`Closes #NN`) — filed as part of the design handover.
+
+## Self-review (done at authoring)
+
+- Spec coverage: every §3 mechanism maps to a task (projection T2, scorer T3, applier T4, faithful
+  run T5, wiring T6, reporting/op-dump/silver T7, capture/prior-exchange T8, ported reuse T1).
+- Type consistency: `CharProjection`, `ReviewScore`, `runReviewOverChapter` signatures are used
+  identically across T2→T6.
+- Open questions O-1..O-5 resolved in-plan: O-1 = server port + shared vector (T1, forced by server
+  rootDir); O-2 = off-roster dumped (T4/T7); O-3 = silver filename tag (T7); O-4 = skip-on-miss
+  (T2); O-5 = report both char + per-line (T3/T7).

--- a/docs/superpowers/specs/2026-07-22-script-review-eval-and-tuning-design.md
+++ b/docs/superpowers/specs/2026-07-22-script-review-eval-and-tuning-design.md
@@ -1,0 +1,306 @@
+# Script-review eval harness + baseline — design
+
+> Status: draft (design thread)
+> Parent: plan [265](../../features/265-attribution-eval-tuning.md) §2 non-goal — "Tuning the
+> **LLM script-review** pass … Explicit **next phase**, layered on the *improved* attribution
+> baseline." That baseline is now raised (deterministic-first #1752, Target C #1761, addressee-tag
+> #1764 all merged), so this is that next phase.
+> Sibling precedent: `docs/superpowers/specs/2026-07-20-attribution-eval-tuning-design.md` (the
+> attribution eval this extends).
+> **Revision note:** an assumption-checker pass killed the first design (reuse the line-level
+> attribution scorer for a 4th stage) — it structurally scores a *correct* `split`/`strip_tag` as a
+> regression and can't pair lines across segmentation change. This version uses a
+> **segmentation-invariant char-level scorer** instead (user decision, option B).
+
+## 1. Problem
+
+The LLM **script-review** pass (`skills/audiobook-script-review.md`, driven by
+`server/src/routes/script-review.ts`) is a per-chapter QA pass over *already-attributed*
+sentences. It emits surgical edit ops in eight classes — `strip_tag`, `split`,
+`extract_dialogue`, `merge`, `fix_emotion`, `validate_instruct`, `reattribute`,
+`flag_nonstory` — applied through the manual-edit reducers.
+
+Unlike attribution, **script-review has no eval harness**. Every attribution win this quarter rode
+a number; script-review has only eyeball spot-checks. We cannot answer the question that decides
+whether — and how — to tune it: **now that attribution is good, does the QA pass net-improve a
+chapter, or fight the now-correct engine?** This is a measurement problem first; tuning direction
+is unknown until the baseline number exists (§7).
+
+## 2. Goals / non-goals
+
+**Goals**
+
+- Score the *real* script-review pass end-to-end against the golden fixtures with a
+  **segmentation-invariant char-level attribution metric** that is sound across the ops the pass
+  actually makes (`reattribute`, `split`, `extract_dialogue`).
+- Produce a per-fixture **`final(char) → reviewed(char)`** delta plus a **helped / harmed** char
+  breakdown (harmed = chars right before review, wrong after — the regression axis).
+- **Eyeball coverage** of the attribution-neutral / un-scoreable classes (`merge`, `strip_tag`,
+  `fix_emotion`, `validate_instruct`, `flag_nonstory`) via a by-class count + op dump.
+- **Widen the corpus** with "silver" fixtures — untuned chapters of the same book, labelled by an
+  independent stronger pass — for more fixture *coverage* (directional, not variance-reducing — see
+  §3.6) and an end-to-end "improvement on a never-tuned chapter" demo.
+- **Capture the baseline** (gold + silver, both engines, `--runs 3`) as the starting number and
+  gate for the §7 tuning follow-up.
+
+**Non-goals (this spec)**
+
+- The actual tuning edits (§7) — designed once the baseline exists; tuning blind violates
+  measure-first.
+- Hard-scoring `fix_emotion` / `validate_instruct` / `vocalization` — no ground truth in the corpus
+  (`LabelledChapter` = `{text, speakerId}` only). Counted + dumped, never scored.
+- Retro-changing the existing **line-level** raw/det/final metric — the shipped attribution
+  baselines are line-recall; those columns stay as-is for comparability. The char metric is a new,
+  parallel track for the review comparison (§3.3).
+- Promoting silver into the hard gate. Gate = gold ch43–46 + Coalfall; silver = directional only
+  (§3.6).
+- Any end-user runtime change. The harness *calls* production code; adds nothing to the default
+  path.
+- A CI job — same local-only, opt-in, triple-gated posture as attribution-eval / golden-audio.
+
+## 3. Design
+
+### 3.1 Faithful-to-production review invocation (fixes assumption-checker #3, #4, #6)
+
+The eval must run the pass **the way production runs it**, or it measures a different pass. The
+analyzer method `runScriptReviewChapter` is a *single LLM call over the prompt it is handed*; all
+of the following live in the **route** (`runScriptReviewJob`/`reviewCore`, `script-review.ts`) and
+must be mirrored by the harness:
+
+- **Chunking.** `chunkSentencesByBudget` + `chapterChunkBudget(engine, …)` + cross-chunk
+  `ownsOp`/`primarySentenceId` de-dup + the force-split-on-truncation recursion. For the cloud
+  engines the baseline requires, budgets are finite/small — ch44 (328 sentences) chunks into
+  several calls in production; a whole-chapter call would skip this entirely. **These four are
+  already standalone exported pure functions** (`chapter-chunker.ts`) — the harness imports and
+  calls them directly; nothing to extract.
+- **Appliability gating.** Production applies only the ops `planApply`
+  (`src/lib/script-review-apply.ts`) *accepts*: it rejects an anchor that doesn't resolve uniquely,
+  a second structural op on the same sentence, a non-adjacent / mixed-speaker `merge`, an
+  `extract_dialogue` with `end<=start`, and a `reattribute` to an id not on the roster; a
+  `strip_tag` deterministically wins a same-id text collision. The eval must apply exactly this
+  accepted set, or its op set is a superset of production's.
+- **Prior-chapter exchange (fs-64).** Production feeds the prior chapter's final two-speaker
+  exchange into chunk 0 so the model can resolve a tagless chapter-opening line. Each fixture
+  therefore **captures that boundary exchange** (the prior chapter's attributed tail, read-only) so
+  chunk 0 is production-faithful. Absent it, opening-line corrections are systematically
+  under-measured.
+- **Config.** Set `analyzer.structure.enabled` so the inbox carries the same `[structure: …]`
+  hints production renders; otherwise the eval measures a different prompt.
+
+**Reuse the pure pieces; do not extract the streaming orchestration.** The route's `reviewCore`
+closes over ~10 pieces of live state (`AbortController`, SSE `send`, `heartbeat`, the
+fallback-mutable `activeSelection`, `withPassEval`, ledger checkpointing, quota/block/abort
+handling) — extracting it as a shared "driver" would be surgery on the most safety-critical route,
+not measurement tooling. So the split is:
+
+- **Reuse directly:** the already-pure `chunkSentencesByBudget` / `ownsOp` / `primarySentenceId` /
+  `chapterChunkBudget` (above), and the `planApply` acceptance + `resolveAnchorOffset` /
+  `normalizeForMatch` machinery from `script-review-apply.ts` (made server-importable — O-1).
+- **Re-implement thin, in the harness:** only the **force-split review-core loop** (call the
+  analyzer per chunk, `ownsOp`-filter, halve-and-retry on `AnalyzerTruncatedError`) — a small
+  non-streaming function over the eval's own analyzer calls, with **no** SSE / ledger / fallback /
+  pacing. It shares the *pure* budgeting/ownership/apply functions with production, so the op set
+  it produces matches; the streaming choreography is legitimately route-only and is **not**
+  duplicated. A `review-driver.test.ts` pins that the harness loop's owned op set equals the
+  route's for a multi-chunk chapter (drift guard).
+
+### 3.2 The char→speaker projection (the metric's foundation)
+
+Both truth and a predicted sentence set are projected onto the chapter body:
+
+```
+projectToChars(chapterText, units: Array<{text, speakerId}>):
+  { speakerByChar: (id|null)[]; spans: Array<{start, end, speakerId}> }
+```
+
+Walk `chapterText` once; for each unit in order, locate its text from the running cursor and assign
+that original-text char span the unit's speaker. **Positional matching primitive:** use
+`normalizeForMatch` + its `origEndForNormLen` index map from `script-review-apply.ts` (the same
+primitive `resolveAnchorOffset` uses) — **not** the scorer's `normalise()`, which collapses
+whitespace / strips brackets / deletes apostrophes and therefore has *no* positional correspondence
+to `chapterText` (you cannot recover an original char offset from it). `normalizeForMatch`
+deliberately preserves positions ("No whitespace collapse — it would desync positions") and its
+index map translates a normalized offset back to an original one. The function emits **both** the
+flat `speakerByChar` array **and** each unit's `{start, end}` span (the applier §3.4 needs per-unit
+chapter-char boundaries to place a split/extract). Chars in no unit's span carry no speaker
+(excluded from the denominator). Computed for:
+
+- **truth** (`chapterText` + `lines`) → `truthSpeakerByChar`
+- **`final`** predicted sentences → `finalSpeakerByChar`
+- **`reviewed`** = `final` with the accepted attribution-changing ops applied (§3.4) →
+  `reviewedSpeakerByChar`
+
+Because it is keyed on **chapter-body character position**, segmentation is irrelevant: whether the
+predicted side splits or merges a span, a char scores correct iff its predicted speaker matches
+truth's. This is what makes `split`/`extract` scoreable (assumption-checker #1) and gives a stable
+final↔reviewed pairing (assumption-checker #2) — the two char maps are the same length and directly
+diffable.
+
+### 3.3 Char-level metric + helped/harmed
+
+- **`charRecall`** = (chars where predicted speaker == truth speaker, via the `canonicalId`
+  aliasMap) / (chars with a truth speaker). Reported for `final` and `reviewed`; the headline is the
+  **`final→reviewed` delta**.
+- **Denominator + weighting (must be pinned).** The corpus truth `lines` cover the **whole
+  chapter** (narration + dialogue — a fully-attributed chapter labels every sentence), so raw
+  char-recall is char-weighted: one wrongly-reattributed 1500-char narration paragraph outweighs
+  ten correctly-fixed 60-char dialogue lines. To keep the number aligned with *perceived* quality
+  (a listener hears per-utterance, not per-char), the runner **also** reports a **per-truth-line
+  char-recall** variant — average each truth line's own char-correctness, so a long narration span
+  and a short dialogue line count once each. Both are segmentation-invariant (both key off the char
+  projection); the per-line-averaged variant is the perceived-quality headline, raw char-recall the
+  volume view. (Plan-time O-5: whether to weight by line or report both un-blended.)
+- **helped** = chars wrong in `final`, right in `reviewed`. **harmed** = right in `final`, wrong in
+  `reviewed` — **the regression axis** the §7 tuning drives down; the direct analog of the
+  frozen-raw "changed lines" gate from #1764.
+- **Expected shape of the number (set expectations up front).** Because the attribution baseline is
+  now good, **most review ops are char-neutral** — `strip_tag`, `merge`, `fix_emotion`,
+  `validate_instruct`, `flag_nonstory`, and same-speaker `split`s (the default
+  `pieceCharacterIds ?? [char, char]`) change no span→speaker mapping and are unscored. So on the
+  gold fixtures `helped ≈ harmed ≈ 0` is the **expected good outcome**: it means the QA pass is
+  *not fighting the improved engine*. The char metric is therefore primarily a **regression guard**
+  (keep `harmed` at 0), and the pass's real value (TTS-quality edits) lives in the **op-dump**
+  (§3.5), which is counted and eyeballed, not scored. A large positive `final→reviewed` delta is
+  *not* the target and would more likely signal the attribution baseline regressed than that review
+  got better.
+- The existing **line-level** raw→det→final columns are unchanged (§2 non-goal). The char track is
+  reported alongside for the review comparison. `final` is scored **both** ways so the char metric
+  has its own baseline point.
+- **No family breakdown on `reviewed`** (assumption-checker #8): the `reasons` array is indexed to
+  the `final` line stream and resegmentation breaks the 1:1 mapping. Reviewed reports char-recall +
+  helped/harmed only.
+
+### 3.4 The char-array applier (small, three ops)
+
+At char granularity only three op classes change span→speaker. `reviewedSpeakerByChar` is a **copy
+of `finalSpeakerByChar` mutated in place** by the accepted ops (§3.1) — it is **never** produced by
+re-running `projectToChars` on post-op sentences (which could shift spans and break the equal-length
+diff). Same length as `final` by construction, so §3.3's helped/harmed diff is a direct index-wise
+comparison. The three mutating ops:
+
+| op | char-array effect |
+|---|---|
+| `reattribute` | set the target sentence's whole span to the new speaker (roster id) |
+| `split` | partition the span at the resolved piece boundaries; assign each sub-span its `pieceCharacterIds[i]` |
+| `extract_dialogue` | the resolved `anchor…anchorEnd` sub-span → speaker; the remainder stays narrator |
+
+`merge` (same-speaker → no char change), `strip_tag` (edits sentence text, not span ownership),
+`fix_emotion` / `validate_instruct` / `flag_nonstory` → **not applied**; they go to the op-dump
+(§3.5). Anchor→offset resolution reuses production's `resolveAnchorOffset`; an op whose anchor
+doesn't resolve was already rejected by `planApply` acceptance (§3.1) and never reaches here.
+Unit-pinned against hand-built cases.
+
+**Off-roster `reattribute`** (assumption-checker #5): an op carrying `proposed` (speaker not on the
+roster) can't be given a truth-matching id by a pure applier and the `rosterAliasMap` seam only
+covers on-roster ids. v1 **dumps** off-roster reattributes (counted, not char-scored) with a stated
+limitation, rather than scoring them wrong. (Plan-time O-2: optional per-fixture alias entry to
+promote a known off-roster speaker into scoring.)
+
+### 3.5 Op-dump (un-scoreable / attribution-neutral classes)
+
+Per fixture: a by-class count + a dump `{id, op, rationale, anchor}` of every op not char-scored
+(`merge`, `strip_tag`, `fix_emotion`, `validate_instruct`, `vocalization`, `flag_nonstory`, plus
+dumped off-roster reattributes). Eyeball-triage surface for the classes with no ground truth —
+counted and inspectable, never scored.
+
+### 3.6 Silver corpus (widen the data)
+
+- **Selection:** a profile scan over the book's untuned chapters recommends a small set (2–4); user
+  confirms which/how many before labelling. Scan at capture time.
+- **Labelling:** an **independent, stronger full-chapter pass** (whole chapter in context —
+  deliberately *not* the chunked small-model production path) writes a `LabelledChapter` (+ captured
+  prior-exchange, §3.1) into the git-ignored corpus, tagged silver.
+- **Tagging:** filename/manifest marks silver so the runner reports it in a **separate block** and
+  **excludes it from the hard gate**.
+- **Confidence posture (user decision — silver, reported separately):** no per-line user
+  spot-check. **Stronger caveat (assumption-checker #7):** the labeller and the pass are both LLMs
+  over the same dialogue conventions and share systematic biases (last-speaker default, FID,
+  quote-collision). "Reviewed moves toward silver" can therefore reward *shared error*, and
+  correlated data does **not** reduce variance like independent data — so silver is **directional
+  only**, never a gate, and a silver `helped`/`harmed` is read as "agrees/disagrees with a stronger
+  model," not "correct/incorrect." Stated on every silver report line.
+
+### 3.7 Run conventions & baseline capture
+
+Opt-in, triple-gated (SKIP + exit 0), local-only corpus, `qwen36-cw-iq4-32k` local + cloud
+(`gemma-4-31b-it` / `gemini-3.1-flash-lite`), `--runs 3` mean±range, Coalfall guardrail every run
+(**note: now fires a real review LLM call per run — added latency/quota**, assumption-checker #9).
+After the harness lands: capture the baseline on gold + silver, both engines, record in ship notes
++ memory. That number is what §7 is designed against.
+
+## 4. Invariants to preserve
+
+1. **Gold-only gate.** Hard no-regression gate = gold ch43–46 + Coalfall (char metric). Silver
+   never blocks; reported separately, labelled directional.
+2. **Same op set as production, without duplicating the route's orchestration.** The harness
+   reuses the *pure* budgeting/ownership/apply functions (`chunkSentencesByBudget`, `ownsOp`,
+   `primarySentenceId`, `chapterChunkBudget`, `planApply` acceptance, `resolveAnchorOffset`,
+   `normalizeForMatch`) and re-implements only the thin non-streaming force-split review-core loop;
+   the SSE / ledger / fallback / pacing orchestration is legitimately route-only and is **not**
+   extracted. `review-driver.test.ts` pins the harness loop's owned op set == the route's for a
+   multi-chunk chapter (§3.1).
+3. **Shared apply/match logic, not re-hosted.** `planApply` acceptance, `resolveAnchorOffset`, and
+   `normalizeForMatch` are reused from one source (made server-importable — O-1); a divergent copy
+   is a measurement bug.
+4. **Line-level raw/det/final unchanged.** Backward-compatible with shipped attribution baselines;
+   the char metric is additive.
+5. **Corpus local-only.** Silver fixtures are copyrighted → git-ignored, same as gold. Only Coalfall
+   committed.
+6. **Opt-in + triple-gated.** No model-touching command in `test:all` / `verify`.
+
+## 5. Test plan (automated)
+
+- `project-to-chars.test.ts` — `projectToChars` span mapping: contiguous lines, smart-quote /
+  spacing tolerance, a dropped line (gap), repeated identical lines by different speakers.
+- `char-score.test.ts` — `charRecall` + helped/harmed from hand-built truth/final/reviewed maps;
+  aliasMap resolution; a `split` that assigns two speakers to two sub-spans scores as a lift (the
+  case the old line scorer got wrong).
+- `apply-review-ops-chars.test.ts` — the three-op char applier per class incl. anchor resolution;
+  a rejected op (bad anchor / second structural op / off-roster reattribute) is a no-op on the map.
+- `review-driver.test.ts` — the shared chunk-loop driver emits the same owned op set as the route
+  for a multi-chunk chapter (guards against eval/prod drift).
+- `run-eval.test.ts` — four stages scored; reviewed carries char-recall + helped/harmed, no
+  byFamily; omitting review leaves line raw/det/final byte-identical.
+- Gating unit — `runEval` returns `{skipped}` (never throws) with no corpus / engine down, review
+  stage included.
+- Live `npm run eval:attribution -- --review` runs are the opt-in runner itself, not gated.
+
+## 6. Net-new / touched code
+
+- New: `projectToChars` + `charRecall`/helped-harmed scorer (+ tests) — the segmentation-invariant
+  metric.
+- New: char-array applier for reattribute/split/extract (+ tests).
+- Import-surface change (**no** route-behaviour refactor): make `planApply` acceptance +
+  `resolveAnchorOffset` + `normalizeForMatch` server-importable from one source (O-1 — lift
+  `src/lib/script-review-apply.ts`'s pure core to a shared module, or a `server` port validated
+  equal by a shared test vector). The route is untouched; the eval re-implements only the thin
+  non-streaming force-split loop and reuses the already-exported pure chunker functions directly.
+- New: `review-driver.test.ts` — the harness loop's owned op set == the route's for a multi-chunk
+  chapter (eval/prod drift guard).
+- New: silver-labelling capture path (extend `capture-cli.ts` or a sibling; label *content*
+  produced by the labelling agent, git-ignored, not committed).
+- Touched: `run-eval.ts`/`run-eval-cli.ts` — reviewed stage, char track, helped/harmed, op-dump,
+  silver partition, `--review` flag + columns; `export buildScriptReviewChapterInbox` if needed.
+- No production runtime behaviour change (the route's extracted driver is behaviour-preserving).
+
+## 7. Sequenced follow-up (out of this thread)
+
+Once the baseline is captured, a separate design/plan tunes the pass against the number — candidate
+levers informed by what the baseline shows (tighten `reattribute` to defer to the now-good engine
+and drive `harmed` down; sharpen structural-op precision; adjust op-gates). Ships as its own
+reviewed diff, gated by the `harmed` / `final→reviewed(char)` numbers — exactly how the attribution
+tuning (#1752/#1761/#1764) rode the attribution-eval this extends.
+
+## 8. Open questions (resolve at plan time)
+
+- **O-1** where the shared review driver lives (a `server/src/analyzer/` module the route imports)
+  and how `planApply`/`resolveAnchorOffset` become server-importable (lift `src/lib` → shared, vs
+  a `server`-side port validated equal by a shared test vector).
+- **O-2** off-roster `reattribute` — dump-only (v1) vs an optional per-fixture alias to score a
+  known off-roster speaker.
+- **O-3** silver fixture tagging mechanism — filename convention vs manifest flag.
+- **O-4** char-projection of a predicted line whose text doesn't occur in `chapterText` at the
+  expected cursor (analyzer paraphrase / segmentation drift) — skip (unmapped, excluded) vs
+  best-effort fuzzy locate; must not silently mis-assign a span.
+- **O-5** char-recall aggregation — report both raw (char-weighted) and per-truth-line-averaged
+  (perceived-quality) headline, or pick one; and whether `harmed`/`helped` mirror the same split.

--- a/server/src/analyzer/attribution-eval/__fixtures__/review-apply-vectors.json
+++ b/server/src/analyzer/attribution-eval/__fixtures__/review-apply-vectors.json
@@ -1,0 +1,128 @@
+[
+  {
+    "name": "reattribute on-roster is accepted",
+    "ops": [
+      { "id": 1, "op": "reattribute", "characterId": "ferra", "rationale": "on-roster reattribute" }
+    ],
+    "live": [
+      { "id": 1, "chapterId": 1, "text": "Hello there.", "characterId": "narrator" }
+    ],
+    "roster": ["narrator", "ferra"],
+    "expected": {
+      "appliableOpIndexes": [0],
+      "unappliable": []
+    }
+  },
+  {
+    "name": "reattribute to a non-roster id is rejected",
+    "ops": [
+      { "id": 1, "op": "reattribute", "characterId": "ghost", "rationale": "off-roster reattribute" }
+    ],
+    "live": [
+      { "id": 1, "chapterId": 1, "text": "Hello there.", "characterId": "narrator" }
+    ],
+    "roster": ["narrator"],
+    "expected": {
+      "appliableOpIndexes": [],
+      "unappliable": [
+        { "opIndex": 0, "reason": "reattribute characterId not in roster" }
+      ]
+    }
+  },
+  {
+    "name": "split with a resolvable anchor is accepted",
+    "ops": [
+      { "id": 1, "op": "split", "anchor": "Hello there.", "pieceCharacterIds": ["narrator", "narrator"], "rationale": "over-long sentence" }
+    ],
+    "live": [
+      { "id": 1, "chapterId": 1, "text": "Hello there. Goodbye now.", "characterId": "narrator" }
+    ],
+    "roster": [],
+    "expected": {
+      "appliableOpIndexes": [0],
+      "unappliable": []
+    }
+  },
+  {
+    "name": "split with an absent anchor is rejected",
+    "ops": [
+      { "id": 1, "op": "split", "anchor": "no such text", "pieceCharacterIds": ["narrator", "narrator"], "rationale": "over-long sentence" }
+    ],
+    "live": [
+      { "id": 1, "chapterId": 1, "text": "Hello there. Goodbye now.", "characterId": "narrator" }
+    ],
+    "roster": [],
+    "expected": {
+      "appliableOpIndexes": [],
+      "unappliable": [
+        { "opIndex": 0, "reason": "anchor not found or not unique" }
+      ]
+    }
+  },
+  {
+    "name": "second structural op on an already-claimed id is rejected",
+    "ops": [
+      { "id": 1, "op": "split", "anchor": "Hello there.", "pieceCharacterIds": ["narrator", "narrator"], "rationale": "first structural op" },
+      { "id": 1, "op": "extract_dialogue", "anchor": "Goodbye", "anchorEnd": "now.", "pieceCharacterIds": ["narrator", "narrator", "narrator"], "rationale": "second structural op, same id" }
+    ],
+    "live": [
+      { "id": 1, "chapterId": 1, "text": "Hello there. Goodbye now.", "characterId": "narrator" }
+    ],
+    "roster": [],
+    "expected": {
+      "appliableOpIndexes": [0],
+      "unappliable": [
+        { "opIndex": 1, "reason": "second structural op on the same id" }
+      ]
+    }
+  },
+  {
+    "name": "adjacent same-speaker merge is accepted",
+    "ops": [
+      { "id": 5, "op": "merge", "mergeIds": [5, 6], "rationale": "under-split" }
+    ],
+    "live": [
+      { "id": 5, "chapterId": 1, "text": "First piece.", "characterId": "narrator" },
+      { "id": 6, "chapterId": 1, "text": "Second piece.", "characterId": "narrator" }
+    ],
+    "roster": [],
+    "expected": {
+      "appliableOpIndexes": [0],
+      "unappliable": []
+    }
+  },
+  {
+    "name": "non-adjacent merge is rejected",
+    "ops": [
+      { "id": 5, "op": "merge", "mergeIds": [5, 7], "rationale": "bad merge span" }
+    ],
+    "live": [
+      { "id": 5, "chapterId": 1, "text": "First piece.", "characterId": "narrator" },
+      { "id": 6, "chapterId": 1, "text": "Middle piece.", "characterId": "narrator" },
+      { "id": 7, "chapterId": 1, "text": "Third piece.", "characterId": "narrator" }
+    ],
+    "roster": [],
+    "expected": {
+      "appliableOpIndexes": [],
+      "unappliable": [
+        { "opIndex": 0, "reason": "merge members not adjacent / same character / same chapter" }
+      ]
+    }
+  },
+  {
+    "name": "extract_dialogue with anchorEnd absent is rejected (anchor itself resolves)",
+    "ops": [
+      { "id": 1, "op": "extract_dialogue", "anchor": "\"At last,\"", "anchorEnd": "no such text here", "pieceCharacterIds": ["narrator", "maerin"], "rationale": "dialogue extract" }
+    ],
+    "live": [
+      { "id": 1, "chapterId": 1, "text": "He sighed. \"At last,\" she said. He left.", "characterId": "narrator" }
+    ],
+    "roster": [],
+    "expected": {
+      "appliableOpIndexes": [],
+      "unappliable": [
+        { "opIndex": 0, "reason": "extract anchorEnd not found or not unique" }
+      ]
+    }
+  }
+]

--- a/server/src/analyzer/attribution-eval/__fixtures__/review-apply-vectors.json
+++ b/server/src/analyzer/attribution-eval/__fixtures__/review-apply-vectors.json
@@ -124,5 +124,71 @@
         { "opIndex": 0, "reason": "extract anchorEnd not found or not unique" }
       ]
     }
+  },
+  {
+    "name": "reattribute targeting a sentence id missing from live is rejected",
+    "ops": [
+      { "id": 99, "op": "reattribute", "characterId": "narrator", "rationale": "target no longer exists" }
+    ],
+    "live": [
+      { "id": 1, "chapterId": 1, "text": "Hello there.", "characterId": "narrator" }
+    ],
+    "roster": ["narrator"],
+    "expected": {
+      "appliableOpIndexes": [],
+      "unappliable": [
+        { "opIndex": 0, "reason": "target id missing" }
+      ]
+    }
+  },
+  {
+    "name": "non-structural op on an id already consumed by a structural op is rejected",
+    "ops": [
+      { "id": 1, "op": "split", "anchor": "Hello there.", "pieceCharacterIds": ["narrator", "narrator"], "rationale": "first structural op" },
+      { "id": 1, "op": "reattribute", "characterId": "narrator", "rationale": "second op, same id, non-structural" }
+    ],
+    "live": [
+      { "id": 1, "chapterId": 1, "text": "Hello there. Goodbye now.", "characterId": "narrator" }
+    ],
+    "roster": ["narrator"],
+    "expected": {
+      "appliableOpIndexes": [0],
+      "unappliable": [
+        { "opIndex": 1, "reason": "id consumed by a structural op" }
+      ]
+    }
+  },
+  {
+    "name": "fix_emotion with an invalid emotion value is rejected",
+    "ops": [
+      { "id": 1, "op": "fix_emotion", "emotion": "furious", "rationale": "delivery correction" }
+    ],
+    "live": [
+      { "id": 1, "chapterId": 1, "text": "Hello there.", "characterId": "narrator" }
+    ],
+    "roster": [],
+    "expected": {
+      "appliableOpIndexes": [],
+      "unappliable": [
+        { "opIndex": 0, "reason": "invalid emotion value" }
+      ]
+    }
+  },
+  {
+    "name": "validate_instruct vocalization edit colliding with a strip_tag on the same id is rejected",
+    "ops": [
+      { "id": 1, "op": "strip_tag", "rationale": "remove leaked tag" },
+      { "id": 1, "op": "validate_instruct", "newVocalizationText": "Hmm.", "rationale": "vocalization text repair" }
+    ],
+    "live": [
+      { "id": 1, "chapterId": 1, "text": "Hmm...", "characterId": "narrator", "vocalization": true }
+    ],
+    "roster": [],
+    "expected": {
+      "appliableOpIndexes": [0],
+      "unappliable": [
+        { "opIndex": 1, "reason": "text already claimed by strip_tag" }
+      ]
+    }
   }
 ]

--- a/server/src/analyzer/attribution-eval/apply-ops-chars.test.ts
+++ b/server/src/analyzer/attribution-eval/apply-ops-chars.test.ts
@@ -1,0 +1,134 @@
+/* Task 4: applies accepted script-review ops (reattribute / split /
+   extract_dialogue) to a final char-position speaker array to produce the
+   "reviewed" char array — the other half of the final→reviewed char-array
+   diff. `resolveAnchorOffset` (review-apply-core.ts) returns the END offset
+   of a unique anchor match, sentence-local; every offset here is derived
+   from that contract. See task-4-brief.md for the exact op rules. */
+import { describe, it, expect } from 'vitest';
+import { applyOpsToCharArray } from './apply-ops-chars.js';
+import type { ScriptReviewOp } from '../../handoff/schemas.js';
+
+interface FinalSentence {
+  id: number;
+  text: string;
+  characterId: string;
+}
+interface FinalSpan {
+  id: number;
+  start: number;
+  end: number;
+}
+
+function makeOp(partial: Partial<ScriptReviewOp> & Pick<ScriptReviewOp, 'id' | 'op'>): ScriptReviewOp {
+  return { rationale: 'test', ...partial } as ScriptReviewOp;
+}
+
+describe('applyOpsToCharArray', () => {
+  it('reattribute recolors the whole span', () => {
+    // 30-char chapter; sentence 1 occupies [0,10) as 'alice'; rest is 'zed' filler.
+    const finalByChar: Array<string | null> = [
+      ...Array(10).fill('alice'),
+      ...Array(20).fill('zed'),
+    ];
+    const finalSentences: FinalSentence[] = [{ id: 1, text: 'irrelevant', characterId: 'alice' }];
+    const finalSpans: FinalSpan[] = [{ id: 1, start: 0, end: 10 }];
+    const ops: ScriptReviewOp[] = [makeOp({ id: 1, op: 'reattribute', characterId: 'bob' })];
+
+    const reviewed = applyOpsToCharArray(finalByChar, finalSentences, finalSpans, ops);
+
+    expect(reviewed.slice(0, 10)).toEqual(Array(10).fill('bob'));
+    expect(reviewed.slice(10, 30)).toEqual(Array(20).fill('zed'));
+  });
+
+  it('split recolors only the second piece (anchor end offset = split point)', () => {
+    // Sentence 2 occupies chapter chars [10,20), text 'abcdefghij' (10 chars).
+    // anchor 'abcde' -> unique match, end offset 5 -> split at chapter char 15.
+    // pieceCharacterIds[0] === original speaker 'alice' (piece0 recolors to itself,
+    // so only the second piece visibly changes), pieceCharacterIds[1] = 'carol'.
+    const finalByChar: Array<string | null> = [
+      ...Array(10).fill('zed'), // [0,10)
+      ...Array(10).fill('alice'), // [10,20) — sentence 2
+      ...Array(10).fill('zed'), // [20,30)
+    ];
+    const finalSentences: FinalSentence[] = [{ id: 2, text: 'abcdefghij', characterId: 'alice' }];
+    const finalSpans: FinalSpan[] = [{ id: 2, start: 10, end: 20 }];
+    const ops: ScriptReviewOp[] = [
+      makeOp({ id: 2, op: 'split', anchor: 'abcde', pieceCharacterIds: ['alice', 'carol'] }),
+    ];
+
+    const reviewed = applyOpsToCharArray(finalByChar, finalSentences, finalSpans, ops);
+
+    expect(reviewed.slice(0, 10)).toEqual(Array(10).fill('zed')); // untouched
+    expect(reviewed.slice(10, 15)).toEqual(Array(5).fill('alice')); // piece0 [10,15)
+    expect(reviewed.slice(15, 20)).toEqual(Array(5).fill('carol')); // piece1 [15,20)
+    expect(reviewed.slice(20, 30)).toEqual(Array(10).fill('zed')); // untouched
+  });
+
+  it('extract_dialogue recolors only the middle sub-span', () => {
+    // Sentence 3 occupies chapter chars [20,30), text '0123456789' (10 chars).
+    // anchor '012' -> end offset 3; anchorEnd '0123456' -> end offset 7.
+    // Middle sentence-local [3,7) -> chapter [23,27) recolors to pieceCharacterIds[1];
+    // flanks [20,23) and [27,30) keep the sentence's original speaker 'alice'.
+    const finalByChar: Array<string | null> = [
+      ...Array(20).fill('zed'), // [0,20)
+      ...Array(10).fill('alice'), // [20,30) — sentence 3
+    ];
+    const finalSentences: FinalSentence[] = [{ id: 3, text: '0123456789', characterId: 'alice' }];
+    const finalSpans: FinalSpan[] = [{ id: 3, start: 20, end: 30 }];
+    const ops: ScriptReviewOp[] = [
+      makeOp({
+        id: 3,
+        op: 'extract_dialogue',
+        anchor: '012',
+        anchorEnd: '0123456',
+        pieceCharacterIds: ['alice', 'dave'],
+      }),
+    ];
+
+    const reviewed = applyOpsToCharArray(finalByChar, finalSentences, finalSpans, ops);
+
+    expect(reviewed.slice(0, 20)).toEqual(Array(20).fill('zed')); // untouched
+    expect(reviewed.slice(20, 23)).toEqual(Array(3).fill('alice')); // left flank
+    expect(reviewed.slice(23, 27)).toEqual(Array(4).fill('dave')); // extracted middle
+    expect(reviewed.slice(27, 30)).toEqual(Array(3).fill('alice')); // right flank
+  });
+
+  it('same-speaker split (no pieceCharacterIds) is a no-op', () => {
+    const finalByChar: Array<string | null> = [...Array(10).fill('alice'), ...Array(10).fill('zed')];
+    const finalSentences: FinalSentence[] = [{ id: 4, text: 'abcdefghij', characterId: 'alice' }];
+    const finalSpans: FinalSpan[] = [{ id: 4, start: 0, end: 10 }];
+    const ops: ScriptReviewOp[] = [makeOp({ id: 4, op: 'split', anchor: 'abcde' })]; // no pieceCharacterIds
+
+    const reviewed = applyOpsToCharArray(finalByChar, finalSentences, finalSpans, ops);
+
+    expect(reviewed).toEqual(finalByChar);
+  });
+
+  it('an op whose anchor does not resolve is a no-op', () => {
+    const finalByChar: Array<string | null> = [...Array(10).fill('alice'), ...Array(10).fill('zed')];
+    const finalSentences: FinalSentence[] = [{ id: 5, text: 'abcdefghij', characterId: 'alice' }];
+    const finalSpans: FinalSpan[] = [{ id: 5, start: 0, end: 10 }];
+    // 'xyz' is absent from the sentence text -> resolveAnchorOffset returns null.
+    const ops: ScriptReviewOp[] = [
+      makeOp({ id: 5, op: 'split', anchor: 'xyz', pieceCharacterIds: ['alice', 'carol'] }),
+    ];
+
+    const reviewed = applyOpsToCharArray(finalByChar, finalSentences, finalSpans, ops);
+
+    expect(reviewed).toEqual(finalByChar);
+  });
+
+  it('returns a distinct copy — the input finalByChar is never mutated', () => {
+    const finalByChar: Array<string | null> = [...Array(10).fill('alice'), ...Array(20).fill('zed')];
+    const original = finalByChar.slice();
+    const finalSentences: FinalSentence[] = [{ id: 1, text: 'irrelevant', characterId: 'alice' }];
+    const finalSpans: FinalSpan[] = [{ id: 1, start: 0, end: 10 }];
+    const ops: ScriptReviewOp[] = [makeOp({ id: 1, op: 'reattribute', characterId: 'bob' })];
+
+    const reviewed = applyOpsToCharArray(finalByChar, finalSentences, finalSpans, ops);
+
+    expect(reviewed).not.toBe(finalByChar);
+    expect(finalByChar).toEqual(original); // input untouched
+    expect(reviewed[0]).toBe('bob'); // the copy DID change
+  });
+});

--- a/server/src/analyzer/attribution-eval/apply-ops-chars.ts
+++ b/server/src/analyzer/attribution-eval/apply-ops-chars.ts
@@ -1,0 +1,79 @@
+/* Task 4: applies accepted script-review ops to the pipeline's final
+   char-position speaker array, producing the "reviewed" char array — so the
+   final→reviewed attribution diff is a direct char-array comparison. Only
+   three op classes act (reattribute / split / extract_dialogue); everything
+   else is a no-op here. Ops are expected to already be `planApply`-accepted
+   (review-apply-core.ts, Task 5 wiring), so anchors normally resolve — every
+   op is still guarded defensively: a null offset, an out-of-range id, or a
+   degenerate/inverted sub-span skips that op without mutating anything. */
+import { resolveAnchorOffset } from './review-apply-core.js';
+import type { ScriptReviewOp } from '../../handoff/schemas.js';
+
+export interface FinalSentenceForApply {
+  id: number;
+  text: string;
+  characterId: string;
+}
+
+export interface FinalSpanForApply {
+  id: number;
+  start: number;
+  end: number;
+}
+
+export function applyOpsToCharArray(
+  finalByChar: Array<string | null>,
+  finalSentences: FinalSentenceForApply[],
+  finalSpans: FinalSpanForApply[],
+  acceptedOps: ScriptReviewOp[],
+): Array<string | null> {
+  const reviewed = finalByChar.slice();
+  const sentenceById = new Map(finalSentences.map((s) => [s.id, s]));
+  const spanById = new Map(finalSpans.map((sp) => [sp.id, sp]));
+
+  for (const op of acceptedOps) {
+    const span = spanById.get(op.id);
+    const sentence = sentenceById.get(op.id);
+    if (!span || !sentence) continue; // target id missing from this projection
+    const { start, end } = span;
+    if (end <= start) continue; // degenerate span
+
+    if (op.op === 'reattribute') {
+      // Off-roster `proposed` reattributions are dumped by the CLI (Task 7),
+      // not applied here.
+      if (op.characterId == null) continue;
+      for (let i = start; i < end; i++) reviewed[i] = op.characterId;
+      continue;
+    }
+
+    if (op.op === 'split') {
+      const pieces = op.pieceCharacterIds;
+      if (!pieces || pieces.length < 2) continue; // same-speaker default -> no-op
+      const off = resolveAnchorOffset(sentence.text, op.anchor ?? '');
+      if (off == null) continue;
+      const splitAt = start + off;
+      if (splitAt <= start || splitAt >= end) continue; // degenerate/inverted piece
+      for (let i = start; i < splitAt; i++) reviewed[i] = pieces[0]!;
+      for (let i = splitAt; i < end; i++) reviewed[i] = pieces[1]!;
+      continue;
+    }
+
+    if (op.op === 'extract_dialogue') {
+      const pieces = op.pieceCharacterIds;
+      if (!pieces || pieces.length < 2) continue;
+      const offStart = resolveAnchorOffset(sentence.text, op.anchor ?? '');
+      const offEnd = resolveAnchorOffset(sentence.text, op.anchorEnd ?? '');
+      if (offStart == null || offEnd == null) continue;
+      const midStart = start + offStart;
+      const midEnd = start + offEnd;
+      if (midEnd <= midStart || midStart < start || midEnd > end) continue; // degenerate/inverted middle
+      for (let i = midStart; i < midEnd; i++) reviewed[i] = pieces[1]!;
+      continue;
+    }
+
+    // Any other op class (strip_tag, merge, fix_emotion, validate_instruct,
+    // flag_nonstory, ...) doesn't touch the char array.
+  }
+
+  return reviewed;
+}

--- a/server/src/analyzer/attribution-eval/capture-cli.test.ts
+++ b/server/src/analyzer/attribution-eval/capture-cli.test.ts
@@ -10,6 +10,9 @@ writeFileSync(
   JSON.stringify({ sentences: [
     { id: 1, chapterId: 44, characterId: 'narrator', text: 'He said.' },
     { id: 2, chapterId: 44, characterId: 'valkyrie', text: 'Hi.' },
+    // Task 8 — prior chapter's final two-speaker exchange (feeds silver capture).
+    { id: 10, chapterId: 43, characterId: 'valkyrie', text: 'Are you coming?' },
+    { id: 11, chapterId: 43, characterId: 'skulduggery', text: 'Right behind you.' },
   ] }),
 );
 writeFileSync(
@@ -17,6 +20,7 @@ writeFileSync(
   JSON.stringify({ characters: [
     { id: 'narrator', name: 'Narrator' },
     { id: 'valkyrie', name: 'Valkyrie Cain', gender: 'female' },
+    { id: 'skulduggery', name: 'Skulduggery Pleasant' },
   ] }),
 );
 
@@ -29,11 +33,14 @@ vi.mock('../../workspace/scan.js', () => ({
 }));
 vi.mock('../../store/manuscripts.js', () => ({
   getOrHydrateManuscript: vi.fn(async () => ({
-    chapterHints: [{ id: 44, title: 'Ch44', body: 'RAW BODY 44' }],
+    chapterHints: [
+      { id: 43, title: 'Ch43', body: 'RAW BODY 43' },
+      { id: 44, title: 'Ch44', body: 'RAW BODY 44' },
+    ],
   })),
 }));
 
-import { captureCorpus } from './capture-cli.js';
+import { captureCorpus, captureSilverCorpus } from './capture-cli.js';
 
 describe('captureCorpus', () => {
   const corpusDir = mkdtempSync(join(tmpdir(), 'cap-corpus-'));
@@ -48,5 +55,32 @@ describe('captureCorpus', () => {
     ]);
     const roster = JSON.parse(readFileSync(res.rosterPath, 'utf8'));
     expect(roster.characters.find((c: any) => c.id === 'valkyrie').gender).toBe('female');
+  });
+});
+
+describe('captureSilverCorpus (Task 8)', () => {
+  const corpusDir = mkdtempSync(join(tmpdir(), 'cap-silver-corpus-'));
+  it('writes a .silver.labelled.json skeleton seeded from current attribution, with the prior chapter exchange attached', async () => {
+    const res = await captureSilverCorpus({ bookId: 'b_pwf', chapters: [44], corpusDir });
+    expect(res.writtenFixtures).toHaveLength(1);
+    expect(res.writtenFixtures[0]).toMatch(/\.silver\.labelled\.json$/);
+    const fixture = JSON.parse(readFileSync(res.writtenFixtures[0], 'utf8'));
+    expect(fixture.chapterText).toContain('RAW BODY 44');
+    expect(fixture.lines).toEqual([
+      { text: 'He said.', speakerId: 'narrator' },
+      { text: 'Hi.', speakerId: 'valkyrie' },
+    ]);
+    expect(fixture.priorExchange).toEqual({
+      turns: [
+        { speakerId: 'valkyrie', speakerName: 'Valkyrie Cain', text: 'Are you coming?' },
+        { speakerId: 'skulduggery', speakerName: 'Skulduggery Pleasant', text: 'Right behind you.' },
+      ],
+    });
+  });
+
+  it('omits priorExchange for a chapter with no preceding chapter', async () => {
+    const res = await captureSilverCorpus({ bookId: 'b_pwf', chapters: [43], corpusDir });
+    const fixture = JSON.parse(readFileSync(res.writtenFixtures[0], 'utf8'));
+    expect(fixture.priorExchange).toBeUndefined();
   });
 });

--- a/server/src/analyzer/attribution-eval/capture-cli.ts
+++ b/server/src/analyzer/attribution-eval/capture-cli.ts
@@ -5,7 +5,8 @@ import { findBookByBookId, bookStateLanguage } from '../../workspace/scan.js';
 import { getOrHydrateManuscript } from '../../store/manuscripts.js';
 import { stripFrontMatterBoilerplate } from '../strip-front-matter.js';
 import { manuscriptEditsJsonPath, castJsonPath } from '../../workspace/paths.js';
-import { buildLabelledChapter, buildRosterSnapshot } from './capture.js';
+import { priorChapterIdFor } from '../../routes/script-review.js';
+import { buildLabelledChapter, buildRosterSnapshot, buildSilverSkeleton } from './capture.js';
 
 const DEFAULT_CORPUS_DIR = fileURLToPath(new URL('./corpus/', import.meta.url));
 
@@ -57,7 +58,79 @@ export async function captureCorpus(opts: {
   return { writtenFixtures, rosterPath };
 }
 
-function parseArgs(argv: string[]): { bookId: string; chapters: number[] } {
+/* Task 8 — silver capture: an untuned chapter's skeleton (current
+   attribution seeded, not yet human-labelled) plus the prior chapter's
+   captured boundary exchange, mirroring captureCorpus except for the
+   `.silver.` filename infix and the extra prior-exchange lookup. Label
+   corrections are authored afterwards by a human labelling pass — this
+   never invents them. */
+export async function captureSilverCorpus(opts: {
+  bookId: string;
+  chapters: number[];
+  corpusDir?: string;
+}): Promise<{ writtenFixtures: string[]; rosterPath: string }> {
+  const corpusDir = opts.corpusDir ?? DEFAULT_CORPUS_DIR;
+  await mkdir(corpusDir, { recursive: true });
+
+  const book = await findBookByBookId(opts.bookId);
+  if (!book) throw new Error(`No book found for bookId ${opts.bookId}`);
+  const { bookDir, state } = book;
+  const author = state.author;
+  const title = state.title;
+  const bookSlug = slug(title);
+  const lang = bookStateLanguage(state);
+
+  const edits = JSON.parse(await readFile(manuscriptEditsJsonPath(bookDir), 'utf8')) as {
+    sentences: Array<{
+      id: number;
+      chapterId: number;
+      characterId: string;
+      text: string;
+      excludeFromSynthesis?: boolean;
+    }>;
+  };
+  const cast = JSON.parse(await readFile(castJsonPath(bookDir), 'utf8')) as {
+    characters: Array<{ id: string; name?: string; gender?: 'male' | 'female' | 'neutral'; aliases?: string[] }>;
+  };
+  const roster = cast.characters.map((c) => ({ id: c.id, name: c.name ?? c.id }));
+
+  const record = await getOrHydrateManuscript(state.manuscriptId);
+  if (!record) throw new Error(`Could not hydrate manuscript ${state.manuscriptId}`);
+  const allChapterIds = record.chapterHints.map((c) => c.id);
+
+  const writtenFixtures: string[] = [];
+  for (const chapterId of opts.chapters) {
+    const hint = record.chapterHints.find((c) => c.id === chapterId);
+    if (!hint) throw new Error(`Chapter ${chapterId} not found in manuscript ${state.manuscriptId}`);
+    const chapterText = stripFrontMatterBoilerplate(hint.body, { author, title });
+    const chapterSentences = edits.sentences
+      .filter((sen) => sen.chapterId === chapterId)
+      .sort((a, b) => a.id - b.id);
+
+    // No exclusion tracking at capture time — the eval harness isn't wired to
+    // the script-review ledger's excludeFromSynthesis-chapter bookkeeping, so
+    // an empty excluded set just walks back to the immediately preceding
+    // chapter id.
+    const priorId = priorChapterIdFor(chapterId, allChapterIds, new Set());
+    const priorChapterSentences =
+      priorId !== null
+        ? edits.sentences.filter((sen) => sen.chapterId === priorId).sort((a, b) => a.id - b.id)
+        : undefined;
+
+    const silver = buildSilverSkeleton(chapterText, chapterSentences, roster, priorChapterSentences);
+    const num = String(chapterId).padStart(2, '0');
+    const path = join(corpusDir, `${bookSlug}-ch${num}.${lang}.silver.labelled.json`);
+    await writeFile(path, JSON.stringify(silver, null, 2));
+    writtenFixtures.push(path);
+  }
+
+  const rosterPath = join(corpusDir, `${bookSlug}.roster.json`);
+  await writeFile(rosterPath, JSON.stringify(buildRosterSnapshot(cast.characters), null, 2));
+
+  return { writtenFixtures, rosterPath };
+}
+
+function parseArgs(argv: string[]): { bookId: string; chapters: number[]; silver: boolean } {
   const get = (flag: string) => {
     const i = argv.indexOf(flag);
     return i >= 0 ? argv[i + 1] : undefined;
@@ -65,18 +138,20 @@ function parseArgs(argv: string[]): { bookId: string; chapters: number[] } {
   const bookId = get('--book');
   const chaptersRaw = get('--chapters');
   if (!bookId || !chaptersRaw) {
-    throw new Error('Usage: capture-cli --book <bookId> --chapters 43,44,45,46');
+    throw new Error('Usage: capture-cli --book <bookId> --chapters 43,44,45,46 [--silver]');
   }
   const chapters = chaptersRaw.split(',').map((n) => Number(n.trim()));
-  return { bookId, chapters };
+  const silver = argv.includes('--silver');
+  return { bookId, chapters, silver };
 }
 
 // Run only when invoked directly (not when imported by tests). Normalise both
 // sides with resolve() — a bare string compare is Windows-brittle (drive-letter
 // casing / slash direction), matching the repo precedent (build-companion-apk.mjs).
 if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
-  const { bookId, chapters } = parseArgs(process.argv.slice(2));
-  captureCorpus({ bookId, chapters })
+  const { bookId, chapters, silver } = parseArgs(process.argv.slice(2));
+  const run = silver ? captureSilverCorpus({ bookId, chapters }) : captureCorpus({ bookId, chapters });
+  run
     .then((r) => {
       console.log(`Wrote ${r.writtenFixtures.length} fixture(s) + roster:`);
       for (const f of r.writtenFixtures) console.log(`  ${f}`);

--- a/server/src/analyzer/attribution-eval/capture.test.ts
+++ b/server/src/analyzer/attribution-eval/capture.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { buildLabelledChapter, buildRosterSnapshot } from './capture.js';
+import { buildLabelledChapter, buildRosterSnapshot, buildSilverSkeleton } from './capture.js';
+import { LabelledChapterSchema } from './schema.js';
 import type { SentenceOutput } from '../../handoff/schemas.js';
 
 const s = (id: number, chapterId: number, characterId: string, text: string): SentenceOutput => ({
@@ -34,5 +35,56 @@ describe('buildRosterSnapshot', () => {
       { id: 'valkyrie', name: 'Valkyrie Cain', gender: 'female', aliases: ['Val'] },
       { id: 'narrator', name: 'narrator' },
     ]);
+  });
+});
+
+describe('buildSilverSkeleton (Task 8)', () => {
+  const roster = [
+    { id: 'valkyrie', name: 'Valkyrie Cain' },
+    { id: 'skulduggery', name: 'Skulduggery Pleasant' },
+  ];
+
+  it('seeds lines from current attribution and schema-parses without priorExchange when none is supplied', () => {
+    const sentences = [
+      s(2, 44, 'skulduggery', 'Line B'),
+      s(1, 44, 'narrator', 'Line A'),
+    ];
+    const out = buildSilverSkeleton('CHAPTER BODY', sentences, roster);
+
+    expect(() => LabelledChapterSchema.parse(out)).not.toThrow();
+    expect(out.chapterText).toBe('CHAPTER BODY');
+    // seeded from current attribution, ordered by sentence id — no label
+    // corrections invented here, just the characterId→speakerId adapter map.
+    expect(out.lines).toEqual([
+      { text: 'Line A', speakerId: 'narrator' },
+      { text: 'Line B', speakerId: 'skulduggery' },
+    ]);
+    expect(out.priorExchange).toBeUndefined();
+  });
+
+  it('attaches the prior chapter final two-speaker exchange when prior-chapter sentences are supplied', () => {
+    const sentences = [s(1, 44, 'narrator', 'Line A')];
+    const priorSentences = [
+      s(1, 43, 'valkyrie', 'Are you coming?'),
+      s(2, 43, 'skulduggery', 'Right behind you.'),
+    ];
+    const out = buildSilverSkeleton('CHAPTER BODY', sentences, roster, priorSentences);
+    const parsed = LabelledChapterSchema.parse(out);
+
+    expect(parsed.priorExchange).toEqual({
+      turns: [
+        { speakerId: 'valkyrie', speakerName: 'Valkyrie Cain', text: 'Are you coming?' },
+        { speakerId: 'skulduggery', speakerName: 'Skulduggery Pleasant', text: 'Right behind you.' },
+      ],
+    });
+  });
+
+  it('omits priorExchange when the supplied prior-chapter sentences do not form a two-speaker exchange', () => {
+    const sentences = [s(1, 44, 'narrator', 'Line A')];
+    const priorSentences = [s(1, 43, 'valkyrie', 'Solo line, no reply.')];
+    const out = buildSilverSkeleton('CHAPTER BODY', sentences, roster, priorSentences);
+
+    expect(out.priorExchange).toBeUndefined();
+    expect(() => LabelledChapterSchema.parse(out)).not.toThrow();
   });
 });

--- a/server/src/analyzer/attribution-eval/capture.ts
+++ b/server/src/analyzer/attribution-eval/capture.ts
@@ -1,6 +1,7 @@
 import type { LabelledChapter } from './schema.js';
 import type { RosterSnapshot } from './roster-schema.js';
 import type { SentenceOutput } from '../../handoff/schemas.js';
+import { priorChapterBoundaryExchange } from '../../routes/script-review.js';
 
 export function buildLabelledChapter(
   chapterText: string,
@@ -12,6 +13,45 @@ export function buildLabelledChapter(
     .sort((a, b) => a.id - b.id)
     .map((s) => ({ text: s.text, speakerId: s.characterId }));
   return { chapterText, lines };
+}
+
+/* Task 8 — silver skeleton for an UNTUNED chapter. `lines` is seeded purely
+   from the book's current attribution (same characterId→speakerId adapter
+   map as buildLabelledChapter) — the corrected speakerId labels are authored
+   later by a human labelling pass; this just marks the file silver and gives
+   it a starting point. `sentences` is expected pre-filtered to the target
+   chapter and sorted by id (the caller already has that per-chapter slice;
+   unlike buildLabelledChapter there's no chapterId param here to filter by).
+   When `priorChapterSentences` is supplied (the prior chapter's raw
+   sentences, oldest last-N), the prior chapter's final two-speaker exchange
+   is captured via the route's own `priorChapterBoundaryExchange` (fs-64) —
+   reused, not reimplemented — and attached as `priorExchange` so a chunk-0
+   review run over this fixture is production-faithful. Omitted or a
+   non-exchange tail (fewer than two distinct trailing speakers) ⇒
+   `priorExchange` is left off the fixture entirely (schema-optional). */
+export function buildSilverSkeleton(
+  chapterText: string,
+  sentences: SentenceOutput[],
+  roster: Array<{ id: string; name: string }>,
+  priorChapterSentences?: Array<{
+    id: number;
+    characterId: string;
+    text: string;
+    excludeFromSynthesis?: boolean;
+  }>,
+): LabelledChapter {
+  const lines = sentences
+    .slice()
+    .sort((a, b) => a.id - b.id)
+    .map((s) => ({ text: s.text, speakerId: s.characterId }));
+  const priorExchange = priorChapterSentences
+    ? priorChapterBoundaryExchange(priorChapterSentences, roster) ?? undefined
+    : undefined;
+  return {
+    chapterText,
+    lines,
+    ...(priorExchange ? { priorExchange } : {}),
+  };
 }
 
 export function buildRosterSnapshot(

--- a/server/src/analyzer/attribution-eval/char-project.test.ts
+++ b/server/src/analyzer/attribution-eval/char-project.test.ts
@@ -1,0 +1,82 @@
+/* projectToChars projects attributed sentence-level units onto chapter-body
+   character positions — the foundation of a segmentation-invariant
+   attribution metric (unlike scorer.ts's line-level scoreAttribution, which
+   collapses whitespace/brackets via normalise() and has no positional
+   correspondence back to chapterText). */
+import { describe, it, expect } from 'vitest';
+import { projectToChars } from './char-project.js';
+
+describe('projectToChars', () => {
+  it('(a) projects two contiguous units over a plain chapterText to correct spans + speakerByChar', () => {
+    const chapterText = 'Hello there. General Kenobi.';
+    const units = [
+      { text: 'Hello there.', speakerId: 'anakin' },
+      { text: 'General Kenobi.', speakerId: 'obiwan' },
+    ];
+    const result = projectToChars(chapterText, units);
+
+    expect(result.dropped).toBe(0);
+    expect(result.spans).toEqual([
+      { start: 0, end: 12, speakerId: 'anakin' },
+      { start: 13, end: 28, speakerId: 'obiwan' },
+    ]);
+    expect(result.speakerByChar.slice(0, 12).every((s) => s === 'anakin')).toBe(true);
+    expect(result.speakerByChar[12]).toBe(null); // the space between units
+    expect(result.speakerByChar.slice(13, 28).every((s) => s === 'obiwan')).toBe(true);
+  });
+
+  it('(b) locates a span despite smart-quote/spacing differences (normalizeForMatch path + index map)', () => {
+    const chapterText = '“Hi,” she said.';
+    const units = [{ text: '"Hi,"', speakerId: 'jane' }];
+    const result = projectToChars(chapterText, units);
+
+    expect(result.dropped).toBe(0);
+    // “Hi,” spans original chars [0,5) — the curly quotes fold 1:1 to ASCII.
+    expect(result.spans).toEqual([{ start: 0, end: 5, speakerId: 'jane' }]);
+    expect(result.speakerByChar.slice(0, 5).every((s) => s === 'jane')).toBe(true);
+    expect(result.speakerByChar[5]).toBe(null);
+  });
+
+  it('(c) skips a unit whose text is absent, leaving its chars null, others unaffected, dropped === 1', () => {
+    const chapterText = 'Hello there. General Kenobi.';
+    const units = [
+      { text: 'Hello there.', speakerId: 'anakin' },
+      { text: 'This text does not appear anywhere.', speakerId: 'ghost' },
+      { text: 'General Kenobi.', speakerId: 'obiwan' },
+    ];
+    const result = projectToChars(chapterText, units);
+
+    expect(result.dropped).toBe(1);
+    expect(result.spans).toEqual([
+      { start: 0, end: 12, speakerId: 'anakin' },
+      { start: 13, end: 28, speakerId: 'obiwan' },
+    ]);
+    expect(result.speakerByChar.some((s) => s === 'ghost')).toBe(false);
+  });
+
+  it('(d) advances the cursor so a second identical-text unit resolves to the second occurrence', () => {
+    const chapterText = 'Stop. Stop.';
+    const units = [
+      { text: 'Stop.', speakerId: 'first' },
+      { text: 'Stop.', speakerId: 'second' },
+    ];
+    const result = projectToChars(chapterText, units);
+
+    expect(result.dropped).toBe(0);
+    expect(result.spans).toEqual([
+      { start: 0, end: 5, speakerId: 'first' },
+      { start: 6, end: 11, speakerId: 'second' },
+    ]);
+  });
+
+  it('(e) speakerByChar.length === chapterText.length', () => {
+    const chapterText = 'Hello there. General Kenobi.';
+    const units = [
+      { text: 'Hello there.', speakerId: 'anakin' },
+      { text: 'General Kenobi.', speakerId: 'obiwan' },
+    ];
+    const result = projectToChars(chapterText, units);
+
+    expect(result.speakerByChar.length).toBe(chapterText.length);
+  });
+});

--- a/server/src/analyzer/attribution-eval/char-project.test.ts
+++ b/server/src/analyzer/attribution-eval/char-project.test.ts
@@ -79,4 +79,62 @@ describe('projectToChars', () => {
 
     expect(result.speakerByChar.length).toBe(chapterText.length);
   });
+
+  it('(f) locks the index map across a length-changing fold (… -> ...): a unit AFTER an earlier … resolves to its true ORIGINAL offsets, not the normalized ones', () => {
+    // "…" (U+2026, 1 char) folds to "..." (3 chars) in normalizeForMatch, so
+    // original and normalized coordinates diverge by +2 from that point on.
+    // A naive implementation that used normalized match offsets directly as
+    // original chapterText offsets would place the second unit's span 2
+    // chars too late (and 2 chars too long, since the divergence also grows
+    // by the match length not being clipped) — this test only passes if the
+    // origEndForNormLen index map is actually doing its job.
+    const chapterText = 'She paused… then left. "Go on," said Mara.';
+    const secondUnitText = '"Go on," said Mara.';
+    // Ground truth computed independently of the normalizer/implementation.
+    const expectedStart = chapterText.indexOf(secondUnitText);
+    const expectedEnd = expectedStart + secondUnitText.length;
+    expect(expectedStart).toBeGreaterThan(0); // sanity: substring actually present
+
+    const units = [
+      { text: 'She paused...', speakerId: 'anakin' }, // normalized form of the "…" text
+      { text: secondUnitText, speakerId: 'mara' },
+    ];
+    const result = projectToChars(chapterText, units);
+
+    expect(result.dropped).toBe(0);
+    expect(result.spans[1]).toEqual({ start: expectedStart, end: expectedEnd, speakerId: 'mara' });
+    for (let i = expectedStart; i < expectedEnd; i++) {
+      expect(result.speakerByChar[i]).toBe('mara');
+    }
+    // The first unit's own span crosses the fold too — its end must land on
+    // the original "…" index (10) + 1, i.e. 11, not the normalized-length 13.
+    expect(result.spans[0]).toEqual({ start: 0, end: 11, speakerId: 'anakin' });
+  });
+
+  it('(g) empty units array: speakerByChar all null (length === chapterText.length), spans empty, dropped === 0', () => {
+    const chapterText = 'Hello there. General Kenobi.';
+    const result = projectToChars(chapterText, []);
+
+    expect(result.dropped).toBe(0);
+    expect(result.spans).toEqual([]);
+    expect(result.speakerByChar.length).toBe(chapterText.length);
+    expect(result.speakerByChar.every((s) => s === null)).toBe(true);
+  });
+
+  it('(h) a unit with empty text is skipped (not matched as a zero-length span at the cursor), counts toward dropped, and does not corrupt speakerByChar', () => {
+    // char-project.ts guards `nUnit ? norm.indexOf(...) : -1` — an empty
+    // string is falsy in JS, so an empty-text unit always takes the -1
+    // branch and is treated exactly like a not-located unit (dropped++,
+    // chars untouched), never a zero-length match at normCursor.
+    const chapterText = 'Hello there. General Kenobi.';
+    const units = [
+      { text: '', speakerId: 'ghost' },
+      { text: 'Hello there.', speakerId: 'anakin' },
+    ];
+    const result = projectToChars(chapterText, units);
+
+    expect(result.dropped).toBe(1);
+    expect(result.spans).toEqual([{ start: 0, end: 12, speakerId: 'anakin' }]);
+    expect(result.speakerByChar.some((s) => s === 'ghost')).toBe(false);
+  });
 });

--- a/server/src/analyzer/attribution-eval/char-project.ts
+++ b/server/src/analyzer/attribution-eval/char-project.ts
@@ -1,0 +1,56 @@
+/* Projects attributed sentence-level units onto chapter-body character
+   positions — the foundation of a segmentation-invariant attribution metric.
+   Uses normalizeForMatch (position-preserving: folds smart quotes/dashes/
+   ellipsis, NEVER collapses whitespace or strips brackets) so the normalized
+   [start,end) match can be mapped back to exact chapterText offsets. NEVER
+   use scorer.ts's normalise() here — it collapses whitespace/strips bracket
+   tags and has no positional correspondence back to the original text. */
+import { normalizeForMatch } from './review-apply-core.js';
+
+export interface CharProjection {
+  speakerByChar: Array<string | null>; // length === chapterText.length
+  spans: Array<{ start: number; end: number; speakerId: string }>; // [start,end) in chapterText
+  dropped: number; // units whose text was NOT located at/after the cursor (skipped, chars stay null)
+}
+
+export function projectToChars(
+  chapterText: string,
+  units: Array<{ text: string; speakerId: string }>,
+): CharProjection {
+  // Build the normalized chapterText + its index map ONCE — same construction
+  // as review-apply-core.ts's resolveAnchorOffset, but retained for the whole
+  // text rather than discarded after locating a single anchor.
+  // origEndForNormLen[k] = original index after k normalized chars.
+  let norm = '';
+  const origEndForNormLen: number[] = [0];
+  for (let i = 0; i < chapterText.length; i++) {
+    const piece = normalizeForMatch(chapterText[i]);
+    for (let j = 0; j < piece.length; j++) origEndForNormLen.push(i + 1);
+    norm += piece;
+  }
+
+  const speakerByChar: Array<string | null> = new Array(chapterText.length).fill(null);
+  const spans: Array<{ start: number; end: number; speakerId: string }> = [];
+  let dropped = 0;
+  let normCursor = 0;
+
+  for (const unit of units) {
+    const nUnit = normalizeForMatch(unit.text);
+    const matchStart = nUnit ? norm.indexOf(nUnit, normCursor) : -1;
+    if (matchStart < 0) {
+      dropped++;
+      continue;
+    }
+    const matchEnd = matchStart + nUnit.length;
+    // origEndForNormLen[k] is the original index AFTER k normalized chars, so
+    // the original start is origEndForNormLen[matchStart] (chars before the
+    // match) and the original end is origEndForNormLen[matchEnd].
+    const start = origEndForNormLen[matchStart]!;
+    const end = origEndForNormLen[matchEnd]!;
+    for (let i = start; i < end; i++) speakerByChar[i] = unit.speakerId;
+    spans.push({ start, end, speakerId: unit.speakerId });
+    normCursor = matchEnd;
+  }
+
+  return { speakerByChar, spans, dropped };
+}

--- a/server/src/analyzer/attribution-eval/char-score.test.ts
+++ b/server/src/analyzer/attribution-eval/char-score.test.ts
@@ -1,0 +1,101 @@
+/* scoreCharRecall + diffHelpedHarmed — the char-level scorer that succeeds
+   scorer.ts's line-level scoreAttribution for review-op evaluation. Keying on
+   character positions (rather than normalised line text) lets a correct
+   split/extract/reattribute op register as a genuine recall lift with
+   harmed === 0 — exactly the case the old line-level scorer, which sees a
+   split as the original line simply vanishing, misread as a regression. */
+import { describe, it, expect } from 'vitest';
+import { scoreCharRecall, diffHelpedHarmed } from './char-score.js';
+import type { CharProjection } from './char-project.js';
+
+function projection(
+  chapterLength: number,
+  spans: Array<{ start: number; end: number; speakerId: string }>
+): CharProjection {
+  const speakerByChar: Array<string | null> = new Array(chapterLength).fill(null);
+  for (const span of spans) {
+    for (let i = span.start; i < span.end; i++) speakerByChar[i] = span.speakerId;
+  }
+  return { speakerByChar, spans, dropped: 0 };
+}
+
+describe('scoreCharRecall', () => {
+  it('(a) all chars correct: charRecall === 1, lineRecall === 1', () => {
+    const truth = projection(10, [{ start: 0, end: 10, speakerId: 'anakin' }]);
+    const predicted = projection(10, [{ start: 0, end: 10, speakerId: 'anakin' }]);
+
+    const score = scoreCharRecall(truth, predicted);
+
+    expect(score.charRecall).toBe(1);
+    expect(score.lineRecall).toBe(1);
+    expect(score.truthChars).toBe(10);
+  });
+
+  it('(b) the split-lift case: a correct split raises charRecall/helped with harmed === 0', () => {
+    // truth: a single 20-char utterance actually spoken by two speakers —
+    // chars [0,10) = A, [10,20) = B.
+    const truth = projection(20, [
+      { start: 0, end: 10, speakerId: 'A' },
+      { start: 10, end: 20, speakerId: 'B' },
+    ]);
+    // final: the whole span attributed to A (second half wrong).
+    const final = projection(20, [{ start: 0, end: 20, speakerId: 'A' }]);
+    // reviewed: split so the second half becomes B, matching truth exactly.
+    const reviewed = projection(20, [
+      { start: 0, end: 10, speakerId: 'A' },
+      { start: 10, end: 20, speakerId: 'B' },
+    ]);
+
+    const finalScore = scoreCharRecall(truth, final);
+    const reviewedScore = scoreCharRecall(truth, reviewed);
+    expect(finalScore.charRecall).toBe(0.5);
+    expect(reviewedScore.charRecall).toBe(1);
+
+    const diff = diffHelpedHarmed(final.speakerByChar, reviewed.speakerByChar, truth.speakerByChar);
+    expect(diff.helped).toBe(10);
+    expect(diff.harmed).toBe(0);
+    expect(diff.churn).toBe(0);
+  });
+
+  it('(c) a harmed case: reviewed overturns a correct span', () => {
+    const truth = projection(10, [{ start: 0, end: 10, speakerId: 'A' }]);
+    const final = projection(10, [{ start: 0, end: 10, speakerId: 'A' }]);
+    const reviewed = projection(10, [{ start: 0, end: 10, speakerId: 'B' }]);
+
+    const diff = diffHelpedHarmed(final.speakerByChar, reviewed.speakerByChar, truth.speakerByChar);
+
+    expect(diff.harmed).toBe(10);
+    expect(diff.helped).toBe(0);
+    expect(diff.churn).toBe(0);
+  });
+
+  it('(d) aliasMap resolves the_torment -> unknown-male so an aliased match scores correct', () => {
+    const truth = projection(10, [{ start: 0, end: 10, speakerId: 'unknown-male' }]);
+    const predicted = projection(10, [{ start: 0, end: 10, speakerId: 'the_torment' }]);
+    const aliasMap = new Map([['the_torment', 'unknown-male']]);
+
+    const withoutAlias = scoreCharRecall(truth, predicted);
+    expect(withoutAlias.charRecall).toBe(0);
+
+    const withAlias = scoreCharRecall(truth, predicted, aliasMap);
+    expect(withAlias.charRecall).toBe(1);
+  });
+
+  it('(e) lineRecall weights a long narration span and a short dialogue line equally', () => {
+    // 90-char narration span (correctly predicted) + 10-char dialogue span
+    // (entirely mis-attributed).
+    const truth = projection(100, [
+      { start: 0, end: 90, speakerId: 'narrator' },
+      { start: 90, end: 100, speakerId: 'anakin' },
+    ]);
+    const predicted = projection(100, [
+      { start: 0, end: 90, speakerId: 'narrator' },
+      { start: 90, end: 100, speakerId: 'obiwan' }, // wrong speaker for the short line
+    ]);
+
+    const score = scoreCharRecall(truth, predicted);
+
+    expect(score.charRecall).toBe(0.9); // only 10 of 100 chars wrong
+    expect(score.lineRecall).toBe(0.5); // (1.0 + 0.0) / 2 — the short line counts as much as the long one
+  });
+});

--- a/server/src/analyzer/attribution-eval/char-score.ts
+++ b/server/src/analyzer/attribution-eval/char-score.ts
@@ -1,0 +1,93 @@
+/* Char-level scorer for review-op evaluation — succeeds scorer.ts's
+   line-level scoreAttribution, which keys truth/predicted lines by
+   normalised TEXT, so any segmentation change (a split, an extract) makes a
+   truth line look like it simply vanished. Scoring character positions
+   instead lets a correct split/extract/reattribute op register as an honest
+   recall lift with harmed === 0 — exactly the case the old line scorer
+   misread as a regression. */
+import type { CharProjection } from './char-project.js';
+
+export interface CharScore {
+  charRecall: number; // char-weighted: correctChars / truthChars
+  lineRecall: number; // per-truth-line-averaged char-correctness (perceived-quality headline)
+  truthChars: number;
+}
+
+/** aliasMap is the rosterAliasMap seam (character id -> canonicalId). null
+    never aliases — it means "not attributed here", not a speaker id. */
+function resolveId(id: string | null, aliasMap?: Map<string, string>): string | null {
+  if (id === null) return null;
+  return aliasMap?.get(id) ?? id;
+}
+
+export function scoreCharRecall(
+  truth: CharProjection,
+  predicted: CharProjection,
+  aliasMap?: Map<string, string>
+): CharScore {
+  let truthChars = 0;
+  let correctChars = 0;
+  for (let i = 0; i < truth.speakerByChar.length; i++) {
+    const truthId = truth.speakerByChar[i]!;
+    if (truthId === null) continue; // denominator: only truth-attributed chars
+    truthChars++;
+    const resolvedTruth = resolveId(truthId, aliasMap);
+    const resolvedPredicted = resolveId(predicted.speakerByChar[i] ?? null, aliasMap);
+    if (resolvedPredicted === resolvedTruth) correctChars++;
+  }
+  const charRecall = truthChars > 0 ? correctChars / truthChars : 1;
+
+  // lineRecall averages each truth span's OWN char-correctness fraction, so a
+  // long narration span and a short dialogue line weigh equally — a
+  // mis-attributed short line drops lineRecall far more than its char share.
+  let lineRecall = 1;
+  if (truth.spans.length > 0) {
+    let sumFractions = 0;
+    for (const span of truth.spans) {
+      const length = span.end - span.start;
+      let spanCorrect = 0;
+      for (let i = span.start; i < span.end; i++) {
+        const resolvedTruth = resolveId(truth.speakerByChar[i]!, aliasMap);
+        const resolvedPredicted = resolveId(predicted.speakerByChar[i] ?? null, aliasMap);
+        if (resolvedPredicted === resolvedTruth) spanCorrect++;
+      }
+      sumFractions += length > 0 ? spanCorrect / length : 1;
+    }
+    lineRecall = sumFractions / truth.spans.length;
+  }
+
+  return { charRecall, lineRecall, truthChars };
+}
+
+export function diffHelpedHarmed(
+  finalByChar: Array<string | null>,
+  reviewedByChar: Array<string | null>,
+  truthByChar: Array<string | null>,
+  aliasMap?: Map<string, string>
+): { helped: number; harmed: number; churn: number } {
+  let helped = 0;
+  let harmed = 0;
+  let churn = 0;
+
+  for (let i = 0; i < truthByChar.length; i++) {
+    const truthId = truthByChar[i]!;
+    if (truthId === null) continue; // denominator: only truth-attributed chars
+
+    const resolvedTruth = resolveId(truthId, aliasMap);
+    const resolvedFinal = resolveId(finalByChar[i] ?? null, aliasMap);
+    const resolvedReviewed = resolveId(reviewedByChar[i] ?? null, aliasMap);
+
+    const finalCorrect = resolvedFinal === resolvedTruth;
+    const reviewedCorrect = resolvedReviewed === resolvedTruth;
+
+    if (!finalCorrect && reviewedCorrect) {
+      helped++;
+    } else if (finalCorrect && !reviewedCorrect) {
+      harmed++;
+    } else if (!finalCorrect && !reviewedCorrect && resolvedFinal !== resolvedReviewed) {
+      churn++; // still wrong, but changed
+    }
+  }
+
+  return { helped, harmed, churn };
+}

--- a/server/src/analyzer/attribution-eval/review-apply-core.test.ts
+++ b/server/src/analyzer/attribution-eval/review-apply-core.test.ts
@@ -1,0 +1,73 @@
+/* Ports the frontend script-review apply/match core (src/lib/script-review-apply.ts)
+   server-side so the attribution eval harness can reuse it without pulling in
+   Redux. review-apply-vectors.json is a SHARED fixture — the frontend test
+   (src/lib/script-review-apply.test.ts) loads the same file and asserts its
+   `planApply` produces an identical result, so the two implementations can
+   never silently drift apart. */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { normalizeForMatch, resolveAnchorOffset, planApply, type LiveSentence } from './review-apply-core.js';
+import type { ScriptReviewOp } from '../../handoff/schemas.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const VECTORS_PATH = path.join(__dirname, '__fixtures__', 'review-apply-vectors.json');
+
+interface Vector {
+  name: string;
+  ops: ScriptReviewOp[];
+  live: LiveSentence[];
+  roster: string[];
+  expected: {
+    appliableOpIndexes: number[];
+    unappliable: Array<{ opIndex: number; reason: string }>;
+  };
+}
+
+function loadVectors(): Vector[] {
+  return JSON.parse(readFileSync(VECTORS_PATH, 'utf8'));
+}
+
+describe('review-apply-core — shared no-drift vector', () => {
+  const vectors = loadVectors();
+
+  for (const vector of vectors) {
+    it(vector.name, () => {
+      const result = planApply(vector.ops, vector.live, new Set(vector.roster));
+
+      const appliableOpIndexes = result.appliable.map((op) => vector.ops.indexOf(op));
+      expect(appliableOpIndexes).toEqual(vector.expected.appliableOpIndexes);
+
+      const unappliable = result.unappliable.map((u) => ({ opIndex: vector.ops.indexOf(u.op), reason: u.reason }));
+      expect(unappliable).toEqual(vector.expected.unappliable);
+    });
+  }
+});
+
+describe('resolveAnchorOffset', () => {
+  it('returns the exact original offset of a unique anchor match', () => {
+    const text = 'He paused—then ran. "Stop," she said.';
+    const off = resolveAnchorOffset(text, 'ran. "Stop,"'); // anchor uses straight quotes
+    expect(off).not.toBeNull();
+    expect(text.slice(off!)).toBe(' she said.');
+  });
+
+  it('returns null when the anchor is not unique', () => {
+    expect(resolveAnchorOffset('he said, he said', 'he said')).toBeNull();
+  });
+
+  it('returns null when the anchor is absent', () => {
+    expect(resolveAnchorOffset('totally different', 'ran.')).toBeNull();
+  });
+});
+
+describe('normalizeForMatch', () => {
+  it('folds smart quotes, dashes, and ellipsis to their plain equivalents', () => {
+    expect(normalizeForMatch('‘a’ “b” – — …')).toBe("'a' \"b\" - - ...");
+  });
+
+  it('does NOT collapse whitespace', () => {
+    expect(normalizeForMatch('a  b')).toBe('a  b');
+  });
+});

--- a/server/src/analyzer/attribution-eval/review-apply-core.ts
+++ b/server/src/analyzer/attribution-eval/review-apply-core.ts
@@ -1,0 +1,177 @@
+/* Server-side port of the frontend script-review apply/match core
+   (src/lib/script-review-apply.ts) so the attribution eval harness can reuse
+   it without pulling in Redux. Ported verbatim, retyped to the server's
+   `ScriptReviewOp` (../../handoff/schemas.js) in place of the frontend's
+   `ReviewOp`. `dispatchAcceptedOps` is intentionally NOT ported — it dispatches
+   Redux actions and has no place in an eval harness.
+
+   review-apply-vectors.json (in __fixtures__/) is a SHARED fixture: the
+   frontend test (src/lib/script-review-apply.test.ts) loads the SAME file and
+   asserts its `planApply` produces an identical result, locking the two
+   implementations against drift. */
+import type { ScriptReviewOp } from '../../handoff/schemas.js';
+
+export const REVIEW_EMOTIONS = ['neutral', 'whisper', 'angry', 'excited', 'sad'] as const;
+
+export interface LiveSentence {
+  id: number;
+  chapterId: number;
+  text: string;
+  characterId: string;
+  instruct?: string;
+  vocalization?: boolean;
+}
+
+/** NFC + quote/dash/ellipsis folds ONLY — every fold maps 1 original char to a
+    known number of normalized chars, so an index map is exact. No whitespace
+    collapse (it would desync positions — the plan-review bug). */
+function normChar(c: string): string {
+  if (c === "‘" || c === "’") return "'";
+  if (c === "“" || c === "”") return '"';
+  if (c === "–" || c === "—") return '-';
+  if (c === "…") return '...';
+  return c.normalize('NFC');
+}
+export function normalizeForMatch(text: string): string {
+  let out = '';
+  for (const ch of text) out += normChar(ch);
+  return out;
+}
+
+/** Returns the ORIGINAL-text offset of the END of a unique anchor match, or null. */
+export function resolveAnchorOffset(text: string, anchor: string): number | null {
+  // Build normalized string + a map from each normalized index to the original index AFTER it.
+  let norm = '';
+  const origEndForNormLen: number[] = [0]; // origEndForNormLen[k] = original index after k normalized chars
+  for (let i = 0; i < text.length; i++) {
+    const piece = normChar(text[i]);
+    for (let j = 0; j < piece.length; j++) origEndForNormLen.push(i + 1);
+    norm += piece;
+  }
+  const nAnchor = normalizeForMatch(anchor);
+  if (!nAnchor) return null;
+  const first = norm.indexOf(nAnchor);
+  if (first < 0 || first !== norm.lastIndexOf(nAnchor)) return null;
+  return origEndForNormLen[first + nAnchor.length];
+}
+
+export function planApply(
+  ops: ScriptReviewOp[],
+  live: LiveSentence[],
+  roster: Set<string> = new Set(),
+): { appliable: ScriptReviewOp[]; unappliable: Array<{ op: ScriptReviewOp; reason: string }> } {
+  const byId = new Map(live.map((s) => [s.id, s]));
+  const appliable: ScriptReviewOp[] = [];
+  const unappliable: Array<{ op: ScriptReviewOp; reason: string }> = [];
+  const STRUCTURAL = new Set(['split', 'extract_dialogue', 'merge']);
+  const consumed = new Set<number>();
+  const structTargets = new Set<number>();
+
+  for (const op of ops.filter((o) => STRUCTURAL.has(o.op))) {
+    if (op.op === 'merge') {
+      // `Array.isArray` (not just `?? []`) so a non-array mergeIds the analyzer
+      // might emit (e.g. a bare number) can't throw on the spread below — same
+      // "malformed op must be unappliable, never crash" contract as the arity
+      // guard a few lines down.
+      const ids = [...(Array.isArray(op.mergeIds) ? op.mergeIds : [])].sort((a, b) => a - b);
+      if (ids.some((id) => structTargets.has(id))) { unappliable.push({ op, reason: 'second structural op on the same id' }); continue; }
+      const members = ids.map((id) => byId.get(id));
+      // A `merge` the analyzer emitted with missing/empty/single mergeIds must
+      // be rejected here: `[].some(m => !m)` is vacuously false, so an empty
+      // `members` slipped this guard and `members[0]!.chapterId` below threw
+      // `Cannot read properties of undefined` — a throw that aborted planApply
+      // mid-hydration and (swallowed by hydrateScriptReview's fire-and-forget
+      // dispatch) silently wiped the whole book's review view. Guard the arity.
+      if (ids.length < 2 || members.some((m) => !m)) { unappliable.push({ op, reason: 'merge needs at least two existing members' }); continue; }
+      const ch = members[0]!.chapterId;
+      const sameChar = members.every((m) => m!.characterId === members[0]!.characterId);
+      const sameChapter = members.every((m) => m!.chapterId === ch);
+      const adjacent = ids.every((id, k) => k === 0 || id === ids[k - 1] + 1);
+      if (!sameChar || !adjacent || !sameChapter) { unappliable.push({ op, reason: 'merge members not adjacent / same character / same chapter' }); continue; }
+      ids.forEach((id) => { consumed.add(id); structTargets.add(id); });
+      appliable.push(op);
+    } else {
+      if (structTargets.has(op.id)) { unappliable.push({ op, reason: 'second structural op on the same id' }); continue; }
+      const s = byId.get(op.id);
+      if (!s) { unappliable.push({ op, reason: 'target id missing' }); continue; }
+      if (resolveAnchorOffset(s.text, op.anchor ?? '') === null) { unappliable.push({ op, reason: 'anchor not found or not unique' }); continue; }
+      if (op.op === 'extract_dialogue' && resolveAnchorOffset(s.text, op.anchorEnd ?? '') === null) { unappliable.push({ op, reason: 'extract anchorEnd not found or not unique' }); continue; }
+      consumed.add(op.id); structTargets.add(op.id); appliable.push(op);
+    }
+  }
+
+  const textTargets = new Set<number>(); // strip_tag / validate_instruct-vocalization collisions
+
+  // strip_tag first so it deterministically wins a same-id text collision.
+  const nonStructural = ops.filter((o) => !STRUCTURAL.has(o.op));
+  const ordered = [
+    ...nonStructural.filter((o) => o.op === 'strip_tag'),
+    ...nonStructural.filter((o) => o.op !== 'strip_tag'),
+  ];
+
+  for (const op of ordered) {
+    if (consumed.has(op.id)) { unappliable.push({ op, reason: 'id consumed by a structural op' }); continue; }
+    const s = byId.get(op.id);
+    if (!s) { unappliable.push({ op, reason: 'target id missing' }); continue; }
+
+    if (op.op === 'strip_tag') {
+      textTargets.add(op.id);
+      appliable.push(op);
+      continue;
+    }
+
+    if (op.op === 'fix_emotion') {
+      if (!REVIEW_EMOTIONS.includes(op.emotion as never)) { unappliable.push({ op, reason: 'invalid emotion value' }); continue; }
+      appliable.push(op);
+      continue;
+    }
+
+    if (op.op === 'validate_instruct') {
+      // Normalize: keep only the appliable halves.
+      const norm: ScriptReviewOp = { ...op };
+      // instruct half
+      if (norm.newInstruct !== undefined) {
+        const isStrip = norm.newInstruct.trim() === '';
+        if (isStrip) {
+          if (!s.instruct) delete norm.newInstruct; // strip on instruct-less = no-op, drop
+        } else if (!s.instruct || s.instruct === norm.newInstruct.trim()) {
+          delete norm.newInstruct; // repair needs an existing, different instruct
+        }
+      }
+      // vocalization half — capture WHY it dropped so a collision is surfaced, not silent
+      let vocalDropReason: string | null = null;
+      if (norm.newVocalizationText !== undefined) {
+        if (!s.vocalization) vocalDropReason = 'sentence is not a vocalization';
+        else if (textTargets.has(op.id)) vocalDropReason = 'text already claimed by strip_tag'; // strip_tag wins
+        if (vocalDropReason) {
+          delete norm.newVocalizationText;
+          delete norm.vocalization;
+        } else {
+          textTargets.add(op.id);
+        }
+      }
+      const hasInstruct = norm.newInstruct !== undefined;
+      const hasVocal = norm.newVocalizationText !== undefined;
+      if (!hasInstruct && !hasVocal) {
+        // A pure-strip-on-instruct-less instruct edit is a silent no-op (not surfaced).
+        // A DROPPED vocalization edit (wrong sentence OR strip_tag collision) IS surfaced
+        // as un-appliable — the collision test asserts this.
+        if (vocalDropReason) unappliable.push({ op, reason: vocalDropReason });
+        continue;
+      }
+      appliable.push(norm);
+      continue;
+    }
+
+    // fs-58 Unit B — reattribute to an existing roster member must hit the roster.
+    // (proposed/off-roster reattributions are handled by the async create→reassign
+    // path before dispatch, so they're not gated here.)
+    if (op.op === 'reattribute' && op.characterId != null && !roster.has(op.characterId)) {
+      unappliable.push({ op, reason: 'reattribute characterId not in roster' });
+      continue;
+    }
+
+    appliable.push(op); // any other non-structural op unchanged (reattribute, flag_nonstory)
+  }
+  return { appliable, unappliable };
+}

--- a/server/src/analyzer/attribution-eval/review-run.test.ts
+++ b/server/src/analyzer/attribution-eval/review-run.test.ts
@@ -1,0 +1,176 @@
+/* Task 5 — route-parity drift test for the thin review-core loop
+   (`runReviewOverChapter`). A STUB analyzer stands in for the model: its
+   `runScriptReviewChapter` keys off the sentenceIds present in the prompt it is
+   handed (every chunk sees its core + up to `overlap` context sentences), so a
+   deliberately multi-chunk chapter exercises the `ownsOp` de-dup — an op on a
+   sentence that is a given chunk's CONTEXT must be dropped there and emitted by
+   the chunk that OWNS it (its core), exactly once.
+
+   The reference in assertion (b) is NOT the route's `reviewCore` (a closure
+   inside runScriptReviewJob, not importable) — it is an independent single-pass
+   ownership computed over the SAME chunks using the SAME shared pure helpers
+   (`chunkSentencesByBudget`/`ownsOp`/`primarySentenceId`) production uses. So it
+   catches internal drift of THIS loop against its own ownership contract, which
+   is the strongest guard available under the no-extract stance. */
+import { describe, it, expect } from 'vitest';
+import { runReviewOverChapter } from './review-run.js';
+import {
+  chunkSentencesByBudget,
+  chunkWithContext,
+  ownsOp,
+  primarySentenceId,
+  chapterChunkBudget,
+  OUTPUT_HEAVY_CLOUD_RESERVED_TOKENS,
+} from '../chapter-chunker.js';
+import { buildReviewSentencesInput } from '../../routes/script-review.js';
+import type { Analyzer, StageCall } from '../index.js';
+import type { SentenceOutput, ScriptReviewOp, ScriptReviewOutput } from '../../handoff/schemas.js';
+
+const CHAPTER_ID = 1;
+const MANUSCRIPT_ID = 'm-review-run';
+const roster = [
+  { id: 'c1', name: 'Alice' },
+  { id: 'c2', name: 'Bob', role: 'narrator' },
+];
+
+/* Big enough sentences that the default local budget (24000 chars) packs them
+   into ≥2 cores — verified below, not assumed. `x`.repeat guarantees the bad
+   anchor `ZZZ_MISSING` never occurs in any sentence text. */
+function makeSentences(count: number, chars: number): SentenceOutput[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: i + 1,
+    chapterId: CHAPTER_ID,
+    characterId: 'c1',
+    text: 'x'.repeat(chars),
+  }));
+}
+
+// The exact serialize + budget the loop uses — so `refChunks` below is identical
+// to the chunking runReviewOverChapter performs internally.
+const serialize = (s: SentenceOutput): string =>
+  JSON.stringify(buildReviewSentencesInput([s], undefined)[0]);
+function refChunksFor(sentences: SentenceOutput[]) {
+  const charBudget = chapterChunkBudget(
+    'local',
+    JSON.stringify(roster).length + 800,
+    sentences.map((s) => s.text).join(' '),
+    OUTPUT_HEAVY_CLOUD_RESERVED_TOKENS,
+  );
+  return chunkSentencesByBudget(sentences, { charBudget, overlap: 3, serialize });
+}
+
+const rationale = 'stub';
+const presentIds = (prompt: string): number[] => {
+  const ids: number[] = [];
+  const re = /"sentenceId":\s*(\d+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(prompt)) !== null) ids.push(Number(m[1]));
+  return ids;
+};
+
+/* Stub analyzer: for every sentenceId visible in the prompt emit a valid
+   `strip_tag`; additionally, for a designated id, emit a `split` with a bad
+   anchor so planApply rejects it (assertion (c)). Ownership de-dup is the loop's
+   job — the stub returns the same op for a sentence whether it is that chunk's
+   core OR context. */
+function makeStub(badAnchorId: number): Analyzer {
+  const stub = {
+    async runScriptReviewChapter(
+      _manuscriptId: string,
+      _chapterId: number,
+      prompt: string,
+      _call: StageCall,
+    ): Promise<ScriptReviewOutput> {
+      const ops: ScriptReviewOp[] = [];
+      for (const id of presentIds(prompt)) {
+        ops.push({ id, op: 'strip_tag', anchor: 'x', rationale } as ScriptReviewOp);
+        if (id === badAnchorId) {
+          ops.push({ id, op: 'split', anchor: 'ZZZ_MISSING', rationale } as ScriptReviewOp);
+        }
+      }
+      return { ops };
+    },
+  } as unknown as Analyzer;
+  return stub;
+}
+
+describe('runReviewOverChapter — route-parity chunk loop', () => {
+  const sentences = makeSentences(10, 6000); // 10 × ~6k → ≥2 cores under a 24k budget
+  const call: StageCall = {};
+
+  it('splits into ≥2 chunks (test precondition)', () => {
+    expect(refChunksFor(sentences).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('(a) emits a context-region op exactly once, from the owning chunk', async () => {
+    const chunks = refChunksFor(sentences);
+    // The first sentence of chunk 1's core is ALSO chunk 0's contextAfter — a
+    // sentence the model "sees" in two chunks. It must be emitted exactly once.
+    const boundaryId = chunks[1].core[0].id;
+    expect(chunks[0].contextAfter.some((s) => s.id === boundaryId)).toBe(true);
+
+    const { ops } = await runReviewOverChapter({
+      analyzer: makeStub(-1),
+      engine: 'local',
+      manuscriptId: MANUSCRIPT_ID,
+      chapterId: CHAPTER_ID,
+      sentences,
+      roster,
+      call,
+    });
+
+    const stripsForBoundary = ops.filter((o) => o.op === 'strip_tag' && o.id === boundaryId);
+    expect(stripsForBoundary).toHaveLength(1);
+  });
+
+  it('(b) owned op set equals an independent single-pass ownership over the same chunks', async () => {
+    const chunks = refChunksFor(sentences);
+    // Reference: reproduce the ownership decision independently with the same
+    // pure helpers — for each chunk, keep only the ops whose primary sentence
+    // the chunk OWNS, over the ids the chunk's prompt would carry.
+    const refOwned = new Set<number>();
+    for (const chunk of chunks) {
+      for (const s of chunkWithContext(chunk)) {
+        if (ownsOp(chunk.coreIds, primarySentenceId({ id: s.id, op: 'strip_tag' }))) {
+          refOwned.add(s.id);
+        }
+      }
+    }
+
+    const { ops } = await runReviewOverChapter({
+      analyzer: makeStub(-1),
+      engine: 'local',
+      manuscriptId: MANUSCRIPT_ID,
+      chapterId: CHAPTER_ID,
+      sentences,
+      roster,
+      call,
+    });
+
+    const runOwned = new Set(ops.filter((o) => o.op === 'strip_tag').map((o) => o.id));
+    expect([...runOwned].sort((a, b) => a - b)).toEqual([...refOwned].sort((a, b) => a - b));
+    // Cores partition the chapter, so every sentence is owned exactly once.
+    expect(runOwned.size).toBe(sentences.length);
+  });
+
+  it('(c) accepted excludes an op planApply rejects (bad anchor)', async () => {
+    const badAnchorId = sentences[0].id; // a chunk-0 core sentence
+    const { ops, accepted } = await runReviewOverChapter({
+      analyzer: makeStub(badAnchorId),
+      engine: 'local',
+      manuscriptId: MANUSCRIPT_ID,
+      chapterId: CHAPTER_ID,
+      sentences,
+      roster,
+      call,
+    });
+
+    // The bad split IS produced (owned, once)…
+    const badSplits = ops.filter((o) => o.op === 'split' && o.id === badAnchorId);
+    expect(badSplits).toHaveLength(1);
+    // …but planApply rejects it (anchor not found), so it is NOT accepted…
+    expect(accepted.some((o) => o.op === 'split' && o.id === badAnchorId)).toBe(false);
+    // …while the same sentence's strip_tag (no anchor requirement) still is.
+    expect(accepted.some((o) => o.op === 'strip_tag' && o.id === badAnchorId)).toBe(true);
+  });
+});

--- a/server/src/analyzer/attribution-eval/review-run.test.ts
+++ b/server/src/analyzer/attribution-eval/review-run.test.ts
@@ -23,6 +23,7 @@ import {
   OUTPUT_HEAVY_CLOUD_RESERVED_TOKENS,
 } from '../chapter-chunker.js';
 import { buildReviewSentencesInput } from '../../routes/script-review.js';
+import { AnalyzerTruncatedError } from '../errors.js';
 import type { Analyzer, StageCall } from '../index.js';
 import type { SentenceOutput, ScriptReviewOp, ScriptReviewOutput } from '../../handoff/schemas.js';
 
@@ -172,5 +173,104 @@ describe('runReviewOverChapter — route-parity chunk loop', () => {
     expect(accepted.some((o) => o.op === 'split' && o.id === badAnchorId)).toBe(false);
     // …while the same sentence's strip_tag (no anchor requirement) still is.
     expect(accepted.some((o) => o.op === 'strip_tag' && o.id === badAnchorId)).toBe(true);
+  });
+});
+
+describe('runReviewOverChapter — force-split retry on AnalyzerTruncatedError', () => {
+  const call: StageCall = {};
+
+  /* Stub: throws AnalyzerTruncatedError whenever the prompt it is handed
+     carries `sizeThreshold`-or-more distinct sentenceIds, and returns a valid
+     `strip_tag` per visible id otherwise. Paired with a chapter sized so the
+     UNSPLIT whole-chapter core is the only prompt that ever hits the
+     threshold — each half's retry prompt (core + up to CHUNK_OVERLAP=3
+     sentences of the other half as context) stays strictly under it — so
+     this reproduces "throws once on the oversized core, succeeds on both
+     halves" without a mutable call-order flag. */
+  function makeThrowAboveSize(sizeThreshold: number): Analyzer {
+    return {
+      async runScriptReviewChapter(
+        _manuscriptId: string,
+        _chapterId: number,
+        prompt: string,
+        _call: StageCall,
+      ): Promise<ScriptReviewOutput> {
+        const ids = presentIds(prompt);
+        if (ids.length >= sizeThreshold) {
+          throw new AnalyzerTruncatedError('ollama', 'length', 999);
+        }
+        return { ops: ids.map((id) => ({ id, op: 'strip_tag', anchor: 'x', rationale } as ScriptReviewOp)) };
+      },
+    } as unknown as Analyzer;
+  }
+
+  // Stub: ALWAYS throws AnalyzerTruncatedError, regardless of core size.
+  function makeAlwaysThrows(): Analyzer {
+    return {
+      async runScriptReviewChapter(): Promise<ScriptReviewOutput> {
+        throw new AnalyzerTruncatedError('ollama', 'length', 999);
+      },
+    } as unknown as Analyzer;
+  }
+
+  it('recovers via halve-and-retry: resolves, collects owned ops from BOTH halves, no duplicate ownership', async () => {
+    // 8 tiny sentences → one top-level chunk (verified below), so the retry
+    // logic under test is exercised in isolation from the top-level chunk loop.
+    const sentences = makeSentences(8, 50);
+    expect(refChunksFor(sentences).length).toBe(1); // precondition: single top-level core
+
+    // The whole (unsplit) core sees all 8 ids. After one halve (mid=4), each
+    // half's retry prompt is its own 4-sentence core plus up to 3 sentences of
+    // context bled in from the other half (CHUNK_OVERLAP) — 7 distinct ids at
+    // most, never all 8 — so the threshold below fires ONLY on the initial,
+    // unsplit call.
+    const stub = makeThrowAboveSize(sentences.length);
+
+    const { ops } = await runReviewOverChapter({
+      analyzer: stub,
+      engine: 'local',
+      manuscriptId: MANUSCRIPT_ID,
+      chapterId: CHAPTER_ID,
+      sentences,
+      roster,
+      call,
+    });
+
+    // (a) the retry recovered — the promise resolved at all (would otherwise
+    // reject, failing this `await`).
+    // (b) ops from BOTH halves were collected: an op owned by a left-half
+    // sentence (id 2, core [1,2,3,4]) AND one owned by a right-half sentence
+    // (id 6, core [5,6,7,8]) both appear.
+    expect(ops.some((o) => o.op === 'strip_tag' && o.id === 2)).toBe(true);
+    expect(ops.some((o) => o.op === 'strip_tag' && o.id === 6)).toBe(true);
+    // (c) no op is duplicated despite the overlap context bled into each
+    // half's retry prompt — ownership de-dup still holds through the split:
+    // exactly one strip_tag per sentence, ids 1..8, nothing more/less.
+    const stripIds = ops
+      .filter((o) => o.op === 'strip_tag')
+      .map((o) => o.id)
+      .sort((a, b) => a - b);
+    expect(stripIds).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+  });
+
+  it('depth-exhaustion: an always-truncating analyzer eventually rejects with AnalyzerTruncatedError (no infinite loop)', async () => {
+    // 16 tiny sentences → one top-level chunk (verified below); halving
+    // 16→8→4→2 across 3 recursive splits still leaves a core of length 2
+    // (>1) at depth 3, so the rejection below is forced by the
+    // MAX_FORCE_SPLIT_DEPTH guard itself, not just the length===1 floor.
+    const sentences = makeSentences(16, 50);
+    expect(refChunksFor(sentences).length).toBe(1); // precondition: single top-level core
+
+    await expect(
+      runReviewOverChapter({
+        analyzer: makeAlwaysThrows(),
+        engine: 'local',
+        manuscriptId: MANUSCRIPT_ID,
+        chapterId: CHAPTER_ID,
+        sentences,
+        roster,
+        call,
+      }),
+    ).rejects.toBeInstanceOf(AnalyzerTruncatedError);
   });
 });

--- a/server/src/analyzer/attribution-eval/review-run.ts
+++ b/server/src/analyzer/attribution-eval/review-run.ts
@@ -1,0 +1,128 @@
+/* Task 5 — a THIN, faithful re-implementation of the script-review chunk loop
+   for the attribution eval harness. It mirrors the production route's core loop
+   (`reviewCore` inside `runScriptReviewJob`, server/src/routes/script-review.ts
+   ~810-875) EXACTLY for the parts that determine which ops a chapter produces:
+   the same budgeted chunking, the same per-chunk inbox, the same op-ownership
+   filter (`ownsOp`/`primarySentenceId`) that de-dups ops across overlapping
+   chunk context, and the same halve-and-retry force-split on truncation.
+
+   It deliberately drops what the route adds around that core and what has no
+   place in a batch eval: SSE streaming (`send`/heartbeat), the ledger/checkpoint
+   machinery, the fallback-engine switch, per-pass eval timing, and abort
+   bookkeeping. Those never change which ops are emitted — the eval only needs
+   the ops + their planApply-accepted subset.
+
+   `reviewCore` is a closure inside `runScriptReviewJob` and is NOT importable, so
+   this re-implements the loop while REUSING the same pure helpers production uses
+   (`chunkSentencesByBudget`, `ownsOp`, `primarySentenceId`, `chapterChunkBudget`,
+   `buildScriptReviewChapterInbox`, `buildReviewSentencesInput`, `planApply`) — the
+   route-parity test pins this loop against an ownership reference computed over
+   the SAME shared helpers, catching internal drift. */
+import type { Analyzer, StageCall } from '../index.js';
+import type { SentenceOutput, ScriptReviewOp } from '../../handoff/schemas.js';
+import {
+  chunkSentencesByBudget,
+  ownsOp,
+  primarySentenceId,
+  chapterChunkBudget,
+  OUTPUT_HEAVY_CLOUD_RESERVED_TOKENS,
+} from '../chapter-chunker.js';
+import {
+  buildScriptReviewChapterInbox,
+  buildReviewSentencesInput,
+  type PriorExchange,
+} from '../../routes/script-review.js';
+import { planApply, type LiveSentence } from './review-apply-core.js';
+import { AnalyzerTruncatedError } from '../errors.js';
+
+/* The route's `MAX_FORCE_SPLIT_DEPTH` and `CHUNK_OVERLAP` are both 3 but not
+   exported — redeclared locally to match (server/src/routes/script-review.ts). */
+const MAX_FORCE_SPLIT_DEPTH = 3;
+const CHUNK_OVERLAP = 3;
+
+export async function runReviewOverChapter(opts: {
+  analyzer: Analyzer;
+  engine: 'local' | 'gemini';
+  manuscriptId: string;
+  chapterId: number;
+  sentences: SentenceOutput[];
+  roster: Array<{ id: string; name: string; role?: string }>;
+  priorExchange?: PriorExchange;
+  evidence?: Map<number, string>;
+  call: StageCall;
+}): Promise<{ ops: ScriptReviewOp[]; accepted: ScriptReviewOp[] }> {
+  const { analyzer, engine, manuscriptId, chapterId, sentences, roster, priorExchange, evidence, call } =
+    opts;
+
+  const chunks = chunkSentencesByBudget(sentences, {
+    charBudget: chapterChunkBudget(
+      engine,
+      JSON.stringify(roster).length + 800, // roster payload + fixed template scaffold
+      sentences.map((s) => s.text).join(' '), // sample → chars/token
+      OUTPUT_HEAVY_CLOUD_RESERVED_TOKENS, // reserve system-prompt overhead so the whole request clears the TPM guard
+    ),
+    overlap: CHUNK_OVERLAP,
+    // Size each sentence by the REAL per-sentence payload buildReviewSentencesInput
+    // emits (the structureEvidence note folded into `text`, plus instruct/vocalization) —
+    // not the bare {id,characterId,text} — matching the route exactly.
+    serialize: (s) => JSON.stringify(buildReviewSentencesInput([s], evidence)[0]),
+  });
+
+  /* Force-split-on-truncation recovery, mirroring the route's `reviewCore`:
+     on AnalyzerTruncatedError, halve the core and retry each half (depth ≤
+     MAX_FORCE_SPLIT_DEPTH). The left/right cores partition the parent core, so
+     `ownsOp` keeps de-duping across the added overlap; a single sentence that
+     still truncates can't split further → re-throws. Returns the owned ops. */
+  const OVERLAP = CHUNK_OVERLAP;
+  const reviewCore = async (
+    core: SentenceOutput[],
+    contextBefore: SentenceOutput[],
+    contextAfter: SentenceOutput[],
+    withPrior: boolean,
+    depth: number,
+  ): Promise<ScriptReviewOp[]> => {
+    const coreIds = new Set(core.map((s) => s.id));
+    const prompt = buildScriptReviewChapterInbox(
+      manuscriptId,
+      chapterId,
+      [...contextBefore, ...core, ...contextAfter],
+      roster,
+      withPrior ? (priorExchange ?? null) : null,
+      evidence,
+    );
+    try {
+      const result = await analyzer.runScriptReviewChapter(manuscriptId, chapterId, prompt, call);
+      return result.ops.filter((op) => ownsOp(coreIds, primarySentenceId(op)));
+    } catch (err) {
+      if (err instanceof AnalyzerTruncatedError && depth < MAX_FORCE_SPLIT_DEPTH && core.length > 1) {
+        const mid = Math.ceil(core.length / 2);
+        const left = core.slice(0, mid);
+        const right = core.slice(mid);
+        const leftOps = await reviewCore(left, contextBefore, [...right.slice(0, OVERLAP), ...contextAfter], withPrior, depth + 1);
+        const rightOps = await reviewCore(right, [...contextBefore, ...left.slice(-OVERLAP)], contextAfter, false, depth + 1);
+        return [...leftOps, ...rightOps];
+      }
+      throw err;
+    }
+  };
+
+  const ops: ScriptReviewOp[] = [];
+  for (let index = 0; index < chunks.length; index += 1) {
+    const chunk = chunks[index];
+    const owned = await reviewCore(chunk.core, chunk.contextBefore, chunk.contextAfter, index === 0, 0);
+    ops.push(...owned);
+  }
+
+  const live: LiveSentence[] = sentences.map((s) => ({
+    id: s.id,
+    chapterId: s.chapterId,
+    text: s.text,
+    characterId: s.characterId,
+    ...(s.instruct !== undefined ? { instruct: s.instruct } : {}),
+    ...(s.vocalization !== undefined ? { vocalization: s.vocalization } : {}),
+  }));
+  const rosterSet = new Set(roster.map((r) => r.id));
+  const accepted = planApply(ops, live, rosterSet).appliable;
+
+  return { ops, accepted };
+}

--- a/server/src/analyzer/attribution-eval/run-eval-cli.test.ts
+++ b/server/src/analyzer/attribution-eval/run-eval-cli.test.ts
@@ -133,6 +133,17 @@ describe('formatReviewLine', () => {
     const line = formatReviewLine(agg, 1);
     expect(line).toContain('4 predicted units unlocated — char coverage incomplete');
   });
+
+  it('omits the truth-side coverage warning when truthDropped.mean is 0', () => {
+    const line = formatReviewLine(baseAgg(), 1);
+    expect(line).not.toContain('recall denominator incomplete');
+  });
+
+  it('adds the truth-side coverage warning when truthDropped.mean > 0', () => {
+    const agg = baseAgg({ truthDropped: st(3) });
+    const line = formatReviewLine(agg, 1);
+    expect(line).toContain('3 truth units unlocated — recall denominator incomplete');
+  });
 });
 
 describe('partitionByTier', () => {

--- a/server/src/analyzer/attribution-eval/run-eval-cli.test.ts
+++ b/server/src/analyzer/attribution-eval/run-eval-cli.test.ts
@@ -2,7 +2,15 @@ import { describe, it, expect } from 'vitest';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { runEval, slotLabel } from './run-eval-cli.js';
+import {
+  runEval,
+  slotLabel,
+  parseFixtureFilename,
+  formatReviewLine,
+  partitionByTier,
+  type ScoredFixture,
+} from './run-eval-cli.js';
+import type { ReviewAgg, Stat } from './run-eval.js';
 
 describe('runEval gating', () => {
   it('SKIPs cleanly when the corpus dir is empty', async () => {
@@ -43,5 +51,103 @@ describe('slotLabel', () => {
     } finally {
       if (prev !== undefined) process.env.GEMINI_MODEL = prev;
     }
+  });
+});
+
+describe('parseFixtureFilename', () => {
+  it('tags a fixture with the .silver segment as silver', () => {
+    expect(parseFixtureFilename('foo-ch12.en.silver.labelled.json')).toEqual({
+      slug: 'foo',
+      chapterId: 12,
+      lang: 'en',
+      tier: 'silver',
+    });
+  });
+
+  it('tags a fixture without the .silver segment as gold', () => {
+    expect(parseFixtureFilename('foo-ch12.en.labelled.json')).toEqual({
+      slug: 'foo',
+      chapterId: 12,
+      lang: 'en',
+      tier: 'gold',
+    });
+  });
+
+  it('tags the committed Coalfall guardrail as gold (no .silver segment)', () => {
+    expect(parseFixtureFilename('coalfall-ch1.en.labelled.json')).toEqual({
+      slug: 'coalfall',
+      chapterId: 1,
+      lang: 'en',
+      tier: 'gold',
+    });
+  });
+
+  it('returns null for a non-matching filename (e.g. a roster sidecar)', () => {
+    expect(parseFixtureFilename('foo.roster.json')).toBeNull();
+  });
+});
+
+describe('formatReviewLine', () => {
+  const st = (n: number): Stat => ({ mean: n, min: n, max: n });
+  const baseAgg = (overrides: Partial<ReviewAgg> = {}): ReviewAgg => ({
+    charFinal: st(0.7),
+    charReviewed: st(0.75),
+    lineFinal: st(0.6),
+    lineReviewed: st(0.65),
+    helped: st(10),
+    harmed: st(2),
+    churn: st(3),
+    predictedDropped: st(0),
+    truthDropped: st(0),
+    opsByClass: {},
+    dump: [],
+    ...overrides,
+  });
+
+  it('renders the char Δ, the line pair, and helped/harmed/churn at runs=1', () => {
+    const line = formatReviewLine(baseAgg(), 1);
+    expect(line).toContain('final(char) 70.0% → reviewed(char) 75.0%');
+    expect(line).toContain('Δ +5.0pp');
+    expect(line).toContain('line 60.0l%→65.0l%');
+    expect(line).toContain('helped 10 harmed 2 churn 3');
+  });
+
+  it('omits the coverage-health warning when predictedDropped.mean is 0', () => {
+    const line = formatReviewLine(baseAgg(), 1);
+    expect(line).not.toContain('unlocated');
+  });
+
+  it('renders a negative Δ when the reviewed stage regresses', () => {
+    const line = formatReviewLine(baseAgg({ charFinal: st(0.8), charReviewed: st(0.75) }), 1);
+    expect(line).toContain('Δ -5.0pp');
+  });
+
+  it('shows a min–max range for the char stats when runs > 1', () => {
+    const agg = baseAgg({ charFinal: { mean: 0.7, min: 0.65, max: 0.75 } });
+    const line = formatReviewLine(agg, 3);
+    expect(line).toContain('[65.0%–75.0%]');
+  });
+
+  it('adds the coverage-health warning when predictedDropped.mean > 0', () => {
+    const agg = baseAgg({ predictedDropped: st(4) });
+    const line = formatReviewLine(agg, 1);
+    expect(line).toContain('4 predicted units unlocated — char coverage incomplete');
+  });
+});
+
+describe('partitionByTier', () => {
+  it('splits gold (incl. the Coalfall guardrail) from silver, preserving relative order', () => {
+    const gold1 = { fixture: 'a', tier: 'gold' } as unknown as ScoredFixture;
+    const coalfall = { fixture: 'coalfall-ch1.en.labelled.json', tier: 'gold' } as unknown as ScoredFixture;
+    const silver1 = { fixture: 'b', tier: 'silver' } as unknown as ScoredFixture;
+
+    const { gold, silver } = partitionByTier([gold1, silver1, coalfall]);
+
+    expect(gold.map((f) => f.fixture)).toEqual(['a', 'coalfall-ch1.en.labelled.json']);
+    expect(silver.map((f) => f.fixture)).toEqual(['b']);
+  });
+
+  it('returns empty arrays for an empty fixture list', () => {
+    expect(partitionByTier([])).toEqual({ gold: [], silver: [] });
   });
 });

--- a/server/src/analyzer/attribution-eval/run-eval-cli.ts
+++ b/server/src/analyzer/attribution-eval/run-eval-cli.ts
@@ -181,6 +181,9 @@ export function formatReviewLine(agg: ReviewAgg, runs: number): string {
   if (agg.predictedDropped.mean > 0) {
     line += `\n      ⚠ ${countFmt(agg.predictedDropped.mean)} predicted units unlocated — char coverage incomplete`;
   }
+  if (agg.truthDropped.mean > 0) {
+    line += `\n      ⚠ ${countFmt(agg.truthDropped.mean)} truth units unlocated — recall denominator incomplete`;
+  }
   return line;
 }
 

--- a/server/src/analyzer/attribution-eval/run-eval-cli.ts
+++ b/server/src/analyzer/attribution-eval/run-eval-cli.ts
@@ -3,7 +3,15 @@ import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseLabelledChapter, type LabelledChapter } from './schema.js';
 import { parseRosterSnapshot, type RosterSnapshot } from './roster-schema.js';
-import { evalFixture, aggregateFixture, type FixtureResult, type FixtureAgg, type StageAgg } from './run-eval.js';
+import {
+  evalFixture,
+  aggregateFixture,
+  type FixtureResult,
+  type FixtureAgg,
+  type StageAgg,
+  type ReviewAgg,
+  type Stat,
+} from './run-eval.js';
 import { OllamaAnalyzer } from '../ollama.js';
 import { GeminiAnalyzer } from '../gemini.js';
 import type { Analyzer } from '../index.js';
@@ -11,12 +19,29 @@ import type { Analyzer } from '../index.js';
 const DEFAULT_CORPUS = fileURLToPath(new URL('./corpus/', import.meta.url));
 const COMMITTED = fileURLToPath(new URL('./__fixtures__/', import.meta.url));
 
-// Fixture: <slug>-ch<NN>.<lang>.labelled.json ; roster (per book): <slug>.roster.json
-const FIXTURE_RE = /^(.+)-ch(\d+)\.([a-z]{2})\.labelled\.json$/;
+// Fixture: <slug>-ch<NN>.<lang>(.silver)?.labelled.json ; roster (per book): <slug>.roster.json
+// The optional `.silver` segment tags a fixture as directional (not gating) —
+// see `parseFixtureFilename`/`partitionByTier`.
+const FIXTURE_RE = /^(.+)-ch(\d+)\.([a-z]{2})(\.silver)?\.labelled\.json$/;
 
 export function slotLabel(engine: 'qwen' | 'gemma'): string {
   if (engine === 'qwen') return `qwen:${process.env.EVAL_QWEN_MODEL ?? 'qwen3.5:9b'}`;
   return `gemma:${process.env.GEMINI_MODEL ?? 'gemma-4-31b-it'}`;
+}
+
+/** Pure — no filesystem access. Parses a fixture filename into its slug/
+    chapter/lang/tier. Returns null for anything that doesn't match
+    `FIXTURE_RE` (e.g. a `.roster.json` sidecar). `tier` is 'silver' only when
+    the optional `.silver` segment is present; otherwise 'gold' — so the
+    committed Coalfall guardrail (`coalfall-ch1.en.labelled.json`, no
+    `.silver` segment) is 'gold' with no special-casing needed. */
+export function parseFixtureFilename(
+  name: string,
+): { slug: string; chapterId: number; lang: string; tier: 'gold' | 'silver' } | null {
+  const m = FIXTURE_RE.exec(name);
+  if (!m) return null;
+  const [, slug, chap, lang, silverFlag] = m;
+  return { slug, chapterId: Number(chap), lang, tier: silverFlag ? 'silver' : 'gold' };
 }
 
 interface CorpusItem {
@@ -25,6 +50,7 @@ interface CorpusItem {
   roster: RosterSnapshot;
   chapterId: number;
   lang: string;
+  tier: 'gold' | 'silver';
 }
 
 async function loadDir(dir: string): Promise<CorpusItem[]> {
@@ -36,12 +62,12 @@ async function loadDir(dir: string): Promise<CorpusItem[]> {
   }
   const out: CorpusItem[] = [];
   for (const f of files) {
-    const m = FIXTURE_RE.exec(f);
-    if (!m) continue;
-    const [, slug, chap, lang] = m;
+    const parsed = parseFixtureFilename(f);
+    if (!parsed) continue;
+    const { slug, chapterId, lang, tier } = parsed;
     const truth = parseLabelledChapter(JSON.parse(await readFile(join(dir, f), 'utf8')));
     const roster = parseRosterSnapshot(JSON.parse(await readFile(join(dir, `${slug}.roster.json`), 'utf8')));
-    out.push({ name: f, truth, roster, chapterId: Number(chap), lang });
+    out.push({ name: f, truth, roster, chapterId, lang, tier });
   }
   return out;
 }
@@ -66,11 +92,17 @@ async function buildAnalyzer(engine: 'qwen' | 'gemma'): Promise<Analyzer | null>
   return new GeminiAnalyzer({ apiKey, model: process.env.GEMINI_MODEL ?? 'gemma-4-31b-it' });
 }
 
+/** A FixtureAgg tagged with its corpus tier, for the CLI's gold/silver
+    partition. Kept as a CLI-local intersection type rather than a change to
+    `FixtureAgg` itself — the eval core (run-eval.ts) has no notion of tiers. */
+export type ScoredFixture = FixtureAgg & { tier: 'gold' | 'silver' };
+
 export async function runEval(opts: {
   engines: Array<'qwen' | 'gemma'>;
   corpusDir?: string;
   runs?: number;
-}): Promise<{ skipped: string | null; runs: number; results: Array<{ engine: string; fixtures: FixtureAgg[] }> }> {
+  review?: boolean;
+}): Promise<{ skipped: string | null; runs: number; results: Array<{ engine: string; fixtures: ScoredFixture[] }> }> {
   const runs = Math.max(1, opts.runs ?? 1);
   const corpus = await loadCorpus(opts.corpusDir ?? DEFAULT_CORPUS);
   if (corpus.length === 0) {
@@ -78,11 +110,11 @@ export async function runEval(opts: {
   }
   const all = [...corpus, ...(await loadDir(COMMITTED))]; // + committed Coalfall guardrail
 
-  const results: Array<{ engine: string; fixtures: FixtureAgg[] }> = [];
+  const results: Array<{ engine: string; fixtures: ScoredFixture[] }> = [];
   for (const engine of opts.engines) {
     const analyzer = await buildAnalyzer(engine);
     if (!analyzer) return { skipped: `engine ${engine} unavailable (Ollama down / no GEMINI_API_KEY)`, runs, results: [] };
-    const fixtures: FixtureAgg[] = [];
+    const fixtures: ScoredFixture[] = [];
     for (const c of all) {
       const perRun: FixtureResult[] = [];
       for (let i = 0; i < runs; i++) {
@@ -96,10 +128,13 @@ export async function runEval(opts: {
             chapterId: c.chapterId,
             stageCall: { language: c.lang } as never,
             fixtureName: c.name,
+            review: opts.review,
+            engine,
+            language: c.lang,
           }),
         );
       }
-      fixtures.push(aggregateFixture(perRun));
+      fixtures.push({ ...aggregateFixture(perRun), tier: c.tier });
     }
     results.push({ engine: slotLabel(engine), fixtures });
   }
@@ -107,8 +142,20 @@ export async function runEval(opts: {
 }
 
 const pct = (n: number) => `${(n * 100).toFixed(1)}%`;
-const range = (s: StageAgg['recall'], runs: number) =>
+const range = (s: Stat, runs: number) =>
   runs > 1 ? `${pct(s.mean)} [${pct(s.min)}–${pct(s.max)}]` : pct(s.mean);
+// Line-level ratios get an `l%` suffix (vs. char-level `%`) so the two scales
+// in `formatReviewLine`'s combined line aren't confused for each other.
+const lrange = (s: Stat, runs: number) => {
+  const fmt = (n: number) => `${(n * 100).toFixed(1)}l%`;
+  return runs > 1 ? `${fmt(s.mean)} [${fmt(s.min)}–${fmt(s.max)}]` : fmt(s.mean);
+};
+// Counts (helped/harmed/churn/predictedDropped) — whole numbers print bare;
+// a fractional mean (runs>1 averaging different per-run integer counts) gets
+// one decimal.
+const countFmt = (n: number) => (Number.isInteger(n) ? String(n) : n.toFixed(1));
+const crange = (s: Stat, runs: number) =>
+  runs > 1 ? `${countFmt(s.mean)} [${countFmt(s.min)}–${countFmt(s.max)}]` : countFmt(s.mean);
 
 function famLine(b: StageAgg['byFamily'][string], runs: number): string {
   if (b.sampleRuns === 0) return `— (drift only, ${b.driftMean.toFixed(1)} avg)`;
@@ -117,19 +164,77 @@ function famLine(b: StageAgg['byFamily'][string], runs: number): string {
   return `${acc} over ${b.sampleRuns} run${b.sampleRuns === 1 ? '' : 's'}${driftNote}`;
 }
 
-function printScorecard(results: Array<{ engine: string; fixtures: FixtureAgg[] }>): void {
+/** Pure — renders the reviewed-stage char/line summary line for one fixture's
+    ReviewAgg, plus (when applicable) the coverage-health warning. Ranges
+    (`[min–max]`) are shown only when `runs > 1`; a single run just prints the
+    mean. `predictedDropped.mean > 0` means some truth-aligned char span in
+    the FINAL projection couldn't be matched back to a sentence span (see
+    `pairSpansToSentences` in run-eval.ts) — reviewed char coverage over that
+    fixture is therefore incomplete, not necessarily wrong. */
+export function formatReviewLine(agg: ReviewAgg, runs: number): string {
+  const deltaPct = (agg.charReviewed.mean - agg.charFinal.mean) * 100;
+  const delta = `${deltaPct >= 0 ? '+' : ''}${deltaPct.toFixed(1)}pp`;
+  let line =
+    `final(char) ${range(agg.charFinal, runs)} → reviewed(char) ${range(agg.charReviewed, runs)} ` +
+    `(Δ ${delta} | line ${lrange(agg.lineFinal, runs)}→${lrange(agg.lineReviewed, runs)} | ` +
+    `helped ${crange(agg.helped, runs)} harmed ${crange(agg.harmed, runs)} churn ${crange(agg.churn, runs)})`;
+  if (agg.predictedDropped.mean > 0) {
+    line += `\n      ⚠ ${countFmt(agg.predictedDropped.mean)} predicted units unlocated — char coverage incomplete`;
+  }
+  return line;
+}
+
+/** Pure — splits a corpus-ordered fixture list into gold (including the
+    committed Coalfall guardrail, which is untagged → 'gold') vs. silver,
+    preserving each partition's relative order. Silver fixtures are
+    directional signal only — never gating. */
+export function partitionByTier<T extends { tier: 'gold' | 'silver' }>(
+  fixtures: T[],
+): { gold: T[]; silver: T[] } {
+  return {
+    gold: fixtures.filter((f) => f.tier === 'gold'),
+    silver: fixtures.filter((f) => f.tier === 'silver'),
+  };
+}
+
+function printFixtureBlock(f: ScoredFixture, marker: string): void {
+  console.log(
+    `  ${f.fixture}${marker}: raw ${range(f.raw.recall, f.runs)} → det ${range(f.deterministic.recall, f.runs)} → final ${range(f.final.recall, f.runs)} (n=${f.final.total}, drift ${f.final.segDriftMean.toFixed(0)}, runs=${f.runs})`,
+  );
+  for (const fam of Object.keys(f.raw.byFamily).sort()) {
+    console.log(`      raw · ${fam}: ${famLine(f.raw.byFamily[fam], f.runs)}`);
+  }
+  for (const fam of Object.keys(f.final.byFamily).sort()) {
+    console.log(`      ${fam}: ${famLine(f.final.byFamily[fam], f.runs)}`);
+  }
+  if (!f.reviewed) return;
+  console.log(`      ${formatReviewLine(f.reviewed, f.runs)}`);
+  const classes = Object.keys(f.reviewed.opsByClass).sort();
+  if (classes.length > 0) {
+    const byClass = classes.map((c) => `${c}=${f.reviewed!.opsByClass[c].toFixed(1)}`).join(', ');
+    console.log(`      ops by class: ${byClass}`);
+  }
+  if (f.reviewed.dump.length > 0) {
+    // NOTE: this dump is the un-scored op classes + off-roster reattributes —
+    // NOT an exhaustive list of ops that changed nothing. A split/extract that
+    // passed planApply but was silently no-op'd by applyOpsToCharArray's
+    // defensive guards is counted as "scored" and won't appear here.
+    console.log(`      op-dump (un-scored ops, illustrative):`);
+    for (const d of f.reviewed.dump) {
+      const anchor = d.anchor !== undefined ? ` (anchor: ${d.anchor})` : '';
+      console.log(`        #${d.id} ${d.op} — ${d.rationale}${anchor}`);
+    }
+  }
+}
+
+function printScorecard(results: Array<{ engine: string; fixtures: ScoredFixture[] }>): void {
   for (const { engine, fixtures } of results) {
     console.log(`\n=== engine: ${engine} ===`);
-    for (const f of fixtures) {
-      console.log(
-        `  ${f.fixture}: raw ${range(f.raw.recall, f.runs)} → det ${range(f.deterministic.recall, f.runs)} → final ${range(f.final.recall, f.runs)} (n=${f.final.total}, drift ${f.final.segDriftMean.toFixed(0)}, runs=${f.runs})`,
-      );
-      for (const fam of Object.keys(f.raw.byFamily).sort()) {
-        console.log(`      raw · ${fam}: ${famLine(f.raw.byFamily[fam], f.runs)}`);
-      }
-      for (const fam of Object.keys(f.final.byFamily).sort()) {
-        console.log(`      ${fam}: ${famLine(f.final.byFamily[fam], f.runs)}`);
-      }
+    const { gold, silver } = partitionByTier(fixtures);
+    for (const f of gold) printFixtureBlock(f, '');
+    if (silver.length > 0) {
+      console.log(`  --- silver (directional, not gating) ---`);
+      for (const f of silver) printFixtureBlock(f, ' [directional]');
     }
   }
 }
@@ -150,9 +255,20 @@ function parseRuns(argv: string[]): number {
   return Math.max(1, Math.floor(n));
 }
 
+function parseReview(argv: string[]): boolean {
+  if (argv.includes('--review')) return true;
+  const v = process.env.EVAL_REVIEW;
+  if (!v) return false;
+  return v === '1' || v.toLowerCase() === 'true';
+}
+
 async function main(): Promise<void> {
   const argv = process.argv.slice(2);
-  const { skipped, results } = await runEval({ engines: parseEngines(argv), runs: parseRuns(argv) });
+  const { skipped, results } = await runEval({
+    engines: parseEngines(argv),
+    runs: parseRuns(argv),
+    review: parseReview(argv),
+  });
   if (skipped) {
     console.log(`[SKIP] attribution eval: ${skipped}`);
     process.exit(0);

--- a/server/src/analyzer/attribution-eval/run-eval.test.ts
+++ b/server/src/analyzer/attribution-eval/run-eval.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { evalFixture, rosterToStage1, familyBreakdown, aggStage, rosterAliasMap, scoreStage, type StageScore } from './run-eval.js';
+import { evalFixture, rosterToStage1, familyBreakdown, aggStage, aggregateFixture, rosterAliasMap, scoreStage, type StageScore, type ReviewScore, type FixtureResult } from './run-eval.js';
 import type { LabelledChapter } from './schema.js';
 import type { RosterSnapshot } from './roster-schema.js';
 import type { SentenceOutput } from '../../handoff/schemas.js';
@@ -158,5 +158,88 @@ describe('evalFixture', () => {
     expect(Object.keys(res.raw.byFamily).sort()).toEqual(
       Object.keys(res.deterministic.byFamily).sort(),
     );
+  });
+
+  it('review:false (default) leaves raw/det/final byte-identical and omits reviewed', async () => {
+    const res = await evalFixture({
+      analyzer: fakeAnalyzer,
+      manuscriptId: 'm', title: 'T', truth, roster, chapterId: 44,
+      stageCall: { language: 'en' } as never,
+    });
+    // The non-review result shape is exactly the four existing keys.
+    expect(Object.keys(res).sort()).toEqual(['deterministic', 'final', 'fixture', 'raw']);
+    expect('reviewed' in res).toBe(false);
+    expect(res.final.recall).toBeCloseTo(1);
+  });
+});
+
+describe('evalFixture — reviewed char-stage (opt-in)', () => {
+  // Analyzer whose review pass emits one on-roster reattribute that HARMS the
+  // (correct) narration span id:2 by pointing it at alice — a deterministic way
+  // to exercise applyOpsToCharArray + diffHelpedHarmed through the char adapter.
+  const reviewAnalyzer: any = {
+    ...fakeAnalyzer,
+    runScriptReviewChapter: () =>
+      Promise.resolve({
+        ops: [{ id: 2, op: 'reattribute', characterId: 'alice', rationale: 'test harm' }],
+      }),
+  };
+
+  it('populates reviewed with char/line recalls, helped/harmed, drops, opsByClass and a scored (non-dumped) op', async () => {
+    const res = await evalFixture({
+      analyzer: reviewAnalyzer,
+      manuscriptId: 'm', title: 'T', truth, roster, chapterId: 44,
+      stageCall: { language: 'en' } as never,
+      review: true,
+      engine: 'qwen',
+    });
+    expect(res.reviewed).toBeDefined();
+    const rv = res.reviewed!;
+    // char adapter (characterId → speakerId) works: final matches truth → charFinal > 0.
+    expect(rv.charFinal).toBeGreaterThan(0);
+    expect(typeof rv.lineFinal).toBe('number');
+    expect(typeof rv.lineReviewed).toBe('number');
+    // The reattribute on the (correct) narration span is a harm → reviewed drops below final.
+    expect(rv.charReviewed).toBeLessThan(rv.charFinal);
+    expect(rv.harmed).toBeGreaterThan(0);
+    expect(rv.helped).toBe(0);
+    expect(rv.churn).toBe(0);
+    // Verbatim final/truth text → nothing drops out of the projection.
+    expect(rv.predictedDropped).toBe(0);
+    expect(rv.truthDropped).toBe(0);
+    // opsByClass counts ALL ops; the accepted char-affecting reattribute is SCORED, so not dumped.
+    expect(rv.opsByClass.reattribute).toBe(1);
+    expect(rv.dump).toEqual([]);
+  });
+});
+
+describe('aggregateFixture — reviewed aggregation (aggReview)', () => {
+  const mkReviewed = (over: Partial<ReviewScore>): ReviewScore => ({
+    charFinal: 1, charReviewed: 1, lineFinal: 1, lineReviewed: 1,
+    helped: 0, harmed: 0, churn: 0, predictedDropped: 0, truthDropped: 0,
+    opsByClass: {}, dump: [], ...over,
+  });
+  const mkResult = (reviewed?: ReviewScore): FixtureResult => ({
+    fixture: 'c', raw: mkStage(1, {}), deterministic: mkStage(1, {}), final: mkStage(1, {}),
+    ...(reviewed ? { reviewed } : {}),
+  });
+
+  it('averages per-run reviewed into a ReviewAgg with Stat fields and run-0 dump', () => {
+    const r0 = mkResult(mkReviewed({ helped: 2, harmed: 1, opsByClass: { reattribute: 1 }, dump: [{ id: 1, op: 'strip_tag', rationale: 'r0' }] }));
+    const r1 = mkResult(mkReviewed({ helped: 4, harmed: 3, opsByClass: { reattribute: 3, split: 1 }, dump: [{ id: 2, op: 'merge', rationale: 'r1' }] }));
+    const agg = aggregateFixture([r0, r1]);
+    expect(agg.reviewed).toBeDefined();
+    expect(agg.reviewed!.helped).toEqual({ mean: 3, min: 2, max: 4 });
+    expect(agg.reviewed!.harmed).toEqual({ mean: 2, min: 1, max: 3 });
+    // mean count per class across runs (split absent in run-0 counts as 0).
+    expect(agg.reviewed!.opsByClass.reattribute).toBeCloseTo(2);
+    expect(agg.reviewed!.opsByClass.split).toBeCloseTo(0.5);
+    // dump is representative: run-0's.
+    expect(agg.reviewed!.dump).toEqual(r0.reviewed!.dump);
+  });
+
+  it('leaves reviewed undefined when no run carries a reviewed score', () => {
+    const agg = aggregateFixture([mkResult(), mkResult()]);
+    expect(agg.reviewed).toBeUndefined();
   });
 });

--- a/server/src/analyzer/attribution-eval/run-eval.ts
+++ b/server/src/analyzer/attribution-eval/run-eval.ts
@@ -3,9 +3,16 @@ import type { LabelledChapter } from './schema.js';
 import type { RosterSnapshot } from './roster-schema.js';
 import { evidenceFamily } from './buckets.js';
 import { attributeChapterStage2 } from '../../routes/analysis.js';
-import type { SentenceOutput, Stage1Output } from '../../handoff/schemas.js';
+import type { SentenceOutput, Stage1Output, ScriptReviewOp } from '../../handoff/schemas.js';
 import type { Analyzer } from '../index.js';
 import type { StageCall } from '../index.js';
+import { runReviewOverChapter } from './review-run.js';
+import { projectToChars } from './char-project.js';
+import { scoreCharRecall, diffHelpedHarmed } from './char-score.js';
+import { applyOpsToCharArray } from './apply-ops-chars.js';
+import { normalizeForMatch } from './review-apply-core.js';
+import { buildStructureEvidence } from '../dialogue-structure/evidence.js';
+import { configValue } from '../../config/resolver.js';
 
 export interface FamilyBreakdown {
   correct: number;
@@ -20,11 +27,32 @@ export interface StageScore {
   total: number;
   byFamily: Record<string, FamilyBreakdown>;
 }
+/** Char-level score of the script-review (`reviewed`) stage for ONE run. The
+    line stages score attribution by normalised TEXT; this scores char positions
+    so a correct split/extract/reattribute op reads as an honest recall lift, not
+    a segmentation regression. `opsByClass`/`dump` cover ALL ops (scored
+    attribution ops + un-scored classes + off-roster `proposed` reattributes);
+    `dump` is the un-scored subset, for human eyeballing. No `byFamily` here. */
+export interface ReviewScore {
+  charFinal: number;
+  charReviewed: number;
+  lineFinal: number;
+  lineReviewed: number;
+  helped: number;
+  harmed: number;
+  churn: number;
+  predictedDropped: number;
+  truthDropped: number;
+  opsByClass: Record<string, number>;
+  dump: Array<{ id: number; op: string; rationale: string; anchor?: string }>;
+}
+
 export interface FixtureResult {
   fixture: string;
   raw: StageScore;
   deterministic: StageScore;
   final: StageScore;
+  reviewed?: ReviewScore;
 }
 
 /** Per-evidence-family accuracy that EXCLUDES segmentation drift. `perLine[i]`
@@ -102,6 +130,39 @@ export function scoreStage(
   };
 }
 
+/** An op is "scored" — i.e. reflected in the reviewed char array — only when
+    it's an accepted char-affecting attribution op (mirrors applyOpsToCharArray:
+    reattribute-with-id, split, extract_dialogue). Everything else (other
+    classes, off-roster `proposed` reattributes) is un-scored → dumped. */
+function isCharAffecting(op: ScriptReviewOp): boolean {
+  if (op.op === 'reattribute') return op.characterId != null;
+  return op.op === 'split' || op.op === 'extract_dialogue';
+}
+
+/** Pairs the projection's spans back to their source sentence ids so accepted
+    ops (keyed by sentence id) can be applied. `projectToChars` walks sentences
+    in order and emits a span only for a matched one, so a dropped sentence
+    consumes no span — we advance the span pointer only when the current span's
+    original slice normalises back to the sentence text. An op targeting a
+    dropped (span-less) sentence then finds no span and is skipped by
+    applyOpsToCharArray. */
+function pairSpansToSentences(
+  chapterText: string,
+  sentences: SentenceOutput[],
+  spans: Array<{ start: number; end: number; speakerId: string }>,
+): Array<{ id: number; start: number; end: number }> {
+  const out: Array<{ id: number; start: number; end: number }> = [];
+  let j = 0;
+  for (const s of sentences) {
+    const sp = spans[j];
+    if (sp && normalizeForMatch(chapterText.slice(sp.start, sp.end)) === normalizeForMatch(s.text)) {
+      out.push({ id: s.id, start: sp.start, end: sp.end });
+      j += 1;
+    }
+  }
+  return out;
+}
+
 export async function evalFixture(opts: {
   analyzer: Analyzer;
   escalationAnalyzer?: Analyzer | null;
@@ -112,6 +173,9 @@ export async function evalFixture(opts: {
   chapterId: number;
   stageCall: StageCall;
   fixtureName?: string;
+  review?: boolean;
+  engine?: 'qwen' | 'gemma';
+  language?: string;
 }): Promise<FixtureResult> {
   const stage1 = rosterToStage1(opts.roster, opts.chapterId);
   let stages: {
@@ -135,12 +199,96 @@ export async function evalFixture(opts: {
   // because escalation changes ids on already-flagged lines but not the evidence class.
   const reasons = stages!.reasons;
   const aliasMap = rosterAliasMap(opts.roster);
-  return {
+  const base: FixtureResult = {
     fixture: opts.fixtureName ?? `chapter-${opts.chapterId}`,
     raw: scoreStage(opts.truth, stages!.raw, reasons, aliasMap),
     deterministic: scoreStage(opts.truth, stages!.deterministic, reasons, aliasMap),
     final: scoreStage(opts.truth, result.sentences, reasons, aliasMap),
   };
+
+  // OPT-IN reviewed stage. Omitting `review` leaves base (raw/det/final) byte-identical.
+  if (!opts.review) return base;
+
+  const finalSentences = result.sentences;
+  const chunkEngine = opts.engine === 'qwen' ? 'local' : 'gemini';
+
+  // Roster carrying gender/aliases (and role) — the SAME object feeds both the
+  // gemini chunk-budget (via JSON.stringify length inside runReviewOverChapter)
+  // and the inbox, so eval chunk boundaries match production's CastCharacterSlim.
+  const reviewRoster = opts.roster.characters.map((c) => ({
+    id: c.id,
+    name: c.name,
+    role: 'character',
+    ...(c.gender ? { gender: c.gender } : {}),
+    ...(c.aliases ? { aliases: c.aliases } : {}),
+  }));
+
+  // Evidence — eval-native (NOT getOrHydrateManuscript, which has no body for the
+  // synthetic eval manuscript). Gated on the SAME config key the route uses; the
+  // full roster (gender/aliases) is what the structure builder needs.
+  const evidence = configValue<boolean>('analyzer.structure.enabled')
+    ? buildStructureEvidence(opts.truth.chapterText, finalSentences, opts.roster.characters, opts.language ?? 'en')
+    : undefined;
+
+  const { ops, accepted } = await runReviewOverChapter({
+    analyzer: opts.analyzer,
+    engine: chunkEngine,
+    manuscriptId: opts.manuscriptId,
+    chapterId: opts.chapterId,
+    sentences: finalSentences,
+    roster: reviewRoster,
+    ...(opts.truth.priorExchange ? { priorExchange: opts.truth.priorExchange } : {}),
+    evidence,
+    call: opts.stageCall,
+  });
+
+  // char adapter: SentenceOutput.characterId → projectToChars's speakerId (precedent: toPredicted).
+  const truthProj = projectToChars(opts.truth.chapterText, opts.truth.lines);
+  const finalProj = projectToChars(
+    opts.truth.chapterText,
+    finalSentences.map((s) => ({ text: s.text, speakerId: s.characterId })),
+  );
+
+  const finalSpans = pairSpansToSentences(opts.truth.chapterText, finalSentences, finalProj.spans);
+  const reviewedByChar = applyOpsToCharArray(finalProj.speakerByChar, finalSentences, finalSpans, accepted);
+  // scoreCharRecall reads only predicted.speakerByChar (spans/dropped unused for the predicted side).
+  const reviewedProj = { speakerByChar: reviewedByChar, spans: finalProj.spans, dropped: finalProj.dropped };
+
+  const finalScore = scoreCharRecall(truthProj, finalProj, aliasMap);
+  const reviewedScore = scoreCharRecall(truthProj, reviewedProj, aliasMap);
+  const { helped, harmed, churn } = diffHelpedHarmed(
+    finalProj.speakerByChar,
+    reviewedByChar,
+    truthProj.speakerByChar,
+    aliasMap,
+  );
+
+  const opsByClass: Record<string, number> = {};
+  for (const op of ops) opsByClass[op.op] = (opsByClass[op.op] ?? 0) + 1;
+  const scoredSet = new Set(accepted.filter(isCharAffecting));
+  const dump = ops
+    .filter((op) => !scoredSet.has(op))
+    .map((op) => ({
+      id: op.id,
+      op: op.op,
+      rationale: op.rationale,
+      ...(op.anchor !== undefined ? { anchor: op.anchor } : {}),
+    }));
+
+  const reviewed: ReviewScore = {
+    charFinal: finalScore.charRecall,
+    charReviewed: reviewedScore.charRecall,
+    lineFinal: finalScore.lineRecall,
+    lineReviewed: reviewedScore.lineRecall,
+    helped,
+    harmed,
+    churn,
+    predictedDropped: finalProj.dropped,
+    truthDropped: truthProj.dropped,
+    opsByClass,
+    dump,
+  };
+  return { ...base, reviewed };
 }
 
 export interface Stat {
@@ -156,12 +304,30 @@ export interface StageAgg {
   byFamily: Record<string, { acc: Stat; sampleRuns: number; driftMean: number }>;
 }
 
+/** Aggregate of the reviewed stage over N runs. Recalls/counts reuse stat()
+    (mean/min/max); opsByClass is the mean count per class across runs; dump is
+    representative (run-0's — dumps are illustrative, not aggregated). */
+export interface ReviewAgg {
+  charFinal: Stat;
+  charReviewed: Stat;
+  lineFinal: Stat;
+  lineReviewed: Stat;
+  helped: Stat;
+  harmed: Stat;
+  churn: Stat;
+  predictedDropped: Stat;
+  truthDropped: Stat;
+  opsByClass: Record<string, number>;
+  dump: ReviewScore['dump'];
+}
+
 export interface FixtureAgg {
   fixture: string;
   runs: number;
   raw: StageAgg;
   deterministic: StageAgg;
   final: StageAgg;
+  reviewed?: ReviewAgg;
 }
 
 function mean(xs: number[]): number {
@@ -202,13 +368,41 @@ export function aggStage(stages: StageScore[]): StageAgg {
   };
 }
 
+/** Average the per-run reviewed scores. Ratios/counts go through stat();
+    opsByClass is the mean count per class across ALL runs (a class absent in a
+    run counts as 0); dump is run-0's (representative, not aggregated). */
+export function aggReview(scores: ReviewScore[]): ReviewAgg {
+  const classes = new Set<string>();
+  for (const s of scores) for (const k of Object.keys(s.opsByClass)) classes.add(k);
+  const opsByClass: Record<string, number> = {};
+  for (const cls of classes) opsByClass[cls] = mean(scores.map((s) => s.opsByClass[cls] ?? 0));
+
+  return {
+    charFinal: stat(scores.map((s) => s.charFinal)),
+    charReviewed: stat(scores.map((s) => s.charReviewed)),
+    lineFinal: stat(scores.map((s) => s.lineFinal)),
+    lineReviewed: stat(scores.map((s) => s.lineReviewed)),
+    helped: stat(scores.map((s) => s.helped)),
+    harmed: stat(scores.map((s) => s.harmed)),
+    churn: stat(scores.map((s) => s.churn)),
+    predictedDropped: stat(scores.map((s) => s.predictedDropped)),
+    truthDropped: stat(scores.map((s) => s.truthDropped)),
+    opsByClass,
+    dump: scores[0]?.dump ?? [],
+  };
+}
+
 /** Aggregate the N runs of ONE fixture (all same fixture name) into a FixtureAgg. */
 export function aggregateFixture(runs: FixtureResult[]): FixtureAgg {
+  const reviewedScores = runs
+    .map((r) => r.reviewed)
+    .filter((r): r is ReviewScore => r !== undefined);
   return {
     fixture: runs[0].fixture,
     runs: runs.length,
     raw: aggStage(runs.map((r) => r.raw)),
     deterministic: aggStage(runs.map((r) => r.deterministic)),
     final: aggStage(runs.map((r) => r.final)),
+    ...(reviewedScores.length > 0 ? { reviewed: aggReview(reviewedScores) } : {}),
   };
 }

--- a/server/src/analyzer/attribution-eval/run-eval.ts
+++ b/server/src/analyzer/attribution-eval/run-eval.ts
@@ -212,13 +212,15 @@ export async function evalFixture(opts: {
   const finalSentences = result.sentences;
   const chunkEngine = opts.engine === 'qwen' ? 'local' : 'gemini';
 
-  // Roster carrying gender/aliases (and role) — the SAME object feeds both the
-  // gemini chunk-budget (via JSON.stringify length inside runReviewOverChapter)
-  // and the inbox, so eval chunk boundaries match production's CastCharacterSlim.
+  // Roster carrying gender/aliases (no `role` — RosterSnapshot has no such field,
+  // and production's stringified cast has no per-character role either; see
+  // review-run.ts's `roster` param, typed `role?: string`) — the SAME object
+  // feeds both the gemini chunk-budget (via JSON.stringify length inside
+  // runReviewOverChapter) and the inbox, so eval chunk boundaries approximate
+  // production's CastCharacterSlim.
   const reviewRoster = opts.roster.characters.map((c) => ({
     id: c.id,
     name: c.name,
-    role: 'character',
     ...(c.gender ? { gender: c.gender } : {}),
     ...(c.aliases ? { aliases: c.aliases } : {}),
   }));

--- a/server/src/analyzer/attribution-eval/schema.ts
+++ b/server/src/analyzer/attribution-eval/schema.ts
@@ -8,6 +8,16 @@ export const LabelledChapterSchema = z.object({
       speakerId: z.string(),
     })
   ),
+  // Optional cross-chapter opener context for the script-review pass (Task 8
+  // capture). Pinned to the route's PriorExchange shape so the fixture value
+  // threads straight into runReviewOverChapter.
+  priorExchange: z
+    .object({
+      turns: z.array(
+        z.object({ speakerId: z.string(), speakerName: z.string(), text: z.string() })
+      ),
+    })
+    .optional(),
 });
 
 export type LabelledChapter = z.infer<typeof LabelledChapterSchema>;

--- a/src/lib/script-review-apply.test.ts
+++ b/src/lib/script-review-apply.test.ts
@@ -1,5 +1,8 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 import {
   resolveAnchorOffset,
   planApply,
@@ -19,6 +22,50 @@ describe('resolveAnchorOffset', () => {
   });
   it('null when not unique', () => expect(resolveAnchorOffset('he said, he said', 'he said')).toBeNull());
   it('null when absent (TOCTOU edit)', () => expect(resolveAnchorOffset('totally different', 'ran.')).toBeNull());
+});
+
+/* Shared no-drift vector (task-1, script-review-eval): the SAME fixture is
+   loaded server-side by server/src/analyzer/attribution-eval/review-apply-core.test.ts
+   against the ported `planApply`. Asserting both implementations against one
+   vector locks them against silently drifting apart. */
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SHARED_VECTORS_PATH = path.join(
+  __dirname,
+  '..',
+  '..',
+  'server',
+  'src',
+  'analyzer',
+  'attribution-eval',
+  '__fixtures__',
+  'review-apply-vectors.json',
+);
+
+interface SharedVector {
+  name: string;
+  ops: ReviewOp[];
+  live: Array<{ id: number; chapterId: number; text: string; characterId: string; instruct?: string; vocalization?: boolean }>;
+  roster: string[];
+  expected: {
+    appliableOpIndexes: number[];
+    unappliable: Array<{ opIndex: number; reason: string }>;
+  };
+}
+
+describe('planApply — shared no-drift vector (server review-apply-core)', () => {
+  const vectors: SharedVector[] = JSON.parse(readFileSync(SHARED_VECTORS_PATH, 'utf8'));
+
+  for (const vector of vectors) {
+    it(vector.name, () => {
+      const result = planApply(vector.ops, vector.live, new Set(vector.roster));
+
+      const appliableOpIndexes = result.appliable.map((op) => vector.ops.indexOf(op));
+      expect(appliableOpIndexes).toEqual(vector.expected.appliableOpIndexes);
+
+      const unappliable = result.unappliable.map((u) => ({ opIndex: vector.ops.indexOf(u.op), reason: u.reason }));
+      expect(unappliable).toEqual(vector.expected.unappliable);
+    });
+  }
 });
 
 describe('planApply', () => {


### PR DESCRIPTION
## Summary

Phase-2 of the attribution arc: an **opt-in, char-level eval harness** that runs the real LLM script-review QA pass over the pipeline's final attributed sentences and scores its **net effect on attribution** with a segmentation-invariant char-level metric — then dumps the un-scoreable ops for eyeballing. Rides plan 265's `attribution-eval` harness. Produces the baseline (gold + silver, both engines) that gates the sequenced script-review *tuning* follow-up.

The central design move: the old line-level scorer wrongly scored a correct `split`/`extract`/`reattribute` as a regression (different segmentation → misaligned lines). This harness projects both truth and predicted sentences onto **chapter-body character positions** (via the position-preserving `normalizeForMatch`), so those ops are scored soundly and the `final → reviewed` diff is a direct char-array comparison.

**Framing (important):** because attribution is already good, most review ops are char-neutral, so **`helped ≈ harmed ≈ 0` is the EXPECTED good outcome** — this metric is a *regression guard*, not an improvement number. A large positive Δ would signal attribution regressed upstream, not that review "helped." The real value of the pass (TTS-quality edits) lives in the op-dump, not the scored track.

## What's in it

- `review-apply-core.ts` — server-side **port** of `planApply` / `normalizeForMatch` / `resolveAnchorOffset` (server tsconfig can't import root `src/`), pinned no-drift to the frontend by a **shared JSON vector** both sides read.
- `char-project.ts` — `projectToChars`: char-position speaker projection (skip-on-miss, `dropped` surfaced).
- `char-score.ts` — `charRecall` (char-weighted) + `lineRecall` (per-truth-line-averaged) + `diffHelpedHarmed`.
- `apply-ops-chars.ts` — copy-then-mutate char-array applier (reattribute / split / extract).
- `review-run.ts` — faithful thin mirror of the route's `reviewCore` chunk loop (chunk-budget, ownership de-dup, halve-and-retry), minus streaming/ledger.
- `run-eval.ts` — opt-in `reviewed` char-stage + `--runs N` aggregation; `review:false` is byte-identical.
- `run-eval-cli.ts` — `--review` scorecard, op-dump, gold/silver partition (gold+Coalfall gate; silver directional, never gates).
- `capture.ts` / `capture-cli.ts` — silver-fixture skeleton (`--silver`) + prior-exchange capture.
- `schema.ts` — optional `priorExchange` on `LabelledChapter`.
- Ship note in `docs/features/265-attribution-eval-tuning.md`.

## Invariants held

- **No production-route behaviour change** — reuses the route's exported pure helpers; `script-review.ts` untouched. Port ↔ frontend pinned by the shared vector.
- **Opt-in, triple-gated** — SKIP + exit-0 on no-corpus / engine-down / no-key; never wired into `test:all` / `verify`.
- **Gold-only gate** — gold ch43–46 + committed Coalfall (char metric); silver reported separately, directional.
- **Corpus local-only** — silver/gold fixtures are git-ignored copyrighted text; only Coalfall committed; no book text in this diff.

## Test plan

- Per-module server tests colocated (`review-apply-core` 13, shared-vector frontend drift, `char-project` 8 incl. length-changing-fold lock, `char-score` 5 incl. the split-lift case, `apply-ops-chars` 6, `review-run` 6 incl. force-split retry + depth-exhaustion, `run-eval` reviewed + aggregation, `run-eval-cli` helpers + silver regex, `capture` silver skeleton).
- Full `test:server` green (5104) at final commit; `verify:fast:branch` green.
- Built via subagent-driven development: fresh implementer per task, independent spec+quality review after each, and a whole-branch Opus review before this PR. Three Important test-gaps were caught and fixed on-branch.

## Notes

- **No release-notes entry** — opt-in dev tooling with no user- or operator-visible runtime delta (same posture as the plan-265 harness).
- **Baseline capture is a follow-up activity** (not code): scan untuned PwF chapters → user confirms a silver set → label → `npm run eval:attribution -- --review --runs 3` → record in the 265 ship note. That number gates the sequenced tuning follow-up.

Closes #1765

🤖 Generated with [Claude Code](https://claude.com/claude-code)
