### PR TITLE
docs(docs): refresh README front door for v1.14 facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ or MP3.
 - **Series memory** — a character keeps the same voice across every book in a
   series, even when an author renames someone mid-series. *(No other tool does
   this for readers.)*
-- **Designed voices** — every character gets a unique voice designed from its persona, kept consistent across the series. (Cloning a voice from your own sample is the next major release.)
-- **Five languages** — performs English, Russian, Spanish, French, and German end-to-end, with the manuscript's language detected on import. A cast never crosses languages within a book.
+- **Designed voices** — every character gets a unique voice designed from its persona (Qwen3-TTS), kept consistent across the series; Kokoro ships a ready-made catalogue alongside it. (Cloning a voice from your own sample is the next major release.)
+- **Seven languages** — performs English, Russian, Spanish, French, German, Chinese, and Japanese end-to-end, with the manuscript's language detected on import. A cast never crosses languages within a book. (CJK attribution leans on the analyzer model — a local Qwen analyzer is recommended for Chinese and Japanese.)
 - **Quality-checked automatically** — every chapter is gated before it's assembled: acoustic checks (dead air, over-long lines, timing drift), optional word-for-word ASR transcript verification, and an opt-in speaker-fingerprint check that catches a voice drifting out of character even when the words are right. Flagged takes are surfaced on the waveform and re-recorded automatically.
 - **On-device by default** — analysis and speech run on your machine; cloud is
   opt-in.
-- **You own the files** — export standard M4B / MP3 / AAC / Opus and keep them.
-  No lock-in.
+- **Listen on your phone or tablet** — an Android companion app plays from your library over your home network, opening into a two-pane layout on tablets and foldables. Chapters you haven't downloaded play instantly on-network, with no OS certificate install.
+- **You own the files** — export standard M4B (cover and chapter markers), MP3, AAC/M4A or Opus, a native **Audiobookshelf** export (series metadata, `metadata.json`, and a folder cover), and SRT/VTT captions (per sentence or per line, whole-book or per-chapter). EBU R128 loudness normalisation is on by default. No lock-in.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

Brings the public README in line with v1.14. Follow-on to #1427 (the original front-door pass); the brand handoff was revised on 26 July with facts that post-dated it.

- **Five languages → seven** — adds Chinese and Japanese, shipped in `fs-59`. This was the only stale live claim; the same string in `RELEASE_NOTES.md` and the v1.10.0 wiki notes is historical and correctly left alone.
- **Engines named** on the designed-voices bullet — Qwen3-TTS designs per-persona voices, Kokoro ships the ready-made catalogue.
- **Audiobookshelf + captions** folded into the "You own the files" bullet, with EBU R128 loudness noted. Caption wording is drawn from the actual contract in `server/src/routes/export.test.ts` (SRT/VTT × sentence/line × whole-book/per-chapter), not from the handoff prose.
- **Companion bullet added** — tablet/foldable two-pane and instant on-network play of undownloaded chapters. The "no OS certificate install" claim is verified against `apps/android/lib/src/data/api_client.dart:379`, which builds a `SecurityContext(withTrustedRoots: false)` pinning the CA from the pairing payload.

Done alongside this PR, outside the diff: the repo About description (`five` → `seven languages`) and Topics (drop `local`, add `voice-cloning`, still 20).

## Why the handoff's anchors were not followed literally

Three of the handoff's targets — the Export bullet, the Qwen3-TTS voice-engines line, and the `## Companion app (Android)` section — no longer exist. `caa7f6f3` shrank the README to a pitch on 4 July, deleting 141 lines including `## Features` and `## Companion app`. Rather than restore sections that were deliberately removed three weeks ago, the content is folded into the surviving bullets. Full companion detail belongs on the wiki.

## Test plan

Docs-only; no automated coverage applies.

- `grep -inE "effortlessly|local-first|seamless|revolutionary|..." README.md` → clean.
- `#demo` anchor verified live at https://www.castwright.ai/#demo — scrolls to the one-narrator/full-cast player.
- Social preview verified set to the branded `public/og.png` card in Settings → General.

No release-notes entry: docs-only, no shippable product delta.

Closes #1814