### PR TITLE
docs(docs): fill fs-35 plan 266 ship notes with merge SHA

### DIFF
--- a/docs/features/266-fs35-per-chapter-detect-emotions.md
+++ b/docs/features/266-fs35-per-chapter-detect-emotions.md
@@ -172,5 +172,6 @@ Run in mock mode (`VITE_USE_MOCKS=true`, the default for `npm run dev`).
 
 ## Ship notes
 
-Shipped 2026-07-24. PR for #592 (fs-35, follow-up to fs-33 #510). Commit SHA
-filled by the controlling thread at merge time.
+Shipped 2026-07-24 via PR #1789 (`Closes #592`, fs-35, follow-up to fs-33 #510),
+merge commit `842212ec`. First PR of the v1.15.0 cycle — bootstrapped the
+release-notes files to 1.15.0. All cloud `verify.yml` checks green.


### PR DESCRIPTION
## Summary

Fills the fs-35 regression plan ([`docs/features/266-fs35-per-chapter-detect-emotions.md`](docs/features/266-fs35-per-chapter-detect-emotions.md)) Ship-notes placeholder with the real merge SHA now that fs-35 has shipped:

- Merged via PR #1789 (merge commit `842212ec`), which closed #592.
- Records that this was the first PR of the v1.15.0 cycle (bootstrapped the release-notes files to 1.15.0).

Docs-only; no runtime surface.

## Test plan

Docs-only change — no tests apply (verify.yml's legs are all out-of-scope for a docs diff and report green after env setup).

Refs #592

🤖 Generated with [Claude Code](https://claude.com/claude-code)