### PR TITLE
fix(frontend): touch press-feedback parity via group-active mirrors (fe-39)

### DIFF
--- a/docs/superpowers/plans/2026-07-24-fe-39-group-active-touch-mirrors.md
+++ b/docs/superpowers/plans/2026-07-24-fe-39-group-active-touch-mirrors.md
@@ -1,0 +1,332 @@
+# fe-39 — Decorative `group-active:` Touch Mirrors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give touch users a press-feedback flash on four decorative controls by adding a `group-active:X` variant mirroring each control's existing `group-hover:X`, with a class-presence regression test per control.
+
+**Architecture:** Pure Tailwind-v4 variant additions. Each edit appends `group-active:` variant(s) alongside the existing `group-hover:` on one leaf `<span>`; no resting classes change, no component logic changes. Each of the four touched components already has a `.test.tsx`; each gets one added `it(...)` block asserting the mirror is present (and, for the Add-book tile, that no resting peach leaked in).
+
+**Tech Stack:** React + TypeScript, Tailwind CSS v4 (CSS-first, no config file), Vitest + `@testing-library/react` (jsdom).
+
+## Global Constraints
+
+- **Add-only:** never change, remove, or reorder an existing resting or `group-hover:` class. Only append `group-active:` variant(s). — verbatim from spec "Approach".
+- **Caveat (a):** the Add-book tile must **not** carry a bare (non-variant) resting `bg-peach` / `border-peach` / `text-white`. Peach appears only under `group-active:` / `hover:`. — verbatim from spec "Caveat (a)".
+- **Tailwind is v4**, no `tailwind.config.js`. `group-active` is built-in; no config change. `active:` variants already compile in this repo (10+ files).
+- **Test shape:** class-presence assertion against the **rendered DOM** `className` (jsdom, Tailwind not compiled) — never a raw-file source scan. Assert both the existing `group-hover:X` and the new `group-active:X` are present on the same element.
+- **Commit style:** conventional commits. Frontend changes use `fix(frontend): …` or `test(frontend): …`. Hooks may bootstrap a Python venv and hang; commit with `git -c core.hooksPath=/dev/null` if a hook stalls (docs/tests/leaf-CSS only — no server code touched).
+- **Line numbers** below are as of 2026-07-24 and may drift; anchor by the quoted className string, not the line number.
+
+---
+
+### Task 1: Rail play badge (`continue-listening-rail.tsx`)
+
+**Files:**
+- Modify: `src/components/library/continue-listening-rail.tsx` (~line 111, the play-badge `<span>`)
+- Test: `src/components/library/continue-listening-rail.test.tsx`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: nothing other tasks rely on. (All four tasks are independent.)
+
+The current element:
+```tsx
+<span className="absolute bottom-2 right-2 w-7 h-7 rounded-full bg-white/20 group-hover:bg-white/35 transition-colors grid place-items-center">
+```
+The `group` ancestor is the native `<button type="button">` card at line 84; `:active` chains to the wrapping `group` div, so the mirror fires on touch.
+
+- [ ] **Step 1: Write the failing test**
+
+Add this block to `continue-listening-rail.test.tsx`. It renders the rail with one item, reaches the card button by its accessible name, then asserts the play badge (the `bg-white/20` span inside it) carries both variants.
+
+```tsx
+it('play badge mirrors group-hover with group-active for touch press feedback (fe-39)', () => {
+  render(<ContinueListeningRail items={items} onOpen={noop} onFinish={noop} onHide={noop} />);
+  const card = screen.getByRole('button', { name: /Continue listening to The Coalfall Commission/i });
+  const badge = card.querySelector('span.bg-white\\/20');
+  expect(badge).not.toBeNull();
+  expect(badge!.className).toContain('group-hover:bg-white/35');
+  expect(badge!.className).toContain('group-active:bg-white/35');
+});
+```
+
+Note: reuse the existing `items` / `noop` fixtures already defined in this test file (the existing "renders … Coalfall" test uses them). If the first item's title differs, match the accessible name to whatever the existing fixtures use.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- src/components/library/continue-listening-rail.test.tsx -t "touch press feedback"`
+Expected: FAIL — `expect(received).toContain('group-active:bg-white/35')`, received string lacks the token.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `continue-listening-rail.tsx`, on the play-badge span, add `group-active:bg-white/35` immediately after `group-hover:bg-white/35`:
+
+```tsx
+<span className="absolute bottom-2 right-2 w-7 h-7 rounded-full bg-white/20 group-hover:bg-white/35 group-active:bg-white/35 transition-colors grid place-items-center">
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- src/components/library/continue-listening-rail.test.tsx -t "touch press feedback"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/library/continue-listening-rail.tsx src/components/library/continue-listening-rail.test.tsx
+git commit -m "fix(frontend): mirror rail play-badge hover with group-active for touch (fe-39)"
+```
+
+---
+
+### Task 2: "Add book" tile (`library-grid.tsx`)
+
+**Files:**
+- Modify: `src/components/library/library-grid.tsx` (~line 559, the inner circle `<span>`)
+- Test: `src/components/library/library-grid.test.tsx`
+
+**Interfaces:**
+- Consumes / Produces: nothing (independent task).
+
+The current element (inner circle inside the `group` button `data-tour-id="new-book-btn"`):
+```tsx
+<span className="w-14 h-14 mx-auto rounded-full bg-white border border-ink/10 grid place-items-center group-hover:bg-peach group-hover:border-peach group-hover:text-white transition-colors text-ink">
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `library-grid.test.tsx`. Reach the Add-book button (rendered when the grid shows the add tile — match how the existing tests trigger it; the button has `data-tour-id="new-book-btn"`), find the inner circle, assert all three `group-active:` mirrors are present **and** caveat (a): the resting classes are intact and no bare `bg-peach` leaked in.
+
+The `NewBookCard` (Add-book tile, `data-tour-id="new-book-btn"`) renders inside `LibraryGrid` whenever the library is non-empty. Reuse the existing module-level `renderGrid(...)` helper and the `authorsWith(...)` fixture builder already in this file (the existing tests call `renderGrid(authorsWith(undefined))`).
+
+```tsx
+it('Add-book tile mirrors hover with group-active, no resting peach (fe-39, caveat a)', () => {
+  renderGrid(authorsWith(undefined));
+  const addBtn = document.querySelector('[data-tour-id="new-book-btn"]') as HTMLElement;
+  expect(addBtn).not.toBeNull();
+  const circle = addBtn.querySelector('span.rounded-full') as HTMLElement;
+  expect(circle).not.toBeNull();
+  // mirrors present
+  expect(circle.className).toContain('group-active:bg-peach');
+  expect(circle.className).toContain('group-active:border-peach');
+  expect(circle.className).toContain('group-active:text-white');
+  // resting appearance intact
+  expect(circle.className).toContain('bg-white');
+  expect(circle.className).toContain('border-ink/10');
+  // caveat (a): peach only ever appears as a variant, never bare
+  // (regex requires start-or-whitespace before the token, so `group-hover:bg-peach`
+  //  and `group-active:bg-peach` — preceded by ':' — do NOT match)
+  expect(circle.className).not.toMatch(/(^|\s)bg-peach(\s|$)/);
+  expect(circle.className).not.toMatch(/(^|\s)border-peach(\s|$)/);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- src/components/library/library-grid.test.tsx -t "caveat a"`
+Expected: FAIL — the three `group-active:` tokens are absent.
+
+- [ ] **Step 3: Write minimal implementation**
+
+On the inner-circle span, append the three mirrors after the existing `group-hover:` trio:
+
+```tsx
+<span className="w-14 h-14 mx-auto rounded-full bg-white border border-ink/10 grid place-items-center group-hover:bg-peach group-hover:border-peach group-hover:text-white group-active:bg-peach group-active:border-peach group-active:text-white transition-colors text-ink">
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- src/components/library/library-grid.test.tsx -t "caveat a"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/library/library-grid.tsx src/components/library/library-grid.test.tsx
+git commit -m "fix(frontend): mirror Add-book tile hover with group-active for touch (fe-39)"
+```
+
+---
+
+### Task 3: "Review ›" chip (`setup-wizard.tsx`)
+
+**Files:**
+- Modify: `src/components/setup/setup-wizard.tsx` (~line 459, the "Review ›" `<span>`)
+- Test: `src/components/setup/setup-wizard.test.tsx`
+
+**Interfaces:**
+- Consumes / Produces: nothing (independent task).
+
+The current element (inside the `group` `<button>` at line 442):
+```tsx
+<span className="text-xs font-medium text-ink/40 group-hover:text-magenta shrink-0">
+  Review &rsaquo;
+</span>
+```
+
+- [ ] **Step 1: Write the failing test**
+
+The "Review ›" chips live in the local `SetupSummary` component, which the orchestrator renders immediately in **`mode="checklist"`** (`wizardStep` starts `null` → `SetupSummary`). No step navigation needed. Reuse the existing module-level `READINESS` fixture and the `SetupWizard` import already in this file. Each summary row renders a "Review ›" chip carrying `group-hover:text-magenta`; `.find(...)` on that class disambiguates and asserting the first is sufficient (all rows get the same mirror).
+
+```tsx
+it('Review chip mirrors group-hover with group-active for touch (fe-39)', () => {
+  render(<SetupWizard readiness={READINESS} mode="checklist" onRefetch={() => {}} onFinish={() => {}} />);
+  const chip = screen
+    .getAllByText(/Review/)
+    .find((el) => el.className.includes('group-hover:text-magenta'));
+  expect(chip).toBeTruthy();
+  expect(chip!.className).toContain('group-hover:text-magenta');
+  expect(chip!.className).toContain('group-active:text-magenta');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- src/components/setup/setup-wizard.test.tsx -t "Review chip mirrors"`
+Expected: FAIL — `group-active:text-magenta` absent.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append `group-active:text-magenta` after `group-hover:text-magenta`:
+
+```tsx
+<span className="text-xs font-medium text-ink/40 group-hover:text-magenta group-active:text-magenta shrink-0">
+  Review &rsaquo;
+</span>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- src/components/setup/setup-wizard.test.tsx -t "Review chip mirrors"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/setup/setup-wizard.tsx src/components/setup/setup-wizard.test.tsx
+git commit -m "fix(frontend): mirror wizard Review chip hover with group-active for touch (fe-39)"
+```
+
+---
+
+### Task 4: Voice-library drag icon (`voice-library-panel.tsx`)
+
+**Files:**
+- Modify: `src/components/voice-library-panel.tsx` (~line 388, the drag-icon `<span>`)
+- Test: `src/components/voice-library-panel.test.tsx`
+
+**Interfaces:**
+- Consumes / Produces: nothing (independent task).
+
+The current element (`group` ancestor is the `<div class="group … active:cursor-grabbing">` row at line 303, already proven to receive `:active`):
+```tsx
+<span className="text-ink/30 group-hover:text-ink/60 transition-colors mt-1 hidden md:inline">
+  <IconDrag className="w-4 h-4" />
+</span>
+```
+The span is `hidden md:inline` — press feedback is only observable on `md`+ touch devices; in jsdom (Tailwind not compiled) the element is present regardless, so the class-presence test is unaffected.
+
+- [ ] **Step 1: Write the failing test**
+
+The drag icon renders in the default (non-`isAssigningTarget`) branch of each voice row. Reuse the `makeVoice`/`makeCharacter` fixtures and the same `VoiceLibraryPanel` prop set the existing tests use (`library`, `characters`, `draggingVoiceId`, `setDraggingVoiceId`, `onOpenProfile`, `onPlaySample`). Query the drag-icon span via its unique `group-hover:text-ink/60` class (CSS-escape the `:` and `/`).
+
+```tsx
+it('drag icon mirrors group-hover with group-active for touch (fe-39)', () => {
+  render(
+    <VoiceLibraryPanel
+      library={[makeVoice('v_marlow', 'Marlow')]}
+      characters={[makeCharacter('marlow', 'v_marlow')]}
+      draggingVoiceId={null}
+      setDraggingVoiceId={vi.fn()}
+      onOpenProfile={vi.fn()}
+      onPlaySample={vi.fn()}
+    />,
+  );
+  const dragIcon = document.querySelector('span.group-hover\\:text-ink\\/60');
+  expect(dragIcon).not.toBeNull();
+  expect(dragIcon!.className).toContain('group-hover:text-ink/60');
+  expect(dragIcon!.className).toContain('group-active:text-ink/60');
+});
+```
+
+Note: the drag-icon span is `hidden md:inline`, but jsdom does not compile Tailwind, so the element is present in the DOM regardless of viewport — the query resolves.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- src/components/voice-library-panel.test.tsx -t "drag icon mirrors"`
+Expected: FAIL — `group-active:text-ink/60` absent.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append `group-active:text-ink/60` after `group-hover:text-ink/60`:
+
+```tsx
+<span className="text-ink/30 group-hover:text-ink/60 group-active:text-ink/60 transition-colors mt-1 hidden md:inline">
+  <IconDrag className="w-4 h-4" />
+</span>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- src/components/voice-library-panel.test.tsx -t "drag icon mirrors"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/voice-library-panel.tsx src/components/voice-library-panel.test.tsx
+git commit -m "fix(frontend): mirror voice-library drag-icon hover with group-active for touch (fe-39)"
+```
+
+---
+
+### Task 5: Verification gates, #799 note, and PR
+
+**Files:** none modified (verification + PR only).
+
+- [ ] **Step 1: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS, no new errors. (Worktree needs `server/node_modules` for a clean typecheck — junction it from the main checkout if missing.)
+
+- [ ] **Step 2: Lint**
+
+Run: `npm run lint`
+Expected: PASS. (Prettier is not a gate here — do not reformat; ESLint only.)
+
+- [ ] **Step 3: Run the four updated test files together**
+
+Run: `npm run test -- src/components/library/continue-listening-rail.test.tsx src/components/library/library-grid.test.tsx src/components/setup/setup-wizard.test.tsx src/components/voice-library-panel.test.tsx`
+Expected: PASS, all four new assertions green. (Full frontend suite is **not** required — no shared component was touched; all four edits are leaf className changes.)
+
+- [ ] **Step 4: One-time manual touch smoke-check**
+
+Start the app, open Chrome DevTools, toggle device/touch emulation (activates `coarse-pointer` + `:active` on tap). Confirm a visible press-flash on at least control #1 (rail play badge) and control #2 (Add-book tile). Record the result in the PR body. Real iOS Safari is best-effort; DevTools touch emulation is accepted as sufficient because the fire-on-touch mechanism is confirmed native in the spec.
+
+- [ ] **Step 5: Post the scope note to #799**
+
+Post a comment on issue #799 recording the 4-of-7 decision: mirrors added to controls #1–#4 (rail badge, Add-book tile, Review chip, drag icon); `revision-diff.tsx:551`/`:584` and `manuscript.tsx:2088` dropped as verified no-ops (state-override and drag-state-redundant respectively); sibling container-level hover effects deliberately left unmirrored.
+
+```bash
+gh issue comment 799 --body "fe-39 scoped to 4 of 7 controls after live verification: mirrored #1 rail play badge, #2 Add-book tile, #3 Review chip, #4 voice-library drag icon. Dropped revision-diff badges (:551/:584 — tap flips isPlaying which overrides the color) and manuscript boundary tint (:2088 — drag sets isThisDragging, redundant). Sibling container-level hover effects (outer tile tint, card shadow, row bg) intentionally not mirrored — see spec."
+```
+
+- [ ] **Step 6: Open the PR**
+
+```bash
+git push -u origin feat/frontend-fe-39-group-active-mirrors
+gh pr create --title "fix(frontend): touch press-feedback parity via group-active mirrors (fe-39)" --body "<mini release notes: what/why, the 4 controls, the 3 dropped no-ops, test approach, manual smoke-check result>
+
+Closes #799"
+```
+
+Expected: PR opens with `Closes #799` (literal) in the body. Validate the title against the repo's PR-title convention before creating.
+
+---
+
+## Notes for the implementer
+
+- **Do the edits in the order above**, but the four component tasks are fully independent — a reviewer can accept or reject any one without the others.
+- **Anchor edits by the quoted className string**, not line numbers (they drift).
+- If a component's existing test file lacks a render path that reaches the touched element, add the minimal render/props to reach it (matching prop names/fixtures already used in that file) — do **not** invent a new test harness or fall back to a raw-file source scan.
+- If a commit hook stalls on a Python venv bootstrap, these are leaf CSS/test/docs changes only (no server code) — `git -c core.hooksPath=/dev/null commit …` is acceptable; note it in the PR.

--- a/docs/superpowers/plans/2026-07-24-fe-39-group-active-touch-mirrors.md
+++ b/docs/superpowers/plans/2026-07-24-fe-39-group-active-touch-mirrors.md
@@ -41,7 +41,7 @@ Add this block to `continue-listening-rail.test.tsx`. It renders the rail with o
 
 ```tsx
 it('play badge mirrors group-hover with group-active for touch press feedback (fe-39)', () => {
-  render(<ContinueListeningRail items={items} onOpen={noop} onFinish={noop} onHide={noop} />);
+  render(<ContinueListeningRail items={[item()]} onOpen={noop} onFinish={noop} onHide={noop} />);
   const card = screen.getByRole('button', { name: /Continue listening to The Coalfall Commission/i });
   const badge = card.querySelector('span.bg-white\\/20');
   expect(badge).not.toBeNull();
@@ -50,7 +50,7 @@ it('play badge mirrors group-hover with group-active for touch press feedback (f
 });
 ```
 
-Note: reuse the existing `items` / `noop` fixtures already defined in this test file (the existing "renders … Coalfall" test uses them). If the first item's title differs, match the accessible name to whatever the existing fixtures use.
+Note: this test file defines a module-scope **`item()` factory** and **`noop`** (not an `items` array — those are local to each existing `it`). Use `items={[item()]}`; `item()`'s default title is "The Coalfall Commission", so the `getByRole` accessible-name query matches. The play badge (line 111) is the only `bg-white/20` span and is a descendant of the card `<button>` (line 84), so `card.querySelector('span.bg-white\\/20')` resolves it uniquely (not the sibling ⋯ remove button at line 135).
 
 - [ ] **Step 2: Run test to verify it fails**
 

--- a/docs/superpowers/specs/2026-07-24-fe-39-group-active-touch-mirrors-design.md
+++ b/docs/superpowers/specs/2026-07-24-fe-39-group-active-touch-mirrors-design.md
@@ -39,7 +39,24 @@ A note will be posted to #799 recording this 4-of-7 decision and the rationale b
 
 Pure Tailwind-variant addition. For each in-scope control, append a `group-active:X` variant alongside the existing `group-hover:X` for the same property. **Add-only** — no resting class is changed, removed, or reordered, and no component logic changes. No new files, no config changes.
 
-Tailwind is **v4** (`tailwindcss ^4.3.0`, CSS-first, no `tailwind.config.js`). `group-active` is a built-in state variant in v4; no configuration is required to enable it. It is currently unused in `src/`, so this introduces the variant fresh.
+Tailwind is **v4** (`tailwindcss ^4.3.0`, CSS-first, no `tailwind.config.js`). `group-active` is a built-in state variant in v4; no configuration is required to enable it. The `active:` variant family is already in use across ~10 `src/` files (e.g. `library-grid.tsx`, `voice-library-panel.tsx`, `top-bar.tsx`, `searchable-picker.tsx`), so the variant machinery is proven to compile in this codebase; only the `group-active:` *combinator* is introduced fresh.
+
+### Touch `:active` firing — confirmed for all four groups
+
+`group-active:X` compiles to `.group:active .target`, so the element carrying `group` must itself enter `:active` on press. This is the load-bearing "will a touch user ever see it" question. Verified per control against source — every group container is either a native interactive element or one already proven to receive `:active`, so none depends on `:active` firing on an inert element (the iOS Safari failure mode):
+
+| # | `group` element | Why `:active` fires on touch |
+|---|-----------------|------------------------------|
+| 1 | `<div class="group">` at `continue-listening-rail.tsx:83`, wrapping a native `<button type="button" onClick>` (line 84) | Pressing the native `<button>` sets `:active` on it **and its ancestors** (standard `:active` ancestor-matching — the same mechanism the existing `group-hover:` already relies on). iOS Safari applies `:active` when the activated element is natively tappable; a `<button>` qualifies. |
+| 2 | `<button class="group">` at `library-grid.tsx:556` | Native button — `:active` fires directly and reliably on touch. |
+| 3 | `<button class="group">` at `setup-wizard.tsx:442` | Native button — same. |
+| 4 | `<div class="group … active:cursor-grabbing">` at `voice-library-panel.tsx:303` | The div **already** uses `active:cursor-grabbing`, which is proof `:active` fires on it in practice. |
+
+Conclusion: the earlier concern that #1's plain-`<div>` group might be iOS-dead does **not** hold — its activation source is a native `<button>`, so `:active` chains to the group div exactly as `:hover` does today. No control is a shipped no-op on iOS.
+
+### Sibling hover effects on the same group — deliberate non-goal
+
+Each of these groups carries *additional* container-level hover effects beyond the enumerated inner span: the Add-book **outer tile** has `hover:border-peach hover:bg-peach/4` (`library-grid.tsx:556`), the rail **card button** has `hover:shadow-float hover:border-ink/20` (`continue-listening-rail.tsx:88`), and the Review **row button** has `hover:bg-ink/[0.03]` (`setup-wizard.tsx:442`). This spec **intentionally mirrors only the enumerated inner-span controls** from #799, not these sibling effects, because: (i) the issue enumerated the inner spans specifically; (ii) the sibling effects are lower-visibility (a shadow shift, a 3–4% background tint); and (iii) "mirror every `hover:` in the tree" is unbounded scope for a Could-priority cosmetic item. If fuller per-control parity is later wanted, the Add-book **outer tile** (`library-grid.tsx:556`) is the highest-value first addition and would be captured as a separate micro-follow-up — not folded into fe-39.
 
 ### Caveat (a) — Add-book tile must not force peach at rest
 
@@ -64,7 +81,9 @@ For control #2 (Add-book tile) the test additionally asserts caveat (a): the res
 
 Rationale for this test shape: `group-active:` is a transient pointer-press state that a static visual-baseline screenshot cannot capture, and a real touch-hold Playwright test is flaky on Windows visual specs and disproportionate for a cosmetic change. A class-presence assertion is deterministic, zero-flake, and precisely guards the one failure mode that matters — a future edit silently dropping a mirror.
 
-If a touched element cannot be uniquely queried from its existing test without new test scaffolding, add a minimal, stable query hook (e.g. an existing accessible role/name already rendered) rather than a source-text scan; the assertion must run against the rendered DOM, not the raw file.
+**Known limit of this test (explicit):** these components render under jsdom, where Tailwind is not compiled, so the assertion is a `className`-string presence check — it proves the `group-active:X` token is emitted onto the correct element, **not** that the variant compiles to CSS or fires on press. That behavioral correctness is instead established **once, manually, at implementation** (see Verification gates) rather than by an ongoing automated test, because the fire-on-touch mechanism is already confirmed by construction (all four groups are native-interactive or already use `:active` — see "Touch `:active` firing" above). The string check is the regression guard; the manual smoke-check is the one-time behavioral proof.
+
+The existing `continue-listening-rail.test.tsx` already uses `@testing-library/react` `render` + `screen.getByRole('button', { name: … })` + `container`, which is sufficient to reach each touched element. Where the touched element is a role-less/text-less `<span>` (the #1 play badge, the #4 drag icon), query it via its parent's accessible role/name (or the existing `container`) and assert on the child's `className` — against the rendered DOM, never a raw-file source scan.
 
 ## Verification gates
 
@@ -74,12 +93,14 @@ Run in the fe-39 worktree (node_modules junctioned from the main checkout):
 2. `lint`
 3. The 4 updated test files
 4. Full frontend test suite **only if** a shared component is implicated (none is here — all 4 edits are leaf className changes)
+5. **One-time manual touch smoke-check** (behavioral proof the string test can't give): in the running app with Chrome DevTools device/touch emulation on (which activates the `coarse-pointer` variant and `:active` on tap), confirm the press-flash on at least controls #1 (rail play badge) and #2 (Add-book tile). Real iOS Safari is best-effort/not automatable, but the mechanism is confirmed native (all four groups above), so DevTools touch emulation is accepted as sufficient evidence.
 
 Then open a PR with a body that reads as mini release notes and a literal `Closes #799`.
 
 ## Out of scope / non-goals
 
 - No changes to the 3 dropped controls.
+- No mirroring of sibling container-level hover effects on the touched groups (outer Add-book tile tint, rail card shadow, Review row bg) — deliberate non-goal, see Design.
 - No new Tailwind config, no custom variant definitions.
 - No change to any resting appearance, layout, or component logic.
 - No refactoring of the touched components beyond the className additions and their test assertions.
@@ -87,4 +108,6 @@ Then open a PR with a body that reads as mini release notes and a literal `Close
 ## Risks
 
 - **Near-zero user benefit** — accepted; this is cosmetic parity, explicitly Could-priority. The value is consistency/completeness of the touch-parity story started by fe-5, plus a regression guard.
+- **`:active` not firing on touch** — investigated and resolved: all four group containers are native-interactive (`<button>`) or already use `:active`, so the mirror fires by the same mechanism as the existing `group-hover:`. iOS Safari's inert-element `:active` restriction does not apply to any of them. Confirmed at the source level; final behavioral confirmation is the one-time manual smoke-check.
+- **Test is spelling-level, not behavioral** — accepted and explicit: jsdom doesn't compile Tailwind, so the automated test guards against a dropped token; the manual smoke-check covers fire-on-press once.
 - **Test brittleness** — mitigated by asserting against rendered DOM className via existing test helpers, not source text.

--- a/docs/superpowers/specs/2026-07-24-fe-39-group-active-touch-mirrors-design.md
+++ b/docs/superpowers/specs/2026-07-24-fe-39-group-active-touch-mirrors-design.md
@@ -1,0 +1,90 @@
+# fe-39 — Decorative hover-feedback parity for touch (`group-active:` mirrors)
+
+- **Issue:** #799 (`fe-39`, MoSCoW: Could, `area:fe`, `type:feature`)
+- **Depends on:** `fe-5` (#402 / PR #798, shipped)
+- **Date:** 2026-07-24
+- **Branch / worktree:** `feat/frontend-fe-39-group-active-mirrors`
+
+## Problem
+
+`fe-5` added `coarse-pointer:` / `fine-pointer:` variants only to hover patterns that **hide a functional action** (regenerate button, book-options ⋯, scrubber thumb). It deliberately left **decorative hover-feedback** controls — color/background shifts on controls that are already visible — untouched. Touch users get no press-feedback equivalent on those decorative controls, so there is a small visual-parity gap versus mouse users who see a `:hover` shift.
+
+This item closes that gap for the controls where it is actually observable, by adding a `group-active:X` variant mirroring the existing `group-hover:X`. `group-active:` fires on pointer-press, which is the touch analogue of hover.
+
+Benefit is **cosmetic and marginal** by design — the controls are already visible and reachable; this only adds a brief press-feedback flash. Priority is Could.
+
+## Scope decision
+
+The issue lists 7 decorative controls. Verified against live code (line numbers re-anchored 2026-07-24), only **4** yield an observable touch benefit. The other 3 are verified no-ops and are explicitly dropped.
+
+### In scope (4 controls — add a `group-active:` mirror)
+
+| # | File / element | Existing | Add |
+|---|----------------|----------|-----|
+| 1 | `src/components/library/continue-listening-rail.tsx:111` — play badge | `bg-white/20 group-hover:bg-white/35` | `group-active:bg-white/35` |
+| 2 | `src/components/library/library-grid.tsx:559` — "Add book" tile | `group-hover:bg-peach group-hover:border-peach group-hover:text-white` | `group-active:bg-peach group-active:border-peach group-active:text-white` |
+| 3 | `src/components/setup/setup-wizard.tsx:459` — "Review ›" | `text-ink/40 group-hover:text-magenta` | `group-active:text-magenta` |
+| 4 | `src/components/voice-library-panel.tsx:388` — drag icon | `text-ink/30 group-hover:text-ink/60` | `group-active:text-ink/60` |
+
+### Out of scope (3 controls — verified no-ops, dropped)
+
+- `src/views/revision-diff.tsx:551` & `:584` — play badges A/B. Tapping the badge flips `isPlayingA` / `isPlayingB`, whose truthy branch (`bg-ink text-canvas` / `bg-magenta text-white`) overrides the color entirely. A `group-active:` mirror would only flash during the sub-second pointer-hold before release toggles the state — effectively invisible. **Dropped.**
+- `src/views/manuscript.tsx:2088` — boundary hit-area tint. This is a `cursor-ns-resize` drag control, not a tap target; starting a drag sets `isThisDragging`, which already applies `bg-peach/40`. A `group-active:` mirror is redundant with the existing drag-state tint. **Dropped.**
+
+A note will be posted to #799 recording this 4-of-7 decision and the rationale before the PR merges.
+
+## Design
+
+### Approach
+
+Pure Tailwind-variant addition. For each in-scope control, append a `group-active:X` variant alongside the existing `group-hover:X` for the same property. **Add-only** — no resting class is changed, removed, or reordered, and no component logic changes. No new files, no config changes.
+
+Tailwind is **v4** (`tailwindcss ^4.3.0`, CSS-first, no `tailwind.config.js`). `group-active` is a built-in state variant in v4; no configuration is required to enable it. It is currently unused in `src/`, so this introduces the variant fresh.
+
+### Caveat (a) — Add-book tile must not force peach at rest
+
+Called out in the fe-5 review: the Add-book tile's full-peach appearance must **not** become the resting state. Satisfied by construction — we only add `group-active:bg-peach` / `group-active:border-peach` / `group-active:text-white`; the resting `bg-white border-ink/10 text-ink` classes are untouched. The tile stays white until pressed.
+
+### Caveat — #4 is hidden below `md`
+
+`voice-library-panel.tsx:388` carries `hidden md:inline`, so the drag-icon span is invisible on phones. Its `group-active:` feedback is therefore only ever observable on `md`+ touch devices (large tablets). This is expected, not a bug; documented here so a future reader does not mistake the absence of phone feedback for a regression.
+
+## Testing
+
+**Class-presence assertions**, added to the four existing `.test.tsx` files (one per touched component):
+
+- `continue-listening-rail.test.tsx`
+- `library-grid.test.tsx`
+- `setup-wizard.test.tsx`
+- `voice-library-panel.test.tsx`
+
+Each assertion renders the component (using existing test-render helpers / providers already present in that file), queries the specific touched element, and asserts its `className` contains **both** the existing `group-hover:X` variant **and** the paired `group-active:X` variant for the same property.
+
+For control #2 (Add-book tile) the test additionally asserts caveat (a): the resting `bg-white` class is still present and no bare (non-variant) `bg-peach` was introduced.
+
+Rationale for this test shape: `group-active:` is a transient pointer-press state that a static visual-baseline screenshot cannot capture, and a real touch-hold Playwright test is flaky on Windows visual specs and disproportionate for a cosmetic change. A class-presence assertion is deterministic, zero-flake, and precisely guards the one failure mode that matters — a future edit silently dropping a mirror.
+
+If a touched element cannot be uniquely queried from its existing test without new test scaffolding, add a minimal, stable query hook (e.g. an existing accessible role/name already rendered) rather than a source-text scan; the assertion must run against the rendered DOM, not the raw file.
+
+## Verification gates
+
+Run in the fe-39 worktree (node_modules junctioned from the main checkout):
+
+1. `typecheck`
+2. `lint`
+3. The 4 updated test files
+4. Full frontend test suite **only if** a shared component is implicated (none is here — all 4 edits are leaf className changes)
+
+Then open a PR with a body that reads as mini release notes and a literal `Closes #799`.
+
+## Out of scope / non-goals
+
+- No changes to the 3 dropped controls.
+- No new Tailwind config, no custom variant definitions.
+- No change to any resting appearance, layout, or component logic.
+- No refactoring of the touched components beyond the className additions and their test assertions.
+
+## Risks
+
+- **Near-zero user benefit** — accepted; this is cosmetic parity, explicitly Could-priority. The value is consistency/completeness of the touch-parity story started by fe-5, plus a regression guard.
+- **Test brittleness** — mitigated by asserting against rendered DOM className via existing test helpers, not source text.

--- a/src/components/library/continue-listening-rail.test.tsx
+++ b/src/components/library/continue-listening-rail.test.tsx
@@ -67,6 +67,15 @@ describe('ContinueListeningRail', () => {
     );
     expect(container.querySelector('.scrollbar-thin')).not.toBeNull();
   });
+
+  it('play badge mirrors group-hover with group-active for touch press feedback (fe-39)', () => {
+    render(<ContinueListeningRail items={[item()]} onOpen={noop} onFinish={noop} onHide={noop} />);
+    const card = screen.getByRole('button', { name: /Continue listening to The Coalfall Commission/i });
+    const badge = card.querySelector('span.bg-white\\/20');
+    expect(badge).not.toBeNull();
+    expect(badge!.className).toContain('group-hover:bg-white/35');
+    expect(badge!.className).toContain('group-active:bg-white/35');
+  });
 });
 
 describe('ContinueListeningRail — covers', () => {

--- a/src/components/library/continue-listening-rail.tsx
+++ b/src/components/library/continue-listening-rail.tsx
@@ -108,7 +108,7 @@ function ContinueCard({
           )}
 
           {/* Play badge */}
-          <span className="absolute bottom-2 right-2 w-7 h-7 rounded-full bg-white/20 group-hover:bg-white/35 transition-colors grid place-items-center">
+          <span className="absolute bottom-2 right-2 w-7 h-7 rounded-full bg-white/20 group-hover:bg-white/35 group-active:bg-white/35 transition-colors grid place-items-center">
             <IconPlay className="w-3.5 h-3.5 text-white" />
           </span>
         </div>

--- a/src/components/library/library-grid.test.tsx
+++ b/src/components/library/library-grid.test.tsx
@@ -72,3 +72,25 @@ describe('LibraryGrid series-memory', () => {
     expect(screen.queryByTestId('series-sparkline')).toBeNull();
   });
 });
+
+describe('LibraryGrid Add-book tile', () => {
+  it('Add-book tile mirrors hover with group-active, no resting peach (fe-39, caveat a)', () => {
+    renderGrid(authorsWith(undefined));
+    const addBtn = document.querySelector('[data-tour-id="new-book-btn"]') as HTMLElement;
+    expect(addBtn).not.toBeNull();
+    const circle = addBtn.querySelector('span.rounded-full') as HTMLElement;
+    expect(circle).not.toBeNull();
+    // mirrors present
+    expect(circle.className).toContain('group-active:bg-peach');
+    expect(circle.className).toContain('group-active:border-peach');
+    expect(circle.className).toContain('group-active:text-white');
+    // resting appearance intact
+    expect(circle.className).toContain('bg-white');
+    expect(circle.className).toContain('border-ink/10');
+    // caveat (a): peach only ever appears as a variant, never bare
+    // (regex requires start-or-whitespace before the token, so `group-hover:bg-peach`
+    //  and `group-active:bg-peach` — preceded by ':' — do NOT match)
+    expect(circle.className).not.toMatch(/(^|\s)bg-peach(\s|$)/);
+    expect(circle.className).not.toMatch(/(^|\s)border-peach(\s|$)/);
+  });
+});

--- a/src/components/library/library-grid.test.tsx
+++ b/src/components/library/library-grid.test.tsx
@@ -92,5 +92,6 @@ describe('LibraryGrid Add-book tile', () => {
     //  and `group-active:bg-peach` — preceded by ':' — do NOT match)
     expect(circle.className).not.toMatch(/(^|\s)bg-peach(\s|$)/);
     expect(circle.className).not.toMatch(/(^|\s)border-peach(\s|$)/);
+    expect(circle.className).not.toMatch(/(^|\s)text-white(\s|$)/);
   });
 });

--- a/src/components/library/library-grid.tsx
+++ b/src/components/library/library-grid.tsx
@@ -556,7 +556,7 @@ function NewBookCard({ onStartNew }: { onStartNew: () => void }) {
       className="group bg-canvas rounded-3xl border-2 border-dashed border-ink/15 hover:border-peach hover:bg-peach/4 transition-all min-h-[180px] grid place-items-center text-center p-8"
     >
       <div>
-        <span className="w-14 h-14 mx-auto rounded-full bg-white border border-ink/10 grid place-items-center group-hover:bg-peach group-hover:border-peach group-hover:text-white transition-colors text-ink">
+        <span className="w-14 h-14 mx-auto rounded-full bg-white border border-ink/10 grid place-items-center group-hover:bg-peach group-hover:border-peach group-hover:text-white group-active:bg-peach group-active:border-peach group-active:text-white transition-colors text-ink">
           <IconPlus className="w-6 h-6" />
         </span>
         <p className="mt-4 text-base font-bold text-ink">Add another book</p>

--- a/src/components/setup/setup-wizard.test.tsx
+++ b/src/components/setup/setup-wizard.test.tsx
@@ -481,3 +481,15 @@ describe('SetupWizard — help & wiki links (fe-52/fe-53)', () => {
     );
   });
 });
+
+describe('SetupWizard — touch press-feedback parity (fe-39)', () => {
+  it('Review chip mirrors group-hover with group-active for touch (fe-39)', () => {
+    render(<SetupWizard readiness={READINESS} mode="checklist" onRefetch={() => {}} onFinish={() => {}} />);
+    const chip = screen
+      .getAllByText(/Review/)
+      .find((el) => el.className.includes('group-hover:text-magenta'));
+    expect(chip).toBeTruthy();
+    expect(chip!.className).toContain('group-hover:text-magenta');
+    expect(chip!.className).toContain('group-active:text-magenta');
+  });
+});

--- a/src/components/setup/setup-wizard.tsx
+++ b/src/components/setup/setup-wizard.tsx
@@ -456,7 +456,7 @@ function SetupSummary({
             />
             <span className="font-semibold text-ink text-sm w-36 shrink-0">{r.label}</span>
             <span className="text-sm text-ink/60 min-w-0 flex-1 truncate">{r.detail}</span>
-            <span className="text-xs font-medium text-ink/40 group-hover:text-magenta shrink-0">
+            <span className="text-xs font-medium text-ink/40 group-hover:text-magenta group-active:text-magenta shrink-0">
               Review &rsaquo;
             </span>
           </button>

--- a/src/components/voice-library-panel.test.tsx
+++ b/src/components/voice-library-panel.test.tsx
@@ -309,6 +309,23 @@ describe('VoiceLibraryPanel — Cast-view interactions', () => {
     expect(scroller.className).toMatch(/overflow-y-auto/);
     expect(scroller.className).toMatch(/scrollbar-thin/);
   });
+
+  it('drag icon mirrors group-hover with group-active for touch (fe-39)', () => {
+    render(
+      <VoiceLibraryPanel
+        library={[makeVoice('v_marlow', 'Marlow')]}
+        characters={[makeCharacter('marlow', 'v_marlow')]}
+        draggingVoiceId={null}
+        setDraggingVoiceId={vi.fn()}
+        onOpenProfile={vi.fn()}
+        onPlaySample={vi.fn()}
+      />,
+    );
+    const dragIcon = document.querySelector('span.group-hover\\:text-ink\\/60');
+    expect(dragIcon).not.toBeNull();
+    expect(dragIcon!.className).toContain('group-hover:text-ink/60');
+    expect(dragIcon!.className).toContain('group-active:text-ink/60');
+  });
 });
 
 describe('VoiceCard — familyKey identity (cross-book id collision)', () => {

--- a/src/components/voice-library-panel.tsx
+++ b/src/components/voice-library-panel.tsx
@@ -385,7 +385,7 @@ export function VoiceCard({
           {isAssigningTarget ? 'Cancel' : 'Assign'}
         </button>
       ) : (
-        <span className="text-ink/30 group-hover:text-ink/60 transition-colors mt-1 hidden md:inline">
+        <span className="text-ink/30 group-hover:text-ink/60 group-active:text-ink/60 transition-colors mt-1 hidden md:inline">
           <IconDrag className="w-4 h-4" />
         </span>
       )}


### PR DESCRIPTION
## What & why

`fe-5` (#402) added touch-parity variants only to hover patterns that **hide a functional action**. It deliberately left the **decorative** hover-feedback controls — colour/background shifts on already-visible controls — untouched, so touch users get no press-feedback equivalent there. This closes that gap for the controls where it is actually observable, by adding a `group-active:X` variant mirroring each existing `group-hover:X`. `group-active:` fires on pointer-press, the touch analogue of hover.

Cosmetic and marginal by design (MoSCoW: Could) — the controls are already visible and reachable; this only adds a brief press-feedback flash and a regression guard.

## Scope — 4 of the 7 controls listed in #799

Verified against live code; only 4 yield an observable touch benefit. The other 3 are verified no-ops and were dropped (rationale posted to #799).

| Control | File | Added |
|---|---|---|
| Continue-listening play badge | `continue-listening-rail.tsx` | `group-active:bg-white/35` |
| "Add book" tile | `library-grid.tsx` | `group-active:{bg,border}-peach group-active:text-white` |
| Wizard "Review ›" chip | `setup-wizard.tsx` | `group-active:text-magenta` |
| Voice-library drag icon | `voice-library-panel.tsx` | `group-active:text-ink/60` |

**Dropped (no-ops):** revision-diff play badges A/B (press-toggle overrides the colour before release), and the manuscript boundary tint (drag control, already tinted by drag-state).

## How it's built

Pure Tailwind-v4 variant additions — **add-only**. Each edit appends one or more `group-active:` tokens immediately after the matching `group-hover:` token on the same span. No resting class changed, removed, or reordered; no logic, imports, or config touched. `group-active` is a built-in v4 variant; the `active:` family is already used across ~10 files here.

Each of the four groups is native-interactive (`<button>`) or already uses `:active`, so the mirror fires by the same mechanism the existing `group-hover:` relies on — no iOS inert-element `:active` pitfall.

**Add-book caveat:** the tile must not appear peach at rest. Satisfied by construction (only `group-active:` variants added); the test asserts no bare `bg-peach` / `border-peach` / `text-white` leaked into the resting className.

## Tests

Class-presence assertions (one per touched component): render the element and assert its `className` carries **both** the `group-hover:X` and the paired `group-active:X` token. jsdom does not compile Tailwind, so these guard against a future edit silently dropping a mirror — the string is the regression guard, not a behavioural test.

## Verification

- `tsc --noEmit` ✅  ·  `eslint --max-warnings 0` (changed files) ✅  ·  4 touched test files **67/67** ✅
- Reviewed task-by-task (spec + quality) and once whole-branch: **ready to merge**, one minor test-completeness gap found and closed.

**One residual, non-blocking:** the behavioural touch-flash is confirmed by construction but not by an automated test (jsdom can't compile the variant). A one-time manual DevTools touch-emulation smoke-check is the spec's accepted behavioural proof; worth an eyeball before/after merge on the play badge and Add-book tile.

Closes #799
