### PR TITLE
docs(frontend): refresh /about for v1.14 (open beta, 7 languages, companion app)

### DIFF
--- a/src/views/about.test.tsx
+++ b/src/views/about.test.tsx
@@ -68,7 +68,7 @@ describe('AboutView', () => {
     expect(screen.getByText(new RegExp(`Castwright v${buildInfo.version}`))).toBeInTheDocument();
   });
 
-  it('carries the alpha-tester ask with the castwright.ai link', () => {
+  it('carries the beta-tester ask with the castwright.ai link', () => {
     renderAbout();
     const link = screen.getByRole('link', { name: new RegExp(DOMAIN.replace('.', '\\.'), 'i') });
     expect(link).toHaveAttribute('href', `https://${DOMAIN}`);

--- a/src/views/about.tsx
+++ b/src/views/about.tsx
@@ -1,7 +1,7 @@
 /* /about — the brand page (reached from Admin, #/about).
    Rebuilt for fe-37: the only in-product explanation of the product. Seven
    blocks (brand guidelines §2/§3): identity · what it is · coming next (teaser,
-   flagged) · engine credits · licence · what's new · alpha ask.
+   flagged) · engine credits · licence · what's new · beta ask.
    All brand copy comes from src/lib/brand.ts so a tagline change is one diff. */
 
 import type { ReactNode } from 'react';
@@ -58,11 +58,15 @@ export function AboutView() {
           <p className="text-ink/70 max-w-prose">
             Castwright turns any book into a full-cast performance — every character its own
             voice, kept true from book one to the last. One narrator can&rsquo;t be everyone: the
-            apprentice sounds thirteen; the swordsmith sounds seventy and a forge.
+            apprentice sounds thirteen; the swordsmith sounds seventy and a forge. It performs seven
+            languages — English, Spanish, French, German, Russian, Chinese and Japanese — reading
+            each book in its own tongue.
           </p>
           <p className="text-ink/70 max-w-prose">
             It renders at home, on a machine you may already own. {HARDWARE_LINE} Your book never
-            leaves the house — no meter, no monthly fee, no server that can take your library away.
+            leaves the house — no meter, no monthly fee, no server that can take your library away. A
+            companion app — Android now, iOS at launch — plays your library anywhere, or export to
+            the audiobook player you already use.
           </p>
         </section>
 
@@ -128,9 +132,9 @@ export function AboutView() {
             Help shape it
           </h2>
           <p className="text-ink/70 max-w-prose">
-            Castwright is in alpha. We&rsquo;d love more testers — especially on Apple Silicon Macs
-            and non-NVIDIA GPUs, where we have the fewest miles. Tell us how it runs on your machine
-            at <ExternalLink href={`https://${DOMAIN}`}>{DOMAIN}</ExternalLink>.
+            Castwright is in open beta. We&rsquo;d love more testers — especially on Apple Silicon
+            Macs and non-NVIDIA GPUs, where we have the fewest miles. Tell us how it runs on your
+            machine at <ExternalLink href={`https://${DOMAIN}`}>{DOMAIN}</ExternalLink>.
           </p>
         </section>
       </div>


### PR DESCRIPTION
Closes #1811

## What

Refresh the in-product `/about` page to match the v1.14 release and the canonical brand narrative (`brand/project-narrative.md`).

- **Status:** "Castwright is in alpha" → "in open beta" — the public repo is live and the open beta is out as of v1.14 (the Help-shape-it section and the file's block-structure comment).
- **Languages:** "What it is" now names the seven supported languages — English, Spanish, French, German, Russian, Chinese and Japanese (Chinese & Japanese new in v1.14) — reading each book in its own tongue.
- **Companion app:** "What it is" now mentions the Android/iOS listener, woven into the existing block rather than adding a new one (the page keeps its deliberate 7-block structure).
- **Test:** renamed the `about.test.tsx` case "alpha-tester ask" → "beta-tester ask" (label only; the assertions still reference `brand.ts` constants, so no copy string is pinned).

Brand strings in `src/lib/brand.ts` (tagline, manifesto, teaser, hardware line) were already current. The version block is already dynamic (`v{buildInfo.version}`).

## Verify

- `vitest run src/views/about.test.tsx` → 9/9 pass
- Full frontend suite green via pre-commit (4084 tests); pre-push `verify` (typecheck + lint + e2e + production build) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015axYtv5mgfcBF6PhjtH5ia