### PR TITLE
fix(frontend): derive the active #/voices language filter

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -49,7 +49,7 @@
 - Auditioning a voice you just designed no longer re-records it. The take from the design was already sitting there; now it actually gets used, so the first play is instant.
 - The higher-quality 1.7B voice model is greyed out until you've actually downloaded it, instead of failing partway into a run.
 - Previewing a voice will now put away a voice model it isn't using to make room, rather than giving up when your graphics card looks full. If something it can't put away is in the way, it tells you which model that is and where the button to stop it lives — instead of just saying the card is full.
-- Filtering your voices by language can't strand you any more. If you'd narrowed the Voices list to, say, Russian and then moved to a book with no Russian voices in it, the list emptied out and the language buttons went with it — a filter still switched on, and nothing left on screen to switch it off. The list now shows everything again the moment the language you'd picked is no longer there.
+- Filtering your voices by language can't strand you any more. If you'd narrowed the Voices list to, say, Russian and then the last Russian voice in it went away while you were looking — you cleared its designed voice, or deleted it — the list emptied out and the language buttons went with it, leaving a filter still switched on and nothing on screen to switch it off. Worse, it told you to go and set up a book, on a library that was perfectly full. The list now shows everything again the moment the language you'd picked is no longer there.
 
 # Castwright 1.14.0
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -49,6 +49,7 @@
 - Auditioning a voice you just designed no longer re-records it. The take from the design was already sitting there; now it actually gets used, so the first play is instant.
 - The higher-quality 1.7B voice model is greyed out until you've actually downloaded it, instead of failing partway into a run.
 - Previewing a voice will now put away a voice model it isn't using to make room, rather than giving up when your graphics card looks full. If something it can't put away is in the way, it tells you which model that is and where the button to stop it lives — instead of just saying the card is full.
+- Filtering your voices by language can't strand you any more. If you'd narrowed the Voices list to, say, Russian and then moved to a book with no Russian voices in it, the list emptied out and the language buttons went with it — a filter still switched on, and nothing left on screen to switch it off. The list now shows everything again the moment the language you'd picked is no longer there.
 
 # Castwright 1.14.0
 

--- a/docs/release-notes-next.md
+++ b/docs/release-notes-next.md
@@ -155,6 +155,18 @@ history at cut time.
   `mockCloneVoice` mirrors the same semantics so mock/e2e mode stops reproducing the bug. Adds
   Invariant 12 to `docs/features/267-fs38-wave3-voice-clone.md`. Closes the run sheet's KL-k
   finding.
+- **`#/voices`' language filter can no longer strand the rollup** (#1834). `languageFilter` was
+  raw local state, but the chip row that clears it renders only while the library still carries
+  the codes it offers — and it lives inside the rollup's non-empty branch. So a mid-session
+  library change that drops the filtered language (a book switch through the book-scoped mount,
+  an engine switch, a re-hydrate) left the filter matching nothing, collapsing the view to the
+  "No voices yet" empty state with the chips gone: a filter still applied and no control left to
+  clear it. The effective filter is now derived during render
+  (`languages.includes(languageFilter) ? languageFilter : null`) so the empty rollup is never
+  painted; `setLanguageFilter` stays the sole state writer. Same shape and same treatment as
+  `activeSection` for #1802 (that derivation is gone with the flag in #1833; this one is not
+  gate-dependent). Two regression cases in `voices.test.tsx` cover the row unmounting entirely
+  and the row surviving with the selected code dropped (the "All" chip reads pressed again).
 
 ---
 

--- a/docs/release-notes-next.md
+++ b/docs/release-notes-next.md
@@ -158,15 +158,28 @@ history at cut time.
 - **`#/voices`' language filter can no longer strand the rollup** (#1834). `languageFilter` was
   raw local state, but the chip row that clears it renders only while the library still carries
   the codes it offers — and it lives inside the rollup's non-empty branch. So a mid-session
-  library change that drops the filtered language (a book switch through the book-scoped mount,
-  an engine switch, a re-hydrate) left the filter matching nothing, collapsing the view to the
-  "No voices yet" empty state with the chips gone: a filter still applied and no control left to
-  clear it. The effective filter is now derived during render
+  library change that drops the filtered language left the filter matching nothing, collapsing
+  the view to the "No voices yet" empty state (wrong copy, too: "Finish setting up a book") with
+  the chips gone — a filter still applied and no control left to clear it. The reachable trigger
+  is the last voice carrying that language losing it: its qwen override cleared from the profile
+  drawer in this same view, the voice deleted, or its design manifest failing to resolve a
+  language on a later read — surfaced by the next `voicesActions.hydrate`, which refires on
+  `[bookId, stageKind, ttsEngine, genProgress]` while the view stays mounted. Explicitly NOT an
+  engine switch or a book switch, both of which the first draft of this entry claimed: the server
+  reads `languageCode` from the design manifest independently of the `engine` query param, and
+  the voices response walks every book under `BOOKS_ROOT` with `currentBookId` only setting
+  `source` — neither can remove a code from `languages` (`server/src/routes/voices.ts:257-260`,
+  `:402-406`). The effective filter is now derived during render
   (`languages.includes(languageFilter) ? languageFilter : null`) so the empty rollup is never
   painted; `setLanguageFilter` stays the sole state writer. Same shape and same treatment as
   `activeSection` for #1802 (that derivation is gone with the flag in #1833; this one is not
-  gate-dependent). Two regression cases in `voices.test.tsx` cover the row unmounting entirely
-  and the row surviving with the selected code dropped (the "All" chip reads pressed again).
+  gate-dependent). Three regression cases in `voices.test.tsx`: the chip row unmounting entirely,
+  the row surviving with the selected code dropped (the "All" chip reads pressed again), and the
+  same stranding on the **Qwen** leg — `filteredQwenLibrary`, which is where the whole library
+  sits under the default engine (`resolveVoiceAssignment` stamps `provider` from the active
+  engine, not per voice) and therefore the only leg a real user can be stranded on, since
+  `languageCode` is only ever set on a designed Qwen voice. The independent review proved that
+  leg had zero coverage — reverting just its memo left all 69 tests green.
 
 ---
 

--- a/src/views/voices.test.tsx
+++ b/src/views/voices.test.tsx
@@ -2238,6 +2238,68 @@ describe('fs-41/fs-50 seam 4b — language facet on the global #/voices view', (
     expect(within(group).getByRole('button', { name: 'German' })).toBeInTheDocument();
   });
 
+  /* #1834 — the chip row is the only control that can clear `languageFilter`,
+     and it only renders while the library still carries a non-English
+     languageCode. A mid-session library change (book switch through the
+     book-scoped mount, engine switch, a re-hydrate that drops the Russian
+     voices) can pull the row out from under an active filter, leaving it
+     narrowing the rollup with nothing left to match and no way to clear it.
+     Same shape as #1802's `section`, fixed the same way: derive the effective
+     filter during render instead of trusting the raw local. */
+  it('stops filtering when the filtered language leaves the library mid-session (#1834)', async () => {
+    const store = makeStore();
+    const ivan = makeLangVoice({ id: 'v_ivan', character: 'Ivan', bookId: 'b1', bookTitle: 'Book One', source: 'current', languageCode: 'ru' });
+    const preset = makeLangVoice({ id: 'v_preset', character: 'Preset', bookId: 'b1', bookTitle: 'Book One', source: 'current' });
+    const { rerender } = render(
+      <Provider store={store}>
+        <LibraryView library={[ivan, preset]} />
+      </Provider>,
+    );
+    await act(async () => {});
+    fireEvent.click(screen.getByRole('button', { name: 'Russian' }));
+    expect(screen.queryByText('Preset')).not.toBeInTheDocument();
+    /* The library's Russian voices go away while the view stays mounted. */
+    rerender(
+      <Provider store={store}>
+        <LibraryView library={[preset]} />
+      </Provider>,
+    );
+    await act(async () => {});
+    /* The chip row that could clear the filter has unmounted… */
+    expect(screen.queryByRole('group', { name: 'Filter by language' })).toBeNull();
+    /* …so the filter must no longer narrow the rollup to nothing. */
+    expect(screen.getByText('Preset')).toBeInTheDocument();
+  });
+
+  it('falls back to All when the filtered language leaves a still-multilingual library (#1834)', async () => {
+    const store = makeStore();
+    const ivan = makeLangVoice({ id: 'v_ivan', character: 'Ivan', bookId: 'b1', bookTitle: 'Book One', source: 'current', languageCode: 'ru' });
+    const dieter = makeLangVoice({ id: 'v_dieter', character: 'Dieter', bookId: 'b1', bookTitle: 'Book One', source: 'current', languageCode: 'de' });
+    const { rerender } = render(
+      <Provider store={store}>
+        <LibraryView library={[ivan, dieter]} />
+      </Provider>,
+    );
+    await act(async () => {});
+    fireEvent.click(screen.getByRole('button', { name: 'Russian' }));
+    expect(screen.queryByText('Dieter')).not.toBeInTheDocument();
+    /* Russian goes away but German remains: the row still renders, so the
+       stale 'ru' must read as All rather than as no-chip-pressed. */
+    rerender(
+      <Provider store={store}>
+        <LibraryView library={[dieter]} />
+      </Provider>,
+    );
+    await act(async () => {});
+    const group = screen.getByRole('group', { name: 'Filter by language' });
+    expect(within(group).queryByRole('button', { name: 'Russian' })).toBeNull();
+    expect(within(group).getByRole('button', { name: 'All' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(screen.getByText('Dieter')).toBeInTheDocument();
+  });
+
   it('falls back to the raw BCP-47 code when the language is not in the label map', async () => {
     const lib: Voice[] = [
       makeLangVoice({ id: 'v_ja', character: 'Tanaka', bookId: 'b1', bookTitle: 'B1', source: 'current', languageCode: 'ja' }),

--- a/src/views/voices.test.tsx
+++ b/src/views/voices.test.tsx
@@ -2271,6 +2271,46 @@ describe('fs-41/fs-50 seam 4b — language facet on the global #/voices view', (
     expect(screen.getByText('Preset')).toBeInTheDocument();
   });
 
+  /* #1834 — the same case again on the Qwen side. The rollup splits into
+     `presetLibrary` and `qwenLibrary` purely by `ttsVoice.provider`, which
+     `resolveVoiceAssignment` stamps from the ACTIVE ENGINE rather than per
+     voice — so under Qwen (the default generation engine) the whole library
+     lands in `filteredQwenLibrary` and the case above exercises none of it.
+     A `languageCode` is only ever set on a designed Qwen voice, which makes
+     this the leg that actually strands a real user. */
+  it('stops filtering the Qwen library too when the language leaves mid-session (#1834)', async () => {
+    const store = makeStore();
+    const ivan = makeLangVoice({
+      id: 'q_ivan', character: 'Ivan', bookId: 'b1', bookTitle: 'Book One', source: 'current',
+      languageCode: 'ru',
+      overrideTtsVoices: { qwen: { name: 'qwen-ivan' } },
+      ttsVoice: { provider: 'qwen', name: 'qwen-ivan', description: 'Designed voice' },
+    });
+    const marlow = makeLangVoice({
+      id: 'q_marlow', character: 'Marlow', bookId: 'b1', bookTitle: 'Book One', source: 'current',
+      overrideTtsVoices: { qwen: { name: 'qwen-marlow' } },
+      ttsVoice: { provider: 'qwen', name: 'qwen-marlow', description: 'Designed voice' },
+    });
+    const { rerender } = render(
+      <Provider store={store}>
+        <LibraryView library={[ivan, marlow]} />
+      </Provider>,
+    );
+    await act(async () => {});
+    fireEvent.click(screen.getByRole('button', { name: 'Russian' }));
+    expect(screen.queryByText('Marlow')).not.toBeInTheDocument();
+    /* Ivan's design manifest stops resolving a language (his qwen override is
+       cleared, or the manifest read fails on the next hydrate). */
+    rerender(
+      <Provider store={store}>
+        <LibraryView library={[marlow]} />
+      </Provider>,
+    );
+    await act(async () => {});
+    expect(screen.queryByRole('group', { name: 'Filter by language' })).toBeNull();
+    expect(screen.getByText('Marlow')).toBeInTheDocument();
+  });
+
   it('falls back to All when the filtered language leaves a still-multilingual library (#1834)', async () => {
     const store = makeStore();
     const ivan = makeLangVoice({ id: 'v_ivan', character: 'Ivan', bookId: 'b1', bookTitle: 'Book One', source: 'current', languageCode: 'ru' });

--- a/src/views/voices.tsx
+++ b/src/views/voices.tsx
@@ -268,11 +268,21 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
   );
   /* fs-41/fs-50 seam 4b follow-up (#1834) — the chip row above is the only
      control that can clear `languageFilter`, and it renders only while the
-     library still carries the codes it offers. A mid-session library change
-     (a book switch through the book-scoped mount, an engine switch, a
-     re-hydrate that drops the Russian voices) can pull that row out from
-     under an active filter, leaving it narrowing the rollup to nothing with
-     no way to clear it. Derive the effective filter during render rather
+     library still carries the codes it offers (and only inside the rollup's
+     non-empty branch). A mid-session library change can therefore pull that
+     row out from under an active filter, leaving it narrowing the rollup to
+     nothing with no way to clear it. The reachable trigger is the last voice
+     carrying that language losing it — its qwen override cleared from the
+     profile drawer in this very view, the voice deleted, or its design
+     manifest failing to resolve a language on a later read (the server's
+     `readJson(...).catch(() => null)`) — surfaced by the next
+     `voicesActions.hydrate` in `layout.tsx`, which refires on
+     `[bookId, stageKind, ttsEngine, genProgress]` while this view stays
+     mounted. NOT an engine switch and NOT a book switch: `languageCode` is
+     read from the design manifest independently of the engine query param,
+     and the voices response walks every book under `BOOKS_ROOT` (see
+     `server/src/routes/voices.ts`), so neither can remove a code from
+     `languages`. Derive the effective filter during render rather
      than correcting `languageFilter` in an effect, so the empty rollup is
      never painted. Every read below goes through this, not `languageFilter`;
      `setLanguageFilter` stays the sole state writer. Same shape and same

--- a/src/views/voices.tsx
+++ b/src/views/voices.tsx
@@ -266,14 +266,27 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
     () => [...new Set(library.map((v) => v.languageCode).filter(Boolean))] as string[],
     [library],
   );
+  /* fs-41/fs-50 seam 4b follow-up (#1834) — the chip row above is the only
+     control that can clear `languageFilter`, and it renders only while the
+     library still carries the codes it offers. A mid-session library change
+     (a book switch through the book-scoped mount, an engine switch, a
+     re-hydrate that drops the Russian voices) can pull that row out from
+     under an active filter, leaving it narrowing the rollup to nothing with
+     no way to clear it. Derive the effective filter during render rather
+     than correcting `languageFilter` in an effect, so the empty rollup is
+     never painted. Every read below goes through this, not `languageFilter`;
+     `setLanguageFilter` stays the sole state writer. Same shape and same
+     treatment as `activeSection` for #1802. */
+  const activeLanguageFilter =
+    languageFilter !== null && languages.includes(languageFilter) ? languageFilter : null;
   /* fs-41/fs-50 seam 4b — language-filtered preset library fed into
      buildFamilies; mirrors how variantFilter narrows filteredQwenLibrary. */
   const languageFilteredPresetLibrary = useMemo(
     () =>
-      languageFilter === null
+      activeLanguageFilter === null
         ? presetLibrary
-        : presetLibrary.filter((v) => v.languageCode === languageFilter),
-    [presetLibrary, languageFilter],
+        : presetLibrary.filter((v) => v.languageCode === activeLanguageFilter),
+    [presetLibrary, activeLanguageFilter],
   );
   const families = useMemo(
     () => buildFamilies(languageFilteredPresetLibrary, tab),
@@ -319,13 +332,19 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
   }, [qwenLibrary, currentBookId, characters, globalCastCache, openBookSentences, sentencesByBookId]);
   const filteredQwenLibrary = useMemo(() => {
     const langFiltered =
-      languageFilter === null
+      activeLanguageFilter === null
         ? qwenLibrary
-        : qwenLibrary.filter((v) => v.languageCode === languageFilter);
+        : qwenLibrary.filter((v) => v.languageCode === activeLanguageFilter);
     if (variantFilter === 'all') return langFiltered;
     const map = variantFilter === 'has' ? variantCountByVoiceId : missingVariantCountByVoiceId;
     return langFiltered.filter((v) => (map.get(v.familyKey ?? v.id) ?? 0) > 0);
-  }, [qwenLibrary, languageFilter, variantFilter, variantCountByVoiceId, missingVariantCountByVoiceId]);
+  }, [
+    qwenLibrary,
+    activeLanguageFilter,
+    variantFilter,
+    variantCountByVoiceId,
+    missingVariantCountByVoiceId,
+  ]);
   const qwenGroups = useMemo(
     () => buildQwenStatusGroups(filteredQwenLibrary, tab),
     [filteredQwenLibrary, tab],
@@ -1233,7 +1252,7 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
                   de: 'German',
                 };
                 const label = code === null ? 'All' : (LANGUAGE_LABELS[code] ?? code);
-                const active = languageFilter === code;
+                const active = activeLanguageFilter === code;
                 return (
                   <button
                     key={code ?? '__all__'}


### PR DESCRIPTION
## Summary

`languageFilter` on `#/voices` was raw local state read by both rollup derivations, but the chip row that can clear it renders only while `languages` (derived from the `library` prop) still carries the offered codes — and that row sits **inside** the rollup's non-empty branch.

So a mid-session library change that drops the filtered language left the filter matching nothing. The view collapsed to the **"No voices yet"** empty state, which took the chips down with it: a filter still applied, wrong copy on screen ("Finish setting up a book" on a full library), and no control left to clear it.

**The reachable trigger** is the last voice carrying that language losing it — its qwen override cleared from the profile drawer in this same view, the voice deleted, or its design manifest failing to resolve a language on a later read — surfaced by the next `voicesActions.hydrate` (`layout.tsx` refires on `[bookId, stageKind, ttsEngine, genProgress]` while the view stays mounted).

Explicitly **not** an engine switch and **not** a book switch, which the first draft of this PR claimed. The independent review refuted both and I confirmed it in the server source: `languageCode` is read from the design manifest with a storage key computed independently of the `engine` query param (`server/src/routes/voices.ts:402-406` says so in as many words), and the voices response walks every book under `BOOKS_ROOT` with `currentBookId` only deciding `source` (`:257-260`). Neither can remove a code from `languages`.

The effective filter is now derived during render — `languages.includes(languageFilter) ? languageFilter : null` — rather than corrected in an effect, so the empty rollup is never painted. The three reads (`languageFilteredPresetLibrary`, `filteredQwenLibrary`, the chip's `active`) go through it; `setLanguageFilter` stays the sole state writer.

Same shape and same treatment as `activeSection` for #1802 (PR #1825). That derivation went away with the feature flag in #1833; this one has no gate to remove, so it isn't exposed to the same deletion.

Filed out of #1825's independent review, which spotted the identical unreset local while fixing `section` and deliberately left it for its own PR.

## Test plan

Three regression cases in `src/views/voices.test.tsx`, each verified non-placebo by neutralizing the specific read it covers and watching it — and only it — go red:

1. **The chip row unmounts entirely** — a `ru` + preset library, "Russian" selected, then rerendered English-only while mounted. Before: no chip row and no voices. After: the preset voice is back.
2. **The row survives but the selected code is gone** — `ru` + `de`, "Russian" selected, then rerendered `de`-only. After: the row renders with no "Russian" chip and **"All"** reading `aria-pressed="true"`. Reverting *only* the chip's `active` read fails exactly this assertion, so it is load-bearing rather than decorative.
3. **The Qwen leg** — the same stranding through `filteredQwenLibrary`. Added in response to the review, which proved this leg had **zero** coverage: reverting just its memo left all 69 tests green. It matters because `resolveVoiceAssignment` stamps `ttsVoice.provider` from the *active engine* rather than per voice, so under Qwen — the default generation engine — the whole library sits in `qwenLibrary` and none of it in `presetLibrary`. Since `languageCode` is only ever set on a designed Qwen voice, this is the leg a real user actually gets stranded on.

Green locally: `npm test` (4263 passed / 321 files), `npm run typecheck`, `npm run lint`, pre-push `verify:fast:branch`. Cloud `verify.yml` green on the first push.

## Review

Independent code-review pass run at `medium` (single-scope `fix`, per `.claude/skills/model-routing/SKILL.md`), no `--fix`. No Critical findings; the derivation, the three reads, and the memo dependencies were all confirmed correct, and the reviewer independently re-ran the placebo probes. Folded in: the missing Qwen coverage (finding 1) and the incorrect trigger claims (finding 2). Finding 3 — the chip row living inside the empty-state ternary, so tab × language still empties the rollup with the wrong copy — is **pre-existing, out of scope, and filed as #1866**. Finding 4 (the stale filter reactivating if the language returns) was judged correct as-is: it survives a transient hydrate blip, and whenever it reactivates the chip row is by definition on screen showing it pressed.

## Checklist notes

No regression plan under `docs/features/` covers the language facet (it shipped from `docs/superpowers/plans/2026-06-23-fs41-fs50-seam4b-early-warning.md`), so per the checklist this small, localized fix is specified by the issue plus its paired tests. No on-box acceptance owed — the trigger is a prop change, fully provable in jsdom. Release notes landed in both `docs/release-notes-next.md` and `RELEASE_NOTES.md`.

Closes #1834

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119NFT6eVG4X9aieu1cmns3
