### PR TITLE
chore(sidecar): bump kokoro-onnx, pin the ONNX Runtime, and move to FastAPI 0.140 via lifespan

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Castwright 1.15.0
 
+- **The speech engine now runs on a version we've actually tested.** Until now, the exact
+  speech runtime Castwright installed depended on the day you installed it — two people with
+  identical machines could quietly end up on different builds, which made "it sounds different
+  on my computer" almost impossible to chase down. It's pinned now. Some installs will step
+  back to the tested version the next time they update.
 - **Build your own stable of narrators in My voices.** Design a voice once — from a persona, with
   a live audition — and it's yours to cast in any book, not just the one you designed it for.
   Not happy with a take? Redesign it and compare old against new side by side before you commit.

--- a/docs/release-notes-next.md
+++ b/docs/release-notes-next.md
@@ -106,3 +106,43 @@ history at cut time.
   the cloud fallback is opt-out (on by default, switchable off), never framed as opt-in-only or
   "never touches the cloud". Guarded by `src/data/help-topics.test.ts`; item-count assertions bumped
   43 → 45.
+
+---
+
+## 🔒 Security & dependencies
+
+- **Sidecar engine deps: kokoro-onnx 0.5.0, a real ONNX Runtime pin, and FastAPI 0.140 via `lifespan`** (#1846).
+  Clears the actionable half of the `side-17` umbrella (#893), which an audit found was carrying three
+  stale rationales.
+  - `kokoro-onnx` `>=0.4.0,<0.5.0` → `>=0.5.0,<0.6.0` across all three overlays. The entire upstream
+    delta is `kokoro_onnx/log.py` dropping `colorlog` for stdlib `logging`; `Kokoro.create()`'s signature
+    and the private `.sess` attribute are unchanged. Two new contract tests in `test_kokoro.py` run
+    against the REAL installed package (the rest of that file stubs `kokoro_onnx` via `sys.modules`) —
+    they exist because the indexed-device pin rebuilds `.sess` in a warn-only `try/except`, so an
+    upstream rename would silently unpin the device rather than raise.
+  - `onnxruntime-gpu` gets an explicit `>=1.27,<1.28` constraint in `scripts/install-ort.mjs`. There was
+    no pin before — the swap ran `pip install --force-reinstall --no-deps onnxruntime-gpu` unversioned,
+    so the runtime executing Kokoro was whatever was latest on the user's install date. The constraint
+    lives in the installer, never the overlays (macOS reads those and has no wheel).
+    **Existing installs on 1.28.x will step back to 1.27.x on first upgrade** — both upgrade paths
+    (`bootstrap-venv.mjs`, `apply.ts`) re-run the swap.
+  - All 12 `@app.on_event` handlers → one `lifespan` context manager (`main.py`), then `fastapi`
+    `0.115` → `0.140` and `uvicorn` `0.30` → `0.51` (starlette rides transitively to 1.3.1).
+    Startup order preserved exactly; shutdown stays in registration order (FastAPI runs it forwards —
+    reversing would be a behaviour change). Teardown is in a `finally`, not after a bare `yield`,
+    because `_DefaultLifespan.__aexit__` discards `exc_info` and runs shutdown unconditionally.
+    `test_lifespan_order.py` pins both sequences against the actually-wired `lifespan_context`.
+  - **Correction to the rationale**: the migration was NOT a hard prerequisite, contrary to what the
+    working notes claimed. FastAPI 0.140 re-implements `_DefaultLifespan`, `APIRouter._startup()`,
+    `._shutdown()`, `.add_event_handler()` and `.on_event()` locally to preserve backward compatibility
+    after Starlette removed them. `on_event` is deprecated on a compat shim carrying its own removal
+    TODO — that is the real reason to move, and the comments now say so.
+  - Follow-ups folded in: `httpx2` adopted in `requirements-dev.txt` (#1843) so Starlette 1.3.1's
+    `testclient` stops warning about the deprecated `httpx` fallback (`httpx` stays — gradio and
+    safehttpx still import it); and `install-ort.mjs` now reports the package it actually swapped in
+    (#1844) instead of hardcoding `onnxruntime-directml`, which was wrong on every profile that
+    reaches the swap.
+  - Still upstream-blocked, with corrected reasons in #893: `torch` 2.12/2.13 is blocked because
+    **torchaudio's last release is 2.11.0**, NOT by the cu130 driver bump originally recorded;
+    `transformers` 5.x and `huggingface_hub` 1.x are both frozen by `qwen-tts==0.1.1`'s exact
+    `transformers==4.57.3` pin (#1228).

--- a/server/src/tts/bootstrap-venv-helpers.test.ts
+++ b/server/src/tts/bootstrap-venv-helpers.test.ts
@@ -52,7 +52,10 @@ describe('installForProfile — Auto + CPU fallback (AMD phase 2)', () => {
     // so onnxruntime-gpu unambiguously owns the shared onnxruntime/ namespace.
     expect(joined[1]).toMatch(/install -r .*nvidia-cuda\.txt/);
     expect(joined[2]).toBe('uninstall -y onnxruntime onnxruntime-gpu');
-    expect(joined[3]).toBe('install --force-reinstall --no-deps onnxruntime-gpu');
+    // side-28: the install step now carries an explicit version constraint (see
+    // install-ort.mjs's ONNXRUNTIME_GPU_CONSTRAINT) so the runtime isn't whatever
+    // happened to be latest on PyPI on install date.
+    expect(joined[3]).toBe('install --force-reinstall --no-deps onnxruntime-gpu>=1.27,<1.28');
     expect(pip.calls).toHaveLength(4);
   });
 

--- a/server/src/tts/install-ort-helpers.test.ts
+++ b/server/src/tts/install-ort-helpers.test.ts
@@ -11,6 +11,10 @@ describe('planOrtSwap', () => {
   it('nvidia → swap: uninstall BOTH (bare names) then force-reinstall onnxruntime-gpu, version-constrained', () => {
     const plan = planOrtSwap('nvidia', 'win32');
     expect(plan.action).toBe('swap');
+    // The CLI's success message interpolates this rather than hardcoding a
+    // package name (#1844 — it used to hardcode 'onnxruntime-directml' even
+    // though nvidia is the only profile that reaches this code path).
+    expect(plan.ortPackage).toBe('onnxruntime-gpu');
     // Uninstall plain onnxruntime AND any cached onnxruntime-gpu so the shared
     // namespace is cleared, then --force-reinstall lays it fresh (a plain install
     // is a no-op when onnxruntime-gpu is cached at a skewed version → broken import).

--- a/server/src/tts/install-ort-helpers.test.ts
+++ b/server/src/tts/install-ort-helpers.test.ts
@@ -8,15 +8,21 @@ describe('planOrtSwap', () => {
   // keyed on installRecipe.ortPackage. Any package other than plain 'onnxruntime'
   // (today: nvidia → onnxruntime-gpu; a future DirectML re-enable → -directml) is a
   // swap; 'onnxruntime' itself is a no-op.
-  it('nvidia → swap: uninstall BOTH then force-reinstall onnxruntime-gpu (skew-proof namespace)', () => {
+  it('nvidia → swap: uninstall BOTH (bare names) then force-reinstall onnxruntime-gpu, version-constrained', () => {
     const plan = planOrtSwap('nvidia', 'win32');
     expect(plan.action).toBe('swap');
     // Uninstall plain onnxruntime AND any cached onnxruntime-gpu so the shared
     // namespace is cleared, then --force-reinstall lays it fresh (a plain install
     // is a no-op when onnxruntime-gpu is cached at a skewed version → broken import).
+    // The uninstall step takes BARE package names (a version spec there is
+    // meaningless to `pip uninstall`); side-28 adds an explicit floor-plus-cap
+    // constraint to the INSTALL step only, so the runtime a user lands on isn't
+    // just "whatever was latest on PyPI on their install date" — bump this
+    // assertion's version alongside install-ort.mjs's ONNXRUNTIME_GPU_CONSTRAINT
+    // when the pin is next deliberately moved.
     expect(plan.steps).toEqual([
       ['uninstall', '-y', 'onnxruntime', 'onnxruntime-gpu'],
-      ['install', '--force-reinstall', '--no-deps', 'onnxruntime-gpu'],
+      ['install', '--force-reinstall', '--no-deps', 'onnxruntime-gpu>=1.27,<1.28'],
     ]);
   });
 

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -36,7 +36,7 @@ import tempfile
 import threading
 import time
 from collections import deque
-from contextlib import contextmanager
+from contextlib import asynccontextmanager, contextmanager
 from typing import Any, Callable, Optional
 
 import numpy as np
@@ -487,7 +487,61 @@ def _log_meta_device_params(model: Any) -> None:
         pass
 
 
-app = FastAPI(title="audiobook-generator local TTS sidecar")
+@asynccontextmanager
+async def _lifespan(_app: FastAPI):
+    """Startup/shutdown sequence for the sidecar (side-27a).
+
+    Replaces the twelve `@app.on_event("startup"|"shutdown")` decorators this
+    module used to carry. FastAPI still exposes that decorator, but its body is
+    a straight delegation to `starlette.routing.Router.on_event`, which Starlette
+    1.3.1 deletes outright — so the decorator had to go before the web stack
+    could be bumped. This is a pure mechanical migration: nothing about WHAT
+    runs, or in WHICH order, changes.
+
+    The handlers themselves are untouched — each is still a module-level
+    `async def` under its original name, defined much further down this file
+    (some of them ~5000 lines below here), because tests call several of them
+    directly (e.g. `main._preload_default_engines`). Naming them here before
+    they exist is fine: Python resolves module globals at CALL time, not at
+    `def` time, so this context manager can sit above the definitions without
+    forcing a reorder of the module.
+
+    Ordering is a verbatim copy of the old registration order in BOTH
+    directions. Starlette ran `on_startup` in registration order and
+    `on_shutdown` in registration order too — it never reversed them — so
+    reversing the teardown here would be a behaviour change smuggled into a
+    migration whose whole premise is that nothing changes. (The four stop
+    handlers are mutually independent anyway; each just cancels its own task.)
+
+    Failure semantics match the decorator form as well. The startup awaits are
+    sequential and unguarded, so a raising handler aborts boot and skips the
+    handlers after it — as `Router.startup()` did. The teardown sits in a
+    `finally` because Starlette's `_DefaultLifespan.__aexit__` ignores its
+    `exc_info` and runs `Router.shutdown()` unconditionally; without the
+    `finally`, an exception thrown in at the `yield` (a cancelled lifespan task)
+    would skip teardown entirely, which the `on_event` form did not do.
+
+    `tests/test_lifespan_order.py` drives this very context manager and pins
+    both sequences by name, so a later edit cannot quietly drop or reshuffle a
+    handler."""
+    await _configure_vd_kokoro_coupling()
+    await _start_design_idle_watchdog()
+    await _start_asr_idle_watchdog()
+    await _start_spk_idle_watchdog()
+    await _start_device_probe()
+    await _start_memory_watchdog()
+    await _preload_default_engines()
+    await _startup_cuda_env_shadow_check()
+    try:
+        yield
+    finally:
+        await _stop_design_idle_watchdog()
+        await _stop_asr_idle_watchdog()
+        await _stop_spk_idle_watchdog()
+        await _stop_memory_watchdog()
+
+
+app = FastAPI(title="audiobook-generator local TTS sidecar", lifespan=_lifespan)
 
 
 async def _read_json_body(req: Request):
@@ -958,7 +1012,6 @@ class _VdKokoroArbiter:
 _VD_KOKORO = _VdKokoroArbiter()
 
 
-@app.on_event("startup")
 async def _configure_vd_kokoro_coupling() -> None:
     """Resolve the real QWEN_DEVICE/KOKORO_DEVICE coupling at startup (not at
     module import time — torch must stay a lazily-imported dependency so
@@ -4912,7 +4965,6 @@ async def _qwen_design_idle_watchdog() -> None:
             log.warning("Qwen idle watchdog tick failed (%s).", e)
 
 
-@app.on_event("startup")
 async def _start_design_idle_watchdog() -> None:
     """Launch the Qwen idle watchdog (frees VoiceDesign + 1.7B-Base on idle;
     see _qwen_design_idle_watchdog)."""
@@ -4924,7 +4976,6 @@ async def _start_design_idle_watchdog() -> None:
     )
 
 
-@app.on_event("shutdown")
 async def _stop_design_idle_watchdog() -> None:
     global _design_idle_task
     if _design_idle_task is not None:
@@ -4972,14 +5023,12 @@ async def _asr_idle_watchdog() -> None:
             log.warning("ASR idle watchdog tick failed (%s).", e)
 
 
-@app.on_event("startup")
 async def _start_asr_idle_watchdog() -> None:
     global _asr_idle_task
     _asr_idle_task = asyncio.create_task(_asr_idle_watchdog())
     log.info("Whisper ASR idle watchdog started (ttl=%.0fs).", _asr_idle_ttl())
 
 
-@app.on_event("shutdown")
 async def _stop_asr_idle_watchdog() -> None:
     global _asr_idle_task
     if _asr_idle_task is not None:
@@ -5026,14 +5075,12 @@ async def _spk_idle_watchdog() -> None:
             log.warning("SPK idle watchdog tick failed (%s).", e)
 
 
-@app.on_event("startup")
 async def _start_spk_idle_watchdog() -> None:
     global _spk_idle_task
     _spk_idle_task = asyncio.create_task(_spk_idle_watchdog())
     log.info("ECAPA speaker idle watchdog started (ttl=%.0fs).", _spk_idle_ttl())
 
 
-@app.on_event("shutdown")
 async def _stop_spk_idle_watchdog() -> None:
     global _spk_idle_task
     if _spk_idle_task is not None:
@@ -5045,7 +5092,6 @@ async def _stop_spk_idle_watchdog() -> None:
         _spk_idle_task = None
 
 
-@app.on_event("startup")
 async def _start_device_probe() -> None:
     """side-14 — resolve per-engine devices in the background. Runs on a worker
     thread (torch import takes seconds); /health reports devices_state='pending'
@@ -5754,7 +5800,6 @@ async def _memory_watchdog() -> None:
             log.warning("sidecar memory watchdog tick failed (%s).", e)
 
 
-@app.on_event("startup")
 async def _start_memory_watchdog() -> None:
     """Launch the host-memory watchdog (see _memory_watchdog)."""
     global _mem_watchdog_task
@@ -5776,7 +5821,6 @@ async def _start_memory_watchdog() -> None:
     )
 
 
-@app.on_event("shutdown")
 async def _stop_memory_watchdog() -> None:
     global _mem_watchdog_task
     if _mem_watchdog_task is not None:
@@ -5788,7 +5832,6 @@ async def _stop_memory_watchdog() -> None:
         _mem_watchdog_task = None
 
 
-@app.on_event("startup")
 async def _preload_default_engines() -> None:
     """Engine preload at startup.
 
@@ -5893,7 +5936,6 @@ def _warn_if_cuda_env_shadow_active() -> None:
         )
 
 
-@app.on_event("startup")
 async def _startup_cuda_env_shadow_check() -> None:
     _warn_if_cuda_env_shadow_active()
 

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -492,11 +492,19 @@ async def _lifespan(_app: FastAPI):
     """Startup/shutdown sequence for the sidecar (side-27a).
 
     Replaces the twelve `@app.on_event("startup"|"shutdown")` decorators this
-    module used to carry. FastAPI still exposes that decorator, but its body is
-    a straight delegation to `starlette.routing.Router.on_event`, which Starlette
-    1.3.1 deletes outright — so the decorator had to go before the web stack
-    could be bumped. This is a pure mechanical migration: nothing about WHAT
-    runs, or in WHICH order, changes.
+    module used to carry. That decorator was NOT a hard blocker for the
+    FastAPI bump this branch also makes: Starlette did drop `_DefaultLifespan`
+    and the `on_startup`/`on_shutdown` machinery from `Router`
+    (Kludex/starlette#3117), but FastAPI re-implemented all of it locally
+    (`fastapi/routing.py`) — its own `_DefaultLifespan`,
+    `APIRouter._startup()`/`._shutdown()`, `add_event_handler()`, and
+    `on_event()` itself all still work, so the decorator keeps resolving fine
+    against the pinned FastAPI 0.140. The real reason to migrate: `on_event`
+    is `@deprecated` there, kept only on a compatibility shim FastAPI's own
+    source marks with a "remove this once the lifespan interface is
+    improved" TODO — `lifespan` is the supported interface going forward.
+    This is a pure mechanical migration: nothing about WHAT runs, or in
+    WHICH order, changes.
 
     The handlers themselves are untouched — each is still a module-level
     `async def` under its original name, defined much further down this file
@@ -507,19 +515,24 @@ async def _lifespan(_app: FastAPI):
     forcing a reorder of the module.
 
     Ordering is a verbatim copy of the old registration order in BOTH
-    directions. Starlette ran `on_startup` in registration order and
-    `on_shutdown` in registration order too — it never reversed them — so
-    reversing the teardown here would be a behaviour change smuggled into a
-    migration whose whole premise is that nothing changes. (The four stop
-    handlers are mutually independent anyway; each just cancels its own task.)
+    directions. FastAPI's `APIRouter._startup()` ran `on_startup` handlers in
+    registration order and `_shutdown()` ran `on_shutdown` handlers in
+    registration order too — neither ever reversed them — so reversing the
+    teardown here would be a behaviour change smuggled into a migration whose
+    whole premise is that nothing changes. (The four stop handlers are
+    mutually independent anyway; each just cancels its own task.)
 
     Failure semantics match the decorator form as well. The startup awaits are
     sequential and unguarded, so a raising handler aborts boot and skips the
-    handlers after it — as `Router.startup()` did. The teardown sits in a
-    `finally` because Starlette's `_DefaultLifespan.__aexit__` ignores its
-    `exc_info` and runs `Router.shutdown()` unconditionally; without the
-    `finally`, an exception thrown in at the `yield` (a cancelled lifespan task)
-    would skip teardown entirely, which the `on_event` form did not do.
+    handlers after it — as FastAPI's `APIRouter._startup()` did. The teardown
+    sits in a `finally` because FastAPI's `_DefaultLifespan.__aexit__`
+    ignores its `exc_info` and runs `APIRouter._shutdown()` unconditionally
+    (`fastapi/routing.py:265-266`) — not Starlette's: the shipped Starlette
+    `_DefaultLifespan.__aenter__`/`__aexit__` are two bare `pass`es, and
+    `Router.startup()`/`Router.shutdown()`/`Router.on_startup` don't exist on
+    Starlette's `Router` at all. Without the `finally`, an exception thrown
+    at the `yield` (a cancelled lifespan task) would skip teardown entirely,
+    which the `on_event` form did not do.
 
     `tests/test_lifespan_order.py` drives this very context manager and pins
     both sequences by name, so a later edit cannot quietly drop or reshuffle a

--- a/server/tts-sidecar/requirements-dev.txt
+++ b/server/tts-sidecar/requirements-dev.txt
@@ -10,3 +10,9 @@
 pytest>=9.0.3,<10
 # FastAPI's TestClient depends on httpx — pin a recent stable line.
 httpx>=0.27,<1.0
+# starlette.testclient (1.3.1+) prefers httpx2 over httpx and warns
+# (StarletteDeprecationWarning) when only httpx is present — see side-29
+# (#1843). httpx is kept too: gradio/gradio_client/safehttpx (transitive
+# deps pulled in by the sidecar's own requirements) still import plain
+# `httpx` directly, so it can't be dropped.
+httpx2>=2.9,<3.0

--- a/server/tts-sidecar/requirements/amd-rocm.txt
+++ b/server/tts-sidecar/requirements/amd-rocm.txt
@@ -19,7 +19,7 @@ qwen-tts==0.1.1
 # (2026-06-15) found DirectML CANNOT run the Kokoro model (ConvTranspose fails on
 # onnxruntime-directml; the CPU EP works), so the AMD profile does NOT swap in
 # onnxruntime-directml — Kokoro runs on CPU here while Qwen (and opt-in Coqui, when installed) ride ROCm torch.
-kokoro-onnx>=0.4.0,<0.5.0
+kokoro-onnx>=0.5.0,<0.6.0
 
 # torch + torchaudio are NOT pinned here. The AMD profile installs the ROCm
 # preview wheels (repo.radeon.com, alpha local-version tags like

--- a/server/tts-sidecar/requirements/base.txt
+++ b/server/tts-sidecar/requirements/base.txt
@@ -1,15 +1,22 @@
 # Vendor-neutral sidecar dependencies (Phase 1 layered-requirements groundwork).
 # These install the same on every box; the torch-engine deps live in the
-# vendor overlay (nvidia-cuda.txt today). Lines moved verbatim from the old
-# flat requirements.txt — same packages, same pins.
+# vendor overlay (nvidia-cuda.txt today). Lines moved from the old flat
+# requirements.txt with the same packages; most pins carried over verbatim,
+# but fastapi/uvicorn below are bumped ~25 minor versions as part of this
+# branch's on_event -> lifespan migration (side-27a).
 
 # fastapi/uvicorn were pinned to the 0.115/0.30 line while this module still used
-# the twelve `@app.on_event("startup"|"shutdown")` decorators (side-27a). Starlette
-# 1.3.1 deletes `on_event`/`add_event_handler` outright, and FastAPI's `@app.on_event`
-# body is a straight `self.router.on_event(...)` delegation into that deleted method
-# — so bumping past the Starlette 1.x floor would have broken registration at import
-# time. side-27a replaced those decorators with a `lifespan` context manager
-# (`main.py`'s `_lifespan`), which unblocks this bump.
+# the twelve `@app.on_event("startup"|"shutdown")` decorators (side-27a). That
+# decorator was not actually at risk from this bump: Starlette dropped
+# `_DefaultLifespan`/`on_startup`/`on_shutdown` from `Router`, but FastAPI
+# re-implemented all of it locally (`fastapi/routing.py`'s own
+# `_DefaultLifespan`, `APIRouter._startup()`/`._shutdown()`, and `on_event()`
+# itself), so it still resolves fine against the pinned FastAPI 0.140. The
+# real reason to migrate is that `on_event` is `@deprecated` there, kept only
+# on a compatibility shim FastAPI's own source flags for future removal —
+# `lifespan` is the supported interface. side-27a replaced those decorators
+# with a `lifespan` context manager (`main.py`'s `_lifespan`) ahead of this
+# bump.
 fastapi>=0.140,<0.141
 uvicorn[standard]>=0.51,<0.52
 

--- a/server/tts-sidecar/requirements/base.txt
+++ b/server/tts-sidecar/requirements/base.txt
@@ -3,8 +3,15 @@
 # vendor overlay (nvidia-cuda.txt today). Lines moved verbatim from the old
 # flat requirements.txt — same packages, same pins.
 
-fastapi>=0.115,<0.116
-uvicorn[standard]>=0.30,<0.32
+# fastapi/uvicorn were pinned to the 0.115/0.30 line while this module still used
+# the twelve `@app.on_event("startup"|"shutdown")` decorators (side-27a). Starlette
+# 1.3.1 deletes `on_event`/`add_event_handler` outright, and FastAPI's `@app.on_event`
+# body is a straight `self.router.on_event(...)` delegation into that deleted method
+# — so bumping past the Starlette 1.x floor would have broken registration at import
+# time. side-27a replaced those decorators with a `lifespan` context manager
+# (`main.py`'s `_lifespan`), which unblocks this bump.
+fastapi>=0.140,<0.141
+uvicorn[standard]>=0.51,<0.52
 
 # Numpy 2.x is required by kokoro-onnx>=0.4.0; coqui-tts 0.27.x only floors
 # at numpy>=1.26 (no upper cap) so the bump is safe. The earlier `<2.0`

--- a/server/tts-sidecar/requirements/cpu.txt
+++ b/server/tts-sidecar/requirements/cpu.txt
@@ -22,6 +22,6 @@ torchaudio==2.11.0
 # Kokoro v1 — plain (no [gpu] extra) so the CPU/CoreML onnxruntime is used; the
 # explicit onnxruntime below is the CPU execution provider. Run
 # scripts/install-kokoro.{ps1,sh} once to fetch the model + voices manifest.
-kokoro-onnx>=0.4.0,<0.5.0
+kokoro-onnx>=0.5.0,<0.6.0
 onnxruntime
 -r speaker-qa.txt

--- a/server/tts-sidecar/requirements/nvidia-cuda.txt
+++ b/server/tts-sidecar/requirements/nvidia-cuda.txt
@@ -53,8 +53,8 @@ torchaudio==2.11.0
 # swapping colorlog for stdlib logging. Kokoro.create()'s signature and the
 # private `.sess` attribute we rebuild for indexed device pinning (see the
 # InferenceSession rebuild in main.py's Kokoro loader) are both unchanged, and
-# the dist metadata is identical — so this moves no transitive deps and does not
-# interact with the install-ort.mjs runtime swap.
+# the only metadata delta is the dropped `colorlog` dependency; no runtime dep
+# moves, and this does not interact with the install-ort.mjs runtime swap.
 kokoro-onnx>=0.5.0,<0.6.0
 
 # Qwen3-TTS — per-character bespoke voices; weights fetched by install-qwen3.mjs.

--- a/server/tts-sidecar/requirements/nvidia-cuda.txt
+++ b/server/tts-sidecar/requirements/nvidia-cuda.txt
@@ -49,7 +49,13 @@ torchaudio==2.11.0
 # macOS/Apple-Silicon keeps the plain CPU/CoreML runtime (no swap for non-nvidia).
 # Run scripts/install-kokoro.{ps1,sh} once to fetch the model + voices manifest
 # into voices/kokoro/ (gitignored, ~330 MB).
-kokoro-onnx>=0.4.0,<0.5.0
+# 0.5.0 floor (side-26): the whole 0.4.9 -> 0.5.0 delta is kokoro_onnx/log.py
+# swapping colorlog for stdlib logging. Kokoro.create()'s signature and the
+# private `.sess` attribute we rebuild for indexed device pinning (see the
+# InferenceSession rebuild in main.py's Kokoro loader) are both unchanged, and
+# the dist metadata is identical — so this moves no transitive deps and does not
+# interact with the install-ort.mjs runtime swap.
+kokoro-onnx>=0.5.0,<0.6.0
 
 # Qwen3-TTS — per-character bespoke voices; weights fetched by install-qwen3.mjs.
 # Pinned to 0.1.1: the raw model.generate() bypass in _icl_instruct_synth (fs-55)

--- a/server/tts-sidecar/scripts/install-ort.mjs
+++ b/server/tts-sidecar/scripts/install-ort.mjs
@@ -26,6 +26,38 @@ import { spawnSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 import { installRecipe } from './accelerator-profile.mjs';
 
+// onnxruntime-gpu version constraint (side-28): without one, the runtime a user
+// actually runs Kokoro on is whatever happened to be latest on PyPI on their
+// install date — this dev box validated 1.27.0, a fresh install today lands
+// 1.28.0, and nobody chose that drift on purpose. Floor-plus-cap on the MINOR
+// line rather than an exact `==` so a same-line patch release (a security fix)
+// still flows without a code change; only crossing the minor boundary needs a
+// deliberate bump of this constant (bump the runtime and this pin together,
+// once 1.28 is desk-validated — never bump one without the other).
+// This is the ONLY place the constraint can live: it must NOT move into
+// requirements/*.txt, because onnxruntime-gpu can never appear there AT ALL —
+// those overlays are also read on macOS (no onnxruntime-gpu wheel exists for
+// Apple Silicon), and test_no_bare_unmarked_onnxruntime_gpu
+// (tests/test_requirements.py) enforces that a bare, unmarked
+// `onnxruntime-gpu` line never lands there and aborts `pip install` on that
+// platform. The swap in this file is reached only for the nvidia profile
+// (win/linux), so pinning it here never touches the mac path.
+const ONNXRUNTIME_GPU_CONSTRAINT = '>=1.27,<1.28';
+
+/**
+ * Apply the onnxruntime-gpu version constraint to an ortPackage name for the
+ * INSTALL step only — the uninstall step takes bare package names (a version
+ * spec there is meaningless to `pip uninstall` and would be a silent no-op).
+ * Any other ortPackage (e.g. a future onnxruntime-directml re-enable) installs
+ * unconstrained until it has its own desk-validated line. Pure — no I/O.
+ * @returns {string}
+ */
+function constrainForInstall(ortPackage) {
+  return ortPackage === 'onnxruntime-gpu'
+    ? `onnxruntime-gpu${ONNXRUNTIME_GPU_CONSTRAINT}`
+    : ortPackage;
+}
+
 /**
  * Decide the ordered pip steps to put the correct ONNX runtime in place after the
  * overlay install. The overlay always lands plain `onnxruntime` (kokoro-onnx's
@@ -55,7 +87,7 @@ export function planOrtSwap(profile, platform) {
       // __version__/get_available_providers) and Kokoro silently fails to load.
       // `--no-deps` keeps the overlay's numpy/protobuf/etc. pins untouched.
       ['uninstall', '-y', 'onnxruntime', ortPackage],
-      ['install', '--force-reinstall', '--no-deps', ortPackage],
+      ['install', '--force-reinstall', '--no-deps', constrainForInstall(ortPackage)],
     ],
   };
 }

--- a/server/tts-sidecar/scripts/install-ort.mjs
+++ b/server/tts-sidecar/scripts/install-ort.mjs
@@ -65,8 +65,10 @@ function constrainForInstall(ortPackage) {
  * onnxruntime-gpu; a future DirectML re-enable → onnxruntime-directml) is a swap;
  * a recipe that already wants plain `onnxruntime` (cpu/amd/apple) is a no-op. Pure
  * — no I/O. `steps` are pip sub-command arg arrays, run in order with the venv
- * python.
- * @returns {{action:'skip', reason:string} | {action:'swap', steps:string[][]}}
+ * python. `ortPackage` on the swap variant lets the CLI report which package it
+ * actually put in place without re-deriving it (#1844) — a second source of
+ * truth there is exactly how the CLI drifted into naming the wrong package.
+ * @returns {{action:'skip', reason:string} | {action:'swap', steps:string[][], ortPackage:string}}
  */
 export function planOrtSwap(profile, platform) {
   const { ortPackage } = installRecipe(profile, platform);
@@ -75,6 +77,7 @@ export function planOrtSwap(profile, platform) {
   }
   return {
     action: 'swap',
+    ortPackage,
     steps: [
       // Uninstall BOTH the plain `onnxruntime` the overlay landed AND any cached
       // `ortPackage` first, so the shared `onnxruntime/` namespace directory is
@@ -113,6 +116,6 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
       process.exit(code);
     }
   }
-  process.stdout.write('[install-ort] onnxruntime-directml in place.\n');
+  process.stdout.write(`[install-ort] ${plan.ortPackage} in place.\n`);
   process.exit(0);
 }

--- a/server/tts-sidecar/tests/test_kokoro.py
+++ b/server/tts-sidecar/tests/test_kokoro.py
@@ -823,8 +823,16 @@ def _real_kokoro():
     import importlib
 
     mod = pytest.importorskip("kokoro_onnx", reason="kokoro-onnx not installed")
-    mod = importlib.reload(mod)
-    if isinstance(mod, types.ModuleType) and not getattr(mod, "__file__", None):
+    try:
+        mod = importlib.reload(mod)
+    except ModuleNotFoundError:
+        # A bare stub module (no __spec__/__file__) left in sys.modules makes
+        # reload() fall back to module.__name__ for the spec lookup; if the
+        # real package isn't installed, that lookup fails and reload() raises
+        # instead of returning the stub. Treat that the same as "stub, not
+        # real" — skip cleanly rather than ERROR-ing.
+        pytest.skip("kokoro_onnx present only as a test stub (reload found no real package)")
+    if not getattr(mod, "__file__", None):
         pytest.skip("kokoro_onnx present only as a test stub")
     return mod
 
@@ -844,10 +852,25 @@ def test_real_kokoro_still_exposes_the_sess_attribute() -> None:
 
 
 def test_real_kokoro_create_keeps_the_positional_signature_we_call() -> None:
-    """main.py calls `create(text, voice, speed, lang)` positionally."""
+    """main.py:1363 calls `create(text, voice, speed, lang)` fully positionally."""
     import inspect
 
-    params = list(inspect.signature(_real_kokoro().Kokoro.create).parameters)
+    sig = inspect.signature(_real_kokoro().Kokoro.create)
+    params = list(sig.parameters)
     assert params[:5] == ["self", "text", "voice", "speed", "lang"], (
         f"kokoro_onnx.Kokoro.create signature drifted: {params}"
     )
+    # Names/order alone don't prove the real call site still works: if
+    # upstream kept these names/order but made voice/speed/lang keyword-only
+    # (`def create(self, text, *, voice, speed, lang, ...)`), the assertion
+    # above would still pass while main.py:1363's positional call would raise
+    # TypeError at runtime. Pin the parameter *kind* too.
+    positional_kinds = (
+        inspect.Parameter.POSITIONAL_ONLY,
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    )
+    for name in ("voice", "speed", "lang"):
+        assert sig.parameters[name].kind in positional_kinds, (
+            f"kokoro_onnx.Kokoro.create's '{name}' parameter became keyword-only — "
+            "main.py:1363 calls create() positionally and would raise TypeError"
+        )

--- a/server/tts-sidecar/tests/test_kokoro.py
+++ b/server/tts-sidecar/tests/test_kokoro.py
@@ -798,3 +798,56 @@ def test_kokoro_provider_options_none_when_not_indexed() -> None:
     assert main._kokoro_provider_options("cpu", ["CPUExecutionProvider"]) is None
     assert main._kokoro_provider_options("cuda", []) is None
     assert main._kokoro_provider_options("auto", []) is None
+
+
+# ── real-package contract (side-26) ──────────────────────────────────────
+#
+# Everything above stubs `kokoro_onnx` via sys.modules, so nothing in this
+# file would notice upstream renaming the two things the device-pin path
+# actually reaches into.  These tests run against the REAL installed package
+# and skip when it's absent (CI / a fresh clone before install-kokoro).
+#
+# Why they matter: the indexed-device pin rebuilds `self._kokoro.sess` inside
+# a try/except that only WARNS on failure — so an upstream rename would not
+# raise, it would silently drop Kokoro back to an unpinned device.  A pin
+# bump must fail here instead.
+
+# NOTE: importorskip lives INSIDE each test, never at module scope — at module
+# scope it would skip this entire file on the CI boxes that never install
+# kokoro-onnx, silently taking the ~40 stubbed tests above with it.
+
+
+def _real_kokoro():
+    """The real installed kokoro_onnx, or skip. Re-imported per test so a
+    leftover sys.modules stub from a fixture can never be mistaken for it."""
+    import importlib
+
+    mod = pytest.importorskip("kokoro_onnx", reason="kokoro-onnx not installed")
+    mod = importlib.reload(mod)
+    if isinstance(mod, types.ModuleType) and not getattr(mod, "__file__", None):
+        pytest.skip("kokoro_onnx present only as a test stub")
+    return mod
+
+
+def test_real_kokoro_still_exposes_the_sess_attribute() -> None:
+    """The indexed-device pin assigns `self._kokoro.sess = rt.InferenceSession(...)`.
+    `sess` is private API, so every kokoro-onnx bump must re-confirm it."""
+    import inspect
+    import re
+
+    src = inspect.getsource(_real_kokoro().Kokoro.__init__)
+    assert re.search(r"self\.sess\s*=", src), (
+        "kokoro_onnx.Kokoro no longer assigns `self.sess` — the indexed-device "
+        "pin in main.py rebuilds that attribute and fails SILENTLY (warn-only) "
+        "if it moves. Update the pin before lifting the kokoro-onnx floor."
+    )
+
+
+def test_real_kokoro_create_keeps_the_positional_signature_we_call() -> None:
+    """main.py calls `create(text, voice, speed, lang)` positionally."""
+    import inspect
+
+    params = list(inspect.signature(_real_kokoro().Kokoro.create).parameters)
+    assert params[:5] == ["self", "text", "voice", "speed", "lang"], (
+        f"kokoro_onnx.Kokoro.create signature drifted: {params}"
+    )

--- a/server/tts-sidecar/tests/test_kokoro.py
+++ b/server/tts-sidecar/tests/test_kokoro.py
@@ -852,7 +852,13 @@ def test_real_kokoro_still_exposes_the_sess_attribute() -> None:
 
 
 def test_real_kokoro_create_keeps_the_positional_signature_we_call() -> None:
-    """main.py:1416 calls `create(text, voice, speed, lang)` fully positionally."""
+    """main.py has two call sites for `create()`, and they are not equivalent.
+    `KokoroEngine.synthesize` (the real synthesis hot path, runs on every synth)
+    calls `create(text, voice=..., speed=..., lang=...)` by keyword.
+    `KokoroEngine._directml_selftest_or_fallback` (the DirectML proof-of-life
+    probe — disabled today, see the `amd-rocm.txt` overlay comment and
+    `installRecipe` in `scripts/accelerator-profile.mjs`) calls
+    `create(text, voice, speed, lang)` fully positionally."""
     import inspect
 
     sig = inspect.signature(_real_kokoro().Kokoro.create)
@@ -860,11 +866,14 @@ def test_real_kokoro_create_keeps_the_positional_signature_we_call() -> None:
     assert params[:5] == ["self", "text", "voice", "speed", "lang"], (
         f"kokoro_onnx.Kokoro.create signature drifted: {params}"
     )
-    # Names/order alone don't prove the real call site still works: if
+    # Names/order alone guard the keyword call in `KokoroEngine.synthesize`: a
+    # rename of `voice`/`speed`/`lang` breaks that call site even though it's
+    # keyword-based. They do NOT prove the positional probe still works: if
     # upstream kept these names/order but made voice/speed/lang keyword-only
     # (`def create(self, text, *, voice, speed, lang, ...)`), the assertion
-    # above would still pass while main.py:1416's positional call would raise
-    # TypeError at runtime. Pin the parameter *kind* too.
+    # above would still pass while `_directml_selftest_or_fallback`'s positional
+    # call would raise TypeError at runtime. Pin the parameter *kind* too — this
+    # only guards the (currently disabled) DirectML path, not the live hot path.
     positional_kinds = (
         inspect.Parameter.POSITIONAL_ONLY,
         inspect.Parameter.POSITIONAL_OR_KEYWORD,
@@ -872,5 +881,7 @@ def test_real_kokoro_create_keeps_the_positional_signature_we_call() -> None:
     for name in ("voice", "speed", "lang"):
         assert sig.parameters[name].kind in positional_kinds, (
             f"kokoro_onnx.Kokoro.create's '{name}' parameter became keyword-only — "
-            "main.py:1416 calls create() positionally and would raise TypeError"
+            "KokoroEngine._directml_selftest_or_fallback calls create() "
+            "positionally and would raise TypeError (latent on the disabled "
+            "DirectML path, but still shipped code)"
         )

--- a/server/tts-sidecar/tests/test_kokoro.py
+++ b/server/tts-sidecar/tests/test_kokoro.py
@@ -852,7 +852,7 @@ def test_real_kokoro_still_exposes_the_sess_attribute() -> None:
 
 
 def test_real_kokoro_create_keeps_the_positional_signature_we_call() -> None:
-    """main.py:1363 calls `create(text, voice, speed, lang)` fully positionally."""
+    """main.py:1416 calls `create(text, voice, speed, lang)` fully positionally."""
     import inspect
 
     sig = inspect.signature(_real_kokoro().Kokoro.create)
@@ -863,7 +863,7 @@ def test_real_kokoro_create_keeps_the_positional_signature_we_call() -> None:
     # Names/order alone don't prove the real call site still works: if
     # upstream kept these names/order but made voice/speed/lang keyword-only
     # (`def create(self, text, *, voice, speed, lang, ...)`), the assertion
-    # above would still pass while main.py:1363's positional call would raise
+    # above would still pass while main.py:1416's positional call would raise
     # TypeError at runtime. Pin the parameter *kind* too.
     positional_kinds = (
         inspect.Parameter.POSITIONAL_ONLY,
@@ -872,5 +872,5 @@ def test_real_kokoro_create_keeps_the_positional_signature_we_call() -> None:
     for name in ("voice", "speed", "lang"):
         assert sig.parameters[name].kind in positional_kinds, (
             f"kokoro_onnx.Kokoro.create's '{name}' parameter became keyword-only — "
-            "main.py:1363 calls create() positionally and would raise TypeError"
+            "main.py:1416 calls create() positionally and would raise TypeError"
         )

--- a/server/tts-sidecar/tests/test_lifespan_order.py
+++ b/server/tts-sidecar/tests/test_lifespan_order.py
@@ -1,0 +1,133 @@
+"""side-27a — pin the startup/shutdown sequence the sidecar's `lifespan`
+context manager runs.
+
+Twelve `@app.on_event("startup"|"shutdown")` handlers were collapsed into a
+single `main._lifespan` so the web stack could move past Starlette 1.3.1, which
+deletes `Router.on_event` outright. With the decorators gone, the ordering is no
+longer expressed by twelve registration sites that are hard to reorder by
+accident — it is twelve consecutive `await` lines that a careless edit could
+reshuffle, drop, or duplicate silently. Hence this file.
+
+These tests drive the ACTUAL wired-up `app.router.lifespan_context`, with every
+handler monkeypatched to a recorder, and compare the observed call order against
+the order the `on_event` form produced. They deliberately do NOT read a
+hand-maintained list off the module — that would pass vacuously against the very
+edit it is supposed to catch. Monkeypatching module attributes is what the
+sidecar's own testing convention prescribes (see the torch-injection note in
+CLAUDE.md), and it works here because `_lifespan` resolves each handler as a
+module global at call time.
+
+Note the shutdown order is registration order, NOT the reverse of startup:
+Starlette's `Router.shutdown()` iterated `on_shutdown` forwards, and the
+migration preserved that rather than "tidying" it into a reversal."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the sidecar package importable: tests/ sits one level below main.py.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import main  # noqa: E402
+
+# The two sequences as the `@app.on_event` decorators registered them, in the
+# order Starlette invoked them. Any change to either list is a behaviour change
+# and must be argued for, not slipped in.
+EXPECTED_STARTUP = [
+    "_configure_vd_kokoro_coupling",
+    "_start_design_idle_watchdog",
+    "_start_asr_idle_watchdog",
+    "_start_spk_idle_watchdog",
+    "_start_device_probe",
+    "_start_memory_watchdog",
+    "_preload_default_engines",
+    "_startup_cuda_env_shadow_check",
+]
+
+EXPECTED_SHUTDOWN = [
+    "_stop_design_idle_watchdog",
+    "_stop_asr_idle_watchdog",
+    "_stop_spk_idle_watchdog",
+    "_stop_memory_watchdog",
+]
+
+
+def _install_recorders(monkeypatch, calls: list[str], raises: str | None = None) -> None:
+    """Replace all twelve handlers with async recorders that append their own
+    name. `raises` optionally makes one of them blow up, so the abort semantics
+    can be exercised without a real handler failure."""
+
+    def _make(name: str):
+        async def _recorder() -> None:
+            calls.append(name)
+            if name == raises:
+                raise RuntimeError(f"boom in {name}")
+
+        return _recorder
+
+    for name in EXPECTED_STARTUP + EXPECTED_SHUTDOWN:
+        # getattr first: a renamed/deleted handler must fail loudly here rather
+        # than have the test quietly patch a name nothing calls.
+        assert callable(getattr(main, name)), name
+        monkeypatch.setattr(main, name, _make(name))
+
+
+async def _run_lifespan(calls: list[str]) -> None:
+    """Enter and exit the app's real lifespan exactly as the ASGI server does."""
+    async with main.app.router.lifespan_context(main.app):
+        calls.append("--serving--")
+
+
+def test_app_is_wired_to_the_lifespan_context_manager():
+    # Guards the seam the other tests depend on: if the app were ever
+    # constructed without `lifespan=`, Starlette would fall back to
+    # `_DefaultLifespan` over the (now empty) on_event lists and every ordering
+    # assertion below would pass against nothing at all.
+    assert main.app.router.lifespan_context is main._lifespan
+    assert main.app.router.on_startup == []
+    assert main.app.router.on_shutdown == []
+
+
+def test_lifespan_runs_startup_then_shutdown_in_the_registered_order(monkeypatch):
+    calls: list[str] = []
+    _install_recorders(monkeypatch, calls)
+
+    asyncio.run(_run_lifespan(calls))
+
+    assert calls == EXPECTED_STARTUP + ["--serving--"] + EXPECTED_SHUTDOWN
+
+
+def test_a_failing_startup_handler_aborts_boot_and_skips_the_rest(monkeypatch):
+    # `Router.startup()` awaited its handlers in an unguarded loop, so the first
+    # raiser aborted the whole startup and neither the handlers after it nor any
+    # shutdown handler ran. The single lifespan must keep that: a half-started
+    # process is meant to die, not limp on with three of eight watchdogs live.
+    calls: list[str] = []
+    _install_recorders(monkeypatch, calls, raises="_start_asr_idle_watchdog")
+
+    with pytest.raises(RuntimeError, match="_start_asr_idle_watchdog"):
+        asyncio.run(_run_lifespan(calls))
+
+    assert calls == EXPECTED_STARTUP[:3]
+
+
+def test_shutdown_still_runs_when_the_serving_phase_raises(monkeypatch):
+    # Starlette's `_DefaultLifespan.__aexit__` ignored its exc_info and ran
+    # `Router.shutdown()` unconditionally, so a lifespan task cancelled while
+    # serving still cancelled the four watchdog tasks. That is why `_lifespan`
+    # wraps its `yield` in try/finally — drop the `finally` and this fails.
+    calls: list[str] = []
+    _install_recorders(monkeypatch, calls)
+
+    async def _raise_while_serving() -> None:
+        async with main.app.router.lifespan_context(main.app):
+            raise RuntimeError("server died mid-flight")
+
+    with pytest.raises(RuntimeError, match="server died mid-flight"):
+        asyncio.run(_raise_while_serving())
+
+    assert calls == EXPECTED_STARTUP + EXPECTED_SHUTDOWN

--- a/server/tts-sidecar/tests/test_lifespan_order.py
+++ b/server/tts-sidecar/tests/test_lifespan_order.py
@@ -2,11 +2,15 @@
 context manager runs.
 
 Twelve `@app.on_event("startup"|"shutdown")` handlers were collapsed into a
-single `main._lifespan` so the web stack could move past Starlette 1.3.1, which
-deletes `Router.on_event` outright. With the decorators gone, the ordering is no
-longer expressed by twelve registration sites that are hard to reorder by
-accident — it is twelve consecutive `await` lines that a careless edit could
-reshuffle, drop, or duplicate silently. Hence this file.
+single `main._lifespan` ahead of the Starlette bump this branch also makes.
+That collapse wasn't forced by import-time breakage — FastAPI re-implements
+`on_startup`/`on_shutdown`/`on_event` locally (`fastapi/routing.py`), so the
+decorators still resolve fine against the pinned FastAPI 0.140. It was done
+because `on_event` is formally deprecated there, kept only on a compatibility
+shim FastAPI's own source marks for future removal. With the decorators gone,
+the ordering is no longer expressed by twelve registration sites that are hard
+to reorder by accident — it is twelve consecutive `await` lines that a
+careless edit could reshuffle, drop, or duplicate silently. Hence this file.
 
 These tests drive the ACTUAL wired-up `app.router.lifespan_context`, with every
 handler monkeypatched to a recorder, and compare the observed call order against
@@ -18,7 +22,7 @@ CLAUDE.md), and it works here because `_lifespan` resolves each handler as a
 module global at call time.
 
 Note the shutdown order is registration order, NOT the reverse of startup:
-Starlette's `Router.shutdown()` iterated `on_shutdown` forwards, and the
+FastAPI's `APIRouter._shutdown()` iterates `on_shutdown` forwards, and the
 migration preserved that rather than "tidying" it into a reversal."""
 
 from __future__ import annotations
@@ -84,9 +88,13 @@ async def _run_lifespan(calls: list[str]) -> None:
 
 def test_app_is_wired_to_the_lifespan_context_manager():
     # Guards the seam the other tests depend on: if the app were ever
-    # constructed without `lifespan=`, Starlette would fall back to
-    # `_DefaultLifespan` over the (now empty) on_event lists and every ordering
-    # assertion below would pass against nothing at all.
+    # constructed without `lifespan=`, it would fall back to FastAPI's own
+    # `_DefaultLifespan` over the (now empty) `on_startup`/`on_shutdown` lists
+    # and every ordering assertion below would pass against nothing at all.
+    # The two asserts below only make sense against FastAPI's `APIRouter`,
+    # which keeps `on_startup`/`on_shutdown` as instance lists for backward
+    # compatibility after Starlette dropped them outright — this would
+    # `AttributeError` on a plain Starlette `Router`, which has no such lists.
     assert main.app.router.lifespan_context is main._lifespan
     assert main.app.router.on_startup == []
     assert main.app.router.on_shutdown == []


### PR DESCRIPTION
## Summary

Clears the actionable half of the `side-17` engine-dep umbrella (#893). An audit on 2026-07-26 found that three of its six deferred items were no longer blocked — and that three of the six recorded rationales were stale. This ships the three that are movable; #893 has been rewritten as an umbrella tracker with the real, current blockers for the rest.

**`kokoro-onnx` 0.4.9 → 0.5.0** (`side-26`). The entire upstream delta is `kokoro_onnx/log.py` swapping `colorlog` for stdlib `logging`. `Kokoro.create()`'s signature and the private `.sess` attribute are unchanged. That `.sess` matters: the indexed-device pin rebuilds it inside a **warn-only** `try/except`, so an upstream rename would not raise — it would silently drop Kokoro back to an unpinned device. The rest of `test_kokoro.py` stubs `kokoro_onnx` via `sys.modules` and would never notice, so this adds two contract tests that run against the real installed package.

**`onnxruntime-gpu` pinned at the ORT swap** (`side-28`). There was no pin to bump — `install-ort.mjs` ran `pip install --force-reinstall --no-deps onnxruntime-gpu` with no version specifier, so the runtime executing Kokoro was whatever was latest on the user's install date. The absent pin was the defect. Now `>=1.27,<1.28` — a floor-plus-cap so patch-level security fixes still flow — and it lives in the installer, never the overlays, which macOS also reads and where no wheel exists.

**FastAPI 0.115 → 0.140, uvicorn 0.30 → 0.51** (`side-27`), preceded by retiring all 12 `@app.on_event` handlers in favour of a `lifespan` context manager.

### A correction worth recording

The original justification for the lifespan migration — repeated across several files during development — was that Starlette 1.3.1 removed `on_event` outright, so the decorator would break at import time. **That was wrong**, and the final review caught it. FastAPI 0.140 re-implements `_DefaultLifespan`, `APIRouter._startup()`, `._shutdown()`, `.add_event_handler()` and `.on_event()` locally, explicitly to preserve backward compatibility after Starlette dropped them. The decorator would still have worked.

The migration is still right — `on_event` is deprecated and survives only on a compat shim carrying its own removal TODO, and `lifespan` is the supported interface — but "it was a blocker" is not why. The comments now say the true thing, verified against the installed FastAPI source rather than assumed.

### Behaviour preservation

The lifespan migration is a pure refactor and was reviewed as one. Startup order is preserved exactly; shutdown stays in **registration** order rather than being reversed for context-manager tidiness, because FastAPI runs it forwards and reversing would smuggle a behaviour change into a migration whose premise is that nothing changes. Teardown sits in a `finally`, not after a bare `yield`, because `_DefaultLifespan.__aexit__` discards `exc_info` and runs shutdown unconditionally — verified by running the real lifespan against a bare-`yield` mutant, which leaked all four watchdogs on a cancelled lifespan (the shape uvicorn actually produces).

### Folded-in follow-ups

Two items surfaced by the reviews, fixed here at request rather than deferred:

- **`httpx2`** (#1843) — Starlette 1.3.1's `testclient` prefers `httpx2` and warns on the `httpx` fallback. Adopted properly rather than suppressed. `httpx` stays pinned alongside it; gradio/gradio_client/safehttpx still import it directly.
- **`install-ort.mjs` success message** (#1844) — it printed `onnxruntime-directml in place` on every successful swap, including the nvidia path where it installs `onnxruntime-gpu`. Since DirectML is disabled (S0.1), it was wrong 100% of the time it printed. `planOrtSwap` now returns the package name so the CLI has one source of truth.

### Explicitly not touched

`torch`/`torchaudio`, `transformers`, `huggingface_hub`, `qwen-tts` — all genuinely upstream-blocked. See #893 for the corrected reasons; the torch blocker in particular is **not** the driver bump originally recorded (this box already runs CUDA 13.3) but that **torchaudio's last release is 2.11.0** while torch has shipped 2.12/2.13.

## Test plan

- Full sidecar suite green throughout: **626 passed, 5 deselected**, at every step and after every fix.
- The two new real-package contract tests **run, not skip**, against the installed kokoro-onnx 0.5.0 — verified explicitly, since a silently-skipping test is the exact failure mode they guard against. The `Parameter.kind` assertion was proven non-vacuous with a keyword-only stand-in class that passes the old name/order check and fails the new one.
- `test_lifespan_order.py` pins both handler sequences against the actually-wired `lifespan_context`, not a hand-maintained duplicate list; proven non-vacuous by four mutations (swap awaits / drop a stop handler / drop the `finally` / drop `lifespan=`), each of which turns it red.
- Fresh-install resolution checked rather than assumed: `pip install --dry-run --ignore-installed` picks starlette 1.3.1 unaided, so a new user does not land fastapi 0.140 against starlette 0.46.2.
- All four accelerator profiles re-checked for coherence. Note macOS resolves `base.txt` + **`nvidia-cuda.txt`** (not `cpu.txt`), which makes the no-`onnxruntime-gpu`-in-overlays invariant more load-bearing than documented; it holds.
- `npm run verify:fast:branch` green on push. One `test:server` run hit the known tinypool worker-exit flake; clean on re-run (433 files, 5282 passed).

Closes #1828
Closes #1829
Closes #1830
Closes #1843
Closes #1844
Refs #893
