### PR TITLE
fix(server): attribution-eval review-run skips a failed chunk instead of aborting the chapter

### DIFF
--- a/server/src/analyzer/attribution-eval/review-run.test.ts
+++ b/server/src/analyzer/attribution-eval/review-run.test.ts
@@ -24,6 +24,7 @@ import {
 } from '../chapter-chunker.js';
 import { buildReviewSentencesInput } from '../../routes/script-review.js';
 import { AnalyzerTruncatedError } from '../errors.js';
+import { DailyQuotaExhaustedError } from '../rate-limit.js';
 import type { Analyzer, StageCall } from '../index.js';
 import type { SentenceOutput, ScriptReviewOp, ScriptReviewOutput } from '../../handoff/schemas.js';
 
@@ -216,6 +217,30 @@ describe('runReviewOverChapter — route-parity chunk loop', () => {
     // …every other chunk's owned ids survive (cores partition the chapter).
     const survivors = chunks.slice(1).flatMap((c) => c.core.map((s) => s.id));
     expect([...stripIds].sort((a, b) => a - b)).toEqual(survivors.sort((a, b) => a - b));
+  });
+
+  it('(e) fast-fails on a terminal quota error instead of skip-and-retrying every remaining chunk', async () => {
+    // A quota (or content-block) error is fatal for EVERY remaining chunk, so
+    // skip-and-continue would burn API calls on a doomed run. Production breaks
+    // the chunk loop on these (routes/script-review.ts:915-922); the eval
+    // re-throws them rather than counting them as a droppable chunk.
+    const stub = {
+      async runScriptReviewChapter(): Promise<ScriptReviewOutput> {
+        throw new DailyQuotaExhaustedError('gemma-4-31b-it', new Date(0));
+      },
+    } as unknown as Analyzer;
+
+    await expect(
+      runReviewOverChapter({
+        analyzer: stub,
+        engine: 'gemini',
+        manuscriptId: MANUSCRIPT_ID,
+        chapterId: CHAPTER_ID,
+        sentences,
+        roster,
+        call,
+      }),
+    ).rejects.toBeInstanceOf(DailyQuotaExhaustedError);
   });
 });
 

--- a/server/src/analyzer/attribution-eval/review-run.test.ts
+++ b/server/src/analyzer/attribution-eval/review-run.test.ts
@@ -174,6 +174,49 @@ describe('runReviewOverChapter — route-parity chunk loop', () => {
     // …while the same sentence's strip_tag (no anchor requirement) still is.
     expect(accepted.some((o) => o.op === 'strip_tag' && o.id === badAnchorId)).toBe(true);
   });
+
+  it('(d) skips a chunk whose analyzer throws a non-truncation error and keeps the rest (droppedChunks)', async () => {
+    // Mirrors production's per-chunk resilience (routes/script-review.ts:906-924):
+    // an LLM schema-validation failure on one chunk must not abort the chapter.
+    // Throw on the FIRST analyzer call (chunk 0) — a non-truncation error force-
+    // splits nothing, so it's exactly one call per chunk — then succeed. Keyed on
+    // call order, not sentence id, since the 3-sentence overlap can leak a core id
+    // into an adjacent chunk's context (which would fail two chunks).
+    const chunks = refChunksFor(sentences);
+    let calls = 0;
+    const stub = {
+      async runScriptReviewChapter(
+        _m: string,
+        _c: number,
+        prompt: string,
+        _call: StageCall,
+      ): Promise<ScriptReviewOutput> {
+        calls += 1;
+        if (calls === 1) {
+          throw new Error('schema-validation — reattribute requires exactly one of characterId or proposed');
+        }
+        return { ops: presentIds(prompt).map((id) => ({ id, op: 'strip_tag', anchor: 'x', rationale } as ScriptReviewOp)) };
+      },
+    } as unknown as Analyzer;
+
+    const { ops, droppedChunks } = await runReviewOverChapter({
+      analyzer: stub,
+      engine: 'local',
+      manuscriptId: MANUSCRIPT_ID,
+      chapterId: CHAPTER_ID,
+      sentences,
+      roster,
+      call,
+    });
+
+    expect(droppedChunks).toBe(1);
+    const stripIds = new Set(ops.filter((o) => o.op === 'strip_tag').map((o) => o.id));
+    // chunk 0's owned ids are gone…
+    for (const s of chunks[0].core) expect(stripIds.has(s.id)).toBe(false);
+    // …every other chunk's owned ids survive (cores partition the chapter).
+    const survivors = chunks.slice(1).flatMap((c) => c.core.map((s) => s.id));
+    expect([...stripIds].sort((a, b) => a - b)).toEqual(survivors.sort((a, b) => a - b));
+  });
 });
 
 describe('runReviewOverChapter — force-split retry on AnalyzerTruncatedError', () => {
@@ -253,24 +296,28 @@ describe('runReviewOverChapter — force-split retry on AnalyzerTruncatedError',
     expect(stripIds).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
   });
 
-  it('depth-exhaustion: an always-truncating analyzer eventually rejects with AnalyzerTruncatedError (no infinite loop)', async () => {
+  it('depth-exhaustion: an always-truncating chunk is dropped-and-skipped, not rejected (no infinite loop)', async () => {
     // 16 tiny sentences → one top-level chunk (verified below); halving
     // 16→8→4→2 across 3 recursive splits still leaves a core of length 2
-    // (>1) at depth 3, so the rejection below is forced by the
-    // MAX_FORCE_SPLIT_DEPTH guard itself, not just the length===1 floor.
+    // (>1) at depth 3, so reviewCore re-throws AnalyzerTruncatedError at the
+    // MAX_FORCE_SPLIT_DEPTH guard. CONTRACT CHANGE (#1777): the chunk loop now
+    // catches that per-chunk error and continues — matching production
+    // (routes/script-review.ts:906-924) — rather than aborting the chapter.
+    // The "no infinite loop" intent is preserved (this resolves); the outcome
+    // is now a dropped chunk, not a rejection.
     const sentences = makeSentences(16, 50);
     expect(refChunksFor(sentences).length).toBe(1); // precondition: single top-level core
 
-    await expect(
-      runReviewOverChapter({
-        analyzer: makeAlwaysThrows(),
-        engine: 'local',
-        manuscriptId: MANUSCRIPT_ID,
-        chapterId: CHAPTER_ID,
-        sentences,
-        roster,
-        call,
-      }),
-    ).rejects.toBeInstanceOf(AnalyzerTruncatedError);
+    const { ops, droppedChunks } = await runReviewOverChapter({
+      analyzer: makeAlwaysThrows(),
+      engine: 'local',
+      manuscriptId: MANUSCRIPT_ID,
+      chapterId: CHAPTER_ID,
+      sentences,
+      roster,
+      call,
+    });
+    expect(ops).toEqual([]);
+    expect(droppedChunks).toBe(1);
   });
 });

--- a/server/src/analyzer/attribution-eval/review-run.ts
+++ b/server/src/analyzer/attribution-eval/review-run.ts
@@ -33,7 +33,9 @@ import {
   type PriorExchange,
 } from '../../routes/script-review.js';
 import { planApply, type LiveSentence } from './review-apply-core.js';
-import { AnalyzerTruncatedError } from '../errors.js';
+import { AnalyzerTruncatedError, GeminiContentBlockedError } from '../errors.js';
+import { AnalysisAbortedError } from '../ollama.js';
+import { DailyQuotaExhaustedError } from '../rate-limit.js';
 
 /* The route's `MAX_FORCE_SPLIT_DEPTH` and `CHUNK_OVERLAP` are both 3 but not
    exported — redeclared locally to match (server/src/routes/script-review.ts). */
@@ -111,7 +113,12 @@ export async function runReviewOverChapter(opts: {
      after retry — or exhausts force-split depth — is SKIPPED (its ops lost) and
      the loop continues, rather than aborting the whole chapter. The eval has no
      SSE `chapter-failed` channel, so it counts drops and returns the tally for
-     the scorecard to surface (a silent drop would understate helped/harmed). */
+     the scorecard to surface (a silent drop would understate helped/harmed).
+
+     TERMINAL errors are re-thrown, not dropped: an abort, an exhausted daily
+     quota, or a content block is fatal for EVERY remaining chunk (the route
+     breaks the loop on these), so swallowing them would burn API calls on a
+     doomed run and report a scorecard of near-total drops. */
   const ops: ScriptReviewOp[] = [];
   let droppedChunks = 0;
   for (let index = 0; index < chunks.length; index += 1) {
@@ -120,6 +127,13 @@ export async function runReviewOverChapter(opts: {
       const owned = await reviewCore(chunk.core, chunk.contextBefore, chunk.contextAfter, index === 0, 0);
       ops.push(...owned);
     } catch (err) {
+      if (
+        err instanceof AnalysisAbortedError ||
+        err instanceof DailyQuotaExhaustedError ||
+        err instanceof GeminiContentBlockedError
+      ) {
+        throw err;
+      }
       droppedChunks += 1;
       console.warn(
         `[review-run] ch${chapterId} chunk ${index + 1}/${chunks.length} dropped: ${(err as Error).message}`,

--- a/server/src/analyzer/attribution-eval/review-run.ts
+++ b/server/src/analyzer/attribution-eval/review-run.ts
@@ -50,7 +50,7 @@ export async function runReviewOverChapter(opts: {
   priorExchange?: PriorExchange;
   evidence?: Map<number, string>;
   call: StageCall;
-}): Promise<{ ops: ScriptReviewOp[]; accepted: ScriptReviewOp[] }> {
+}): Promise<{ ops: ScriptReviewOp[]; accepted: ScriptReviewOp[]; droppedChunks: number }> {
   const { analyzer, engine, manuscriptId, chapterId, sentences, roster, priorExchange, evidence, call } =
     opts;
 
@@ -106,11 +106,25 @@ export async function runReviewOverChapter(opts: {
     }
   };
 
+  /* Per-chunk resilience, mirroring the route's chunk loop
+     (routes/script-review.ts:906-924): a chunk whose model call fails validation
+     after retry — or exhausts force-split depth — is SKIPPED (its ops lost) and
+     the loop continues, rather than aborting the whole chapter. The eval has no
+     SSE `chapter-failed` channel, so it counts drops and returns the tally for
+     the scorecard to surface (a silent drop would understate helped/harmed). */
   const ops: ScriptReviewOp[] = [];
+  let droppedChunks = 0;
   for (let index = 0; index < chunks.length; index += 1) {
     const chunk = chunks[index];
-    const owned = await reviewCore(chunk.core, chunk.contextBefore, chunk.contextAfter, index === 0, 0);
-    ops.push(...owned);
+    try {
+      const owned = await reviewCore(chunk.core, chunk.contextBefore, chunk.contextAfter, index === 0, 0);
+      ops.push(...owned);
+    } catch (err) {
+      droppedChunks += 1;
+      console.warn(
+        `[review-run] ch${chapterId} chunk ${index + 1}/${chunks.length} dropped: ${(err as Error).message}`,
+      );
+    }
   }
 
   const live: LiveSentence[] = sentences.map((s) => ({
@@ -124,5 +138,5 @@ export async function runReviewOverChapter(opts: {
   const rosterSet = new Set(roster.map((r) => r.id));
   const accepted = planApply(ops, live, rosterSet).appliable;
 
-  return { ops, accepted };
+  return { ops, accepted, droppedChunks };
 }

--- a/server/src/analyzer/attribution-eval/run-eval-cli.test.ts
+++ b/server/src/analyzer/attribution-eval/run-eval-cli.test.ts
@@ -99,6 +99,7 @@ describe('formatReviewLine', () => {
     churn: st(3),
     predictedDropped: st(0),
     truthDropped: st(0),
+    droppedChunks: st(0),
     opsByClass: {},
     dump: [],
     ...overrides,
@@ -143,6 +144,17 @@ describe('formatReviewLine', () => {
     const agg = baseAgg({ truthDropped: st(3) });
     const line = formatReviewLine(agg, 1);
     expect(line).toContain('3 truth units unlocated — recall denominator incomplete');
+  });
+
+  it('omits the dropped-chunk warning when droppedChunks.mean is 0', () => {
+    const line = formatReviewLine(baseAgg(), 1);
+    expect(line).not.toContain('review chunk(s) dropped');
+  });
+
+  it('adds the dropped-chunk warning when droppedChunks.mean > 0', () => {
+    const agg = baseAgg({ droppedChunks: st(2) });
+    const line = formatReviewLine(agg, 1);
+    expect(line).toContain('2 review chunk(s) dropped after a model/validation failure');
   });
 });
 

--- a/server/src/analyzer/attribution-eval/run-eval-cli.ts
+++ b/server/src/analyzer/attribution-eval/run-eval-cli.ts
@@ -184,6 +184,9 @@ export function formatReviewLine(agg: ReviewAgg, runs: number): string {
   if (agg.truthDropped.mean > 0) {
     line += `\n      ⚠ ${countFmt(agg.truthDropped.mean)} truth units unlocated — recall denominator incomplete`;
   }
+  if (agg.droppedChunks.mean > 0) {
+    line += `\n      ⚠ ${countFmt(agg.droppedChunks.mean)} review chunk(s) dropped after a model/validation failure — ops incomplete, helped/harmed understated (#1777)`;
+  }
   return line;
 }
 

--- a/server/src/analyzer/attribution-eval/run-eval.test.ts
+++ b/server/src/analyzer/attribution-eval/run-eval.test.ts
@@ -216,7 +216,7 @@ describe('evalFixture — reviewed char-stage (opt-in)', () => {
 describe('aggregateFixture — reviewed aggregation (aggReview)', () => {
   const mkReviewed = (over: Partial<ReviewScore>): ReviewScore => ({
     charFinal: 1, charReviewed: 1, lineFinal: 1, lineReviewed: 1,
-    helped: 0, harmed: 0, churn: 0, predictedDropped: 0, truthDropped: 0,
+    helped: 0, harmed: 0, churn: 0, predictedDropped: 0, truthDropped: 0, droppedChunks: 0,
     opsByClass: {}, dump: [], ...over,
   });
   const mkResult = (reviewed?: ReviewScore): FixtureResult => ({
@@ -225,12 +225,13 @@ describe('aggregateFixture — reviewed aggregation (aggReview)', () => {
   });
 
   it('averages per-run reviewed into a ReviewAgg with Stat fields and run-0 dump', () => {
-    const r0 = mkResult(mkReviewed({ helped: 2, harmed: 1, opsByClass: { reattribute: 1 }, dump: [{ id: 1, op: 'strip_tag', rationale: 'r0' }] }));
-    const r1 = mkResult(mkReviewed({ helped: 4, harmed: 3, opsByClass: { reattribute: 3, split: 1 }, dump: [{ id: 2, op: 'merge', rationale: 'r1' }] }));
+    const r0 = mkResult(mkReviewed({ helped: 2, harmed: 1, droppedChunks: 1, opsByClass: { reattribute: 1 }, dump: [{ id: 1, op: 'strip_tag', rationale: 'r0' }] }));
+    const r1 = mkResult(mkReviewed({ helped: 4, harmed: 3, droppedChunks: 0, opsByClass: { reattribute: 3, split: 1 }, dump: [{ id: 2, op: 'merge', rationale: 'r1' }] }));
     const agg = aggregateFixture([r0, r1]);
     expect(agg.reviewed).toBeDefined();
     expect(agg.reviewed!.helped).toEqual({ mean: 3, min: 2, max: 4 });
     expect(agg.reviewed!.harmed).toEqual({ mean: 2, min: 1, max: 3 });
+    expect(agg.reviewed!.droppedChunks).toEqual({ mean: 0.5, min: 0, max: 1 });
     // mean count per class across runs (split absent in run-0 counts as 0).
     expect(agg.reviewed!.opsByClass.reattribute).toBeCloseTo(2);
     expect(agg.reviewed!.opsByClass.split).toBeCloseTo(0.5);

--- a/server/src/analyzer/attribution-eval/run-eval.ts
+++ b/server/src/analyzer/attribution-eval/run-eval.ts
@@ -43,6 +43,7 @@ export interface ReviewScore {
   churn: number;
   predictedDropped: number;
   truthDropped: number;
+  droppedChunks: number; // review chunks skipped after a per-chunk model/validation failure (#1777)
   opsByClass: Record<string, number>;
   dump: Array<{ id: number; op: string; rationale: string; anchor?: string }>;
 }
@@ -232,7 +233,7 @@ export async function evalFixture(opts: {
     ? buildStructureEvidence(opts.truth.chapterText, finalSentences, opts.roster.characters, opts.language ?? 'en')
     : undefined;
 
-  const { ops, accepted } = await runReviewOverChapter({
+  const { ops, accepted, droppedChunks } = await runReviewOverChapter({
     analyzer: opts.analyzer,
     engine: chunkEngine,
     manuscriptId: opts.manuscriptId,
@@ -287,6 +288,7 @@ export async function evalFixture(opts: {
     churn,
     predictedDropped: finalProj.dropped,
     truthDropped: truthProj.dropped,
+    droppedChunks,
     opsByClass,
     dump,
   };
@@ -319,6 +321,7 @@ export interface ReviewAgg {
   churn: Stat;
   predictedDropped: Stat;
   truthDropped: Stat;
+  droppedChunks: Stat;
   opsByClass: Record<string, number>;
   dump: ReviewScore['dump'];
 }
@@ -389,6 +392,7 @@ export function aggReview(scores: ReviewScore[]): ReviewAgg {
     churn: stat(scores.map((s) => s.churn)),
     predictedDropped: stat(scores.map((s) => s.predictedDropped)),
     truthDropped: stat(scores.map((s) => s.truthDropped)),
+    droppedChunks: stat(scores.map((s) => s.droppedChunks)),
     opsByClass,
     dump: scores[0]?.dump ?? [],
   };


### PR DESCRIPTION
## Summary

`runReviewOverChapter` (`server/src/analyzer/attribution-eval/review-run.ts`) — the eval harness's faithful re-implementation of production's script-review chunk loop — had **no per-chunk try/catch**. A single chunk's model failure (an LLM op that fails schema validation after retry → `OllamaAnalyzer.runStage` throws, or force-split depth exhaustion) propagated out and **aborted the entire fixture/eval run**. Production's loop (`routes/script-review.ts:906-924`) catches per chunk and continues, so the eval was strictly less resilient than the thing it mirrors.

Observed live during the #1769 on-box eval: one malformed `reattribute` op killed a ch41 review run; a fresh run passed. On a 90-min `--runs 3` full-corpus pass, that's expensive to hit.

**Fix:** catch per chunk, skip the failed chunk, continue — matching production. The eval has no SSE `chapter-failed` channel, so it **counts dropped chunks** and threads the tally through `ReviewScore` → `ReviewAgg` → a scorecard ⚠ line. A silently-dropped chunk loses ops and understates helped/harmed, so a run with drops must never read as clean — the same eval-integrity concern #1769 was about.

## Test plan

- `review-run.test.ts` (+1, ~1 revised): a chunk whose analyzer throws a non-truncation error is skipped, other chunks' ops survive, `droppedChunks=1`. The depth-exhaustion test is **consciously revised** — its no-infinite-loop intent preserved, its outcome changed from *reject* to *drop-and-continue* (documented in the test as a #1777 contract change), matching production.
- `run-eval-cli.test.ts` (+2): scorecard ⚠ shown when `droppedChunks.mean > 0`, omitted at 0.
- `run-eval.test.ts` (+1 assertion): `droppedChunks` aggregates through `aggReview`.
- Full `attribution-eval` suite: **123/123**; server typecheck clean.

## Out of scope

Per-op salvage — keeping the *valid* ops from a chunk that contained one malformed op (the shared validator currently rejects the whole chunk response, in eval **and** production). That touches shared `runStage`/validation and production script-review behavior, so it's a separate, larger design (noted on #1777).

Closes #1777

🤖 Generated with [Claude Code](https://claude.com/claude-code)