### PR TITLE
chore: bump version to 1.14.0

### DIFF
--- a/apps/android/pubspec.yaml
+++ b/apps/android/pubspec.yaml
@@ -21,7 +21,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # 3-digit build-iteration band so successive Play uploads of the same marketing
 # version take base+1, base+2, … via `flutter build … --build-number=<N>`).
 # Plan 188.
-version: 1.13.0+11300000
+version: 1.14.0+11400000
 
 environment:
   sdk: ^3.12.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "castwright",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "castwright",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "castwright",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "private": true,
   "type": "commonjs",
   "engines": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "castwright-server",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "castwright-server",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "dependencies": {
         "@google/genai": "^2.7.0",
         "@lingo-reader/mobi-parser": "^0.4.6",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "castwright-server",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/tts-sidecar/version.py
+++ b/server/tts-sidecar/version.py
@@ -7,4 +7,4 @@ SIDECAR_PROTOCOL_VERSION in main.py: the protocol version gates adopt/replace of
 a running sidecar, while __version__ is purely informational.
 """
 
-__version__ = "1.13.0"
+__version__ = "1.14.0"


### PR DESCRIPTION
## Summary

Version bump for the **v1.14.0** release cut. Created by `scripts/bump-version.mjs --level minor`; landing via PR because `main` blocks direct pushes (required status checks).

Bumps `1.13.0 → 1.14.0` across `package.json`, `server/package.json`, both lockfiles, `apps/android/pubspec.yaml`, and `server/tts-sidecar/version.py` (kept in lockstep, per the bumper's invariant).

The annotated tag **`v1.14.0`** already exists locally, points at this commit (`4c31e2c1`), and carries `docs/release-notes-next.md` as its body. The **cross-OS gate passed** before the tag was created (macOS + Windows verify/build + mobile-e2e, run 30047806031). Once this merges, the tag becomes reachable from `main` and I push it → `release.yml` publishes.

## Test plan

- Cross-OS gate green (the bumper blocks the tag on it).
- Version lockstep enforced by the bumper across all six files.
- No behavior change — version-string bump only.

Refs #1779