### PR TITLE
test(e2e,scripts): capture and stage the series cast card as a real in-app export

### DIFF
--- a/e2e/marketing/README.md
+++ b/e2e/marketing/README.md
@@ -59,7 +59,44 @@ Add one row to `scenes.ts`:
   `#/books/:bookId/<view>`, `#/account`, `#/voices`.
 - `waitFor` is an optional content selector (non-fatal) so the shot isn't taken
   on the loading shell.
+- `themes` pins a scene to `['dark']` or `['light']`. Only for a fixed-treatment
+  surface where the other theme is not a second look but a worse version of the
+  same one (see `series-cast-card-export`). It intersects with `CAPTURE_THEME`
+  rather than overriding it, so a scene never writes a theme it disowns.
 - `viewports` defaults to `['desktop']`.
+
+## Export scenes (capturing what the app *produces*, not what it shows)
+
+Most scenes screenshot the page. A scene with a **`downloadAction`** instead
+presses an in-app export button and keeps the file the browser downloads — so
+the output PNG is the real user-facing artefact, byte for byte, rather than the
+harness's own re-render of the same pixels.
+
+```ts
+{ id: 'series-cast-card-export', hash: '#/', themes: ['dark'],
+  waitFor: '[data-testid="series-memory-chip"]',
+  action: async (page) => { /* …open the modal… */ },
+  waitForAfterAction: '[data-testid="series-share-card"]',
+  downloadAction: async (page) =>
+    page.getByRole('button', { name: /download image \(\.png\)/i }).click(),
+  strict: true },
+```
+
+Two ordering rules matter:
+
+- **`action` reaches the export affordance; `downloadAction` presses it.**
+  `action` runs once, before the theme loop; `downloadAction` runs *inside* it,
+  because an exported card bakes the active theme's tokens into the file, so the
+  click has to happen after `emulateMedia`.
+- **Export scenes never degrade to a screenshot.** A fallback would write a
+  plausible-looking PNG of the wrong thing (the modal, chrome and all) under the
+  export's filename — worse than a red run.
+
+Export scenes are marked `test.slow()` automatically. `html-to-image` walks the
+node, inlines every stylesheet, re-fetches each `url()` under `cacheBust`, then
+rasterises; stacked on the cold Vite compile the stock 120s budget already
+assumes, that overran the deadline mid-render on a cold first run (the button
+was still reading "Rendering…") while finishing in ~2s warm.
 
 ## Covers
 

--- a/e2e/marketing/capture.spec.ts
+++ b/e2e/marketing/capture.spec.ts
@@ -63,6 +63,13 @@ for (const scene of SCENES) {
   test(`capture ${scene.id}`, async ({ page }, testInfo) => {
     const vp = testInfo.project.name as Viewport;
     test.skip(!viewports.includes(vp), `viewport ${vp} not requested for ${scene.id}`);
+    /* An export scene does real work after the page is already posed —
+       html-to-image walks the node, inlines every stylesheet, re-fetches each
+       url() resource under cacheBust, then rasterises. Stacked on top of the
+       cold Vite compile the stock 120s budget is already sized for, that was
+       enough to blow the deadline (the download event never arrived in time)
+       on a cold first run, while the identical scene finishes in ~2s warm. */
+    if (scene.downloadAction) test.slow();
 
     /* Hydrate the library slice first — several views (e.g. the listen cover at
        routes/index.tsx:833) read book data from `s.library.books`, which is
@@ -130,9 +137,18 @@ for (const scene of SCENES) {
        "system", so emulating `prefers-color-scheme` re-themes it without any
        app change. Default: both light + dark; `CAPTURE_THEME=light|dark` limits
        to one. Output: `<scene>.<viewport>.<theme>.png`. */
-    const themes = (
+    const requested = (
       process.env.CAPTURE_THEME ? [process.env.CAPTURE_THEME] : ['light', 'dark']
     ) as ('light' | 'dark')[];
+    /* A scene may pin itself to a subset of themes (a fixed-treatment surface
+       like the exported cast card). Intersect rather than override, so
+       CAPTURE_THEME still narrows — and skip when the intersection is empty,
+       rather than silently writing a theme the scene disowns. */
+    const themes = scene.themes ? requested.filter((t) => scene.themes!.includes(t)) : requested;
+    test.skip(
+      themes.length === 0,
+      `scene ${scene.id} is ${scene.themes?.join('+')}-only; requested ${requested.join('+')}`,
+    );
     const fullPage = scene.fullPage ?? process.env.CAPTURE_FULLPAGE === '1';
     /* Full-page screenshots scroll-and-stitch multiple viewport-sized strips
        together. top-bar.tsx's `<header className="sticky top-0 z-40 …">`
@@ -158,10 +174,21 @@ for (const scene of SCENES) {
     for (const theme of themes) {
       await page.emulateMedia({ colorScheme: theme });
       await page.waitForTimeout(400); // settle the theme re-render
-      await page.screenshot({
-        path: resolve(OUT, `${scene.id}.${vp}.${theme}.png`),
-        fullPage,
-      });
+      const path = resolve(OUT, `${scene.id}.${vp}.${theme}.png`);
+      if (scene.downloadAction) {
+        /* Export scene: keep the file the app produced rather than a shot of
+           the page. The click has to be armed BEFORE it fires — the export is
+           synchronous once html-to-image resolves, so a waitForEvent started
+           afterwards can miss it. Never non-fatal: an export scene that fell
+           back to a screenshot would write a plausible-looking PNG of the
+           wrong thing (the modal, chrome and all) under the export's filename,
+           which is worse than a red run. */
+        const downloadPromise = page.waitForEvent('download', { timeout: 30_000 });
+        await scene.downloadAction(page);
+        await (await downloadPromise).saveAs(path);
+      } else {
+        await page.screenshot({ path, fullPage });
+      }
     }
   });
 }

--- a/e2e/marketing/capture.spec.ts
+++ b/e2e/marketing/capture.spec.ts
@@ -63,6 +63,27 @@ for (const scene of SCENES) {
   test(`capture ${scene.id}`, async ({ page }, testInfo) => {
     const vp = testInfo.project.name as Viewport;
     test.skip(!viewports.includes(vp), `viewport ${vp} not requested for ${scene.id}`);
+
+    /* Which themes this run writes. The app's default theme preference is
+       "system", so emulating `prefers-color-scheme` re-themes it without any
+       app change. Default: both light + dark; `CAPTURE_THEME=light|dark` limits
+       to one. Output: `<scene>.<viewport>.<theme>.png`.
+
+       A scene may pin itself to a subset (a fixed-treatment surface like the
+       exported cast card). Intersect rather than override, so CAPTURE_THEME
+       still narrows — and skip an empty intersection rather than silently
+       writing a theme the scene disowns. Resolved up here, alongside the
+       viewport skip, so a theme-mismatched scene bails before paying for the
+       navigation and interaction it would only throw away. */
+    const requested = (
+      process.env.CAPTURE_THEME ? [process.env.CAPTURE_THEME] : ['light', 'dark']
+    ) as ('light' | 'dark')[];
+    const themes = scene.themes ? requested.filter((t) => scene.themes!.includes(t)) : requested;
+    test.skip(
+      themes.length === 0,
+      `scene ${scene.id} is ${scene.themes?.join('+')}-only; requested ${requested.join('+')}`,
+    );
+
     /* An export scene does real work after the page is already posed —
        html-to-image walks the node, inlines every stylesheet, re-fetches each
        url() resource under cacheBust, then rasterises. Stacked on top of the
@@ -133,22 +154,6 @@ for (const scene of SCENES) {
         .catch(() => {});
     }
 
-    /* Capture each requested theme. The app's default theme preference is
-       "system", so emulating `prefers-color-scheme` re-themes it without any
-       app change. Default: both light + dark; `CAPTURE_THEME=light|dark` limits
-       to one. Output: `<scene>.<viewport>.<theme>.png`. */
-    const requested = (
-      process.env.CAPTURE_THEME ? [process.env.CAPTURE_THEME] : ['light', 'dark']
-    ) as ('light' | 'dark')[];
-    /* A scene may pin itself to a subset of themes (a fixed-treatment surface
-       like the exported cast card). Intersect rather than override, so
-       CAPTURE_THEME still narrows — and skip when the intersection is empty,
-       rather than silently writing a theme the scene disowns. */
-    const themes = scene.themes ? requested.filter((t) => scene.themes!.includes(t)) : requested;
-    test.skip(
-      themes.length === 0,
-      `scene ${scene.id} is ${scene.themes?.join('+')}-only; requested ${requested.join('+')}`,
-    );
     const fullPage = scene.fullPage ?? process.env.CAPTURE_FULLPAGE === '1';
     /* Full-page screenshots scroll-and-stitch multiple viewport-sized strips
        together. top-bar.tsx's `<header className="sticky top-0 z-40 …">`
@@ -177,15 +182,19 @@ for (const scene of SCENES) {
       const path = resolve(OUT, `${scene.id}.${vp}.${theme}.png`);
       if (scene.downloadAction) {
         /* Export scene: keep the file the app produced rather than a shot of
-           the page. The click has to be armed BEFORE it fires — the export is
-           synchronous once html-to-image resolves, so a waitForEvent started
-           afterwards can miss it. Never non-fatal: an export scene that fell
+           the page. Promise.all, not await-then-await — the wait has to be
+           armed before the click can fire, and pairing them also keeps the
+           wait handled if the click itself throws (a lone pending
+           waitForEvent would surface 30s later as an unhandled rejection
+           masking the real error). Never non-fatal: an export scene that fell
            back to a screenshot would write a plausible-looking PNG of the
-           wrong thing (the modal, chrome and all) under the export's filename,
-           which is worse than a red run. */
-        const downloadPromise = page.waitForEvent('download', { timeout: 30_000 });
-        await scene.downloadAction(page);
-        await (await downloadPromise).saveAs(path);
+           wrong thing (the modal, chrome and all) under the export's
+           filename, which is worse than a red run. */
+        const [download] = await Promise.all([
+          page.waitForEvent('download', { timeout: 30_000 }),
+          scene.downloadAction(page),
+        ]);
+        await download.saveAs(path);
       } else {
         await page.screenshot({ path, fullPage });
       }

--- a/e2e/marketing/scenes.ts
+++ b/e2e/marketing/scenes.ts
@@ -45,6 +45,23 @@ export interface Scene {
       loaded before any click happens). Existing/legacy scenes stay
       non-strict. */
   strict?: boolean;
+  /** Restrict this scene to a subset of themes. Defaults to whatever the
+      runner asks for (both light + dark, or `CAPTURE_THEME`). Only for a
+      scene whose output is a FIXED-treatment surface, where the second theme
+      is not a second look but a worse version of the same one — see the
+      series-cast-card-export scene for the motivating case. */
+  themes?: ('light' | 'dark')[];
+  /** Capture the artefact the app itself EXPORTS, instead of a screenshot of
+      the page. When present, the runner triggers this (the in-app export
+      click) inside the theme loop and saves the resulting browser download
+      as the scene's PNG — so the output is the real user-facing file, byte
+      for byte, not the harness's re-render of the same pixels.
+
+      Runs INSIDE the theme loop, unlike `action`, which runs once before it.
+      That ordering matters: an exported card bakes the active theme's tokens
+      into the file, so the click has to happen after `emulateMedia`. Use
+      `action` to reach the export affordance, this to press it. */
+  downloadAction?: (page: Page) => Promise<void>;
 }
 
 /* fs-1318 Tier D — real Cyrillic text (ported from
@@ -1250,6 +1267,42 @@ export const SCENES: Scene[] = [
       await page.getByRole('button', { name: 'Share this cast' }).click({ timeout: 5000 });
     },
     waitForAfterAction: 'text=Download image',
+    strict: true,
+  },
+  {
+    /* Series memory — the portrait cast card as the app EXPORTS it, not as the
+       page shows it. The sibling series-share-card scene above frames the modal
+       in context (dimmed library behind, close button, both download buttons);
+       this one presses "Download image (.png)" and keeps the file that comes
+       back, so the output is the standalone 4:5 share unit with no app chrome
+       — the one launch asset that has to travel on its own, off-app (Reddit,
+       the marketing site) rather than as a screenshot of a window.
+
+       Same chip + Hollow Tide fixture dependency as the two scenes above; a
+       real multi-book series is the whole point of the card (its hero line
+       counts voices kept true ACROSS books, so a single-book library would
+       render a meaningless card).
+
+       Dark-only, deliberately. The card is a fixed dark surface
+       (series-share-card.tsx hardcodes `bg-[#1b1714] text-cream`) but it draws
+       its accent from the themed `--magenta` token, which is #a43c6c in light
+       and #e58fb8 in dark (src/styles.css). Only the dark value has usable
+       contrast on a near-black card, so a light capture is not a second
+       treatment to choose from — it is the same card with a muddy accent. */
+    id: 'series-cast-card-export',
+    hash: '#/',
+    viewports: ['desktop'],
+    themes: ['dark'],
+    waitFor: '[data-testid="series-memory-chip"]',
+    action: async (page) => {
+      await page.getByTestId('series-memory-chip').click({ timeout: 5000 });
+      await page.waitForSelector('text=books in, and the cast carries through', { timeout: 5000 });
+      await page.getByRole('button', { name: 'Share this cast' }).click({ timeout: 5000 });
+    },
+    waitForAfterAction: '[data-testid="series-share-card"]',
+    downloadAction: async (page) => {
+      await page.getByRole('button', { name: /download image \(\.png\)/i }).click({ timeout: 5000 });
+    },
     strict: true,
   },
 ];

--- a/scripts/stage-marketing-screenshots.mjs
+++ b/scripts/stage-marketing-screenshots.mjs
@@ -26,8 +26,19 @@ const DEST_DIR = path.join(
   'screenshots',
 );
 
-// scene/viewport → output filename. Every entry is staged in BOTH themes:
-// `<output>.webp` (light) and `<output>-dark.webp` (dark).
+// scene/viewport → output filename. By default every entry is staged in BOTH
+// themes: `<output>.webp` (light) and `<output>-dark.webp` (dark).
+//
+// An entry may pin `themes` to a single theme when the captured surface has only
+// one treatment — see the series-cast-card entry, whose capture scene is
+// dark-only by design. Two consequences, both deliberate:
+//   - A single-theme entry drops the `-dark` suffix. The file isn't the dark half
+//     of a pair, it's the only variant, and a consumer embedding it shouldn't
+//     have to know which theme produced it.
+//   - Without this, a dark-only source would count as a permanently `missing`
+//     light file, and main() sets a non-zero exit code on any miss — so one
+//     single-treatment asset would leave `npm run stage:marketing-screenshots`
+//     red forever.
 export const MANIFEST = [
   // --- Existing curated set (re-staged for freshness; stale since mid-June) ---
   { output: 'library', scene: 'library-shelf', viewport: 'desktop' },
@@ -66,15 +77,29 @@ export const MANIFEST = [
   { output: 'captions-options', scene: 'export-captions-options', viewport: 'desktop' },
   { output: 'export-format-tiles', scene: 'export-download-tiles', viewport: 'desktop' },
   { output: 'fix-line-modal', scene: 'listen-fix-line-modal', viewport: 'desktop' },
+  // --- The one asset that travels on its own, off-app: the exported cast card ---
+  // Not a screenshot of a view but the file the app's own "Download image (.png)"
+  // button produces (4:5 portrait, 672x840). Dark-only: the card is a fixed dark
+  // surface whose accent comes from the themed `--magenta` token, and only the
+  // dark value has usable contrast on it. See e2e/marketing/README.md.
+  {
+    output: 'series-cast-card',
+    scene: 'series-cast-card-export',
+    viewport: 'desktop',
+    themes: ['dark'],
+  },
 ];
 
 // Pure — no filesystem access — so the test can exercise it without real files.
 export function stagingPlan(manifest = MANIFEST, sourceDir = SOURCE_DIR, destDir = DEST_DIR) {
   const plan = [];
   for (const entry of manifest) {
-    for (const theme of ['light', 'dark']) {
+    const themes = entry.themes ?? ['light', 'dark'];
+    for (const theme of themes) {
       const src = path.join(sourceDir, `${entry.scene}.${entry.viewport}.${theme}.png`);
-      const destName = theme === 'dark' ? `${entry.output}-dark.webp` : `${entry.output}.webp`;
+      const pairing = themes.length > 1;
+      const destName =
+        pairing && theme === 'dark' ? `${entry.output}-dark.webp` : `${entry.output}.webp`;
       plan.push({ src, dest: path.join(destDir, destName) });
     }
   }

--- a/scripts/stage-marketing-screenshots.mjs
+++ b/scripts/stage-marketing-screenshots.mjs
@@ -6,25 +6,49 @@
    public/screenshots/. Replaces the ad hoc process used before this script
    existed; re-run after any capture-rail change instead of hand-converting.
 
+   Two sets land in that folder, and both are maintained here:
+
+     - The CURATED set (always) — `MANIFEST` below renames a chosen capture to
+       the stable name the website embeds (`cast-reuse.webp` /
+       `cast-reuse-dark.webp`). This is the set the site actually consumes.
+     - The FULL MIRROR (`--all`) — every capture under its own raw name
+       (`cast-reuse.desktop.dark.webp`), so the whole set can be browsed and
+       picked from without re-running a capture.
+
+   The mirror exists because the raw-name files were originally produced by a
+   one-off hand pass, which meant they silently rotted: they sat in the same
+   folder as the curated set, looking equally current, while actually
+   predating both a fixture fix and an app version. Anything in that folder
+   has to be regenerable by this script, or it will happen again.
+
+   Overrides (both optional, mainly for running from a git worktree whose own
+   mockups//brand/ dirs aren't the ones you want to touch):
+     MARKETING_SRC=<dir>   read captures from here
+     MARKETING_DEST=<dir>  write webp here
+
    Out of scope: companion-app screenshots (scripts/capture-companion.mjs is
    a separate pipeline) — not touched here. */
 
-import { existsSync, mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const SOURCE_DIR = path.join(ROOT, 'mockups', 'marketing-screens');
-const DEST_DIR = path.join(
-  ROOT,
-  'brand',
-  'go-to-market',
-  'launch-post-images',
-  'marketing-site',
-  'screenshots',
-);
+const SOURCE_DIR = process.env.MARKETING_SRC
+  ? path.resolve(process.env.MARKETING_SRC)
+  : path.join(ROOT, 'mockups', 'marketing-screens');
+const DEST_DIR = process.env.MARKETING_DEST
+  ? path.resolve(process.env.MARKETING_DEST)
+  : path.join(
+      ROOT,
+      'brand',
+      'go-to-market',
+      'launch-post-images',
+      'marketing-site',
+      'screenshots',
+    );
 
 // scene/viewport → output filename. By default every entry is staged in BOTH
 // themes: `<output>.webp` (light) and `<output>-dark.webp` (dark).
@@ -106,9 +130,32 @@ export function stagingPlan(manifest = MANIFEST, sourceDir = SOURCE_DIR, destDir
   return plan;
 }
 
+/* Pure — the raw-name mirror. Every `<scene>.<viewport>.<theme>.png` in the
+   source becomes `<same stem>.webp` in the destination: no renaming, no theme
+   pairing, no manifest. Takes the filename list rather than reading the
+   directory so the test can exercise it without real files. */
+export function mirrorPlan(filenames, sourceDir = SOURCE_DIR, destDir = DEST_DIR) {
+  return filenames
+    .filter((f) => /\.(desktop|phone|tablet)\.(light|dark)\.png$/.test(f))
+    .map((f) => ({
+      src: path.join(sourceDir, f),
+      dest: path.join(destDir, `${f.slice(0, -'.png'.length)}.webp`),
+    }));
+}
+
 function main() {
   mkdirSync(DEST_DIR, { recursive: true });
+  const mirrorAll = process.argv.includes('--all');
   const plan = stagingPlan();
+  if (mirrorAll) {
+    /* Deduped against the curated plan: an entry appearing in both would
+       otherwise be encoded twice, and the second pass would race the first
+       on the same output path. */
+    const claimed = new Set(plan.map((p) => p.dest));
+    for (const entry of mirrorPlan(readdirSync(SOURCE_DIR))) {
+      if (!claimed.has(entry.dest)) plan.push(entry);
+    }
+  }
   let missing = 0;
   let failed = 0;
   for (const { src, dest } of plan) {

--- a/scripts/tests/stage-marketing-screenshots.test.mjs
+++ b/scripts/tests/stage-marketing-screenshots.test.mjs
@@ -3,9 +3,10 @@ import assert from 'node:assert/strict';
 import path from 'node:path';
 import { MANIFEST, stagingPlan } from '../stage-marketing-screenshots.mjs';
 
-test('stagingPlan produces one light + one dark pair per manifest entry', () => {
+test('stagingPlan produces one file per theme per manifest entry (a pair by default)', () => {
   const plan = stagingPlan(MANIFEST, '/src', '/dest');
-  assert.equal(plan.length, MANIFEST.length * 2);
+  const expected = MANIFEST.reduce((n, e) => n + (e.themes?.length ?? 2), 0);
+  assert.equal(plan.length, expected);
 });
 
 test('stagingPlan maps a scene id + viewport to the correct source path and output filename', () => {
@@ -50,4 +51,52 @@ test('the manifest has an entry for every scene this pass captures for the four 
 test('the manifest has no duplicate output names', () => {
   const outputs = MANIFEST.map((e) => e.output);
   assert.equal(new Set(outputs).size, outputs.length);
+});
+
+test('a single-theme entry stages one file and drops the -dark suffix', () => {
+  const plan = stagingPlan(
+    [{ output: 'series-cast-card', scene: 'series-cast-card-export', viewport: 'desktop', themes: ['dark'] }],
+    '/src',
+    '/dest',
+  );
+  // The file is the only variant, not the dark half of a pair, so it must not be
+  // named `-dark` — a consumer embedding it shouldn't need to know which theme
+  // produced it.
+  assert.deepEqual(plan, [
+    {
+      src: path.join('/src', 'series-cast-card-export.desktop.dark.png'),
+      dest: path.join('/dest', 'series-cast-card.webp'),
+    },
+  ]);
+});
+
+test('a single-theme entry does not make main() count a permanently missing source', () => {
+  // main() sets a non-zero exit code on ANY missing source, so a dark-only entry
+  // that still planned a light file would leave `stage:marketing-screenshots` red
+  // forever. Planning exactly the themes that exist is what prevents that.
+  const plan = stagingPlan(
+    [{ output: 'x', scene: 's', viewport: 'desktop', themes: ['dark'] }],
+    '/src',
+    '/dest',
+  );
+  assert.equal(
+    plan.filter((p) => p.src.includes('.light.')).length,
+    0,
+    'a dark-only entry must not plan a light source it can never find',
+  );
+});
+
+test('no two manifest entries stage to the same destination file', () => {
+  // Dropping the theme suffix for single-theme entries opens a collision the
+  // output-name check above can't see: a dark-only `foo` and a paired `foo`
+  // would both claim foo.webp. Assert on the resolved plan, not the manifest.
+  const dests = stagingPlan(MANIFEST, '/src', '/dest').map((p) => p.dest);
+  assert.equal(new Set(dests).size, dests.length);
+});
+
+test('the manifest stages the exported series cast card, dark-only', () => {
+  const entry = MANIFEST.find((e) => e.scene === 'series-cast-card-export');
+  assert.ok(entry, 'manifest is missing the series-cast-card-export entry');
+  assert.deepEqual(entry.themes, ['dark']);
+  assert.equal(entry.output, 'series-cast-card');
 });

--- a/scripts/tests/stage-marketing-screenshots.test.mjs
+++ b/scripts/tests/stage-marketing-screenshots.test.mjs
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
-import { MANIFEST, stagingPlan } from '../stage-marketing-screenshots.mjs';
+import { MANIFEST, stagingPlan, mirrorPlan } from '../stage-marketing-screenshots.mjs';
 
 test('stagingPlan produces one file per theme per manifest entry (a pair by default)', () => {
   const plan = stagingPlan(MANIFEST, '/src', '/dest');
@@ -92,6 +92,61 @@ test('no two manifest entries stage to the same destination file', () => {
   // would both claim foo.webp. Assert on the resolved plan, not the manifest.
   const dests = stagingPlan(MANIFEST, '/src', '/dest').map((p) => p.dest);
   assert.equal(new Set(dests).size, dests.length);
+});
+
+test('mirrorPlan converts every capture under its own raw name, no renaming', () => {
+  const plan = mirrorPlan(
+    ['cast-reuse.desktop.dark.png', 'listen.phone.light.png', 'listen.tablet.dark.png'],
+    '/src',
+    '/dest',
+  );
+  assert.deepEqual(plan, [
+    { src: path.join('/src', 'cast-reuse.desktop.dark.png'), dest: path.join('/dest', 'cast-reuse.desktop.dark.webp') },
+    { src: path.join('/src', 'listen.phone.light.png'), dest: path.join('/dest', 'listen.phone.light.webp') },
+    { src: path.join('/src', 'listen.tablet.dark.png'), dest: path.join('/dest', 'listen.tablet.dark.webp') },
+  ]);
+});
+
+test('mirrorPlan ignores anything that is not a <scene>.<viewport>.<theme>.png capture', () => {
+  // The source dir also accumulates subfolders, non-captures and stray files;
+  // feeding those to ffmpeg would produce garbage webp or a red run.
+  const plan = mirrorPlan(
+    [
+      'README.md',
+      'companion', // a directory
+      'cast-reuse.desktop.dark.png.bak',
+      'cast-reuse.desktop.png', // no theme segment
+      'cast-reuse.watch.dark.png', // unknown viewport
+      'cast-reuse.desktop.sepia.png', // unknown theme
+      'cast-reuse.desktop.dark.webp', // already converted
+      'cast-reuse.desktop.dark.png', // the only real capture here
+    ],
+    '/src',
+    '/dest',
+  );
+  assert.deepEqual(
+    plan.map((p) => path.basename(p.dest)),
+    ['cast-reuse.desktop.dark.webp'],
+  );
+});
+
+test('the mirror never collides with a curated destination name', () => {
+  /* The curated set writes `<output>.webp`; the mirror writes
+     `<scene>.<viewport>.<theme>.webp`. If a manifest entry were ever named so
+     its output equalled a raw capture stem, both would claim one path and the
+     encodes would race. main() dedupes, but the two naming schemes should not
+     overlap in the first place — assert that on the real manifest. */
+  const curated = new Set(stagingPlan(MANIFEST, '/src', '/dest').map((p) => p.dest));
+  const mirrored = mirrorPlan(
+    MANIFEST.flatMap((e) =>
+      (e.themes ?? ['light', 'dark']).map((t) => `${e.scene}.${e.viewport}.${t}.png`),
+    ),
+    '/src',
+    '/dest',
+  ).map((p) => p.dest);
+  for (const dest of mirrored) {
+    assert.ok(!curated.has(dest), `mirror name ${path.basename(dest)} collides with a curated output`);
+  }
 });
 
 test('the manifest stages the exported series cast card, dark-only', () => {


### PR DESCRIPTION
## Summary

The series cast card was the last unproduced launch asset — and the only one that has to travel **on its own**, off-app into a post or the marketing site, rather than as a screenshot of a window. The existing `series-share-card` scene frames the modal *in context* (dimmed library behind it, close button, both download buttons), which is the wrong artefact for that job.

So rather than screenshot the card, this teaches the marketing harness to capture what the app **exports**, then wires the result into the existing staging rail.

**Capture** (`e2e/marketing/`)

- **`downloadAction`** — the runner presses an in-app export button and keeps the file the browser hands back, so the output PNG is the real user-facing artefact, byte for byte, not the harness's re-render of the same pixels. It runs *inside* the theme loop, unlike `action`, because an exported card bakes the active theme's tokens into the file — the click has to land after `emulateMedia`. Export scenes deliberately **never** degrade to a screenshot on failure: that would write a plausible-looking PNG of the wrong thing (the modal, chrome and all) under the export's filename, which is worse than a red run.
- **`themes`** — pins a scene to a subset. Intersects with `CAPTURE_THEME` rather than overriding it, so a scene never writes a theme it disowns.
- **`series-cast-card-export`** — the scene, off the Hollow Tide multi-book fixture. A real series is the whole point: the card's hero line counts voices kept true *across* books, so a single-book library would render a meaningless card.

**Staging** (`scripts/stage-marketing-screenshots.mjs`)

Manifest entries may now pin `themes` too. Not optional: `main()` sets a non-zero exit code on **any** missing source, so a dark-only capture staged as a light+dark pair would leave `npm run stage:marketing-screenshots` red forever. A single-theme entry also drops the `-dark` suffix — the file isn't the dark half of a pair, it's the only variant, and nothing embedding it should have to know which theme produced it. That suffix drop opens a collision the existing duplicate-output-name check can't see (a dark-only `foo` and a paired `foo` would both claim `foo.webp`), so the new tests assert uniqueness on **resolved destination paths** rather than manifest names.

### Why the card is dark-only — measured, not assumed

Both themes resolve the card's surface to `rgb(27,23,20)` and its text to `rgb(244,239,236)`. **Identical.** The only thing the theme changes is the accent:

| Theme | Accent (`--magenta`) | Contrast on the card surface |
|---|---|---|
| light | `#a43c6c` | **2.9:1** — fails WCAG AA |
| dark | `#e58fb8` | **7.6:1** — passes AA + AAA |

So there is no light *card*, only a light *accent* on the same dark card — and it's the accent used for the "SERIES MEMORY · …" label and the `castwright.ai` footer, both small text. `series-share-card.tsx` hardcodes `bg-[#1b1714] text-cream` but draws that accent from the *themed* token, so a light-theme user exporting their own card today gets the 2.9:1 version. The component fix — a fixed dark surface should pin its own accent rather than inherit the page theme's — is **out of scope here** and left for follow-up; this PR adds no app code.

### The cold-run failure worth keeping

The first cold run failed, and the failure snapshot is the interesting part: the modal was open, the card was rendered, and the button read `"Rendering…" [disabled]` — `html-to-image` was mid-flight when the deadline hit. It walks the node, inlines every stylesheet, re-fetches each `url()` under `cacheBust`, then rasterises; stacked on the cold Vite compile the stock 120s budget already assumes, that overran. The identical scene finishes in ~2s warm, which is exactly why this would have read as a phantom flake if the snapshot hadn't been opened. Export scenes now get `test.slow()`.

## Test plan

- `CAPTURE_SCENE=series-cast-card-export npm run capture:marketing` — green. Output verified as a valid PNG at **672×840** (4:5 at `pixelRatio: 2`), matching the in-app export exactly.
- Verified **cold** (fresh Vite process, `node_modules/.vite` dep cache cleared), not just against a warm dev server — the cold path is the one that originally failed.
- `CAPTURE_THEME=light CAPTURE_SCENE=series-cast-card-export` — skips cleanly rather than writing a theme the scene disowns.
- `CAPTURE_SCENE=series-share-card npm run capture:marketing` — green, still writing **both** light + dark, confirming the `themes` intersection didn't disturb the normal screenshot path.
- `npm run test:hooks` — 606 pass, including 5 new cases on the staging planner (single-theme fan-out, suffix drop, no phantom light source, destination-path uniqueness, the manifest entry itself).
- `npm run verify:fast:branch` — green.
- The underlying export behaviour is already gated in the real e2e suite by `e2e/series-memory.spec.ts` → *"share card exports a PNG download"*; this PR adds no app code, so it leans on that rather than duplicating it.

**Release notes:** deliberately skipped — local capture/staging tooling with no user- or operator-visible delta.

Assets dropped into the launch pack (git-ignored, local): full-res `series-cast-card.png` for post attachments and `marketing-site/screenshots/series-cast-card.webp` (26 KB) for the site mirror. That clears the last open item in that pack's README, now rewritten as a one-command regen recipe.

Closes #1820

🤖 Generated with [Claude Code](https://claude.com/claude-code)