### PR TITLE
docs(frontend): mirror the local-first privacy FAQ into the app Help view

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Castwright 1.15.0
 
+- **In-app Help now answers "Is my data private?" and "Does it work offline?"** — the same plain-language answers as the website, so both agree: analysis reads your book on a local model by default, and the optional cloud fallback is on by default but a single switch turns it off for good.
 - **The demo library shows the right covers again.** In the built-in sample library, _Saltgrave_ and _The Tidewatcher's Oath_ were wearing each other's cover art — they now each show their own.
 - **Re-detect one chapter, not the whole book.** Edited a single chapter? "Detect emotions" now works on just the chapter you're reading — the whole-book pass is one click away in its menu.
 - **You can see the chapter title on the timeline now.** Every chapter opens with its title read

--- a/docs/release-notes-next.md
+++ b/docs/release-notes-next.md
@@ -51,3 +51,14 @@ history at cut time.
   the filename-mapping test could not see it. Swapped both the committed downscaled assets and the
   git-ignored `brand/book-covers/` sources (so regeneration stays correct), and added a SHA-256
   regression guard in `scripts/tests/build-demo-covers.test.mjs` that pins the corrected art.
+
+---
+
+## 📖 Help
+
+- **Mirror the marketing site's local-first privacy FAQ into the app Help view** (#1793). Adds two
+  Help topics — `is-my-data-private` (files) and `does-it-work-offline` (analysis) — to
+  `src/data/help-topics.ts`, matching the website's corrected copy: analysis is local by default and
+  the cloud fallback is opt-out (on by default, switchable off), never framed as opt-in-only or
+  "never touches the cloud". Guarded by `src/data/help-topics.test.ts`; item-count assertions bumped
+  43 → 45.

--- a/src/data/help-categories.test.ts
+++ b/src/data/help-categories.test.ts
@@ -20,7 +20,7 @@ describe('help categories', () => {
     expect(IDS.size).toBe(HELP_CATEGORIES.length);
     expect(HELP_CATEGORIES.every((c) => c.label.length > 0)).toBe(true);
   });
-  it('has exactly 43 items (19 failures + 24 topics)', () => {
-    expect(HELP_FAILURE_ENTRIES.length + HELP_TOPICS.length).toBe(43);
+  it('has exactly 45 items (19 failures + 26 topics)', () => {
+    expect(HELP_FAILURE_ENTRIES.length + HELP_TOPICS.length).toBe(45);
   });
 });

--- a/src/data/help-topics.test.ts
+++ b/src/data/help-topics.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { HELP_TOPICS } from './help-topics';
+
+/* Privacy / offline Help topics mirror the marketing-site FAQ (Castwright-Website
+   #126) after the v1.14 local-first analysis flip. They must state the honest
+   claim — analysis is local BY DEFAULT, and the cloud fallback is opt-out and
+   can be switched off — and must NOT overclaim that the cloud is opt-in only or
+   never used. These guards keep the app copy from drifting back. See issue #1793. */
+describe('privacy & offline Help topics (local-first mirror, #1793)', () => {
+  const byId = (id: string) => HELP_TOPICS.find((t) => t.id === id);
+
+  it('has an "Is my data private?" topic filed under files', () => {
+    const t = byId('is-my-data-private');
+    expect(t).toBeDefined();
+    expect(t!.category).toBe('files');
+    expect(t!.title).toMatch(/private/i);
+    expect(t!.body).toMatch(/local model by default|reads your chapter text on a local model/i);
+  });
+
+  it('has a "Does it work offline?" topic filed under analysis', () => {
+    const t = byId('does-it-work-offline');
+    expect(t).toBeDefined();
+    expect(t!.category).toBe('analysis');
+    expect(t!.title).toMatch(/offline/i);
+    expect(t!.body).toMatch(/local Ollama model by default|by default/i);
+  });
+
+  it('neither topic overclaims that the cloud is opt-in-only or never used', () => {
+    for (const id of ['is-my-data-private', 'does-it-work-offline']) {
+      const body = byId(id)!.body.toLowerCase();
+      expect(body).not.toContain('never touches the cloud');
+      expect(body).not.toContain('never leaves your machine');
+      // the fallback is opt-out (on by default), never framed as opt-in only
+      expect(body).not.toContain('only if you choose');
+    }
+  });
+
+  it('states the cloud fallback is on by default and can be switched off', () => {
+    const privacy = byId('is-my-data-private')!.body.toLowerCase();
+    expect(privacy).toContain('on by default');
+    expect(privacy).toMatch(/turns it off|switch it off|switched off/i);
+  });
+});

--- a/src/data/help-topics.ts
+++ b/src/data/help-topics.ts
@@ -314,4 +314,30 @@ export const HELP_TOPICS: HelpTopic[] = [
       'choice can land on Gemini. Want it to stop and tell you instead? Start Ollama before you ' +
       'analyse, or set the analyzer engine to Gemini outright.',
   },
+  {
+    id: 'is-my-data-private',
+    category: 'files',
+    title: 'Is my data private?',
+    body:
+      'Your books, voices, library and rendered audio stay on your machine — nothing is uploaded to ' +
+      'a Castwright server, and there is no account. Working out who speaks each line reads your ' +
+      'chapter text on a local model by default too. The one thing that can leave your machine is ' +
+      'the optional cloud analyzer (the free Gemini tier): if you have set a Gemini key, it sends ' +
+      "chapter text only when your local model isn't running. Cloud fallback stays on by default, " +
+      'and a single switch in analyzer settings turns it off for good — and whenever Castwright does ' +
+      'fall back to Gemini it tells you, rather than switching behind your back.',
+  },
+  {
+    id: 'does-it-work-offline',
+    category: 'analysis',
+    title: 'Does it work offline?',
+    body:
+      'Yes, once the models are installed. Rendering the audio and playing it back are fully ' +
+      'offline — nothing is sent anywhere while Castwright synthesises — and working out who speaks ' +
+      'each line runs on a local Ollama model by default. The optional cloud analyzer (Gemini) is ' +
+      'the one part that wants a connection: leave it switched off in analyzer settings, or keep ' +
+      'your local model running, and the whole pipeline works with no internet at all. Voice design ' +
+      'follows the same analyzer engine, so a no-key, fully-offline setup can still design a cast ' +
+      'from scratch.',
+  },
 ];

--- a/src/views/help.test.tsx
+++ b/src/views/help.test.tsx
@@ -76,7 +76,7 @@ describe('HelpView (fe-29)', () => {
     renderHelp();
     const box = screen.getByRole('searchbox', { name: /search troubleshooting/i });
     fireEvent.change(box, { target: { value: 'gpu' } });
-    expect(screen.getByText(/of 43/i)).toBeInTheDocument();
+    expect(screen.getByText(/of 45/i)).toBeInTheDocument();
     fireEvent.change(box, { target: { value: '' } });
     // back to default: setup open, performance collapsed
     expect(screen.getByText("The app won't start")).toBeInTheDocument();


### PR DESCRIPTION
## Summary

Mirrors the marketing site's corrected local-first analysis privacy claim (Castwright-Website#126) into the in-app Help view, per the FAQ-mirror convention. The app's Help topics already stated the semantics correctly in passing (`design-without-cloud-key`, `picked-local-but-ran-on-gemini`), but had no dedicated consumer answer to the two questions the website FAQ answers. This adds them so both surfaces agree.

### What changed
- `src/data/help-topics.ts` — two new Help topics:
  - **`is-my-data-private`** (category `files`) — "Is my data private?"
  - **`does-it-work-offline`** (category `analysis`) — "Does it work offline?"
- Both state the honest post-v1.14 semantics: analysis reads your book on a **local model by default**; the optional Gemini cloud analyser sends chapter text **only when a key is set and the local model isn't running**; the fallback is **on by default and a single switch turns it off**. Neither claims cloud use is opt-in-only or that the product "never touches the cloud".
- `src/data/help-topics.test.ts` — new guard test pinning those claims and blocking the overclaims (mirrors the website's regression guards).
- Item-count assertions bumped 43 → 45 in `help-categories.test.ts` and `help.test.tsx`.
- Release notes: user-facing line in `RELEASE_NOTES.md`, technical entry in `docs/release-notes-next.md`.

## Test plan
- `npx vitest run src/data/help-topics.test.ts src/data/help-categories.test.ts src/data/help-failures.test.ts` — pass.
- `npx vitest run src/views/help.test.tsx` — pass (updated the "of 45" search-count assertion).
- `npx tsc --noEmit` — clean.
- Pre-commit hook ran the scoped frontend suite green.

Closes #1793

🤖 Generated with [Claude Code](https://claude.com/claude-code)
