### PR TITLE
chore(scripts): stage companion screenshots from this repo

### DIFF
--- a/scripts/stage-marketing-screenshots.mjs
+++ b/scripts/stage-marketing-screenshots.mjs
@@ -125,12 +125,41 @@ export const MANIFEST = [
   //     Omit `viewport` and stagingPlan() drops that path segment.
   //   - `scaleWidth`: captures are at native device resolution, far larger
   //     than the marketing site's embed width, so these need a downscale the
-  //     rest of the manifest doesn't. `scaleWidth: 480` reproduces the
-  //     480x1072 the site already embeds (1280-wide source × 0.375).
+  //     rest of the manifest doesn't. Each value is the width the site already
+  //     embeds: 480 for the phone pair (1280-wide source), 720 for the tablet
+  //     (2560-wide source, landing at 720x450).
+  //
+  // Unlike every other entry, these sources come from `capture:companion`, not
+  // `capture:marketing` — so a box that has run only the latter is missing six
+  // sources and this script exits 1 (`missing source, skipped` names each one).
+  // That is the intended loud-not-silent behaviour, but it IS new: before
+  // #1838 a marketing-only capture staged clean. Run both capture rails, or
+  // expect the six warnings. Deliberately not softened to a silent skip —
+  // "companion assets quietly stopped updating" is the exact failure #1838 was
+  // filed for.
   { output: 'companion-iphone', scene: 'companion/player', scaleWidth: 480 },
   { output: 'companion-pixel', scene: 'companion/library-home', scaleWidth: 480 },
   { output: 'companion-tablet', scene: 'companion/tablet10/book-detail', scaleWidth: 720 },
 ];
+
+/* Pure — the ffmpeg command line for one plan entry. Extracted from main() so
+   the scale threading is testable: the encode is the whole point of a
+   `scaleWidth` entry, and inlined in main() nothing pinned it (dropping the
+   -vf push, or `-2` -> `-1`, left every test green while silently restaging
+   the site's assets at the wrong size).
+
+   On `-2`: it derives the height from the source aspect ratio and rounds to an
+   even number. That is NOT an encoder requirement — libwebp encodes odd heights
+   fine — it is dimension-matching. A 1280x2856 capture at width 480 is 1071
+   exactly, but the site embeds 480x1072, so `-1` would restage every companion
+   asset one pixel short. See the 1280x2856 -> 480x1072 case in
+   scripts/tests/stage-marketing-screenshots.test.mjs. */
+export function ffmpegArgs({ src, dest, scaleWidth }) {
+  const args = ['-y', '-i', src];
+  if (scaleWidth) args.push('-vf', `scale=${scaleWidth}:-2`);
+  args.push('-quality', '85', dest);
+  return args;
+}
 
 // Pure — no filesystem access — so the test can exercise it without real files.
 export function stagingPlan(manifest = MANIFEST, sourceDir = SOURCE_DIR, destDir = DEST_DIR) {
@@ -187,14 +216,7 @@ function main() {
       missing++;
       continue;
     }
-    // -2 lets ffmpeg derive the height from the source aspect ratio while
-    // rounding to the nearest even number (required by the encoder) — see
-    // scripts/tests/stage-marketing-screenshots.test.mjs for the exact
-    // 1280x2856 -> 480x1072 case this reproduces.
-    const args = ['-y', '-i', src];
-    if (scaleWidth) args.push('-vf', `scale=${scaleWidth}:-2`);
-    args.push('-quality', '85', dest);
-    const result = spawnSync('ffmpeg', args, {
+    const result = spawnSync('ffmpeg', ffmpegArgs({ src, dest, scaleWidth }), {
       stdio: 'inherit',
     });
     if (result.status !== 0) {

--- a/scripts/stage-marketing-screenshots.mjs
+++ b/scripts/stage-marketing-screenshots.mjs
@@ -26,8 +26,12 @@
      MARKETING_SRC=<dir>   read captures from here
      MARKETING_DEST=<dir>  write webp here
 
-   Out of scope: companion-app screenshots (scripts/capture-companion.mjs is
-   a separate pipeline) — not touched here. */
+   Companion-app screenshots: `scripts/capture-companion.mjs` owns CAPTURING
+   them (needs a Flutter emulator) into mockups/marketing-screens/companion/
+   — that stays a separate, manual pipeline, out of scope here. But once
+   captured, STAGING those PNGs into brand/ webp is this script's job like
+   everything else in this folder — "captured elsewhere" doesn't mean "staged
+   elsewhere". See the `companion-*` entries in MANIFEST below (#1838). */
 
 import { existsSync, mkdirSync, readdirSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
@@ -112,6 +116,20 @@ export const MANIFEST = [
     viewport: 'desktop',
     themes: ['dark'],
   },
+  // --- Companion-app screenshots (#1838) ---
+  // Captured by the separate scripts/capture-companion.mjs pipeline, so these
+  // entries differ from the rest of the manifest in two ways:
+  //   - No `viewport`: the companion app has no desktop/tablet/phone variants
+  //     to switch between, so there's no viewport segment in the source
+  //     filename (`companion/player.light.png`, not `....desktop.light.png`).
+  //     Omit `viewport` and stagingPlan() drops that path segment.
+  //   - `scaleWidth`: captures are at native device resolution, far larger
+  //     than the marketing site's embed width, so these need a downscale the
+  //     rest of the manifest doesn't. `scaleWidth: 480` reproduces the
+  //     480x1072 the site already embeds (1280-wide source × 0.375).
+  { output: 'companion-iphone', scene: 'companion/player', scaleWidth: 480 },
+  { output: 'companion-pixel', scene: 'companion/library-home', scaleWidth: 480 },
+  { output: 'companion-tablet', scene: 'companion/tablet10/book-detail', scaleWidth: 720 },
 ];
 
 // Pure — no filesystem access — so the test can exercise it without real files.
@@ -120,11 +138,16 @@ export function stagingPlan(manifest = MANIFEST, sourceDir = SOURCE_DIR, destDir
   for (const entry of manifest) {
     const themes = entry.themes ?? ['light', 'dark'];
     for (const theme of themes) {
-      const src = path.join(sourceDir, `${entry.scene}.${entry.viewport}.${theme}.png`);
+      const srcName = entry.viewport
+        ? `${entry.scene}.${entry.viewport}.${theme}.png`
+        : `${entry.scene}.${theme}.png`;
+      const src = path.join(sourceDir, srcName);
       const pairing = themes.length > 1;
       const destName =
         pairing && theme === 'dark' ? `${entry.output}-dark.webp` : `${entry.output}.webp`;
-      plan.push({ src, dest: path.join(destDir, destName) });
+      const planEntry = { src, dest: path.join(destDir, destName) };
+      if (entry.scaleWidth) planEntry.scaleWidth = entry.scaleWidth;
+      plan.push(planEntry);
     }
   }
   return plan;
@@ -158,13 +181,20 @@ function main() {
   }
   let missing = 0;
   let failed = 0;
-  for (const { src, dest } of plan) {
+  for (const { src, dest, scaleWidth } of plan) {
     if (!existsSync(src)) {
       console.warn(`[stage-marketing-screenshots] missing source, skipped: ${src}`);
       missing++;
       continue;
     }
-    const result = spawnSync('ffmpeg', ['-y', '-i', src, '-quality', '85', dest], {
+    // -2 lets ffmpeg derive the height from the source aspect ratio while
+    // rounding to the nearest even number (required by the encoder) — see
+    // scripts/tests/stage-marketing-screenshots.test.mjs for the exact
+    // 1280x2856 -> 480x1072 case this reproduces.
+    const args = ['-y', '-i', src];
+    if (scaleWidth) args.push('-vf', `scale=${scaleWidth}:-2`);
+    args.push('-quality', '85', dest);
+    const result = spawnSync('ffmpeg', args, {
       stdio: 'inherit',
     });
     if (result.status !== 0) {

--- a/scripts/tests/stage-marketing-screenshots.test.mjs
+++ b/scripts/tests/stage-marketing-screenshots.test.mjs
@@ -1,7 +1,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
-import { MANIFEST, stagingPlan, mirrorPlan } from '../stage-marketing-screenshots.mjs';
+import {
+  MANIFEST,
+  stagingPlan,
+  mirrorPlan,
+  ffmpegArgs,
+} from '../stage-marketing-screenshots.mjs';
 
 test('stagingPlan produces one file per theme per manifest entry (a pair by default)', () => {
   const plan = stagingPlan(MANIFEST, '/src', '/dest');
@@ -241,5 +246,49 @@ test('existing non-companion entries are unaffected by the viewport-less / scale
   for (const p of plan) {
     assert.match(path.basename(p.src), /\.(desktop|phone|tablet)\.(light|dark)\.png$/);
     assert.ok(!('scaleWidth' in p));
+  }
+});
+
+test('ffmpegArgs threads scaleWidth into a -vf scale filter, rounding height to even', () => {
+  // The 1280x2856 -> 480x1072 case the companion entries exist for. `-2` is
+  // load-bearing: 2856 * (480/1280) is 1071 exactly, and the marketing site
+  // embeds 480x1072, so `-1` would restage every companion asset one pixel
+  // short. Verified against real ffmpeg during #1838 review.
+  assert.deepEqual(ffmpegArgs({ src: '/s/player.light.png', dest: '/d/x.webp', scaleWidth: 480 }), [
+    '-y',
+    '-i',
+    '/s/player.light.png',
+    '-vf',
+    'scale=480:-2',
+    '-quality',
+    '85',
+    '/d/x.webp',
+  ]);
+});
+
+test('ffmpegArgs omits the scale filter entirely when no scaleWidth is set', () => {
+  // Pins that the pre-#1838 command line is byte-for-byte unchanged for every
+  // non-companion entry — a scale filter applied to the desktop captures would
+  // silently resize the whole marketing set.
+  assert.deepEqual(ffmpegArgs({ src: '/s/cast.desktop.light.png', dest: '/d/cast.webp' }), [
+    '-y',
+    '-i',
+    '/s/cast.desktop.light.png',
+    '-quality',
+    '85',
+    '/d/cast.webp',
+  ]);
+});
+
+test('every companion manifest entry reaches ffmpeg with a scale filter', () => {
+  // Guards the seam end to end: manifest -> stagingPlan -> ffmpegArgs. Dropping
+  // the `if (scaleWidth)` push in ffmpegArgs, or scaleWidth from stagingPlan's
+  // plan entries, fails here rather than silently restaging at native size.
+  const companion = MANIFEST.filter((e) => e.scene.startsWith('companion/'));
+  assert.ok(companion.length > 0, 'manifest must still carry companion entries');
+  for (const p of stagingPlan(companion, '/src', '/dest')) {
+    const args = ffmpegArgs(p);
+    assert.ok(args.includes('-vf'), `${p.dest} must be scaled`);
+    assert.match(args[args.indexOf('-vf') + 1], /^scale=\d+:-2$/);
   }
 });

--- a/scripts/tests/stage-marketing-screenshots.test.mjs
+++ b/scripts/tests/stage-marketing-screenshots.test.mjs
@@ -155,3 +155,91 @@ test('the manifest stages the exported series cast card, dark-only', () => {
   assert.deepEqual(entry.themes, ['dark']);
   assert.equal(entry.output, 'series-cast-card');
 });
+
+test('an entry with no viewport builds a <scene>.<theme>.png source path, no viewport segment', () => {
+  const plan = stagingPlan(
+    [{ output: 'companion-iphone', scene: 'companion/player', scaleWidth: 480 }],
+    '/src',
+    '/dest',
+  );
+  assert.deepEqual(plan, [
+    {
+      src: path.join('/src', 'companion/player.light.png'),
+      dest: path.join('/dest', 'companion-iphone.webp'),
+      scaleWidth: 480,
+    },
+    {
+      src: path.join('/src', 'companion/player.dark.png'),
+      dest: path.join('/dest', 'companion-iphone-dark.webp'),
+      scaleWidth: 480,
+    },
+  ]);
+});
+
+test('an entry without scaleWidth does not carry a scaleWidth field into the plan', () => {
+  const plan = stagingPlan(
+    [{ output: 'library', scene: 'library-shelf', viewport: 'desktop' }],
+    '/src',
+    '/dest',
+  );
+  for (const entry of plan) {
+    assert.ok(!('scaleWidth' in entry), 'a non-companion entry must not gain a scaleWidth field');
+  }
+});
+
+test('the companion manifest entries resolve to the right src -> dest pairs, including the nested tablet10/ path', () => {
+  const companionEntries = MANIFEST.filter((e) => e.scene.startsWith('companion/'));
+  assert.deepEqual(
+    companionEntries.map((e) => e.scene),
+    ['companion/player', 'companion/library-home', 'companion/tablet10/book-detail'],
+  );
+
+  const plan = stagingPlan(companionEntries, '/src', '/dest');
+  assert.deepEqual(plan, [
+    {
+      src: path.join('/src', 'companion/player.light.png'),
+      dest: path.join('/dest', 'companion-iphone.webp'),
+      scaleWidth: 480,
+    },
+    {
+      src: path.join('/src', 'companion/player.dark.png'),
+      dest: path.join('/dest', 'companion-iphone-dark.webp'),
+      scaleWidth: 480,
+    },
+    {
+      src: path.join('/src', 'companion/library-home.light.png'),
+      dest: path.join('/dest', 'companion-pixel.webp'),
+      scaleWidth: 480,
+    },
+    {
+      src: path.join('/src', 'companion/library-home.dark.png'),
+      dest: path.join('/dest', 'companion-pixel-dark.webp'),
+      scaleWidth: 480,
+    },
+    {
+      src: path.join('/src', 'companion/tablet10/book-detail.light.png'),
+      dest: path.join('/dest', 'companion-tablet.webp'),
+      scaleWidth: 720,
+    },
+    {
+      src: path.join('/src', 'companion/tablet10/book-detail.dark.png'),
+      dest: path.join('/dest', 'companion-tablet-dark.webp'),
+      scaleWidth: 720,
+    },
+  ]);
+});
+
+test('existing non-companion entries are unaffected by the viewport-less / scaleWidth support', () => {
+  // Every pre-existing manifest entry still has a `viewport` and produces the
+  // same <scene>.<viewport>.<theme>.png source shape as before.
+  const nonCompanion = MANIFEST.filter((e) => !e.scene.startsWith('companion/'));
+  for (const entry of nonCompanion) {
+    assert.ok(entry.viewport, `non-companion entry "${entry.scene}" must keep a viewport`);
+    assert.ok(!('scaleWidth' in entry), `non-companion entry "${entry.scene}" must not gain scaleWidth`);
+  }
+  const plan = stagingPlan(nonCompanion, '/src', '/dest');
+  for (const p of plan) {
+    assert.match(path.basename(p.src), /\.(desktop|phone|tablet)\.(light|dark)\.png$/);
+    assert.ok(!('scaleWidth' in p));
+  }
+});


### PR DESCRIPTION
## Summary

`scripts/stage-marketing-screenshots.mjs` excluded companion-app captures by design — its header said so, on the grounds that `scripts/capture-companion.mjs` is a separate pipeline. But "captured separately" was read as "staged elsewhere", and **nothing in this repo picked them up**: the staging logic actually lived in the Castwright-Website repo, reading this repo's captures across a directory boundary. A capture refresh here therefore never propagated. `--all` didn't reach them either — the raw-name mirror walks only the top level of `mockups/marketing-screens/`, and the companion captures sit in a `companion/` subdirectory.

Two manifest-shape mismatches blocked reusing the curated path. Both are now addressed:

- **No viewport segment.** Companion captures are `companion/player.light.png`, not `<scene>.<viewport>.<theme>.png`. `stagingPlan()` now drops that segment when an entry omits `viewport`.
- **No scale.** Captures are at native device resolution; the site embeds 480px wide. Added an optional `scaleWidth`, threaded into ffmpeg as `scale=<w>:-2`.

The `-2` is load-bearing rather than cosmetic: `scale=480:-1` yields **1071px** of height, one short of the **480×1072** already staged, because the 1280×2856 source scales to an odd number. `-2` rounds to even and reproduces the staged dimensions exactly.

The header's "Out of scope: companion-app screenshots" note is now false, and is rewritten to state the split — capture stays manual (needs a Flutter emulator, still out of scope), staging lives here like everything else in that folder.

## Two corrections to the issue

**1. The staleness half of #1838 no longer held.** The issue reports the 4 webps as dated 7 Jul; they had already been refreshed by hand to 26 Jul before this branch was cut, and inspection confirmed they already carried the cover-art header, 7-chapter list, progress indicator and now-playing label the issue lists as missing. So this PR fixes the *root cause* (no regeneration path) rather than the reported symptom.

**Evidentiary caveat, added after review.** That correction rests on an observation made before this branch regenerated the artifacts, and `brand/` is git-ignored — so no pre-regeneration copy survives and the comparison is no longer independently re-checkable by a reviewer. Circumstantially, sibling `export-format-companion.*.webp` files in the same folder are dated 26 Jul 13:57, consistent with a bulk refresh that day. Treat the correction as defensible but not independently confirmable.

**2. A behaviour change the issue doesn't anticipate.** These six sources come from `capture:companion`, not `capture:marketing`. A box that has run only the marketing rail is now missing six sources, so `npm run stage:marketing-screenshots` exits 1 where it previously exited 0 (each missing file is named in a warning). Deliberately not softened to a silent skip — "companion assets quietly stopped updating" is precisely the failure #1838 was filed for. Documented in the manifest.

## Test plan

- Extended `scripts/tests/stage-marketing-screenshots.test.mjs`: the viewport-less source-path shape, `scaleWidth` correctly absent on non-companion entries, all 3 companion entries' full `src`→`dest` resolution (including the nested `tablet10/` path), and a guard that pre-existing entries are unaffected.
- **`ffmpegArgs()` extracted and pinned** (second commit, from review — see below): scaled command line, unscaled command line, and an end-to-end `MANIFEST → stagingPlan → ffmpegArgs` seam check.
- **Mutation-tested**, because this repo has a history of placebo tests. Deleting the `-vf` push → 2 tests fail. Flipping `-2` to `-1` → 2 tests fail. Restoring → 18/18 green. The tests constrain the behaviour rather than restating it.
- `npm run test:hooks` — **616/616 pass**.
- `npm run stage:marketing-screenshots` — `staged 59/59, missing 0, failed 0`.
- `ffprobe` on all 6 regenerated companion webps: `480×1072` (iphone/pixel pairs), `720×450` (tablet pair).

## Review findings folded in (commit `e869e9f9`)

An independent review verified the `-2` claim against real ffmpeg and found it correct — and stronger than stated: re-encoding all six sources produces output **byte-identical** (`cmp` clean, not merely size-equal) to the staged files. It raised three findings, all addressed:

- **Significant — the encode was untested, and its comment cited a test that did not exist.** `main()` isn't exported, so nothing pinned the `scaleWidth` → `-vf` threading; the comment pointed at a `1280x2856 -> 480x1072` case the test file did not contain. Fixed by extracting `ffmpegArgs()` and adding the three cases above, which also makes the cross-reference true.
- **Minor — "rounding to the nearest even number (required by the encoder)" was factually wrong.** libwebp encodes odd heights fine (verified). The real reason is dimension-matching. Corrected, since a reader trusting it would apply `-2` where even-rounding distorts aspect ratio.
- **Minor — the new entries turn the script red on a marketing-only box.** Now documented in the manifest (see correction 2 above).

Explicitly checked and clean by review: no `--all` mirror collision or double-encode (`readdirSync` returns `companion` as a bare string, which fails the capture-filename filter and is dropped; 59 curated + 187 mirror = 246 dests, zero duplicates); the viewport-less branch degrades loudly rather than silently; no drive-by reformatting.

## Notes

- **Release notes: skipped deliberately.** Internal marketing-asset tooling, no user- or operator-visible product delta.
- **Regression plan: skipped deliberately.** Small and localized — per CLAUDE.md the issue body plus the paired tests are the spec.
- The regenerated `brand/**` assets are git-ignored (local-only, all-rights-reserved), so they do not appear in this diff by design.

Closes #1838