### PR TITLE
test(frontend,e2e): close the mock and browser gaps in the clone transcript cap

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -141,7 +141,11 @@ jobs:
           match() { echo "$FILES" | grep -qE "$1"; }
           frontend=false; server=false; sidecar=false
           e2e=false; scripts=false; hooks=false; pinokio=false; shared=false
-          match '^(src/|index\.html$|vite\.config\.ts$|tailwind\.config\.ts$|tsconfig\.json$|tsconfig\.node\.json$|postcss\.config\.js$|eslint\.config\.(js|mjs)$)' && frontend=true
+          # openapi.yaml is a FRONTEND input too, not just a server one: it
+          # generates src/lib/api-types.ts, and api.clone-voice.test.ts pins
+          # the clone-transcript cap against it. Without this an openapi-only
+          # diff skipped the frontend job entirely and that pin never ran.
+          match '^(src/|index\.html$|vite\.config\.ts$|tailwind\.config\.ts$|tsconfig\.json$|tsconfig\.node\.json$|postcss\.config\.js$|eslint\.config\.(js|mjs)$|openapi\.yaml$)' && frontend=true
           match '^(server/src/|server/package(-lock)?\.json$|server/tsconfig\.json$|server/vitest\.config(\.slow)?\.ts$|openapi\.yaml$|server/\.env\.example$|server/scripts/sync-env-example\.ts$)' && server=true
           match '^server/tts-sidecar/' && sidecar=true
           match '^(e2e/|playwright\.config\.ts$)' && e2e=true

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -100,6 +100,7 @@ jobs:
       hooks: ${{ steps.changes.outputs.hooks }}
       pinokio: ${{ steps.changes.outputs.pinokio }}
       shared: ${{ steps.changes.outputs.shared }}
+      openapi: ${{ steps.changes.outputs.openapi }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -114,7 +115,7 @@ jobs:
           # A manual dispatch has no PR base/head to diff against — run the
           # FULL battery (every scope true) and skip the diff logic.
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            for k in frontend server sidecar e2e scripts hooks pinokio shared; do
+            for k in frontend server sidecar e2e scripts hooks pinokio shared openapi; do
               echo "$k=true" >> "$GITHUB_OUTPUT"
               echo "scope $k=true (workflow_dispatch → full run)"
             done
@@ -141,21 +142,26 @@ jobs:
           match() { echo "$FILES" | grep -qE "$1"; }
           frontend=false; server=false; sidecar=false
           e2e=false; scripts=false; hooks=false; pinokio=false; shared=false
-          # openapi.yaml is a FRONTEND input too, not just a server one: it
-          # generates src/lib/api-types.ts, and api.clone-voice.test.ts pins
-          # the clone-transcript cap against it. Without this an openapi-only
-          # diff skipped the frontend job entirely and that pin never ran.
-          match '^(src/|index\.html$|vite\.config\.ts$|tailwind\.config\.ts$|tsconfig\.json$|tsconfig\.node\.json$|postcss\.config\.js$|eslint\.config\.(js|mjs)$|openapi\.yaml$)' && frontend=true
+          openapi=false
+          match '^(src/|index\.html$|vite\.config\.ts$|tailwind\.config\.ts$|tsconfig\.json$|tsconfig\.node\.json$|postcss\.config\.js$|eslint\.config\.(js|mjs)$)' && frontend=true
           match '^(server/src/|server/package(-lock)?\.json$|server/tsconfig\.json$|server/vitest\.config(\.slow)?\.ts$|openapi\.yaml$|server/\.env\.example$|server/scripts/sync-env-example\.ts$)' && server=true
           match '^server/tts-sidecar/' && sidecar=true
           match '^(e2e/|playwright\.config\.ts$)' && e2e=true
           match '^scripts/' && scripts=true
           match '^(\.husky/|scripts/run-hooks-tests\.mjs$|scripts/validate-commit-msg\.mjs$)' && hooks=true
           match '^(pinokio\.js$|pinokio-scripts/|scripts/run-pinokio-tests\.mjs$)' && pinokio=true
+          # openapi.yaml is a frontend input too (it generates
+          # src/lib/api-types.ts, and api.clone-voice.test.ts pins the
+          # clone-transcript cap against it), but its own flag rather than
+          # `frontend=true`: the frontend flag ALSO gates the 4-shard e2e job
+          # and the visual battery, and nothing under e2e/ reads the contract.
+          # Before this, an openapi-only diff matched only the server regex, so
+          # the frontend job was skipped and that pin could never run.
+          match '^openapi\.yaml$' && openapi=true
           # `shared` = a ROOT dependency manifest changed → treat as global
           # (a dep/lockfile bump can affect every leg), so run everything.
           match '^(package\.json|package-lock\.json)$' && shared=true
-          for k in frontend server sidecar e2e scripts hooks pinokio shared; do
+          for k in frontend server sidecar e2e scripts hooks pinokio shared openapi; do
             echo "$k=${!k}" >> "$GITHUB_OUTPUT"
             echo "scope $k=${!k}"
           done
@@ -231,7 +237,7 @@ jobs:
       # default triggers. test:a11y stays always-on as a cheap core-view gate.
       # See docs/features/118-ci-cost-round-2.md.
       - name: Frontend tests + a11y
-        if: needs.detect.outputs.frontend == 'true' || needs.detect.outputs.e2e == 'true' || needs.detect.outputs.shared == 'true'
+        if: needs.detect.outputs.frontend == 'true' || needs.detect.outputs.e2e == 'true' || needs.detect.outputs.shared == 'true' || needs.detect.outputs.openapi == 'true'
         run: |
           BASE="${{ github.event.pull_request.base.sha }}"
           # On a manual dispatch BASE is empty (no PR) → run the full suite.

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -193,6 +193,23 @@ jobs:
         if: needs.detect.outputs.server == 'true' || needs.detect.outputs.shared == 'true'
         run: npm run config:check
 
+      # Drift guard, sibling to the one above: src/lib/api-types.ts is
+      # GENERATED from openapi.yaml and is committed, and openapi-typescript
+      # emits each schema `description` into it as JSDoc. So an openapi edit
+      # that skips `npm run openapi:types` ships a generated artifact whose
+      # prose contradicts its own source — which is exactly what happened on
+      # this PR, undetected, because nothing gated codegen drift. Gated on
+      # `frontend` too, so a hand-edit of the generated file is caught the
+      # same way.
+      - name: OpenAPI types up to date
+        if: needs.detect.outputs.openapi == 'true' || needs.detect.outputs.frontend == 'true' || needs.detect.outputs.shared == 'true'
+        run: |
+          npm run openapi:types
+          git diff --exit-code -- src/lib/api-types.ts || {
+            echo "::error::src/lib/api-types.ts is stale. Run 'npm run openapi:types' and commit the result."
+            exit 1
+          }
+
       - name: Hooks tests
         if: needs.detect.outputs.hooks == 'true' || needs.detect.outputs.scripts == 'true' || needs.detect.outputs.shared == 'true'
         run: npm run test:hooks

--- a/docs/features/267-fs38-wave3-voice-clone.md
+++ b/docs/features/267-fs38-wave3-voice-clone.md
@@ -200,8 +200,9 @@ Umbrella doc: [`194-voice-cloning.md`](194-voice-cloning.md) · fs-38 · [#624](
     `e2e/` must import it into a Node process) — plus `openapi.yaml`'s
     `maxLength`, which is normative but enforces nothing at runtime (no request
     is validated against the schema; the route hand-validates). A test on each
-    side of the wire pins its implementation against that contract. `src/lib/api-types.ts` is not a fourth: openapi-typescript does
-    not encode `maxLength`. #1840 shipped a contract documenting two caps 2×
+    side of the wire pins its implementation against that contract.
+    `src/lib/api-types.ts` is not a fourth: openapi-typescript does not encode
+    `maxLength`. #1840 shipped a contract documenting two caps 2×
     apart because the schema description and the `400` both restated the
     number; both now defer to `maxLength`, so the contract states it exactly
     once and a test asserts that. Descriptive prose elsewhere (this plan, the

--- a/docs/features/267-fs38-wave3-voice-clone.md
+++ b/docs/features/267-fs38-wave3-voice-clone.md
@@ -192,13 +192,20 @@ Umbrella doc: [`194-voice-cloning.md`](194-voice-cloning.md) · fs-38 · [#624](
     ≤8000 base64); a separate byte check would be unreachable at that cap, and
     a test derives the arithmetic from the constant so raising it without
     redoing the sums fails (#1836). **`mockCloneVoice` enforces the same cap**,
-    so mock/e2e mode is never more permissive than the real server on the one
-    rejection the wizard can surface. The number lives in four places — the
-    route's `MAX_CLONE_TRANSCRIPT_CHARS`, the frontend's
-    (`src/lib/clone-transcript-limit.ts`, its own module so a `vi.mock` of
-    `lib/api` can't blank the panel's guard), `openapi.yaml`'s `maxLength`, and
-    the types generated from it — with a test on each side of the wire pinning
-    its copy against the contract.
+    with a message byte-identical to the one `realCloneVoice` builds from the
+    route's JSON body — a prettier mock string would hide a real-mode wart the
+    wizard renders verbatim. The number lives in two implementations plus the
+    contract: the route's `MAX_CLONE_TRANSCRIPT_CHARS`, the frontend's
+    (`src/lib/clone-transcript-limit.ts` — its own module because `e2e/` must
+    import it into a Node process), and `openapi.yaml`'s `maxLength` *and* the
+    byte arithmetic in that schema's description. A test on each side of the
+    wire pins its implementation against the contract, and the frontend one
+    also scans the schema block for any stale number, since #1840 shipped a
+    contract documenting two caps 2× apart. `src/lib/api-types.ts` is not a
+    fourth copy — openapi-typescript does not encode `maxLength`. Note this
+    closes ONE of the route's six documented failure modes in mock mode
+    (400/404/409/422/502/503): the mock still validates neither `candidateId`
+    nor consent, so it stays materially more permissive than the route.
 
 ## Test plan
 
@@ -292,11 +299,19 @@ No new Playwright e2e in 3a — added in 3b1 (below).
   mirrors the real precedence (supplied wins, blank/absent falls back,
   matching text stays `'whisper'`), so mock/e2e mode can't keep reproducing
   the bug the real route fixed. It also mirrors the route's **rejection**:
-  over-cap throws and appends no entry, at-cap is accepted. A fourth test pins
-  `MAX_CLONE_TRANSCRIPT_CHARS` against `openapi.yaml`'s `maxLength` — the
-  frontend-side twin of the server's pin, so the cap can't drift on one side
-  of the wire alone. All three were mutation-checked: raising the constant to
-  6000 fails the pin, and deleting the mock's guard fails the rejection test.
+  over-cap throws the exact message `realCloneVoice` would build (JSON envelope
+  included) and appends no entry; at-cap is accepted (the discriminating
+  mutation being `>` → `>=`). Two further tests pin
+  `MAX_CLONE_TRANSCRIPT_CHARS` against `openapi.yaml` — one on `maxLength`, one
+  scanning the schema block and the clone `400` for stale numbers. Both are the
+  frontend-side twin of the server's pin. Mutation-checked: raising the
+  constant to 6000 fails the pin, deleting the mock's guard fails the rejection
+  test. Both pins read `openapi.yaml` at runtime with no module-graph edge to
+  it, so `openapi.yaml` is registered in both vitest configs'
+  `forceRerunTriggers`, in `verify.yml`'s **frontend** scope regex, and in
+  `verify-cache.mjs`'s `test`/`test:server` inputs — without those four, CI's
+  `vitest --changed` would never select the pins on the openapi-only diff they
+  exist to catch.
 - Playwright (`e2e/voice-library.spec.ts`, step 6) — the clone wizard's
   transcript field in a real browser: the ingested Whisper text lands in the
   box, an over-cap value disables Continue with the reason rendered on screen

--- a/docs/features/267-fs38-wave3-voice-clone.md
+++ b/docs/features/267-fs38-wave3-voice-clone.md
@@ -317,7 +317,15 @@ No new Playwright e2e in 3a — added in 3b1 (below).
   vitest configs' `forceRerunTriggers`, as its own `openapi` scope in
   `verify.yml` (its own flag, not `frontend`, which would also fire the four
   e2e shards and the visual battery for a contract-only change), and in
-  `verify-cache.mjs`'s `test`/`test:server` inputs. Note `forceRerunTriggers`
+  `verify-cache.mjs`'s `test`/`test:server` inputs. A sibling `OpenAPI types
+  up to date` step guards the *other* half: `src/lib/api-types.ts` is
+  generated from `openapi.yaml` and committed, and openapi-typescript emits
+  each schema `description` into it as JSDoc — so editing the contract without
+  re-running `npm run openapi:types` ships a generated artifact whose prose
+  contradicts its source. That happened on this very PR (the removed
+  "Capped at 2000 characters…" paragraph survived in the generated file) and
+  nothing caught it, because codegen drift was ungated. Note
+  `forceRerunTriggers`
   **replaces** vitest's defaults rather than extending them, so both configs
   re-list `**/package.json/**` and `**/{vitest,vite}.config.*/**`. Measured:
   omitting them does not currently collapse a manifest-only server run to zero

--- a/docs/features/267-fs38-wave3-voice-clone.md
+++ b/docs/features/267-fs38-wave3-voice-clone.md
@@ -194,15 +194,18 @@ Umbrella doc: [`194-voice-cloning.md`](194-voice-cloning.md) · fs-38 · [#624](
     redoing the sums fails (#1836). **`mockCloneVoice` enforces the same cap**,
     with a message byte-identical to the one `realCloneVoice` builds from the
     route's JSON body — a prettier mock string would hide a real-mode wart the
-    wizard renders verbatim. The number lives in two implementations plus the
-    contract: the route's `MAX_CLONE_TRANSCRIPT_CHARS`, the frontend's
-    (`src/lib/clone-transcript-limit.ts` — its own module because `e2e/` must
-    import it into a Node process), and `openapi.yaml`'s `maxLength` *and* the
-    byte arithmetic in that schema's description. A test on each side of the
-    wire pins its implementation against the contract, and the frontend one
-    also scans the schema block for any stale number, since #1840 shipped a
-    contract documenting two caps 2× apart. `src/lib/api-types.ts` is not a
-    fourth copy — openapi-typescript does not encode `maxLength`. Note this
+    wizard renders verbatim. Three *enforcing* copies of the number exist —
+    the route's `MAX_CLONE_TRANSCRIPT_CHARS`, the frontend's
+    (`src/lib/clone-transcript-limit.ts`, its own module because `e2e/` must
+    import it into a Node process), and `openapi.yaml`'s `maxLength` — with a
+    test on each side of the wire pinning its implementation against the
+    contract. `src/lib/api-types.ts` is not a fourth: openapi-typescript does
+    not encode `maxLength`. #1840 shipped a contract documenting two caps 2×
+    apart because the schema description and the `400` both restated the
+    number; both now defer to `maxLength`, so the contract states it exactly
+    once and a test asserts that. Descriptive prose elsewhere (this plan, the
+    release notes) still cites the value and is deliberately not pinned. Note
+    this
     closes ONE of the route's six documented failure modes in mock mode
     (400/404/409/422/502/503): the mock still validates neither `candidateId`
     nor consent, so it stays materially more permissive than the route.
@@ -302,16 +305,25 @@ No new Playwright e2e in 3a — added in 3b1 (below).
   over-cap throws the exact message `realCloneVoice` would build (JSON envelope
   included) and appends no entry; at-cap is accepted (the discriminating
   mutation being `>` → `>=`). Two further tests pin
-  `MAX_CLONE_TRANSCRIPT_CHARS` against `openapi.yaml` — one on `maxLength`, one
-  scanning the schema block and the clone `400` for stale numbers. Both are the
-  frontend-side twin of the server's pin. Mutation-checked: raising the
-  constant to 6000 fails the pin, deleting the mock's guard fails the rejection
-  test. Both pins read `openapi.yaml` at runtime with no module-graph edge to
-  it, so `openapi.yaml` is registered in both vitest configs'
-  `forceRerunTriggers`, in `verify.yml`'s **frontend** scope regex, and in
-  `verify-cache.mjs`'s `test`/`test:server` inputs — without those four, CI's
-  `vitest --changed` would never select the pins on the openapi-only diff they
-  exist to catch.
+  `MAX_CLONE_TRANSCRIPT_CHARS` against `openapi.yaml`: one on `maxLength`, one
+  asserting the schema states the number exactly *once* so that first pin
+  covers the whole contract. Both are the frontend-side twin of the server's
+  pin. Mutation-checked: raising the constant to 6000 fails the pin, deleting
+  the mock's guard fails the rejection test.
+- **The pins only run because CI was taught about them.** Both read
+  `openapi.yaml` at runtime, so neither has a module-graph edge to it and
+  `vitest --changed` — what CI runs — selected *zero* files on an openapi-only
+  diff (measured, both ways). `openapi.yaml` is therefore registered in both
+  vitest configs' `forceRerunTriggers`, as its own `openapi` scope in
+  `verify.yml` (its own flag, not `frontend`, which would also fire the four
+  e2e shards and the visual battery for a contract-only change), and in
+  `verify-cache.mjs`'s `test`/`test:server` inputs. Note `forceRerunTriggers`
+  **replaces** vitest's defaults rather than extending them, so both configs
+  re-list `**/package.json/**` and `**/{vitest,vite}.config.*/**`. Measured:
+  omitting them does not currently collapse a manifest-only server run to zero
+  tests — vitest full-runs when the changed set falls outside the project root
+  — but leaning on that fallback to cover a documented default is how a gate
+  quietly stops gating, so they stay listed.
 - Playwright (`e2e/voice-library.spec.ts`, step 6) — the clone wizard's
   transcript field in a real browser: the ingested Whisper text lands in the
   box, an over-cap value disables Continue with the reason rendered on screen

--- a/docs/features/267-fs38-wave3-voice-clone.md
+++ b/docs/features/267-fs38-wave3-voice-clone.md
@@ -194,12 +194,13 @@ Umbrella doc: [`194-voice-cloning.md`](194-voice-cloning.md) · fs-38 · [#624](
     redoing the sums fails (#1836). **`mockCloneVoice` enforces the same cap**,
     with a message byte-identical to the one `realCloneVoice` builds from the
     route's JSON body — a prettier mock string would hide a real-mode wart the
-    wizard renders verbatim. Three *enforcing* copies of the number exist —
-    the route's `MAX_CLONE_TRANSCRIPT_CHARS`, the frontend's
-    (`src/lib/clone-transcript-limit.ts`, its own module because `e2e/` must
-    import it into a Node process), and `openapi.yaml`'s `maxLength` — with a
-    test on each side of the wire pinning its implementation against the
-    contract. `src/lib/api-types.ts` is not a fourth: openapi-typescript does
+    wizard renders verbatim. The number exists in three places: two that
+    actually enforce it — the route's `MAX_CLONE_TRANSCRIPT_CHARS` and the
+    frontend's (`src/lib/clone-transcript-limit.ts`, its own module because
+    `e2e/` must import it into a Node process) — plus `openapi.yaml`'s
+    `maxLength`, which is normative but enforces nothing at runtime (no request
+    is validated against the schema; the route hand-validates). A test on each
+    side of the wire pins its implementation against that contract. `src/lib/api-types.ts` is not a fourth: openapi-typescript does
     not encode `maxLength`. #1840 shipped a contract documenting two caps 2×
     apart because the schema description and the `400` both restated the
     number; both now defer to `maxLength`, so the contract states it exactly
@@ -327,11 +328,11 @@ No new Playwright e2e in 3a — added in 3b1 (below).
   nothing caught it, because codegen drift was ungated. Note
   `forceRerunTriggers`
   **replaces** vitest's defaults rather than extending them, so both configs
-  re-list `**/package.json/**` and `**/{vitest,vite}.config.*/**`. Measured:
-  omitting them does not currently collapse a manifest-only server run to zero
-  tests — vitest full-runs when the changed set falls outside the project root
-  — but leaning on that fallback to cover a documented default is how a gate
-  quietly stops gating, so they stay listed.
+  re-list `**/package.json/**` and `**/{vitest,vite}.config.*/**`. That is
+  load-bearing, measured on a clean tree: with them stripped, a root-manifest
+  diff makes `cd server && vitest run --changed` report *"No test files found"*
+  and exit 0 — so a release-cut version bump would run zero server tests and
+  report green — while the same diff with them restored selects 5389.
 - Playwright (`e2e/voice-library.spec.ts`, step 6) — the clone wizard's
   transcript field in a real browser: the ingested Whisper text lands in the
   box, an over-cap value disables Continue with the reason rendered on screen

--- a/docs/features/267-fs38-wave3-voice-clone.md
+++ b/docs/features/267-fs38-wave3-voice-clone.md
@@ -191,7 +191,14 @@ Umbrella doc: [`194-voice-cloning.md`](194-voice-cloning.md) · fs-38 · [#624](
     multi-byte scripts (worst case 3 bytes per UTF-16 unit → ≤6000 bytes →
     ≤8000 base64); a separate byte check would be unreachable at that cap, and
     a test derives the arithmetic from the constant so raising it without
-    redoing the sums fails (#1836).
+    redoing the sums fails (#1836). **`mockCloneVoice` enforces the same cap**,
+    so mock/e2e mode is never more permissive than the real server on the one
+    rejection the wizard can surface. The number lives in four places — the
+    route's `MAX_CLONE_TRANSCRIPT_CHARS`, the frontend's
+    (`src/lib/clone-transcript-limit.ts`, its own module so a `vi.mock` of
+    `lib/api` can't blank the panel's guard), `openapi.yaml`'s `maxLength`, and
+    the types generated from it — with a test on each side of the wire pinning
+    its copy against the contract.
 
 ## Test plan
 
@@ -284,7 +291,20 @@ No new Playwright e2e in 3a — added in 3b1 (below).
 - Vitest frontend (`src/lib/api.clone-voice.test.ts`) — `mockCloneVoice`
   mirrors the real precedence (supplied wins, blank/absent falls back,
   matching text stays `'whisper'`), so mock/e2e mode can't keep reproducing
-  the bug the real route fixed.
+  the bug the real route fixed. It also mirrors the route's **rejection**:
+  over-cap throws and appends no entry, at-cap is accepted. A fourth test pins
+  `MAX_CLONE_TRANSCRIPT_CHARS` against `openapi.yaml`'s `maxLength` — the
+  frontend-side twin of the server's pin, so the cap can't drift on one side
+  of the wire alone. All three were mutation-checked: raising the constant to
+  6000 fails the pin, and deleting the mock's guard fails the rejection test.
+- Playwright (`e2e/voice-library.spec.ts`, step 6) — the clone wizard's
+  transcript field in a real browser: the ingested Whisper text lands in the
+  box, an over-cap value disables Continue with the reason rendered on screen
+  *and leaves the full text intact* for trimming, and a corrected value
+  re-enables it. jsdom can't attest that the message renders beside the field
+  the user has to fix. The assertion that the corrected text reaches the wire
+  stays in Vitest — no view renders `sampleTranscript`, so there is nothing
+  for the browser to observe without adding UI purely for the test.
 - Vitest server (`server/src/tts/synthesise-chapter-cloned-exemption.test.ts`)
   — `applyQwenFallback` raises `UnresolvableClonedVoiceError` for a cloned
   Qwen-routed character when Qwen is unavailable, and leaves every other

--- a/e2e/voice-library.spec.ts
+++ b/e2e/voice-library.spec.ts
@@ -248,10 +248,12 @@ test.describe('Voice library — create / assign / cross-book reuse / promote', 
     /* #1836 — the transcript box, which this spec previously walked straight
        past. The mock ingest's canned "Whisper" text lands in an editable
        field; waiting on its value also gates on ingest having resolved. */
-    /* getByRole, not getByLabel. Observed, not assumed: getByLabel('transcript')
-       failed here with "Not an input element" — despite the textarea carrying
-       aria-label="transcript" — so it resolved to the wrapping <label> (which
-       also holds the over-cap message) rather than the control. */
+    /* getByRole, not getByLabel. The only claim made here is the observation:
+       getByLabel('transcript') failed in this spec with "Not an input
+       element", despite the textarea carrying aria-label="transcript". Why is
+       undiagnosed — Playwright's `retarget(…, 'follow-label')` should have
+       followed the wrapping <label> to its control — so no mechanism is
+       asserted. getByRole works and is unambiguous here. */
     const transcriptBox = page.getByRole('textbox', { name: 'transcript' });
     await expect(transcriptBox).toHaveValue('the quick brown fox jumped', { timeout: 10_000 });
 

--- a/e2e/voice-library.spec.ts
+++ b/e2e/voice-library.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from '@playwright/test';
 import { waitForRouteReady } from './helpers';
+/* The one src import in the e2e suite: the clone-transcript cap is already
+   duplicated across the panel, the route, and openapi.yaml, and a fourth
+   hardcoded copy here would fail this spec on any legitimate cap change.
+   `clone-transcript-limit.ts` is a zero-dependency constant module. */
+import { MAX_CLONE_TRANSCRIPT_CHARS } from '../src/lib/clone-transcript-limit';
 
 /**
  * fs-38 Wave 1, Task 17 — Voice library golden path (create / assign /
@@ -239,10 +244,43 @@ test.describe('Voice library — create / assign / cross-book reuse / promote', 
       mimeType: 'audio/wav',
       buffer: Buffer.from('RIFFfake-wav-bytes-for-mock-ingest'),
     });
+
+    /* #1836 — the transcript box, which this spec previously walked straight
+       past. The mock ingest's canned "Whisper" text lands in an editable
+       field; waiting on its value also gates on ingest having resolved. */
+    /* getByRole, not getByLabel: the textarea sits inside a wrapping <label>
+       that also holds the over-cap message, and getByLabel resolves to that
+       wrapper ("Not an input element") rather than the control. */
+    const transcriptBox = page.getByRole('textbox', { name: 'transcript' });
+    await expect(transcriptBox).toHaveValue('the quick brown fox jumped', { timeout: 10_000 });
+
     await page.getByLabel('person name').fill('Mum');
     await page.getByLabel('relationship').selectOption('family-with-permission');
     await page.getByLabel('I attest').check();
-    await page.getByRole('button', { name: 'Continue' }).click();
+    const continueBtn = page.getByRole('button', { name: 'Continue' });
+    await expect(continueBtn).toBeEnabled();
+
+    /* Over the cap → Continue is blocked with the reason on screen, in the
+       phase where the field is still editable. jsdom can't tell you that the
+       message actually renders next to the box the user has to fix, nor that
+       the over-length text survives intact for trimming (the textarea carries
+       no `maxLength`, so nothing is silently cut). After Continue the panel
+       unmounts, which is why the gate can't live on the server 400 alone. */
+    const overCap = 'x'.repeat(MAX_CLONE_TRANSCRIPT_CHARS + 1);
+    await transcriptBox.fill(overCap);
+    await expect(continueBtn).toBeDisabled();
+    await expect(page.getByText(/transcript is too long/i)).toBeVisible();
+    await expect(transcriptBox).toHaveValue(overCap);
+
+    /* Correct the transcript instead — the edit #1836 used to discard. The
+       assertion that this text reaches the wire stays in Vitest
+       (api.clone-voice.test.ts / clone-voice-wizard.test.tsx): no view
+       renders `sampleTranscript`, so there is nothing for the browser to
+       observe here without adding UI purely for the test. */
+    await transcriptBox.fill('the quick brown fox jumped over Thea');
+    await expect(page.getByText(/transcript is too long/i)).toHaveCount(0);
+    await expect(continueBtn).toBeEnabled();
+    await continueBtn.click();
 
     // Phase 2: name + Save.
     await page.getByTestId('clone-voice-wizard-name').fill('E2E Mum');

--- a/e2e/voice-library.spec.ts
+++ b/e2e/voice-library.spec.ts
@@ -248,9 +248,10 @@ test.describe('Voice library — create / assign / cross-book reuse / promote', 
     /* #1836 — the transcript box, which this spec previously walked straight
        past. The mock ingest's canned "Whisper" text lands in an editable
        field; waiting on its value also gates on ingest having resolved. */
-    /* getByRole, not getByLabel: the textarea sits inside a wrapping <label>
-       that also holds the over-cap message, and getByLabel resolves to that
-       wrapper ("Not an input element") rather than the control. */
+    /* getByRole, not getByLabel. Observed, not assumed: getByLabel('transcript')
+       failed here with "Not an input element" — despite the textarea carrying
+       aria-label="transcript" — so it resolved to the wrapping <label> (which
+       also holds the over-cap message) rather than the control. */
     const transcriptBox = page.getByRole('textbox', { name: 'transcript' });
     await expect(transcriptBox).toHaveValue('the quick brown fox jumped', { timeout: 10_000 });
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5123,14 +5123,18 @@ components:
             falls back to the stored transcript (which may itself legitimately
             be empty for a non-speech clip).
 
-            Capped at 2000 characters — a sanity bound, already far above any
-            real transcript of the ≤60 s sample clip. The limit is enforced in
-            characters only; it is set at 2000 so that the value stays bounded
-            in BYTES too, since it reaches the sidecar as a base64 `X-Ref-Text`
-            header and base64 applies to UTF-8 bytes rather than characters.
-            No UTF-16 string of 2000 units exceeds 6000 UTF-8 bytes (8000
-            base64), so the character limit is the only one needed. Over-length
-            is a 400, never a silent truncation.
+            Bounded by `maxLength` above — a sanity limit, already far above
+            any real transcript of the ≤60 s sample clip. It is expressed in
+            characters only, and sized so the value stays bounded in BYTES too:
+            the text reaches the sidecar as a base64 `X-Ref-Text` header, and
+            base64 applies to UTF-8 bytes rather than characters. Worst case is
+            3 UTF-8 bytes per UTF-16 unit, then 4/3 again for base64, so
+            `maxLength` implies the byte bound and no separate byte check is
+            needed. Over-length is a 400, never a silent truncation.
+
+            The number itself appears ONCE, in `maxLength`. Restating it in
+            prose is how this schema previously came to document two different
+            caps at the same time (#1836).
         consent:
           type: object
           required: [personName, relationship, permittedUse]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3223,7 +3223,7 @@ paths:
             schema: { $ref: '#/components/schemas/CloneVoiceRequest' }
       responses:
         '200': { description: Cloned voice created, content: { application/json: { schema: { $ref: '#/components/schemas/VoiceLibraryEntry' } } } }
-        '400': { description: Missing candidateId, or a transcript longer than 2000 characters }
+        '400': { description: Missing candidateId, or a transcript longer than the CloneVoiceRequest transcript maxLength }
         '404': { description: No such candidate / voice library disabled }
         '409': { description: A clone for this candidate is already running }
         '422': { description: Consent is absent or structurally invalid }

--- a/scripts/verify-cache.mjs
+++ b/scripts/verify-cache.mjs
@@ -71,6 +71,10 @@ export const STEPS = [
         'tailwind.config.ts',
         'postcss.config.js',
         'index.html',
+        /* api.clone-voice.test.ts pins the clone-transcript cap against the
+           contract, so an openapi-only edit must bust this step's cache —
+           otherwise the local run reports [cached] and the pin never fires. */
+        'openapi.yaml',
       ],
       includeLockfiles: ['root'],
     },
@@ -79,7 +83,9 @@ export const STEPS = [
     name: 'test:server',
     inputs: {
       globs: ['server/src/**'],
-      extraFiles: ['server/vitest.config.ts', 'server/tsconfig.json'],
+      /* openapi.yaml: voice-library.test.ts pins the clone-transcript cap
+         against it (see the `test` step above for the same reasoning). */
+      extraFiles: ['server/vitest.config.ts', 'server/tsconfig.json', 'openapi.yaml'],
       includeLockfiles: ['server'],
     },
   },

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -81,11 +81,23 @@ export default defineConfig({
     ],
     testTimeout: 15_000,
     hookTimeout: 30_000,
-    /* voice-library.test.ts pins MAX_CLONE_TRANSCRIPT_CHARS against
-       openapi.yaml by reading the file at RUNTIME — no module-graph edge, so
-       `vitest --changed` (what CI runs) would skip it on the openapi-only diff
-       it exists to catch. Mirrors the root vitest.config.ts trigger. */
-    forceRerunTriggers: ['**/openapi.yaml/**'],
+    /* Setting this key REPLACES vitest's defaults rather than extending them,
+       so the first two entries re-list them — same note the root
+       vitest.config.ts has always carried. (Measured: dropping them does NOT
+       currently collapse a manifest-only run to zero tests — vitest full-runs
+       when the changed set falls outside the project root, which `cd server`
+       makes true for most of this repo. Re-listed anyway: relying on that
+       fallback to cover a documented default is how a gate quietly stops
+       gating.)
+       openapi.yaml: voice-library.test.ts pins MAX_CLONE_TRANSCRIPT_CHARS
+       against it by reading the file at RUNTIME — no module-graph edge, so
+       `--changed` would otherwise skip the pin on the openapi-only diff it
+       exists to catch. */
+    forceRerunTriggers: [
+      '**/package.json/**',
+      '**/{vitest,vite}.config.*/**',
+      '**/openapi.yaml/**',
+    ],
     pool: 'forks',
     /* Vitest 4 removed `poolOptions`; `poolOptions.forks.maxForks` is now the
        top-level `maxWorkers` (and `minForks` was dropped). `pool: 'forks'`

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -83,12 +83,13 @@ export default defineConfig({
     hookTimeout: 30_000,
     /* Setting this key REPLACES vitest's defaults rather than extending them,
        so the first two entries re-list them — same note the root
-       vitest.config.ts has always carried. (Measured: dropping them does NOT
-       currently collapse a manifest-only run to zero tests — vitest full-runs
-       when the changed set falls outside the project root, which `cd server`
-       makes true for most of this repo. Re-listed anyway: relying on that
-       fallback to cover a documented default is how a gate quietly stops
-       gating.)
+       vitest.config.ts has always carried. This is load-bearing, measured on a
+       clean tree: with them stripped, a root-manifest diff makes `cd server &&
+       vitest run --changed` report "No test files found" and exit 0 — a
+       release-cut version bump would run ZERO server tests and show green.
+       With them restored the same diff selects 5389. (An earlier run here
+       appeared to contradict that; it was measuring a dirty tree whose other
+       modified files matched the openapi trigger below.)
        openapi.yaml: voice-library.test.ts pins MAX_CLONE_TRANSCRIPT_CHARS
        against it by reading the file at RUNTIME — no module-graph edge, so
        `--changed` would otherwise skip the pin on the openapi-only diff it

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -81,6 +81,11 @@ export default defineConfig({
     ],
     testTimeout: 15_000,
     hookTimeout: 30_000,
+    /* voice-library.test.ts pins MAX_CLONE_TRANSCRIPT_CHARS against
+       openapi.yaml by reading the file at RUNTIME — no module-graph edge, so
+       `vitest --changed` (what CI runs) would skip it on the openapi-only diff
+       it exists to catch. Mirrors the root vitest.config.ts trigger. */
+    forceRerunTriggers: ['**/openapi.yaml/**'],
     pool: 'forks',
     /* Vitest 4 removed `poolOptions`; `poolOptions.forks.maxForks` is now the
        top-level `maxWorkers` (and `minForks` was dropped). `pool: 'forks'`

--- a/src/components/voices/clone-capture-panel.test.tsx
+++ b/src/components/voices/clone-capture-panel.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { configureStore } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
 import { voiceLibrarySlice } from '../../store/voice-library-slice';
+import { MAX_CLONE_TRANSCRIPT_CHARS } from '../../lib/clone-transcript-limit';
 import { CloneCapturePanel } from './clone-capture-panel';
 
 const cloneVoiceSample = vi.fn().mockResolvedValue({ candidateId: 'cand-1', transcript: 'hi there', durationSeconds: 9, sampleRate: 24_000, qualityWarnings: [] });
@@ -81,17 +82,22 @@ describe('CloneCapturePanel', () => {
     const cont = () => screen.getByRole('button', { name: /continue/i });
     await waitFor(() => expect(cont()).toBeEnabled());
 
+    /* Derived from the constant, not from a literal: a literal would keep
+       passing if the panel's cap drifted away from the contract's. */
+    const atCap = 'x'.repeat(MAX_CLONE_TRANSCRIPT_CHARS);
+    const overCap = 'x'.repeat(MAX_CLONE_TRANSCRIPT_CHARS + 1);
+
     // Over the cap → blocked, with the reason on screen rather than a silent cut.
-    fireEvent.change(screen.getByLabelText('transcript'), { target: { value: 'x'.repeat(2001) } });
+    fireEvent.change(screen.getByLabelText('transcript'), { target: { value: overCap } });
     await waitFor(() => expect(cont()).toBeDisabled());
     expect(screen.getByText(/too long/i)).toBeInTheDocument();
     fireEvent.click(cont());
     expect(onReady).not.toHaveBeenCalled();
 
     // Trimming to the cap unblocks it, with the full text preserved.
-    fireEvent.change(screen.getByLabelText('transcript'), { target: { value: 'x'.repeat(2000) } });
+    fireEvent.change(screen.getByLabelText('transcript'), { target: { value: atCap } });
     await waitFor(() => expect(cont()).toBeEnabled());
     fireEvent.click(cont());
-    expect(onReady).toHaveBeenCalledWith(expect.objectContaining({ transcript: 'x'.repeat(2000) }));
+    expect(onReady).toHaveBeenCalledWith(expect.objectContaining({ transcript: atCap }));
   });
 });

--- a/src/components/voices/clone-capture-panel.tsx
+++ b/src/components/voices/clone-capture-panel.tsx
@@ -1,11 +1,8 @@
 import { useState } from 'react';
 import { useAppDispatch } from '../../store';
 import { cloneSample } from '../../store/voice-library-slice';
+import { MAX_CLONE_TRANSCRIPT_CHARS } from '../../lib/clone-transcript-limit';
 import { VoiceRecorder } from './voice-recorder';
-
-/** Keep in step with `CloneVoiceRequest.transcript`'s `maxLength` in
- *  openapi.yaml and `MAX_CLONE_TRANSCRIPT_CHARS` in the clone route. */
-const MAX_TRANSCRIPT_CHARS = 2000;
 
 type Relationship = 'self' | 'family-with-permission' | 'guardian-of-minor';
 export interface ConsentDraft { personName: string; relationship: Relationship; permittedUse: 'personal'; }
@@ -34,14 +31,13 @@ export function CloneCapturePanel({ onReady }: { onReady: (r: { candidateId: str
     finally { setBusy(false); }
   }
 
-  /* Mirrors CloneVoiceRequest.transcript's maxLength / the route's
-     MAX_CLONE_TRANSCRIPT_CHARS (#1836). Deliberately NOT a textarea
-     `maxLength`: the browser would silently drop the tail of a long paste,
-     and a half-a-correction is exactly the silent discard this fixes. Caught
-     here instead, while the field is still on screen and editable — after
-     Continue the panel unmounts, so a server 400 would leave nowhere to fix
-     it. The route still enforces the same cap for non-UI callers. */
-  const transcriptTooLong = transcript.length > MAX_TRANSCRIPT_CHARS;
+  /* #1836 — deliberately NOT a textarea `maxLength`: the browser would
+     silently drop the tail of a long paste, and half a correction is exactly
+     the silent discard this fixes. Caught here instead, while the field is
+     still on screen and editable — after Continue the panel unmounts, so a
+     server 400 would leave nowhere to fix it. The route (and the mock) still
+     enforce the same cap for non-UI callers. */
+  const transcriptTooLong = transcript.length > MAX_CLONE_TRANSCRIPT_CHARS;
   const consentComplete = personName.trim().length > 0 && attested;
   const canContinue = !!candidateId && consentComplete && !busy && !transcriptTooLong;
 
@@ -64,7 +60,7 @@ export function CloneCapturePanel({ onReady }: { onReady: (r: { candidateId: str
           {transcriptTooLong && (
             <p className="text-magenta text-xs">
               That transcript is too long — {transcript.length.toLocaleString()} characters, and the
-              limit is {MAX_TRANSCRIPT_CHARS.toLocaleString()}. Trim it to continue.
+              limit is {MAX_CLONE_TRANSCRIPT_CHARS.toLocaleString()}. Trim it to continue.
             </p>
           )}
         </label>

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -3914,14 +3914,18 @@ export interface components {
              *     falls back to the stored transcript (which may itself legitimately
              *     be empty for a non-speech clip).
              *
-             *     Capped at 2000 characters — a sanity bound, already far above any
-             *     real transcript of the ≤60 s sample clip. The limit is enforced in
-             *     characters only; it is set at 2000 so that the value stays bounded
-             *     in BYTES too, since it reaches the sidecar as a base64 `X-Ref-Text`
-             *     header and base64 applies to UTF-8 bytes rather than characters.
-             *     No UTF-16 string of 2000 units exceeds 6000 UTF-8 bytes (8000
-             *     base64), so the character limit is the only one needed. Over-length
-             *     is a 400, never a silent truncation.
+             *     Bounded by `maxLength` above — a sanity limit, already far above
+             *     any real transcript of the ≤60 s sample clip. It is expressed in
+             *     characters only, and sized so the value stays bounded in BYTES too:
+             *     the text reaches the sidecar as a base64 `X-Ref-Text` header, and
+             *     base64 applies to UTF-8 bytes rather than characters. Worst case is
+             *     3 UTF-8 bytes per UTF-16 unit, then 4/3 again for base64, so
+             *     `maxLength` implies the byte bound and no separate byte check is
+             *     needed. Over-length is a 400, never a silent truncation.
+             *
+             *     The number itself appears ONCE, in `maxLength`. Restating it in
+             *     prose is how this schema previously came to document two different
+             *     caps at the same time (#1836).
              */
             transcript?: string;
             consent: {

--- a/src/lib/api.clone-voice.test.ts
+++ b/src/lib/api.clone-voice.test.ts
@@ -67,13 +67,20 @@ describe('mockCloneVoice', () => {
      would only ever appear against a real backend. */
   it('rejects an over-length transcript the way the route does', async () => {
     const before = (await mockListVoiceLibrary()).voices.length;
+    /* The exact string realCloneVoice would build: it interpolates
+       `await res.text()` and the route replies `res.status(400).json({ error })`,
+       so the JSON envelope is part of the message. Pinned in full, because
+       a mock that renders a *prettier* error than production hides a real
+       wart the wizard shows verbatim — and no test could catch it. */
     await expect(
       mockCloneVoice({
         candidateId: 'cand-1',
         transcript: 'x'.repeat(MAX_CLONE_TRANSCRIPT_CHARS + 1),
         consent,
       }),
-    ).rejects.toThrow(/too long/i);
+    ).rejects.toThrow(
+      `Voice clone failed (400): {"error":"Transcript is too long (max ${MAX_CLONE_TRANSCRIPT_CHARS} characters)."}`,
+    );
     /* Rejected outright, not truncated-and-saved — no entry appears. */
     expect((await mockListVoiceLibrary()).voices.length).toBe(before);
   });
@@ -104,5 +111,35 @@ describe('MAX_CLONE_TRANSCRIPT_CHARS', () => {
     const transcriptBlock = yaml.slice(yaml.indexOf('        transcript:', anchor));
     const maxLength = /maxLength:\s*(\d+)/.exec(transcriptBlock)?.[1];
     expect(maxLength).toBe(String(MAX_CLONE_TRANSCRIPT_CHARS));
+  });
+
+  /* `maxLength` is not the only place the contract states the number: the
+     schema description explains the byte arithmetic, and #1840 already shipped
+     a version documenting two caps 2x apart. Pinning `maxLength` alone leaves
+     that prose free to rot, so scan the whole transcript block plus the clone
+     400 for any 4-digit number and require each to be the cap or one of its
+     two derived bounds. Reword-proof in a way phrase-matching wouldn't be. */
+  it('states no stale copy of the cap anywhere in the clone contract', async () => {
+    const { readFile } = await import('node:fs/promises');
+    const { resolve } = await import('node:path');
+    const yaml = await readFile(resolve(process.cwd(), 'openapi.yaml'), 'utf8');
+
+    const schemaAnchor = yaml.indexOf('    CloneVoiceRequest:');
+    const blockStart = yaml.indexOf('        transcript:', schemaAnchor);
+    const blockEnd = yaml.indexOf('        consent:', blockStart);
+    // Fail closed if the schema is renamed or its properties reordered.
+    expect(schemaAnchor).toBeGreaterThan(-1);
+    expect(blockEnd).toBeGreaterThan(blockStart);
+    const fourHundred = /'400': \{ description: Missing candidateId[^}]*\}/.exec(yaml)?.[0];
+    expect(fourHundred).toBeDefined();
+
+    const cap = MAX_CLONE_TRANSCRIPT_CHARS;
+    // The cap itself, its worst-case UTF-8 byte bound (3 bytes per UTF-16
+    // unit), and that bound base64-encoded (4/3). Nothing else belongs here.
+    const allowed = [cap, cap * 3, cap * 4].map(String);
+    const region = `${yaml.slice(blockStart, blockEnd)}\n${fourHundred}`;
+    for (const found of region.match(/\d{4,}/g) ?? []) {
+      expect(allowed).toContain(found);
+    }
   });
 });

--- a/src/lib/api.clone-voice.test.ts
+++ b/src/lib/api.clone-voice.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { mockCloneVoice, _resetMockVoiceLibrary, mockListVoiceLibrary } from './api';
+import { MAX_CLONE_TRANSCRIPT_CHARS } from './clone-transcript-limit';
+
+const consent = { personName: 'Mum', relationship: 'self', permittedUse: 'personal' } as const;
 
 beforeEach(() => _resetMockVoiceLibrary());
 
@@ -56,5 +59,50 @@ describe('mockCloneVoice', () => {
       consent: { personName: 'Mum', relationship: 'self', permittedUse: 'personal' },
     });
     expect(entry.master?.transcriptSource).toBe('whisper');
+  });
+
+  /* #1836 follow-up — the route 400s an over-length transcript. A mock that
+     accepted it would make mock/e2e mode strictly more permissive than the
+     real server on the one rejection the wizard can surface, so the failure
+     would only ever appear against a real backend. */
+  it('rejects an over-length transcript the way the route does', async () => {
+    const before = (await mockListVoiceLibrary()).voices.length;
+    await expect(
+      mockCloneVoice({
+        candidateId: 'cand-1',
+        transcript: 'x'.repeat(MAX_CLONE_TRANSCRIPT_CHARS + 1),
+        consent,
+      }),
+    ).rejects.toThrow(/too long/i);
+    /* Rejected outright, not truncated-and-saved — no entry appears. */
+    expect((await mockListVoiceLibrary()).voices.length).toBe(before);
+  });
+
+  it('accepts a transcript exactly at the cap', async () => {
+    const atCap = 'x'.repeat(MAX_CLONE_TRANSCRIPT_CHARS);
+    const entry = await mockCloneVoice({ candidateId: 'cand-1', transcript: atCap, consent });
+    expect(entry.master?.transcript).toBe(atCap);
+  });
+});
+
+/* The cap exists in four places — this constant, the route's
+   MAX_CLONE_TRANSCRIPT_CHARS, openapi.yaml's CloneVoiceRequest.transcript
+   maxLength, and (generated from that) api-types.ts — tied together only by
+   prose. The server suite pins its copy against the contract; this pins the
+   frontend's, so raising one in isolation fails on both sides of the wire.
+   Asserting against a second literal here would pin nothing. */
+describe('MAX_CLONE_TRANSCRIPT_CHARS', () => {
+  it('agrees with openapi.yaml CloneVoiceRequest.transcript maxLength', async () => {
+    const { readFile } = await import('node:fs/promises');
+    const { resolve } = await import('node:path');
+    /* Not `new URL(..., import.meta.url)`: Vite rewrites import.meta.url to a
+       non-file scheme under jsdom. Vitest runs with cwd at the config root,
+       which is the repo root. */
+    const yaml = await readFile(resolve(process.cwd(), 'openapi.yaml'), 'utf8');
+    const anchor = yaml.indexOf('    CloneVoiceRequest:');
+    expect(anchor).toBeGreaterThan(-1); // fail closed if the schema is renamed
+    const transcriptBlock = yaml.slice(yaml.indexOf('        transcript:', anchor));
+    const maxLength = /maxLength:\s*(\d+)/.exec(transcriptBlock)?.[1];
+    expect(maxLength).toBe(String(MAX_CLONE_TRANSCRIPT_CHARS));
   });
 });

--- a/src/lib/api.clone-voice.test.ts
+++ b/src/lib/api.clone-voice.test.ts
@@ -69,9 +69,11 @@ describe('mockCloneVoice', () => {
     const before = (await mockListVoiceLibrary()).voices.length;
     /* The exact string realCloneVoice would build: it interpolates
        `await res.text()` and the route replies `res.status(400).json({ error })`,
-       so the JSON envelope is part of the message. Pinned in full, because
-       a mock that renders a *prettier* error than production hides a real
-       wart the wizard shows verbatim — and no test could catch it. */
+       so the JSON envelope is part of the message. A mock rendering a
+       *prettier* error than production would hide a real wart the wizard
+       shows verbatim, and no test could catch it. Passed as an Error, not a
+       string — `toThrow('…')` is a SUBSTRING match, which would accept a mock
+       that appended to the message. */
     await expect(
       mockCloneVoice({
         candidateId: 'cand-1',
@@ -79,7 +81,9 @@ describe('mockCloneVoice', () => {
         consent,
       }),
     ).rejects.toThrow(
-      `Voice clone failed (400): {"error":"Transcript is too long (max ${MAX_CLONE_TRANSCRIPT_CHARS} characters)."}`,
+      new Error(
+        `Voice clone failed (400): {"error":"Transcript is too long (max ${MAX_CLONE_TRANSCRIPT_CHARS} characters)."}`,
+      ),
     );
     /* Rejected outright, not truncated-and-saved — no entry appears. */
     expect((await mockListVoiceLibrary()).voices.length).toBe(before);
@@ -92,10 +96,12 @@ describe('mockCloneVoice', () => {
   });
 });
 
-/* The cap exists in four places — this constant, the route's
-   MAX_CLONE_TRANSCRIPT_CHARS, openapi.yaml's CloneVoiceRequest.transcript
-   maxLength, and (generated from that) api-types.ts — tied together only by
-   prose. The server suite pins its copy against the contract; this pins the
+/* The cap exists in three places — this constant, the route's
+   MAX_CLONE_TRANSCRIPT_CHARS, and openapi.yaml's
+   CloneVoiceRequest.transcript.maxLength — tied together only by prose.
+   (api-types.ts is NOT a fourth: openapi-typescript does not encode
+   `maxLength`, so the generated type carries no bound and cannot drift.)
+   The server suite pins its copy against the contract; this pins the
    frontend's, so raising one in isolation fails on both sides of the wire.
    Asserting against a second literal here would pin nothing. */
 describe('MAX_CLONE_TRANSCRIPT_CHARS', () => {
@@ -113,13 +119,15 @@ describe('MAX_CLONE_TRANSCRIPT_CHARS', () => {
     expect(maxLength).toBe(String(MAX_CLONE_TRANSCRIPT_CHARS));
   });
 
-  /* `maxLength` is not the only place the contract states the number: the
-     schema description explains the byte arithmetic, and #1840 already shipped
-     a version documenting two caps 2x apart. Pinning `maxLength` alone leaves
-     that prose free to rot, so scan the whole transcript block plus the clone
-     400 for any 4-digit number and require each to be the cap or one of its
-     two derived bounds. Reword-proof in a way phrase-matching wouldn't be. */
-  it('states no stale copy of the cap anywhere in the clone contract', async () => {
+  /* #1840 shipped a contract documenting two caps 2x apart, because the
+     schema description and the 400 both restated the number. The durable fix
+     was to delete those restatements rather than to pin them: `maxLength` is
+     now the only place the contract states it, so the single pin above covers
+     the whole contract. A prose-scanning test was tried here and removed —
+     it could not tell a stale `200` from a deliberate one, treated the byte
+     and base64 bounds as interchangeable, and false-positived on an issue
+     reference like (#1836). Fewer numbers beats a cleverer test. */
+  it('states the cap only once, so the pin above covers the whole contract', async () => {
     const { readFile } = await import('node:fs/promises');
     const { resolve } = await import('node:path');
     const yaml = await readFile(resolve(process.cwd(), 'openapi.yaml'), 'utf8');
@@ -127,19 +135,19 @@ describe('MAX_CLONE_TRANSCRIPT_CHARS', () => {
     const schemaAnchor = yaml.indexOf('    CloneVoiceRequest:');
     const blockStart = yaml.indexOf('        transcript:', schemaAnchor);
     const blockEnd = yaml.indexOf('        consent:', blockStart);
-    // Fail closed if the schema is renamed or its properties reordered.
+    /* Fail closed if the schema is renamed or its properties reordered.
+       blockStart needs its own guard: indexOf clamps a -1 fromIndex to 0, so
+       blockEnd would resolve against a DIFFERENT schema's `consent:` and the
+       slice would silently collapse to empty. */
     expect(schemaAnchor).toBeGreaterThan(-1);
+    expect(blockStart).toBeGreaterThan(-1);
     expect(blockEnd).toBeGreaterThan(blockStart);
-    const fourHundred = /'400': \{ description: Missing candidateId[^}]*\}/.exec(yaml)?.[0];
-    expect(fourHundred).toBeDefined();
 
-    const cap = MAX_CLONE_TRANSCRIPT_CHARS;
-    // The cap itself, its worst-case UTF-8 byte bound (3 bytes per UTF-16
-    // unit), and that bound base64-encoded (4/3). Nothing else belongs here.
-    const allowed = [cap, cap * 3, cap * 4].map(String);
-    const region = `${yaml.slice(blockStart, blockEnd)}\n${fourHundred}`;
-    for (const found of region.match(/\d{4,}/g) ?? []) {
-      expect(allowed).toContain(found);
-    }
+    const block = yaml.slice(blockStart, blockEnd);
+    expect(block).toContain('base64'); // the slice really is the transcript block
+    /* Exactly one occurrence, and it is the maxLength the test above pins. */
+    const occurrences = block.match(new RegExp(String(MAX_CLONE_TRANSCRIPT_CHARS), 'g')) ?? [];
+    expect(occurrences).toHaveLength(1);
+    expect(block).toContain(`maxLength: ${MAX_CLONE_TRANSCRIPT_CHARS}`);
   });
 });

--- a/src/lib/api.clone-voice.test.ts
+++ b/src/lib/api.clone-voice.test.ts
@@ -94,6 +94,18 @@ describe('mockCloneVoice', () => {
     const entry = await mockCloneVoice({ candidateId: 'cand-1', transcript: atCap, consent });
     expect(entry.master?.transcript).toBe(atCap);
   });
+
+  /* The route pins the same fallback ("ignores a non-string transcript"), so
+     the mock has to survive it rather than TypeError on `.trim()`. */
+  it('ignores a non-string transcript the way the route does', async () => {
+    const entry = await mockCloneVoice({
+      candidateId: 'cand-1',
+      transcript: 42 as unknown as string,
+      consent,
+    });
+    expect(entry.master?.transcript).toBe('the quick brown fox jumped');
+    expect(entry.master?.transcriptSource).toBe('whisper');
+  });
 });
 
 /* The cap exists in three places — this constant, the route's
@@ -113,8 +125,18 @@ describe('MAX_CLONE_TRANSCRIPT_CHARS', () => {
        which is the repo root. */
     const yaml = await readFile(resolve(process.cwd(), 'openapi.yaml'), 'utf8');
     const anchor = yaml.indexOf('    CloneVoiceRequest:');
-    expect(anchor).toBeGreaterThan(-1); // fail closed if the schema is renamed
-    const transcriptBlock = yaml.slice(yaml.indexOf('        transcript:', anchor));
+    const blockStart = yaml.indexOf('        transcript:', anchor);
+    const blockEnd = yaml.indexOf('        consent:', blockStart);
+    /* Fail closed if the schema is renamed or its properties reordered — and
+       BOUND the slice at the next property. Slicing to EOF would let a
+       `maxLength` from any later schema satisfy this test if transcript's own
+       were deleted; it only fails today because transcript's happens to be the
+       file's last one. `maxLength: 2000` already appears elsewhere (an
+       unrelated `path` field), so that coincidence is not load-bearing. */
+    expect(anchor).toBeGreaterThan(-1);
+    expect(blockStart).toBeGreaterThan(-1);
+    expect(blockEnd).toBeGreaterThan(blockStart);
+    const transcriptBlock = yaml.slice(blockStart, blockEnd);
     const maxLength = /maxLength:\s*(\d+)/.exec(transcriptBlock)?.[1];
     expect(maxLength).toBe(String(MAX_CLONE_TRANSCRIPT_CHARS));
   });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -9791,7 +9791,11 @@ export async function mockCloneVoice(body: CloneVoiceBody): Promise<VoiceLibrary
   /* #1836 — mirror the real route: a supplied non-blank transcript wins over
      the canned Whisper text and flips transcriptSource to 'user'. Without
      this the mock keeps reproducing the very bug the real path just fixed. */
-  const supplied = body.transcript?.trim() ?? '';
+  /* typeof-narrowed like the guard above and like the route, which pins
+     "ignores a non-string transcript and falls back to the Whisper text".
+     `body.transcript?.trim()` alone would TypeError in the mock on a truthy
+     non-string, where the real route 200s. */
+  const supplied = typeof body.transcript === 'string' ? body.transcript.trim() : '';
   const transcript = supplied || MOCK_WHISPER_TRANSCRIPT;
   const entry: VoiceLibraryEntry = {
     voiceUuid: `lib-clone-${Math.random().toString(36).slice(2, 10)}`,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -62,6 +62,7 @@ import type {
 import type { components as ApiComponents } from './api-types';
 import { type DesignPhase, DESIGN_PHASE_ORDER } from './design-phase';
 import { FRONTEND_ACCOUNT_DEFAULTS } from './account-defaults';
+import { MAX_CLONE_TRANSCRIPT_CHARS } from './clone-transcript-limit';
 import { initialCharacters } from '../data/characters';
 import { initialSentences } from '../data/sentences';
 import { ANALYSIS_NORTHERN_STAR } from '../mocks/canned-data';
@@ -9772,6 +9773,16 @@ export async function mockCloneVoiceSample(_form: FormData): Promise<CloneSample
 
 export async function mockCloneVoice(body: CloneVoiceBody): Promise<VoiceLibraryEntry> {
   await wait(300);
+  /* #1836 — mirror the route's 400 on an over-length transcript. Without it
+     mock mode accepts what the real server rejects, so the one rejection path
+     the wizard can surface is unreachable in mock/e2e. Message shape matches
+     realCloneVoice's (`Voice clone failed (<status>): <body>`), since the
+     wizard renders it verbatim. */
+  if (typeof body.transcript === 'string' && body.transcript.length > MAX_CLONE_TRANSCRIPT_CHARS) {
+    throw new Error(
+      `Voice clone failed (400): Transcript is too long (max ${MAX_CLONE_TRANSCRIPT_CHARS} characters).`,
+    );
+  }
   const now = new Date().toISOString();
   /* #1836 — mirror the real route: a supplied non-blank transcript wins over
      the canned Whisper text and flips transcriptSource to 'user'. Without

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -9773,14 +9773,18 @@ export async function mockCloneVoiceSample(_form: FormData): Promise<CloneSample
 
 export async function mockCloneVoice(body: CloneVoiceBody): Promise<VoiceLibraryEntry> {
   await wait(300);
-  /* #1836 — mirror the route's 400 on an over-length transcript. Without it
-     mock mode accepts what the real server rejects, so the one rejection path
-     the wizard can surface is unreachable in mock/e2e. Message shape matches
-     realCloneVoice's (`Voice clone failed (<status>): <body>`), since the
-     wizard renders it verbatim. */
+  /* #1836 — mirror the route's 400 on an over-length transcript, so mock mode
+     is never more permissive than the real server on a rejection the wizard
+     can surface. (The panel blocks Continue before this can fire from the UI;
+     the guard is here for parity, and for the day that panel gate moves.)
+     Byte-identical to what realCloneVoice produces — it interpolates
+     `await res.text()`, and the route replies `res.status(400).json({ error })`
+     — JSON envelope and all. The wizard renders the message verbatim, so a
+     prettier mock string would hide a real-mode wart no test could ever
+     catch. */
   if (typeof body.transcript === 'string' && body.transcript.length > MAX_CLONE_TRANSCRIPT_CHARS) {
     throw new Error(
-      `Voice clone failed (400): Transcript is too long (max ${MAX_CLONE_TRANSCRIPT_CHARS} characters).`,
+      `Voice clone failed (400): {"error":"Transcript is too long (max ${MAX_CLONE_TRANSCRIPT_CHARS} characters)."}`,
     );
   }
   const now = new Date().toISOString();

--- a/src/lib/clone-transcript-limit.ts
+++ b/src/lib/clone-transcript-limit.ts
@@ -5,16 +5,21 @@
  * it is bounded — and rejected rather than truncated, since a silent trim is
  * the exact bug class #1836 fixed.
  *
- * Deliberately its own module rather than a `src/lib/api.ts` export: the
- * capture panel's tests `vi.mock('../../lib/api')`, and a mock factory that
- * forgot to re-export the constant would leave the panel comparing against
- * `undefined` — disabling the guard silently. Nothing can mock this away.
+ * Deliberately its own module rather than a `src/lib/api.ts` export, for two
+ * reasons: `e2e/voice-library.spec.ts` needs the value in a Node/Playwright
+ * process, and dragging ~9,900 lines of browser-facing api.ts in for one
+ * number is not viable; and 81 files under `src/` do `vi.mock('…lib/api')`, so
+ * an api.ts export would be one forgotten factory key away from resolving to
+ * `undefined` in some future test. (That failure would be loud, not silent —
+ * the capture panel's own cap test would time out — but a constant nothing can
+ * mock away is simply cheaper than relying on that.)
  *
- * Three OTHER copies of this number exist and are pinned against each other by
- * test, not by prose:
+ * TWO other copies of this number exist:
  *   - `MAX_CLONE_TRANSCRIPT_CHARS` in `server/src/routes/voice-library.ts`
- *   - `CloneVoiceRequest.transcript.maxLength` in `openapi.yaml`
- *   - (via that schema) `src/lib/api-types.ts`
+ *   - `CloneVoiceRequest.transcript.maxLength` in `openapi.yaml` (plus the
+ *     byte arithmetic in that schema's description)
+ * `src/lib/api-types.ts` is NOT a third: openapi-typescript does not encode
+ * `maxLength`, so the generated type carries no bound and cannot drift.
  * `api.clone-voice.test.ts` pins this constant against the contract, and
  * `server/src/routes/voice-library.test.ts` pins the route's against it too —
  * so raising one without the others fails on both sides of the wire.

--- a/src/lib/clone-transcript-limit.ts
+++ b/src/lib/clone-transcript-limit.ts
@@ -7,7 +7,7 @@
  *
  * Deliberately its own module rather than a `src/lib/api.ts` export, for two
  * reasons: `e2e/voice-library.spec.ts` needs the value in a Node/Playwright
- * process, and dragging ~9,900 lines of browser-facing api.ts in for one
+ * process, and dragging ~10,500 lines of browser-facing api.ts in for one
  * number is not viable; and 81 files under `src/` do `vi.mock('…lib/api')`, so
  * an api.ts export would be one forgotten factory key away from resolving to
  * `undefined` in some future test. (That failure would be loud, not silent —

--- a/src/lib/clone-transcript-limit.ts
+++ b/src/lib/clone-transcript-limit.ts
@@ -1,0 +1,22 @@
+/* fs-38 / #1836 — the cap on a clone-wizard transcript, in UTF-16 units.
+ *
+ * The transcript is the first CLIENT-controlled value to reach the derive's
+ * `ref_text`, which travels to the sidecar as a base64 `X-Ref-Text` header, so
+ * it is bounded — and rejected rather than truncated, since a silent trim is
+ * the exact bug class #1836 fixed.
+ *
+ * Deliberately its own module rather than a `src/lib/api.ts` export: the
+ * capture panel's tests `vi.mock('../../lib/api')`, and a mock factory that
+ * forgot to re-export the constant would leave the panel comparing against
+ * `undefined` — disabling the guard silently. Nothing can mock this away.
+ *
+ * Three OTHER copies of this number exist and are pinned against each other by
+ * test, not by prose:
+ *   - `MAX_CLONE_TRANSCRIPT_CHARS` in `server/src/routes/voice-library.ts`
+ *   - `CloneVoiceRequest.transcript.maxLength` in `openapi.yaml`
+ *   - (via that schema) `src/lib/api-types.ts`
+ * `api.clone-voice.test.ts` pins this constant against the contract, and
+ * `server/src/routes/voice-library.test.ts` pins the route's against it too —
+ * so raising one without the others fails on both sides of the wire.
+ */
+export const MAX_CLONE_TRANSCRIPT_CHARS = 2000;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,6 +41,14 @@ export default defineConfig({
       '**/package.json/**',
       '**/{vitest,vite}.config.*/**',
       '**/src/test/setup.ts',
+      /* Tests that pin a value against the contract (e.g. the clone-transcript
+         cap in api.clone-voice.test.ts) read openapi.yaml at RUNTIME, so they
+         have no module-graph edge to it and `vitest --changed` — which CI uses
+         — would never select them for an openapi-only diff. That is exactly
+         the drift they exist to catch. Every api-types import is `import
+         type`, erased at transform time, so regenerating the types doesn't
+         create an edge either. */
+      '**/openapi.yaml/**',
     ],
     /* One retry to absorb transient jsdom/timer flakes inside a single
        verify run instead of forcing a full pre-push re-execution. See


### PR DESCRIPTION
## Summary

#1836 shipped with two coverage gaps written into PR #1840's description under **Not covered**. This closes both.

**1. `mockCloneVoice` had no length cap.** The real route 400s a transcript over `MAX_CLONE_TRANSCRIPT_CHARS`; the mock accepted anything. Mock/e2e mode was therefore strictly *more permissive* than the server on the one rejection the clone wizard can surface — a failure that could only ever appear against a real backend. The mock now throws the same message `realCloneVoice` would produce, since the wizard renders that string verbatim.

**2. `e2e/voice-library.spec.ts` never touched the transcript field.** Its clone step walked from the file upload straight to Continue, so the round-3 UI fix — Continue blocked with an on-screen reason while the field is still editable — had no browser-level coverage. Step 6 now drives the field: the ingested Whisper text lands in the box, an over-cap value disables Continue with the reason rendered *and the full text left intact* for trimming, and a correction re-enables it.

### The bit that wasn't in the gap list

The cap was a bare literal in `clone-capture-panel.tsx` — a fourth copy of a number already living in the route, in `openapi.yaml`, and in the generated types, and the only copy pinned by nothing. (The server already pins its own against the contract.) It moves to `src/lib/clone-transcript-limit.ts`, with a new test pinning it against `CloneVoiceRequest.transcript.maxLength` — the frontend twin of the server's pin, so the cap can't drift on one side of the wire alone.

Its own module rather than an `api.ts` export on purpose: the capture panel's tests `vi.mock('../../lib/api')`, and a mock factory that forgot to re-export the constant would leave the panel comparing `transcript.length` against `undefined` — guard silently disabled, every test still green. Nothing can mock a standalone constant module away.

### What e2e deliberately does *not* assert

That the corrected transcript reaches the wire stays pinned in Vitest (`clone-capture-panel.test.tsx` → `clone-voice-wizard.test.tsx` → `api.clone-voice.test.ts`, one per hop). No view renders `sampleTranscript`, so there is nothing for a browser to observe without adding UI purely to be tested. What e2e adds is the half jsdom can't attest: that the over-cap message renders next to the field the user has to fix, and that the over-length text survives intact for trimming.

## Test plan

Every new guard was mutation-checked, not just run green — the round-3 lesson from #1840, where two "guard" tests turned out to pin literals rather than the constant:

- Raising `MAX_CLONE_TRANSCRIPT_CHARS` to 6000 → the contract-pin test fails (verified, then reverted).
- Deleting `mockCloneVoice`'s guard → the over-length rejection test fails (verified, then restored).
- The panel test's `2001`/`2000` literals now derive from the constant, so they can't drift into passing.

New coverage:

- `src/lib/api.clone-voice.test.ts` — over-cap rejects and appends no entry; at-cap is accepted; the constant matches `openapi.yaml`.
- `e2e/voice-library.spec.ts` step 6 — the three transcript-field assertions above.

Verification run locally:

- `npm run test` — 320 files, **4223 passed** (4220 before; +3).
- `npm run typecheck` — clean, frontend + server.
- `npx playwright test --project=chromium e2e/voice-library.spec.ts` — **2 passed** (warmup + golden path).
- pre-push `verify:fast:branch` — green, including `build`. `test:server` correctly skipped as out of scope (no server file changed).

**Release notes: deliberately skipped.** Tests, a mock-mode-only behaviour change, and a plan-doc update — no delta a user of a real install can observe.

**Backlog row: deliberately skipped.** #1845 was filed and shipped in the same round, so a `docs/BACKLOG.md` row would be added and removed in the same breath (and that file is generated by `backlog:sync`, not hand-edited).

Closes #1845
Refs #1836
Refs #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review rounds (appended after the initial description)

Four independent review passes ran on this branch — three Opus, then a Fable whole-branch pass at the user's explicit request. Each found real defects, and the pattern is worth recording: **every round found the same defect shape — a published artifact asserting something its source no longer says.** Six instances, in order:

| # | Artifact | Claim it made | Reality |
|---|---|---|---|
| 1 | `api.clone-voice.test.ts` (new pin) | pins the cap against the contract | CI's `vitest --changed` could never select it — no module-graph edge |
| 2 | `mockCloneVoice` comment | message is byte-identical to production's | production's carries a JSON envelope the mock omitted |
| 3 | `clone-transcript-limit.ts` comment | a `vi.mock` omission would fail *silently* | it fails loudly; the real reason is the `e2e/` Node import |
| 4 | the `\d{4,}` scan test | catches stale numbers in the contract | passed vacuously on a renamed property (zero loop iterations) |
| 5 | `src/lib/api-types.ts` (generated) | matches `openapi.yaml` | still carried a paragraph deleted from the source; codegen drift was ungated |
| 6 | `server/vitest.config.ts` comment | *"Measured:"* the zero-tests impact doesn't reproduce | it reproduces exactly; the measurement ran against a dirty tree |

Number 6 was mine, and it is the one that mattered most: a false negative published as a measurement invites the next editor to strip the defaults as redundant. Corrected with an isolated re-measurement — defaults stripped → `"No test files found"`, exit 0; restored → 5389 tests. A release-cut version bump would have run **zero server tests and reported green**.

Two structural fixes came out of this rather than more policing:

- **The contract now states the cap once.** The schema description and the `400` both restated it (that is how #1840 shipped two caps 2× apart). Both defer to `maxLength`, and the scan test that policed the duplication was deleted along with it. Fewer numbers beat a cleverer test.
- **The guards actually run.** `openapi.yaml` is registered in both vitest configs' `forceRerunTriggers`, as its own `openapi` CI scope (its own flag, not `frontend`, which would also fire four e2e shards and the visual battery for a contract-only change), and in `verify-cache.mjs`. A sibling `OpenAPI types up to date` step closes the codegen half — it ran on the Ubuntu runner and reported no drift, ruling out line-ending and generator-version false positives.

Every new guard was mutation-checked, not just run green. Final Fable pass: **SHIP** — measurement independently reproduced to the digit, all minors fixed and pinned, nothing new introduced.

Follow-up filed: **#1848 (ops-30)** — vitest's own `**/{vitest,vite}.config.*/**` default matches no path under picomatch, so a config-only diff selects zero tests. Pre-existing, affects both configs, out of scope here.
