### PR TITLE
chore(deps): clear 9 Dependabot alerts, document the 4 we can't take

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -49,6 +49,10 @@
 - Auditioning a voice you just designed no longer re-records it. The take from the design was already sitting there; now it actually gets used, so the first play is instant.
 - The higher-quality 1.7B voice model is greyed out until you've actually downloaded it, instead of failing partway into a run.
 - Previewing a voice will now put away a voice model it isn't using to make room, rather than giving up when your graphics card looks full. If something it can't put away is in the way, it tells you which model that is and where the button to stop it lives — instead of just saying the card is full.
+- **Security housekeeping on the parts you don't see.** We've taken the latest patched versions of the
+  outside code Castwright is built on — including the component that opens your EPUB files, where a
+  malformed book could previously have made Castwright try to swallow far more memory than it should.
+  Nothing to do at your end, and nothing looks different.
 
 # Castwright 1.14.0
 

--- a/docs/release-notes-next.md
+++ b/docs/release-notes-next.md
@@ -267,8 +267,11 @@ history at cut time.
     is not installed, so the adm-zip fallback in `epub2/zipfile.js` **is** the live path, and epub2's
     exact call sequence (`new AdmZip(file)` → `getEntries().entryName` → `getEntry` → `readFileAsync`)
     was exercised against a real fixture EPUB on 0.6.0 alongside the 27 `src/parsers/epub.test.ts` cases.
-  - **Dismissed, not fixed:** `react-router` (GHSA-qwww-vcr4-c8h2) as `not_used`. Scored CVSS 0.0 and
-    reachable only in RSC/framework mode; we drive a client-side `createHashRouter`. The nominal fix is
+  - **Dismissed, not fixed:** `react-router` (GHSA-qwww-vcr4-c8h2) as `not_used`. GitHub-rated **high**
+    (CVSS v4 7.1) but reachable only in RSC/framework mode; we drive a client-side `createHashRouter`,
+    so the vulnerable path does not exist here. Reachability is the whole justification — an earlier
+    draft of this note cited "CVSS 0.0", which was the advisory's *unscored v3 placeholder* (null
+    vector), not a real low rating. The nominal fix is
     8.3.0, but `react-router-dom` has no v8 — it's frozen at 7.18.1 — so it means rewriting 24 files'
     imports **and** raising the product's Node floor from `>=20.19.0` to `>=22.22.0`. Tracked as
     `fe-56` (#1859) on currency grounds rather than as a security fix.
@@ -276,3 +279,17 @@ history at cut time.
     memory corruption; patched in 2.13.0). Recorded on #893 with measured evidence: the `cu128` index we
     install from tops out at torch 2.11.0 while 2.12+ ships only on `cu130`, and — the harder blocker —
     torchaudio's last release is 2.11.0, with Qwen importing `torchaudio.compliance.kaldi` at runtime.
+  - **`npm audit` is deliberately still not clean, and that is not an oversight.** A *second*
+    brace-expansion advisory (GHSA-mh99-v99m-4gvg, high — unbounded expansion → OOM) expresses its
+    affected range as a single `<= 5.0.7` spanning every major line, first patched in **5.0.8**. The
+    5.x copy here is 5.0.8 and clears it; the 1.1.16 and 2.1.2 copies cannot, because upstream never
+    backported a 1.x or 2.x fix. It is not a Dependabot alert, so the 9-cleared tally above is exact
+    against its own source of truth — but a bare `npm run audit` at root will report high findings, and
+    the next person to run one should know why rather than assume the sweep missed something. No CI leg
+    runs `npm audit`, so nothing goes red on it.
+  - The adm-zip override is written `>=0.6.0`, **not** `^0.6.0`: adm-zip has only ever published `0.x`
+    releases, and for a `0.x` package a caret caps at `<0.7.0` — which would silently hold the tree back
+    the day the next fix lands as 0.7.0, with `npm update` reporting nothing to do.
+    `server/src/parsers/adm-zip-pin.test.ts` guards the block, since deleting it reinstalls a vulnerable
+    0.5.x with no error (epub2's declared `^0.5.10` is satisfied) and the 27 existing parser cases return
+    byte-identical results on both versions, so they cannot detect the regression.

--- a/docs/release-notes-next.md
+++ b/docs/release-notes-next.md
@@ -247,3 +247,32 @@ history at cut time.
     **torchaudio's last release is 2.11.0**, NOT by the cu130 driver bump originally recorded;
     `transformers` 5.x and `huggingface_hub` 1.x are both frozen by `qwen-tts==0.1.1`'s exact
     `transformers==4.57.3` pin (#1228).
+
+- **Dependabot sweep: 9 alerts cleared, 1 dismissed as unreachable, 3 recorded as upstream-blocked** (#1858).
+  Nine bumps, all of which npm resolves within existing ranges except where noted:
+  - Frontend (dev-only, build tooling): `postcss` 8.5.15 → 8.5.23 (GHSA-r28c-9q8g-f849, source-map path
+    traversal), `js-yaml` 4.2.0 → 4.3.0 (GHSA-52cp-r559-cp3m, quadratic merge-key chains),
+    `brace-expansion` on all three of its major lines — 1.1.15 → 1.1.16, 2.1.1 → 2.1.2, 5.0.6 → 5.0.8
+    (GHSA-3jxr-9vmj-r5cp). `nanoid` 3.3.12 → 3.3.16 rides along as postcss's own dependency.
+  - `shell-quote` 1.8.4 → 1.9.0 (GHSA-395f-4hp3-45gv) is reached by bumping **`concurrently`
+    10.0.3 → 10.0.4**, not the leaf: concurrently pins shell-quote exactly, so `npm update shell-quote`
+    is a no-op. 10.0.4 carries 1.9.0 itself.
+  - Server: `postcss` 8.5.15 → 8.5.23 (dev), `protobufjs` 7.6.4 → 7.6.5 via `@google/genai`'s `^7.5.4`
+    (GHSA-j3f2-48v5-ccww, infinite loop parsing `.proto` options).
+  - **`adm-zip` 0.5.17 → 0.6.0 needs an `overrides` entry** in `server/package.json` (GHSA-xcpc-8h2w-3j85,
+    crafted ZIP triggers a 4 GB allocation). It arrives via `epub2@3.0.2` — already the latest release, so
+    no upstream fix is coming — which requires `^0.5.10`, putting 0.6.0 out of range. This is the one
+    runtime-behaviour risk in the sweep: a 0.x minor is breaking by semver, and adm-zip is what parses
+    every uploaded EPUB. Verified rather than assumed — `zipfile` (epub2's optional native preference)
+    is not installed, so the adm-zip fallback in `epub2/zipfile.js` **is** the live path, and epub2's
+    exact call sequence (`new AdmZip(file)` → `getEntries().entryName` → `getEntry` → `readFileAsync`)
+    was exercised against a real fixture EPUB on 0.6.0 alongside the 27 `src/parsers/epub.test.ts` cases.
+  - **Dismissed, not fixed:** `react-router` (GHSA-qwww-vcr4-c8h2) as `not_used`. Scored CVSS 0.0 and
+    reachable only in RSC/framework mode; we drive a client-side `createHashRouter`. The nominal fix is
+    8.3.0, but `react-router-dom` has no v8 — it's frozen at 7.18.1 — so it means rewriting 24 files'
+    imports **and** raising the product's Node floor from `>=20.19.0` to `>=22.22.0`. Tracked as
+    `fe-56` (#1859) on currency grounds rather than as a security fix.
+  - **Still upstream-blocked:** the three `torch` alerts (GHSA-rrmf-rvhw-rf47, low/5.3, `torch.jit.script`
+    memory corruption; patched in 2.13.0). Recorded on #893 with measured evidence: the `cu128` index we
+    install from tops out at torch 2.11.0 while 2.12+ ships only on `cu130`, and — the harder blocker —
+    torchaudio's last release is 2.11.0, with Qwen importing `torchaudio.compliance.kaldi` at runtime.

--- a/docs/release-notes-next.md
+++ b/docs/release-notes-next.md
@@ -248,7 +248,7 @@ history at cut time.
     `transformers` 5.x and `huggingface_hub` 1.x are both frozen by `qwen-tts==0.1.1`'s exact
     `transformers==4.57.3` pin (#1228).
 
-- **Dependabot sweep: 9 alerts cleared, 1 dismissed as unreachable, 3 recorded as upstream-blocked** (#1858).
+- **Dependabot sweep: 9 alerts cleared, 1 dismissed as unreachable, 3 recorded as upstream-blocked** (#1863).
   Nine bumps, all of which npm resolves within existing ranges except where noted:
   - Frontend (dev-only, build tooling): `postcss` 8.5.15 → 8.5.23 (GHSA-r28c-9q8g-f849, source-map path
     traversal), `js-yaml` 4.2.0 → 4.3.0 (GHSA-52cp-r559-cp3m, quadratic merge-key chains),

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^6.0.2",
         "archiver": "^8",
-        "concurrently": "^10.0.3",
+        "concurrently": "^10.0.4",
         "cross-env": "^10.1.0",
         "eslint": "^9",
         "eslint-config-prettier": "^10",
@@ -1764,9 +1764,9 @@
       }
     },
     "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2897,16 +2897,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -3637,9 +3637,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3930,15 +3930,15 @@
       "license": "MIT"
     },
     "node_modules/concurrently": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.3.tgz",
-      "integrity": "sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.4.tgz",
+      "integrity": "sha512-trZql+7l/0+WRAsAnEdctr4+iiOS6ZrViI6H8QWcCF9MFS/LT0dKpe8vluB1to6it+OxSI4VospFTIFMW8DJRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "5.6.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.4",
+        "shell-quote": "1.9.0",
         "supports-color": "10.2.2",
         "tree-kill": "1.2.2",
         "yargs": "18.0.0"
@@ -6583,9 +6583,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -7254,9 +7254,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -7697,9 +7697,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -7717,7 +7717,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8166,16 +8166,16 @@
       }
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/readdir-glob/node_modules/minimatch": {
@@ -8673,9 +8673,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.2",
     "archiver": "^8",
-    "concurrently": "^10.0.3",
+    "concurrently": "^10.0.4",
     "cross-env": "^10.1.0",
     "eslint": "^9",
     "eslint-config-prettier": "^10",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2061,12 +2061,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -3835,9 +3835,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -3855,7 +3855,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3864,9 +3864,9 @@
       }
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -3883,9 +3883,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -32,6 +32,9 @@
     "yazl": "^3.3.1",
     "zod": "^4.0.0"
   },
+  "overrides": {
+    "adm-zip": "^0.6.0"
+  },
   "devDependencies": {
     "@types/cookie": "^0.6.0",
     "@types/express": "^5.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -33,7 +33,7 @@
     "zod": "^4.0.0"
   },
   "overrides": {
-    "adm-zip": "^0.6.0"
+    "adm-zip": ">=0.6.0"
   },
   "devDependencies": {
     "@types/cookie": "^0.6.0",

--- a/server/src/parsers/adm-zip-pin.test.ts
+++ b/server/src/parsers/adm-zip-pin.test.ts
@@ -1,0 +1,59 @@
+// Guards the `overrides: { "adm-zip": ">=0.6.0" }` block in server/package.json.
+//
+// adm-zip is the ZIP reader behind every EPUB upload, reached transitively
+// through epub2 -> epub2/zipfile.js (which prefers an optional native `zipfile`
+// package and falls back to adm-zip when it is absent, as it is here).
+//
+// epub2@3.0.2 is the latest release and declares `adm-zip: ^0.5.10`, so the
+// patched 0.6.0 is OUT of that range and arrives ONLY via the override. That
+// makes the override a load-bearing security fix delivered entirely by config:
+// delete it and npm happily reinstalls 0.5.17, satisfying epub2's declared
+// range, with no error and no warning.
+//
+// Nothing else would notice. The 27 cases in epub.test.ts produce byte-identical
+// results on 0.5.17 and 0.6.0, so the parser suite cannot detect the regression
+// — hence this explicit floor assertion.
+//
+// 0.6.0 fixes GHSA-xcpc-8h2w-3j85 (crafted ZIP triggers a ~4 GB allocation) and,
+// separately, removes a data-descriptor CRC path in which 0.5.17 threw from
+// inside a zlib 'end' handler with no surrounding try/catch — an uncaught throw
+// that a malformed uploaded EPUB could use to take down the server process.
+
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+
+/** Compare dotted numeric versions: -1 | 0 | 1. Avoids taking on a semver dep. */
+function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (d !== 0) return d < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+describe('adm-zip override', () => {
+  it('resolves adm-zip at or above the patched 0.6.0', () => {
+    const { version } = require('adm-zip/package.json') as { version: string };
+    expect(compareVersions(version, '0.6.0')).toBeGreaterThanOrEqual(0);
+  });
+
+  it('keeps the override declared, since epub2 alone would pull a vulnerable 0.5.x', () => {
+    const pkg = require('../../package.json') as {
+      overrides?: Record<string, string>;
+    };
+    // `>=0.6.0`, deliberately NOT `^0.6.0`: adm-zip has only ever published 0.x
+    // releases, so a caret would cap at <0.7.0 and silently hold the tree back
+    // when the next fix lands as 0.7.0.
+    expect(pkg.overrides?.['adm-zip']).toBe('>=0.6.0');
+  });
+
+  it('still reaches adm-zip through epub2 (the fallback path, not the native `zipfile`)', () => {
+    // If `zipfile` ever gets installed, epub2 prefers it and adm-zip stops being
+    // the live path — at which point the reasoning above needs revisiting.
+    expect(() => require.resolve('zipfile')).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Clears the actionable half of the Dependabot backlog and gives every remaining alert an explicit written disposition, so "open" goes back to meaning "real, unfixed, tracked".

**13 alerts open at the start → 9 fixed here, 1 dismissed, 3 left open and documented.**

### Fixed in range (8 alerts)

| Package | Change | Advisory |
|---|---|---|
| `postcss` (root + server, dev) | 8.5.15 → 8.5.23 | GHSA-r28c-9q8g-f849 |
| `js-yaml` (dev) | 4.2.0 → 4.3.0 | GHSA-52cp-r559-cp3m |
| `brace-expansion` ×3 (dev) | 1.1.15 → 1.1.16, 2.1.1 → 2.1.2, 5.0.6 → 5.0.8 | GHSA-3jxr-9vmj-r5cp |
| `protobufjs` (server, runtime) | 7.6.4 → 7.6.5 | GHSA-j3f2-48v5-ccww |
| `shell-quote` (dev) | 1.8.4 → 1.9.0 | GHSA-395f-4hp3-45gv |

Two of those deserve a note:

- **`shell-quote` is fixed by bumping `concurrently` 10.0.3 → 10.0.4**, not the leaf. concurrently pins shell-quote *exactly*, so `npm update shell-quote` is a no-op; 10.0.4 carries 1.9.0 itself.
- **`nanoid` 3.3.12 → 3.3.16** appears in both lockfiles and is not a target — it's postcss's own dependency riding along in range.

Everything else resolved through existing semver ranges. I'd initially flagged that `@redocly/openapi-core`'s exact `js-yaml@4.1.1` pin would need its own override — that was wrong; npm dedupes it onto 4.3.0, so no override is needed.

### Fixed with an override (1 alert)

**`adm-zip` 0.5.17 → 0.6.0** (GHSA-xcpc-8h2w-3j85 — crafted ZIP triggers a 4 GB allocation) via a new `overrides` block in `server/package.json`. It arrives through `epub2@3.0.2`, which is *already* the latest release, so no upstream fix is coming, and it requires `^0.5.10` — putting 0.6.0 out of range.

This is the only runtime-behaviour risk in the PR: a `0.x` minor is breaking by semver, and adm-zip parses every uploaded EPUB. See the test plan for how it was verified rather than assumed.

### Dismissed, not fixed (1 alert)

**`react-router`** (GHSA-qwww-vcr4-c8h2) dismissed as `not_used`. GitHub-rated **high (CVSS v4 7.1)**, but reachable only in RSC/framework mode; this app drives a client-side `createHashRouter` and has no RSC surface — so it is dismissed on **reachability, not severity**.

> Corrected during review: I originally wrote "CVSS 0.0" here and in the dismissal comment. That figure was the advisory's *unscored v3 placeholder* (`cvss_v3.score = 0` with a `null` vector), not a real low rating — Dependabot's own record says `severity: high`. The reachability argument is unchanged and still carries the dismissal on its own, but the written justification of record now states the real severity.

The nominal fix is 8.3.0, but `react-router-dom` **has no v8** — it is frozen at 7.18.1 — so taking it means rewriting 24 files' imports *and* raising the product's Node floor from `>=20.19.0` to `>=22.22.0` (react-router 8's own `engines`), which ripples into INSTALL docs and the installer prerequisite gate.

That upgrade is now tracked as **fe-56 (#1859)** on currency grounds rather than as a security fix — deliberately not bundled here, where it would be the entire PR.

### Left open and documented (3 alerts)

The three **`torch`** alerts (GHSA-rrmf-rvhw-rf47, low/5.3, `torch.jit.script` memory corruption, patched in 2.13.0) stay **open** — the vulnerability is real and we genuinely cannot take the fix. Recorded on #893 with measured evidence:

- The `whl/cu128` index we install from tops out at torch **2.11.0**; 2.12.0/2.12.1/2.13.0 exist only on `cu130`. Surmountable, but it means a deployer CUDA driver bump.
- The harder blocker: **torchaudio's last release is 2.11.0**, and Qwen — our default generation engine — does `import torchaudio.compliance.kaldi` at runtime. There is no torchaudio to pair with torch 2.13, so "drop torchaudio" isn't an option at all.

`docs/release-notes-next.md` previously read that the cu130 constraint was *not* the blocker, which risked reading as though it were imagined. Both are real; they differ in kind. The #893 addendum records the measured index contents so this stops getting re-litigated.

## Test plan

- `npm run verify:fast:branch` — green. (A root `package.json`/`package-lock.json` change makes cloud `verify.yml` run every leg unscoped.)
- **adm-zip 0.6.0 specifically**, since a green install proves nothing here:
  - Confirmed the optional native `zipfile` dep is **not** installed, so the adm-zip fallback in `epub2/zipfile.js` is genuinely the live path — otherwise the whole check would have been a placebo.
  - Drove epub2's exact call sequence (`new AdmZip(file)` → `getEntries().entryName` → `getEntry` → `readFileAsync`) against a real fixture EPUB on 0.6.0: 6 entries enumerated, `mimetype` read back as `application/epub+zip`, no error.
  - `server/src/parsers/epub.test.ts` — 27/27 pass.
  - New `server/src/parsers/adm-zip-pin.test.ts` — 3/3 pass, and **verified to actually fail** when the override is removed (2 of 3 assertions go red), so it is a real guard rather than a test that would pass either way.
- Alert states re-checked after merge: #26/#28/#29/#30/#31/#32/#33/#34/#37 closed, #35 `dismissed/not_used`, #24/#25/#27 still open by design.

## Review

Independent review pass run before merge (per CLAUDE.md's mandatory gate). It went further than the claims in this PR and reproduced them: it diffed adm-zip 0.5.17 vs 0.6.0 over all 7 committed fixtures **and** the 5 real ~316 KB `samples/*/manuscript.epub` books (61 entries) — byte-identical SHA-1s and identical error strings throughout — and confirmed 0.6.0 still calls back **buffer-first**, which is the unusual argument order `epub2/zipfile.js` depends on. It also regenerated both lockfiles from the manifests and got byte-identical output, so there is no manifest↔lockfile drift.

Four findings, all folded in:

1. **The CVSS 0.0 claim was wrong** (above) — corrected here, in the release note, in the fe-56 issue, and in the alert's dismissal comment.
2. **`npm audit` is still not clean, and that is now documented** rather than left to look like an oversight. A *second* brace-expansion advisory (GHSA-mh99-v99m-4gvg) expresses its range as one `<= 5.0.7` spanning all majors, patched only in 5.0.8 — so the 5.x copy clears it but the 1.1.16 and 2.1.2 copies cannot, upstream having never backported. It is not a Dependabot alert, so the tally above stays exact; no CI leg runs `npm audit`.
3. **The override said `^0.6.0`, which caps at `<0.7.0`** — wrong for a package whose entire history is `0.x`, since it would silently hold the tree back when the next fix lands as 0.7.0. Now `>=0.6.0`.
4. **Nothing guarded the override.** Added `server/src/parsers/adm-zip-pin.test.ts`. This mattered: the review proved the 27 existing parser cases return byte-identical results on 0.5.17 and 0.6.0, so they **cannot** detect the override being deleted — and deleting it reinstalls a vulnerable 0.5.x with no error, because epub2's declared `^0.5.10` is satisfied. I verified the new guard is not a placebo by removing the override and watching 2 of its 3 assertions fail, then restoring.

Worth knowing (not a defect): 0.6.0 also fixes an uncaught throw in 0.5.17's data-descriptor CRC path — it threw from inside a zlib `'end'` handler with no surrounding try/catch, so a malformed uploaded EPUB could have taken down the Node process. That is a second DoS fix riding along with the advisory this PR was chasing. Separately, 0.6.0 changed the zip *writer*, so re-running `scripts/gen-parser-fixtures.mjs` will now emit different bytes than the committed fixtures — harmless today (nothing runs it automatically), but fixture regeneration is no longer byte-reproducible against history.

Closes #1860
Refs #893, #1859
