### PR TITLE
chore(ops): add a low-friction 'Idea or feedback' issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Backlog & priorities
     url: https://github.com/dudarenok-maker/Castwright/blob/main/docs/BACKLOG.md

--- a/.github/ISSUE_TEMPLATE/idea-or-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/idea-or-feedback.yml
@@ -1,0 +1,34 @@
+name: Idea or feedback
+description: A feature idea, a rough edge, or how your first book went. No format required.
+labels: ["feedback"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Issues are welcome from anyone — this form has no required format, no ID scheme,
+        and nothing you need to know about the codebase. Write it however it comes out.
+
+        A maintainer triages this and, if it becomes tracked work, rewrites it as a
+        backlog item — you don't need to do that part. (Code changes are by invitation
+        for now, so please don't feel you need to offer a fix.)
+  - type: textarea
+    id: what
+    attributes:
+      label: What's on your mind?
+      description: An idea, something that annoyed you, something confusing, or just how it went.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: What were you trying to do?
+      description: Optional — the book, the step you were on, or what you expected to happen.
+    validations:
+      required: false
+  - type: input
+    id: setup
+    attributes:
+      label: Your setup
+      description: Optional — OS, graphics card, and app version (the pill in the top bar), if it seems relevant.
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -325,15 +325,32 @@ Bugs are **out-of-band** — file the **Bug** form (auto-labels `bug`), keep a
 plain descriptive title (no `<prefix>-<n>`), and leave them **off**
 `docs/BACKLOG.md`. They still get triage, history, and PR-linking.
 
+### Ideas & feedback
+
+The **Backlog item** and **Bug** forms above are maintainer-shaped — they ask
+for a `<prefix>-<n>` ID, acceptance criteria, and key files, which nobody
+outside the project can supply. Anyone who just wants to report a rough edge,
+suggest something, or say how their first book went files the **Idea or
+feedback** form (`.github/ISSUE_TEMPLATE/idea-or-feedback.yml`, auto-labels
+`feedback`): one required free-text field, no title format, no jargon. Blank
+issues are enabled as a further escape hatch.
+
+**Issues are welcome from anyone; code changes stay by invitation.** A
+maintainer triages `feedback` issues and rewrites the ones that become tracked
+work as proper Backlog items or Bugs — the reporter never has to learn the
+`<prefix>-<n>` convention. This is also why `good first issue` is deliberately
+applied to **zero** issues: it advertises "send us a PR", which the
+invitation-only contribution policy does not accept. Leave it unused.
+
 ### Labels
 
-Three axes + two helpers, version-controlled in `scripts/gh-labels.mjs` (run
+Three axes + three helpers, version-controlled in `scripts/gh-labels.mjs` (run
 `node scripts/gh-labels.mjs --apply` to create/reconcile them):
 
-- `area:fe` · `area:srv` · `area:side` · `area:ops` · `area:fs`
+- `area:fe` · `area:srv` · `area:side` · `area:app` · `area:ops` · `area:fs`
 - `moscow:must` · `moscow:should` · `moscow:could` · `moscow:wont`
 - `type:feature` · `type:chore` · `bug`
-- `needs-plan` (owes a `docs/features/NN-*.md`) · `tracking` (watchdog, no direct fix)
+- `needs-plan` (owes a `docs/features/NN-*.md`) · `tracking` (watchdog, no direct fix) · `feedback` (inbound user report, awaiting triage)
 
 ### The board
 

--- a/scripts/gh-labels.mjs
+++ b/scripts/gh-labels.mjs
@@ -44,6 +44,10 @@ export const LABELS = [
   // Helpers — amber.
   { name: 'needs-plan', color: 'fbca04', description: 'Substantial — owes a docs/features/NN-*.md regression plan' },
   { name: 'tracking', color: 'fbca04', description: 'Watchdog item, no direct code fix' },
+
+  // Inbound — pale blue. Applied by the "Idea or feedback" issue form; triaged
+  // into a backlog item or a bug by a maintainer.
+  { name: 'feedback', color: 'bfd4f2', description: 'Product/UX feedback from users, not a bug report' },
 ];
 
 function info(msg) {


### PR DESCRIPTION
## Summary

Opens the top of the inbound funnel. The repo is **issues-welcome, PRs-by-invitation** — but the issue surface only served maintainers, so in practice newcomers had no way to file anything that wasn't a reproducible bug.

`backlog-item.yml` requires a `<prefix>-<n>` title, *Acceptance*, *Key files* and *Benefit (axis)*; `blank_issues_enabled` was `false`. Someone whose EPUB chaptered oddly, or who wants to ask for Korean, had nowhere to go except pinned issue #1428 — where it can't be triaged, tracked or closed.

- **New `idea-or-feedback.yml`** — one required free-text field ("What's on your mind?"), two optional ones, no title format, no jargon. Auto-labels `feedback`. For contrast: the new form asks 1 required field, `bug.yml` asks 5.
- **Blank issues enabled** as a further escape hatch.
- **`feedback` added to `scripts/gh-labels.mjs`** — the label existed on the repo but sat outside the taxonomy the script reconciles, so a fresh setup wouldn't create it and the new form would silently fail to label. Colour/description match the live label exactly, so `--apply` is a no-op against today's repo.
- **CONTRIBUTING** documents the form and records that **`good first issue` is deliberately applied to zero issues** — it advertises "send us a PR", which the invitation-only policy doesn't accept. Written down so it doesn't get "fixed" later.

Also corrected `area:app` into CONTRIBUTING's label list — it's in `gh-labels.mjs` but was missing from the documented set. Adjacent to the list this PR edits; called out rather than slipped in.

## Test plan

No runtime surface — issue forms are consumed by GitHub, and `gh-labels.mjs` gains one entry in an exported array with no test file.

- All three templates parse as valid YAML (`js-yaml`); the new form resolves to fields `what*, context, setup`.
- `gh label list` confirms the `feedback` entry added to `LABELS` matches the live label's colour (`bfd4f2`) and description byte-for-byte, so reconciling won't churn it.
- Renders correctly only once merged to the default branch — GitHub reads issue forms from `main`, so the chooser gains the third option on merge.

No release-notes entry: repo process only, no user- or operator-visible product delta.

Closes #1816