### PR TITLE
docs(docs): correct the analyzer privacy claim in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 Turn a manuscript into a finished, **full-cast** audiobook on your own machine —
 every character in their own voice, consistent across a whole series. Castwright
-runs locally end-to-end; nothing leaves your computer unless you opt into a cloud
-analyzer.
+runs locally end-to-end; with no cloud analyzer key set, nothing leaves your
+computer.
 
 Upload `.md` / `.txt` / `.epub` / `.pdf` / `.mobi` / `.azw3` → an analyzer
 extracts characters, chapters, and per-sentence speaker tags → assign a voice to
@@ -26,8 +26,9 @@ or MP3.
 - **Designed voices** — every character gets a unique voice designed from its persona (Qwen3-TTS), kept consistent across the series; Kokoro ships a ready-made catalogue alongside it. (Cloning a voice from your own sample is the next major release.)
 - **Seven languages** — performs English, Russian, Spanish, French, German, Chinese, and Japanese end-to-end, with the manuscript's language detected on import. A cast never crosses languages within a book. (CJK attribution leans on the analyzer model — a local Qwen analyzer is recommended for Chinese and Japanese.)
 - **Quality-checked automatically** — every chapter is gated before it's assembled: acoustic checks (dead air, over-long lines, timing drift), optional word-for-word ASR transcript verification, and an opt-in speaker-fingerprint check that catches a voice drifting out of character even when the words are right. Flagged takes are surfaced on the waveform and re-recorded automatically.
-- **On-device by default** — analysis and speech run on your machine; cloud is
-  opt-in.
+- **On-device by default** — speech is always local. The analyzer is local too;
+  add a cloud key and it falls back to the cloud automatically unless you switch
+  that off.
 - **Listen on your phone or tablet** — an Android companion app plays from your library over your home network, opening into a two-pane layout on tablets and foldables. Chapters you haven't downloaded play instantly on-network, with no OS certificate install.
 - **You own the files** — export standard M4B (cover and chapter markers), MP3, AAC/M4A or Opus, a native **Audiobookshelf** export (series metadata, `metadata.json`, and a folder cover), and SRT/VTT captions (per sentence or per line, whole-book or per-chapter). EBU R128 loudness normalisation is on by default. No lock-in.
 


### PR DESCRIPTION
## Summary

Fixes a privacy claim on the front door that understated what supplying a Gemini key enables.

**Before**

> Castwright runs locally end-to-end; nothing leaves your computer **unless you opt into a cloud analyzer**.
> - **On-device by default** — analysis and speech run on your machine; **cloud is opt-in**.

**After**

> Castwright runs locally end-to-end; **with no cloud analyzer key set**, nothing leaves your computer.
> - **On-device by default** — speech is always local. The analyzer is local too; **add a cloud key and it falls back to the cloud automatically unless you switch that off.**

## Why

`allowCloudFallback` defaults to **true** (`server/src/workspace/user-settings.ts:146`, pinned by `user-settings.test.ts:156`), so once a key exists the analyzer falls back to Gemini automatically whenever Ollama is unreachable — `select-analyzer.test.ts:79` calls this out as the default path. Adding the key is the opt-in, but it opts you into *automatic fallback*, not just into cloud being available to pick. Someone who added a key once to try Gemini wouldn't expect chapter text to leave on a later run because their daemon was down.

Equally, the new wording avoids over-warning: with no key, `select-analyzer` returns a bare `OllamaAnalyzer` and there is no fallback path at all. Saying flatly "the cloud fallback can be switched off" would tell every keyless user — the default fresh install — to go disable something they don't have. Stating the condition keeps both directions honest.

## Test plan

Docs-only; no automated coverage applies.

- Behaviour verified at source, not from prose: `user-settings.ts:146` (`z.boolean().default(true)`), `user-settings.test.ts:156`, `select-analyzer.test.ts:69/79` (the with-key and without-key branches).
- `grep -inE "effortlessly|local-first|seamless|revolutionary|robust" README.md` → clean.
- `grep -in "analyser" README.md` → none; the file stays on American "analyzer", matching the codebase.

No release-notes entry: documentation accuracy, no product behaviour change.

Closes #1818