### PR TITLE
fix(server,sidecar): deterministic device env for the sidecar; codec knob resolves UUID pins

### DIFF
--- a/docs/superpowers/plans/2026-07-27-gpu-device-list-boot-warm.md
+++ b/docs/superpowers/plans/2026-07-27-gpu-device-list-boot-warm.md
@@ -1,934 +1,309 @@
-# GPU device-list boot warm + codec device-knob parity — Implementation Plan
+# Deterministic sidecar device env + codec knob parity — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make the Qwen codec honour a `cuda-uuid:` device pin, and warm the Node-side GPU device-list cache from a server-owned boot loop instead of depending on a frontend HTTP request.
+**Goal:** Make the sidecar's device env deterministic — always the raw `cuda-uuid:` literal, which the sidecar resolves live on every spawn — and make the Qwen codec knob honour a UUID pin.
 
-**Architecture:** Six tasks. Tasks 1–2 harden the two pieces of shared state a new concurrent writer would otherwise destabilise (the device-list cache, and the sidecar health probe's side effects). Task 3 adds the warm module itself. Task 4 wires it into boot and de-duplicates the existing warmer. Task 5 pins the `buildSidecarEnv` contract under both cache states. Task 6 is the independent sidecar fix and can be done at any point.
+**Architecture:** Two independent tasks. Task 1 is Node/TypeScript: a second resolver entry point that skips device-UUID reconciliation, used only by `buildSidecarEnv`. Task 2 is the Python sidecar: a named `_codec_device_pref()` helper with a `cpu` fallback. Neither depends on the other; either can land alone.
 
-**Tech Stack:** TypeScript (Node/Express, ESM, `.js` import specifiers), Vitest for server tests; Python 3.12 + FastAPI for the TTS sidecar, pytest for its tests.
+**Tech Stack:** TypeScript (Node/Express, ESM, `.js` import specifiers), Vitest; Python 3.12 + FastAPI sidecar, pytest.
 
 **Spec:** `docs/superpowers/specs/2026-07-27-gpu-device-list-boot-warm-design.md`
 
 ## Global Constraints
 
 - Worktree: `C:\Claude\Projects\Audiobook-Generator\.claude\worktrees\fix+1857-gpu-device-cache-boot-warm`, branch `fix/1857-gpu-device-cache-boot-warm`. Run every command from there; never `cd` to the main checkout.
-- Server imports use ESM `.js` specifiers even for TypeScript sources (`./gpu-device-list-state.js`).
-- `gpu/**` must never import from `routes/**` — including type-only imports, which still count as cycle edges. Cross-layer access goes through the registered-provider gates in `gpu/*-gate.ts`.
-- Commit messages follow Conventional Commits with a scope (`fix(server): …`, `test(server): …`, `fix(sidecar): …`). Every commit body ends with:
+- Server imports use ESM `.js` specifiers even for TypeScript sources.
+- Server tests: `npm --prefix server run test -- <path>` from the worktree root, where `<path>` is relative to `server/` (e.g. `src/config/resolver.test.ts`). `server/vitest.config.ts` has `include: src/**` resolved against cwd, so `npx vitest --config server/vitest.config.ts server/src/…` from the root matches the *frontend* tree and exits "No test files found".
+- Sidecar tests: `server/tts-sidecar/.venv/Scripts/python.exe -m pytest server/tts-sidecar/tests/<file> -v`.
+- Commit messages follow Conventional Commits with a scope. Every commit body ends with:
   ```
   Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
   Claude-Session: https://claude.ai/code/session_01VxtGhVyXqmikbXSpsvuEmg
   ```
-- Server tests: `npm --prefix server run test -- <path>` from the worktree root, where `<path>` is relative to `server/` (e.g. `src/gpu/foo.test.ts`, **not** `server/src/gpu/foo.test.ts`). `server/vitest.config.ts` has `include: src/**`, resolved against whatever cwd vitest runs in — so `npx vitest run --config server/vitest.config.ts server/src/...` from the worktree root resolves `src/**` against the *frontend* tree, matches nothing, and exits 1 with "No test files found". Verified by running it.
-- Sidecar tests: `server/tts-sidecar/.venv/Scripts/python.exe -m pytest server/tts-sidecar/tests/<file> -v`.
-- No task requires a GPU. Every test added here runs on a CPU-only box.
+- No task requires a GPU.
 
 ## File Structure
 
 | File | Responsibility |
 |---|---|
-| `server/src/gpu/gpu-device-list-state.ts` (modify) | Owns the cached uuid↔idx list. Gains the no-downgrade invariant + a test reset seam. |
-| `server/src/gpu/gpu-device-list-state.test.ts` (create) | Pins the no-downgrade invariant. |
-| `server/src/gpu/sidecar-health-gate.ts` (modify) | Zero-import leaf gate. Gains a second provider slot for `devices_state` only. |
-| `server/src/routes/sidecar-health.ts` (modify) | Gains a `recordState` opt to suppress its three cache writes; registers the new provider. |
-| `server/src/gpu/warm-device-list.ts` (create) | Idempotent warm helper + bounded retry loop. |
-| `server/src/gpu/warm-device-list.test.ts` (create) | Covers dedup, retry, stop conditions. |
-| `server/src/routes/config.ts` (modify) | Drops its private warmer, imports the shared one. |
-| `server/src/index.ts` (modify) | Starts the warm loop at boot. |
-| `server/src/tts/sidecar-env.test.ts` (modify) | Pins `buildSidecarEnv` under warm and cold caches. |
-| `server/tts-sidecar/main.py` (modify) | Routes `QWEN_CODEC_DEVICE` through `_read_device_env`. |
-| `server/tts-sidecar/tests/test_device_parse.py` (modify) | Pins codec UUID resolution. |
+| `server/src/config/resolver.ts` (modify) | Gains `resolveKnobForSidecarEnv`, sharing one implementation with `resolveKnob`. |
+| `server/src/config/resolver.test.ts` (modify) | Pins that the two entry points diverge exactly on the device-UUID branch. |
+| `server/src/tts/spawn-sidecar.ts` (modify) | `buildSidecarEnv` switches to the non-reconciling resolver. |
+| `server/src/tts/sidecar-env.test.ts` (modify) | Pins the emitted env under warm **and** cold caches. |
+| `server/tts-sidecar/main.py` (modify) | Adds `_codec_device_pref()`; routes the codec read through it. |
+| `server/tts-sidecar/tests/test_device_parse.py` (modify) | Pins codec UUID resolution and the `cpu` fallback. |
 
 ---
 
-### Task 1: No-downgrade rule in the device-list state module
+### Task 1: Deterministic sidecar device env
 
-An empty device list must never overwrite a warm cache — otherwise the boot loop added in Task 3, racing `GET /api/gpu/devices` and `toUuidForm`, can flip resolved UUID pins back to `uuid_unresolved` during a sidecar recycle.
-
-**Files:**
-- Modify: `server/src/gpu/gpu-device-list-state.ts:15-23`
-- Create: `server/src/gpu/gpu-device-list-state.test.ts`
-- Modify: `server/src/routes/config.test.ts:344,350,383,387`
-- Modify: `server/src/routes/gpu-devices.test.ts:10,25`
-
-**Interfaces:**
-- Produces: `setLastKnownGpuDevices(devices: GpuDeviceInfo[]): void` (unchanged signature, new guard), `_resetGpuDeviceListForTests(): void`, `getLastKnownGpuDevices(): GpuDeviceInfo[]` (unchanged).
-
-- [ ] **Step 1: Write the failing test**
-
-Create `server/src/gpu/gpu-device-list-state.test.ts`:
-
-```ts
-/* Pins the no-downgrade invariant (#1857): once the device list is warm, an
-   empty list never replaces it. Three writers reach this setter — the boot
-   warm loop (gpu/warm-device-list.ts), GET /api/gpu/devices, and toUuidForm on
-   a PUT — and a transient empty from any of them would otherwise unpin every
-   cuda-uuid: assignment until something re-warmed the cache. */
-
-import { describe, it, expect, beforeEach } from 'vitest';
-import {
-  setLastKnownGpuDevices,
-  getLastKnownGpuDevices,
-  _resetGpuDeviceListForTests,
-} from './gpu-device-list-state.js';
-
-describe('setLastKnownGpuDevices no-downgrade rule', () => {
-  beforeEach(() => {
-    _resetGpuDeviceListForTests();
-  });
-
-  it('stores a non-empty list', () => {
-    setLastKnownGpuDevices([{ uuid: 'GPU-1', idx: 1 }]);
-    expect(getLastKnownGpuDevices()).toEqual([{ uuid: 'GPU-1', idx: 1 }]);
-  });
-
-  it('ignores an empty list when the cache is already warm', () => {
-    setLastKnownGpuDevices([{ uuid: 'GPU-1', idx: 1 }]);
-    setLastKnownGpuDevices([]);
-    expect(getLastKnownGpuDevices()).toEqual([{ uuid: 'GPU-1', idx: 1 }]);
-  });
-
-  it('accepts an empty list when the cache is already empty (no-op)', () => {
-    setLastKnownGpuDevices([]);
-    expect(getLastKnownGpuDevices()).toEqual([]);
-  });
-
-  it('always replaces a warm cache with another non-empty list', () => {
-    setLastKnownGpuDevices([{ uuid: 'GPU-1', idx: 1 }]);
-    setLastKnownGpuDevices([{ uuid: 'GPU-2', idx: 0 }]);
-    expect(getLastKnownGpuDevices()).toEqual([{ uuid: 'GPU-2', idx: 0 }]);
-  });
-
-  it('_resetGpuDeviceListForTests clears a warm cache', () => {
-    setLastKnownGpuDevices([{ uuid: 'GPU-1', idx: 1 }]);
-    _resetGpuDeviceListForTests();
-    expect(getLastKnownGpuDevices()).toEqual([]);
-  });
-});
-```
-
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `npm --prefix server run test -- src/gpu/gpu-device-list-state.test.ts`
-Expected: FAIL — `_resetGpuDeviceListForTests` is not exported, and "ignores an empty list when the cache is already warm" returns `[]`.
-
-- [ ] **Step 3: Add the guard and the reset seam**
-
-In `server/src/gpu/gpu-device-list-state.ts`, replace the setter and add the reset:
-
-```ts
-/** Store the live device list. An EMPTY list never replaces a warm one
-    (#1857): `_enumerate_cuda_devices` in the sidecar returns [] both for "no
-    CUDA cards" and for "torch isn't imported yet / the probe raised", so a
-    transient empty during a sidecar recycle is indistinguishable from a real
-    one. Three writers reach this setter — the boot warm loop, GET
-    /api/gpu/devices, and toUuidForm — and downgrading here would flip every
-    resolved 'cuda-uuid:' pin to staleReason:'uuid_unresolved' and make
-    buildSidecarEnv emit raw literals after having emitted indices. The
-    tradeoff is deliberate: a genuinely-unplugged card keeps serving its last
-    known mapping (same staleness contract as vram-state.ts, see file header). */
-export function setLastKnownGpuDevices(devices: GpuDeviceInfo[]): void {
-  if (devices.length === 0 && lastKnownGpuDevices.length > 0) return;
-  lastKnownGpuDevices = devices;
-}
-
-/** Test seam — the ONLY way to clear a warm cache, since the setter above
-    deliberately ignores an empty list. */
-export function _resetGpuDeviceListForTests(): void {
-  lastKnownGpuDevices = [];
-}
-```
-
-- [ ] **Step 4: Run test to verify it passes**
-
-Run: `npm --prefix server run test -- src/gpu/gpu-device-list-state.test.ts`
-Expected: PASS, 5 tests.
-
-- [ ] **Step 5: Migrate the three existing empty-reset call sites**
-
-These pass `[]` to mean "reset", which is now a no-op and would make their cold-cache assertions pass for the wrong reason (or fail outright when an earlier test in the file left the cache warm).
-
-In `server/src/routes/config.test.ts`, at lines 344 and 383 change the dynamic import, and at 350 and 387 change the call:
-
-```ts
-// line 344 and line 383 — was: const { setLastKnownGpuDevices } = await import(...)
-const { _resetGpuDeviceListForTests } = await import('../gpu/gpu-device-list-state.js');
-
-// line 350 and line 387 — was: setLastKnownGpuDevices([]);
-_resetGpuDeviceListForTests();
-```
-
-Leave line 370/374 alone — that test sets a non-empty list and is unaffected.
-
-In `server/src/routes/gpu-devices.test.ts`, line 10 and line 25. **Drop
-`setLastKnownGpuDevices` from the import** — line 25 is its only use in the file,
-so keeping it would leave an unused binding and fail lint/typecheck.
-`getLastKnownGpuDevices` stays; it is still used at line 87.
-
-```ts
-// line 10 — was: import { setLastKnownGpuDevices, getLastKnownGpuDevices } from '../gpu/gpu-device-list-state.js';
-import {
-  getLastKnownGpuDevices,
-  _resetGpuDeviceListForTests,
-} from '../gpu/gpu-device-list-state.js';
-
-// line 25, inside beforeEach — was: setLastKnownGpuDevices([]);
-_resetGpuDeviceListForTests();
-```
-
-In `server/src/routes/config.test.ts` the setter is imported dynamically inside
-each test, so removing it from the two dynamic imports at 344 and 383 leaves
-nothing dangling. The test at 370/374 keeps its own `setLastKnownGpuDevices`
-import — it passes a non-empty list.
-
-- [ ] **Step 6: Run the affected suites**
-
-Run: `npm --prefix server run test -- src/gpu/gpu-device-list-state.test.ts src/routes/config.test.ts src/routes/gpu-devices.test.ts`
-Expected: PASS, all three files green.
-
-- [ ] **Step 7: Commit**
-
-```bash
-git add server/src/gpu/gpu-device-list-state.ts server/src/gpu/gpu-device-list-state.test.ts server/src/routes/config.test.ts server/src/routes/gpu-devices.test.ts
-git commit -F - <<'EOF'
-fix(server): never downgrade a warm GPU device list to empty
-
-Refs #1857
-
-Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
-Claude-Session: https://claude.ai/code/session_01VxtGhVyXqmikbXSpsvuEmg
-EOF
-```
-
----
-
-### Task 2: Side-effect-free `devices_state` accessor
-
-The warm loop needs the sidecar's `devices_state` to tell "no CUDA cards" from "torch still importing". The obvious route, `probeSidecarHealthIfRegistered()`, would drag three cache writes (`setLastKnownQwenInstallState`, `setLastKnownVram`, `setLastKnownEngineDevices`) into a boot timer that runs while the supervisor is deciding what to spawn.
+Today `buildSidecarEnv` reads through `resolveKnob`, which translates a stored
+`cuda-uuid:` override to `cuda:N` **only when the device cache happens to be
+warm** — i.e. only if someone opened Advanced settings this server session. The
+warm branch freezes an index that `buildOpts` then re-emits on every respawn
+(`sidecar-supervisor.ts:234`), so a card that vanishes or renumbers afterwards
+yields a hard `_validate_cuda_index` failure or a silently wrong card. The cold
+branch hands over the UUID, which the sidecar resolves live and degrades safely.
+Make the safe branch unconditional.
 
 **Files:**
-- Modify: `server/src/gpu/sidecar-health-gate.ts:45-58`
-- Modify: `server/src/routes/sidecar-health.ts:235`, `:263-268`, `:331`
-- Create: `server/src/routes/sidecar-health-record-state.test.ts`
-
-**Interfaces:**
-- Consumes: nothing from Task 1.
-- Produces: `probeSidecarHealth(opts?: { recordState?: boolean }): Promise<SidecarHealthResult>`; `type DeviceProbeState = 'pending' | 'ready' | 'error'`; `setDeviceProbeStateProvider(fn: () => Promise<DeviceProbeState | null>): void`; `probeDeviceProbeStateIfRegistered(): Promise<DeviceProbeState | null>`.
-
-- [ ] **Step 1: Write the failing test**
-
-Create `server/src/routes/sidecar-health-record-state.test.ts`. **Its own file,
-not appended to `sidecar-health.test.ts`:** asserting "these setters were NOT
-called" requires the state modules to be mocked, and mocking them wholesale
-inside that file would change what every pre-existing test there exercises.
-`vi.spyOn` on the shared file is not an option either — `server/vitest.config.ts`
-sets no `restoreMocks`, so spies would leak across its tests.
-
-```ts
-/* #1857 — probeSidecarHealth({ recordState: false }) parses identically but
-   performs NONE of its three last-known-state writes, so the boot-time GPU
-   device-list warm loop can read devices_state without moving Qwen install
-   state / VRAM / per-engine device ground truth while the supervisor is still
-   deciding what to spawn. Also pins that sidecar-health.ts actually REGISTERS
-   the non-recording probe with the gate at module init — without that, the
-   warm loop's early exit silently degrades to "always null, always retry". */
-
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-
-vi.mock('../tts/sidecar-supervisor.js', () => ({
-  getActiveSupervisor: vi.fn(() => null),
-  registerActiveSupervisor: vi.fn(),
-  createSidecarSupervisor: vi.fn(),
-}));
-vi.mock('../gpu/capacity-retry.js', () => ({ withCapacityRetry: vi.fn() }));
-/* All three use the importOriginal SPREAD, not a bare factory. vi.mock replaces
-   the module for every importer in this test's graph, and each of these has
-   other live consumers: vram-state also exports getLastKnownVram (analyzer/
-   ollama.ts, routes/ollama-health.ts), engine-device-state also exports
-   getLastKnownEngineDevice + _resetEngineDevicesForTests (gpu/engine-device.ts),
-   and user-settings exports most of the settings surface. A bare factory
-   listing only the setter would kill the import with "does not provide an
-   export named …". Spread first, override the one setter. */
-vi.mock('../gpu/vram-state.js', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../gpu/vram-state.js')>()),
-  setLastKnownVram: vi.fn(),
-}));
-vi.mock('../gpu/engine-device-state.js', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../gpu/engine-device-state.js')>()),
-  setLastKnownEngineDevices: vi.fn(),
-}));
-vi.mock('../workspace/user-settings.js', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../workspace/user-settings.js')>()),
-  setLastKnownQwenInstallState: vi.fn(),
-}));
-
-import { probeSidecarHealth } from './sidecar-health.js';
-import { probeDeviceProbeStateIfRegistered } from '../gpu/sidecar-health-gate.js';
-import { setLastKnownVram } from '../gpu/vram-state.js';
-import { setLastKnownEngineDevices } from '../gpu/engine-device-state.js';
-import { setLastKnownQwenInstallState } from '../workspace/user-settings.js';
-
-const fetchMock = vi.fn();
-
-function okHealth() {
-  return new Response(
-    JSON.stringify({
-      model_loaded: true,
-      vram_total_mb: 16000,
-      devices: { qwen: 'cuda' },
-      devices_state: 'ready',
-    }),
-    { status: 200, headers: { 'Content-Type': 'application/json' } },
-  );
-}
-
-beforeEach(() => {
-  fetchMock.mockReset();
-  vi.stubGlobal('fetch', fetchMock);
-  vi.mocked(setLastKnownVram).mockClear();
-  vi.mocked(setLastKnownEngineDevices).mockClear();
-  vi.mocked(setLastKnownQwenInstallState).mockClear();
-});
-
-afterEach(() => {
-  vi.unstubAllGlobals();
-});
-
-describe('probeSidecarHealth recordState opt', () => {
-  it('records last-known state by default', async () => {
-    fetchMock.mockResolvedValue(okHealth());
-
-    const res = await probeSidecarHealth();
-
-    expect(res.status).toBe('reachable');
-    expect(res.devicesState).toBe('ready');
-    expect(setLastKnownVram).toHaveBeenCalled();
-    expect(setLastKnownEngineDevices).toHaveBeenCalled();
-    expect(setLastKnownQwenInstallState).toHaveBeenCalled();
-  });
-
-  it('performs no state writes when recordState is false, but parses the same result', async () => {
-    fetchMock.mockResolvedValue(okHealth());
-
-    const res = await probeSidecarHealth({ recordState: false });
-
-    expect(res.status).toBe('reachable');
-    expect(res.devicesState).toBe('ready');
-    expect(res.vramTotalMb).toBe(16000);
-    expect(setLastKnownVram).not.toHaveBeenCalled();
-    expect(setLastKnownEngineDevices).not.toHaveBeenCalled();
-    expect(setLastKnownQwenInstallState).not.toHaveBeenCalled();
-  });
-});
-
-describe('device-probe-state provider registration', () => {
-  it('is registered by importing sidecar-health.ts, and does not record state', async () => {
-    fetchMock.mockResolvedValue(okHealth());
-
-    // Not null => sidecar-health.ts called setDeviceProbeStateProvider at init.
-    await expect(probeDeviceProbeStateIfRegistered()).resolves.toBe('ready');
-    expect(setLastKnownVram).not.toHaveBeenCalled();
-  });
-
-  it('resolves null when the sidecar is unreachable, so the warm loop keeps waiting', async () => {
-    fetchMock.mockRejectedValue(new TypeError('fetch failed'));
-
-    await expect(probeDeviceProbeStateIfRegistered()).resolves.toBeNull();
-  });
-});
-```
-
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `npm --prefix server run test -- src/routes/sidecar-health-record-state.test.ts`
-Expected: FAIL — `probeSidecarHealth` takes no arguments (so the `recordState: false` test still sees all three writes), and `probeDeviceProbeStateIfRegistered` is not exported from the gate.
-
-- [ ] **Step 3: Add the opt to `probeSidecarHealth`**
-
-In `server/src/routes/sidecar-health.ts`, change the signature at line 235 and guard the three writes at 263-268:
-
-```ts
-/** Options for {@link probeSidecarHealth}. */
-export interface ProbeSidecarHealthOpts {
-  /** When false, parse and return exactly as normal but perform NONE of the
-      three last-known-state writes below. Used by the boot-time GPU
-      device-list warm loop (gpu/warm-device-list.ts), which needs
-      `devices_state` while the supervisor is still deciding what to spawn —
-      letting a background timer move Qwen install state there could change
-      which model the first spawn preloads (index.ts seeds it from a DISK
-      probe for exactly that reason). Defaults to true: every other caller,
-      including the /health route the UI polls, still records. */
-  recordState?: boolean;
-}
-
-export async function probeSidecarHealth(
-  opts: ProbeSidecarHealthOpts = {},
-): Promise<SidecarHealthResult> {
-  const { recordState = true } = opts;
-```
-
-and:
-
-```ts
-    const devices = normaliseDevices(body.devices);
-    if (recordState) {
-      setLastKnownQwenInstallState(qwenInstallState);
-      setLastKnownVram({
-        totalMb: typeof body.vram_total_mb === 'number' ? body.vram_total_mb : null,
-      });
-      setLastKnownEngineDevices(devices);
-    }
-```
-
-(Move the `const devices = …` line above the block, as shown — the returned object still uses it.)
-
-- [ ] **Step 4: Add the provider slot to the gate**
-
-Append to `server/src/gpu/sidecar-health-gate.ts`:
-
-```ts
-/** The sidecar's startup device-probe state: 'pending' until torch finishes
-    importing in the background, 'ready' once it has, 'error' when torch is
-    missing or the probe raised. Spelled locally rather than imported from
-    routes/sidecar-health.ts for the same cycle reason as
-    SidecarHealthSnapshot above — a type-only import is still an edge. */
-export type DeviceProbeState = 'pending' | 'ready' | 'error';
-
-let deviceProbeStateProvider: (() => Promise<DeviceProbeState | null>) | null = null;
-
-/** Registered by routes/sidecar-health.ts with a NON-recording probe — the
-    caller (the boot warm loop) must not perturb last-known Qwen/VRAM/device
-    state just by asking whether the device probe has settled. */
-export function setDeviceProbeStateProvider(
-  fn: () => Promise<DeviceProbeState | null>,
-): void {
-  deviceProbeStateProvider = fn;
-}
-
-/** Resolves to the sidecar's device-probe state, or `null` when nothing has
-    registered or the sidecar is unreachable — fail closed (see file header):
-    `null` means "can't tell", and callers must treat it as "keep waiting",
-    never as "settled". */
-export async function probeDeviceProbeStateIfRegistered(): Promise<DeviceProbeState | null> {
-  if (!deviceProbeStateProvider) return null;
-  return deviceProbeStateProvider();
-}
-```
-
-- [ ] **Step 5: Register it**
-
-In `server/src/routes/sidecar-health.ts`, next to line 331:
-
-```ts
-import {
-  setProbeSidecarHealthProvider,
-  setDeviceProbeStateProvider,
-} from '../gpu/sidecar-health-gate.js';
-
-// …at the bottom, beside the existing registration:
-setProbeSidecarHealthProvider(probeSidecarHealth);
-setDeviceProbeStateProvider(() =>
-  probeSidecarHealth({ recordState: false }).then((r) => r.devicesState ?? null),
-);
-```
-
-- [ ] **Step 6: Run tests**
-
-Run: `npm --prefix server run test -- src/routes/sidecar-health-record-state.test.ts src/routes/sidecar-health.test.ts`
-Expected: PASS — the four new tests, plus every pre-existing test in the original file unchanged.
-
-**If the new file fails on a mock-resolution error rather than an assertion,
-re-run once before debugging.** This repo has a recorded intermittent failure
-with `importOriginal`-based mocks that clears on a re-run. A *consistent*
-failure is a real defect; a one-off is the known flake.
-
-- [ ] **Step 7: Commit**
-
-```bash
-git add server/src/gpu/sidecar-health-gate.ts server/src/routes/sidecar-health.ts server/src/routes/sidecar-health-record-state.test.ts
-git commit -F - <<'EOF'
-feat(server): side-effect-free devices_state accessor for the health gate
-
-Refs #1857
-
-Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
-Claude-Session: https://claude.ai/code/session_01VxtGhVyXqmikbXSpsvuEmg
-EOF
-```
-
----
-
-### Task 3: The warm module
-
-**Files:**
-- Create: `server/src/gpu/warm-device-list.ts`
-- Create: `server/src/gpu/warm-device-list.test.ts`
-
-**Interfaces:**
-- Consumes: `setLastKnownGpuDevices`, `getLastKnownGpuDevices`, `_resetGpuDeviceListForTests` (Task 1); `probeDeviceProbeStateIfRegistered`, `DeviceProbeState` (Task 2); `fetchSidecarDevices` from `./fetch-sidecar-devices.js` (existing).
-- Produces: `ensureGpuDeviceListWarm(): Promise<void>`; `runGpuDeviceListWarmup(opts?: WarmupOpts): Promise<void>`; `startGpuDeviceListWarmup(opts?: WarmupOpts): void`; `_resetWarmDeviceListForTests(): void`; `interface WarmupOpts { maxAttempts?: number; attemptDelayMs?: number; log?: (msg: string) => void; delayFn?: (ms: number) => Promise<void> }`.
-
-- [ ] **Step 1: Write the failing test**
-
-Create `server/src/gpu/warm-device-list.test.ts`:
-
-```ts
-/* #1857 — the GPU device-list cache had exactly one warmer, GET /api/config,
-   so nothing warmed it until the user opened Advanced settings. These cover
-   the server-owned replacement: dedup, retry, and the two stop conditions. */
-
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-
-vi.mock('./fetch-sidecar-devices.js', () => ({ fetchSidecarDevices: vi.fn() }));
-vi.mock('./sidecar-health-gate.js', () => ({
-  probeDeviceProbeStateIfRegistered: vi.fn(async () => null),
-}));
-
-import { fetchSidecarDevices } from './fetch-sidecar-devices.js';
-import { probeDeviceProbeStateIfRegistered } from './sidecar-health-gate.js';
-import {
-  ensureGpuDeviceListWarm,
-  runGpuDeviceListWarmup,
-  _resetWarmDeviceListForTests,
-} from './warm-device-list.js';
-import {
-  getLastKnownGpuDevices,
-  _resetGpuDeviceListForTests,
-} from './gpu-device-list-state.js';
-
-const mockFetch = vi.mocked(fetchSidecarDevices);
-const mockState = vi.mocked(probeDeviceProbeStateIfRegistered);
-
-const ONE_CARD = {
-  devices: [{ uuid: 'GPU-1', idx: 1, name: 'x', total_mb: 16000, free_mb: 14000 }],
-  cpu: true,
-};
-const NO_CARDS = { devices: [], cpu: true };
-
-/* delayFn is replaced so the retry loop never actually waits — the tests
-   assert attempt COUNTS, not wall-clock behaviour. */
-const noWait = async () => {};
-
-beforeEach(() => {
-  mockFetch.mockReset();
-  mockState.mockReset();
-  mockState.mockResolvedValue(null);
-  _resetGpuDeviceListForTests();
-  _resetWarmDeviceListForTests();
-});
-
-describe('ensureGpuDeviceListWarm', () => {
-  it('warms a cold cache from a reachable sidecar', async () => {
-    mockFetch.mockResolvedValue(ONE_CARD);
-    await ensureGpuDeviceListWarm();
-    expect(getLastKnownGpuDevices()).toEqual([{ uuid: 'GPU-1', idx: 1 }]);
-  });
-
-  it('issues no fetch when the cache is already warm', async () => {
-    mockFetch.mockResolvedValue(ONE_CARD);
-    await ensureGpuDeviceListWarm();
-    mockFetch.mockClear();
-    await ensureGpuDeviceListWarm();
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
-
-  it('concurrent callers share a single in-flight fetch', async () => {
-    mockFetch.mockResolvedValue(ONE_CARD);
-    await Promise.all([
-      ensureGpuDeviceListWarm(),
-      ensureGpuDeviceListWarm(),
-      ensureGpuDeviceListWarm(),
-    ]);
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-  });
-
-  it('leaves the cache cold when the sidecar is unreachable', async () => {
-    mockFetch.mockResolvedValue(null);
-    await ensureGpuDeviceListWarm();
-    expect(getLastKnownGpuDevices()).toEqual([]);
-  });
-});
-
-describe('runGpuDeviceListWarmup', () => {
-  it('retries an unreachable sidecar and warms once it answers', async () => {
-    mockFetch.mockResolvedValueOnce(null).mockResolvedValueOnce(null).mockResolvedValue(ONE_CARD);
-    await runGpuDeviceListWarmup({ maxAttempts: 5, delayFn: noWait });
-    expect(getLastKnownGpuDevices()).toEqual([{ uuid: 'GPU-1', idx: 1 }]);
-    expect(mockFetch).toHaveBeenCalledTimes(3);
-  });
-
-  it('keeps retrying an empty list while devices_state is pending', async () => {
-    mockFetch.mockResolvedValueOnce(NO_CARDS).mockResolvedValue(ONE_CARD);
-    mockState.mockResolvedValue('pending');
-    await runGpuDeviceListWarmup({ maxAttempts: 5, delayFn: noWait });
-    expect(getLastKnownGpuDevices()).toEqual([{ uuid: 'GPU-1', idx: 1 }]);
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-  });
-
-  it('stops early when devices_state is ready with zero cards', async () => {
-    mockFetch.mockResolvedValue(NO_CARDS);
-    mockState.mockResolvedValue('ready');
-    await runGpuDeviceListWarmup({ maxAttempts: 24, delayFn: noWait });
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(getLastKnownGpuDevices()).toEqual([]);
-  });
-
-  it('stops early when devices_state is error', async () => {
-    mockFetch.mockResolvedValue(NO_CARDS);
-    mockState.mockResolvedValue('error');
-    await runGpuDeviceListWarmup({ maxAttempts: 24, delayFn: noWait });
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-  });
-
-  it('keeps retrying when no state provider is registered (null)', async () => {
-    mockFetch.mockResolvedValue(NO_CARDS);
-    mockState.mockResolvedValue(null);
-    await runGpuDeviceListWarmup({ maxAttempts: 4, delayFn: noWait });
-    expect(mockFetch).toHaveBeenCalledTimes(4);
-  });
-
-  it('exhausts its budget without throwing', async () => {
-    mockFetch.mockResolvedValue(null);
-    await expect(
-      runGpuDeviceListWarmup({ maxAttempts: 3, delayFn: noWait }),
-    ).resolves.toBeUndefined();
-    expect(mockFetch).toHaveBeenCalledTimes(3);
-  });
-
-  it('swallows a throwing fetch and keeps going', async () => {
-    mockFetch.mockRejectedValueOnce(new Error('boom')).mockResolvedValue(ONE_CARD);
-    await runGpuDeviceListWarmup({ maxAttempts: 3, delayFn: noWait });
-    expect(getLastKnownGpuDevices()).toEqual([{ uuid: 'GPU-1', idx: 1 }]);
-  });
-});
-```
-
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `npm --prefix server run test -- src/gpu/warm-device-list.test.ts`
-Expected: FAIL — `Cannot find module './warm-device-list.js'`.
-
-- [ ] **Step 3: Write the module**
-
-Create `server/src/gpu/warm-device-list.ts`:
-
-```ts
-/* Server-owned warm for the GPU device-list cache (#1857).
-
-   Until PR #1852 the frontend dispatched fetchConfig() at app boot, so every
-   page load in any view incidentally warmed this cache. That dispatch existed
-   only to hydrate the deleted voices.library.enabled gate; with it gone, all
-   three warmers (GET /api/config, GET /api/gpu/devices, and a PUT device
-   write) are dispatched from src/views/advanced.tsx alone — so nothing warmed
-   the cache until a user opened Advanced settings.
-
-   This does NOT warm before the first spawnSidecar: the only source of the
-   uuid<->idx mapping is the sidecar's own GET /devices, and at the initial
-   boot spawn that process doesn't exist yet. It doesn't need to. The sidecar
-   resolves 'cuda-uuid:<uuid>' itself via _read_device_env ->
-   _resolve_uuid_to_index (main.py), which exists precisely because this cache
-   is cold at spawn time. This loop is for the NODE-side consumers of a
-   resolved device knob, and for the Advanced UI's staleReason reconcile. */
-
-import { fetchSidecarDevices } from './fetch-sidecar-devices.js';
-import { getLastKnownGpuDevices, setLastKnownGpuDevices } from './gpu-device-list-state.js';
-import { probeDeviceProbeStateIfRegistered } from './sidecar-health-gate.js';
-
-/* Sized to outlast a cold torch import, not a single probe. fetchSidecarDevices
-   aborts each attempt at 2s (PROBE_TIMEOUT_MS) and the sidecar's /devices is a
-   sync def whose first call triggers `import torch` on FastAPI's threadpool —
-   so early attempts WILL abort. That's survivable because the aborted client
-   fetch doesn't cancel the server-side import (a running Python thread can't be
-   interrupted by a disconnect), so a later attempt lands on a warm module.
-   Mirrors runCatalogAudit's 24 x 5s, which solves the same "sidecar takes
-   30-60s to come up" problem. */
-const DEFAULT_MAX_ATTEMPTS = 24;
-const DEFAULT_ATTEMPT_DELAY_MS = 5_000;
-
-export interface WarmupOpts {
-  maxAttempts?: number;
-  attemptDelayMs?: number;
-  log?: (msg: string) => void;
-  delayFn?: (ms: number) => Promise<void>;
-}
-
-/* Shared in-flight promise so the boot loop and a concurrent GET /api/config
-   pay ONE sidecar round-trip rather than two. */
-let inFlight: Promise<void> | null = null;
-
-/** Warm the cache if it isn't already. Idempotent, deduped, and NEVER throws —
-    GET /api/config awaits this inline (routes/config.ts), so a throw here would
-    turn a warm failure into a 500 on the Advanced Settings load. fetchSidecarDevices
-    already swallows everything and returns null; the catch is belt-and-braces
-    against that contract changing. */
-export async function ensureGpuDeviceListWarm(): Promise<void> {
-  if (getLastKnownGpuDevices().length > 0) return;
-  if (inFlight) return inFlight;
-  inFlight = (async () => {
-    try {
-      const result = await fetchSidecarDevices();
-      if (result) {
-        setLastKnownGpuDevices(result.devices.map((d) => ({ uuid: d.uuid, idx: d.idx })));
-      }
-    } catch {
-      // leave the cache cold; the retry loop (or the next request) tries again
-    }
-  })().finally(() => {
-    inFlight = null;
-  });
-  return inFlight;
-}
-
-/** Test seam — clears the shared in-flight promise. Distinct from
-    _resetGpuDeviceListForTests(), which clears the cached list itself. */
-export function _resetWarmDeviceListForTests(): void {
-  inFlight = null;
-}
-
-function defaultDelay(ms: number): Promise<void> {
-  return new Promise<void>((resolve) => {
-    const t = setTimeout(resolve, ms);
-    // Never hold the process open on our own — same contract as the other
-    // boot-time background timers (see startBackupScheduler in index.ts).
-    t.unref?.();
-  });
-}
-
-/** The retry loop. Exported separately from the fire-and-forget starter so
-    tests can await it with an injected delayFn instead of real timers.
-    Never throws — a boot-time warm failing must not affect anything else. */
-export async function runGpuDeviceListWarmup(opts: WarmupOpts = {}): Promise<void> {
-  const {
-    maxAttempts = DEFAULT_MAX_ATTEMPTS,
-    attemptDelayMs = DEFAULT_ATTEMPT_DELAY_MS,
-    log = console.log,
-    delayFn = defaultDelay,
-  } = opts;
-
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      await ensureGpuDeviceListWarm();
-      const cards = getLastKnownGpuDevices();
-      if (cards.length > 0) {
-        log(`[gpu] device list warm: ${cards.length} card(s) after ${attempt} attempt(s).`);
-        return;
-      }
-      /* An empty list is ambiguous — the sidecar returns [] both for "no CUDA
-         cards" and for "torch isn't imported yet / the probe raised". Ask the
-         sidecar which it is. Only a SETTLED state ends the loop: 'ready' means
-         torch is up and there genuinely are no cards, 'error' means the probe
-         failed and won't fix itself. 'pending' and null (unregistered provider,
-         or unreachable sidecar) both mean "can't tell yet" — keep waiting. */
-      const state = await probeDeviceProbeStateIfRegistered();
-      if (state === 'ready' || state === 'error') {
-        log(`[gpu] device list warm: sidecar reports no CUDA cards (devices_state=${state}).`);
-        return;
-      }
-    } catch {
-      // fall through to the retry — never let a warm failure escape
-    }
-    if (attempt < maxAttempts) await delayFn(attemptDelayMs);
-  }
-  log(
-    `[gpu] device list warm: gave up after ${maxAttempts} attempt(s) — ` +
-      `sidecar never reported a card list. UUID device pins will resolve sidecar-side.`,
-  );
-}
-
-/** Fire-and-forget starter for the boot path. */
-export function startGpuDeviceListWarmup(opts: WarmupOpts = {}): void {
-  void runGpuDeviceListWarmup(opts);
-}
-```
-
-- [ ] **Step 4: Run test to verify it passes**
-
-Run: `npm --prefix server run test -- src/gpu/warm-device-list.test.ts`
-Expected: PASS, 12 tests.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add server/src/gpu/warm-device-list.ts server/src/gpu/warm-device-list.test.ts
-git commit -F - <<'EOF'
-feat(server): server-owned GPU device-list warm loop
-
-Refs #1857
-
-Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
-Claude-Session: https://claude.ai/code/session_01VxtGhVyXqmikbXSpsvuEmg
-EOF
-```
-
----
-
-### Task 4: Wire it into boot; de-duplicate the route's private warmer
-
-**Files:**
-- Modify: `server/src/routes/config.ts:20-46`
-- Modify: `server/src/index.ts` (import block, and `listenerCallback` after line 301)
-
-**Interfaces:**
-- Consumes: `ensureGpuDeviceListWarm`, `startGpuDeviceListWarmup` (Task 3).
-- Produces: nothing new.
-
-- [ ] **Step 1: Replace the route's private warmer with the shared one**
-
-In `server/src/routes/config.ts`, delete the local `ensureGpuDeviceListWarm` function **and** its docblock (lines 26-43). The `GET /` handler's `await ensureGpuDeviceListWarm();` call at line 46 stays exactly as it is — it now resolves to the imported helper.
-
-Import changes, precisely:
-
-- **Line 21, keep unchanged.** `import { fetchSidecarDevices, type SidecarDevicesResponse } from '../gpu/fetch-sidecar-devices.js';` — the `PUT` handler still uses both (lines 82 and 101).
-- **Line 22, delete.** `import { getLastKnownGpuDevices, setLastKnownGpuDevices } from '../gpu/gpu-device-list-state.js';` — both bindings become unused once the local function is gone.
-- **Add**, beside the other `../gpu/` imports:
-
-```ts
-import { ensureGpuDeviceListWarm } from '../gpu/warm-device-list.js';
-```
-
-Then put a shortened docblock immediately above `configRouter.get('/', …)`, replacing the deleted one:
-
-```ts
-/* resolveAll() -> resolveKnob() reconciles a stored 'cuda-uuid:<uuid>' override
-   against getLastKnownGpuDevices()'s cache SYNCHRONOUSLY. AdvancedView's mount
-   effect fires fetchConfig() and getGpuDevices() concurrently with no ordering,
-   and this route is a synchronous local computation that routinely resolves
-   BEFORE the sidecar round-trip GET /api/gpu/devices needs — which would
-   mislabel a valid uuid pin as staleReason:'uuid_unresolved' on the first
-   Advanced Settings load after a restart. Warming here (a no-op once anything
-   else has warmed it, including the boot loop) keeps that race closed. See
-   gpu/warm-device-list.ts. */
-```
-
-**Note:** `fetchSidecarDevices` and `SidecarDevicesResponse` are still used by the `PUT` handler at lines 82 and 101 — keep that import. Only the `gpu-device-list-state.js` import becomes unused.
-
-- [ ] **Step 2: Verify the config route still passes**
-
-Run: `npm --prefix server run test -- src/routes/config.test.ts`
-Expected: PASS — identical behaviour, warmer just lives elsewhere now.
-
-- [ ] **Step 3: Start the loop at boot**
-
-In `server/src/index.ts`, add to the import block (near line 48's `initDeviceTotalVram` import):
-
-```ts
-import { startGpuDeviceListWarmup } from './gpu/warm-device-list.js';
-```
-
-and immediately after `registerActiveSupervisor(sidecarSupervisor);` (line 302), inside `listenerCallback`:
-
-```ts
-    /* #1857 — warm the GPU device-list cache from the SERVER, not from a
-       frontend request. Until PR #1852 the store's boot fetchConfig() dispatch
-       warmed it incidentally on every page load; that dispatch existed only for
-       the deleted voices.library.enabled gate, so with it gone nothing warmed
-       the cache until a user opened Advanced settings. Started after the
-       supervisor so the sidecar it polls is already being spawned; the loop
-       retries while the sidecar comes up and stops as soon as it reports a
-       settled devices_state. Fire-and-forget and unref'd — it never blocks boot
-       and never holds the process open. */
-    startGpuDeviceListWarmup();
-```
-
-- [ ] **Step 4: Verify boot wiring compiles and the shutdown suite is unaffected**
-
-Run: `npx tsc -p server/tsconfig.json --noEmit`
-Expected: no errors.
-
-Run: `npm --prefix server run test -- src/index.test.ts`
-Expected: PASS — `index.test.ts` imports the module but the main-module guard keeps `main()` (and therefore `listenerCallback` and the timer) from running.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add server/src/routes/config.ts server/src/index.ts
-git commit -F - <<'EOF'
-fix(server): warm the GPU device list at boot, not on first GET /api/config
-
-Refs #1857
-
-Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
-Claude-Session: https://claude.ai/code/session_01VxtGhVyXqmikbXSpsvuEmg
-EOF
-```
-
----
-
-### Task 5: Pin the `buildSidecarEnv` contract under both cache states
-
-The cold-cache case is **not** a bug — the sidecar resolves the literal itself. This test documents that so the next reader doesn't "fix" it.
-
-**This task is a characterization test, not a TDD cycle.** Both assertions pass
-against unmodified production code; there is deliberately no "verify it fails"
-step, because there is no behaviour change here to drive. Its value is pinning a
-contract that currently exists only as tribal knowledge — #1857 was filed because
-a reader saw the cold-cache literal and reasonably concluded it was a defect.
-
-**Files:**
+- Modify: `server/src/config/resolver.ts:15-53`
+- Modify: `server/src/config/resolver.test.ts` (append to the existing device-UUID describe at :75-95)
+- Modify: `server/src/tts/spawn-sidecar.ts:474`
 - Modify: `server/src/tts/sidecar-env.test.ts`
 
 **Interfaces:**
-- Consumes: `_resetGpuDeviceListForTests` (Task 1).
+- Produces: `resolveKnobForSidecarEnv(knob: ConfigKnob): KnobValueState` — same shape as `resolveKnob`, never sets `staleReason`, never rewrites a `cuda-uuid:` override.
 
-- [ ] **Step 1: Write the test**
+- [ ] **Step 1: Write the failing tests**
+
+Append to the existing `describe('resolveKnob — device UUID reconcile …')` block in `server/src/config/resolver.test.ts`, and add `resolveKnobForSidecarEnv` to the import on line 11:
+
+```ts
+describe('resolveKnobForSidecarEnv — deliberately does NOT reconcile', () => {
+  beforeEach(() => {
+    (gds.getLastKnownGpuDevices as any).mockReturnValue([]);
+  });
+
+  /* #1857 B1 — the sidecar resolves 'cuda-uuid:' itself against LIVE
+     enumeration on every spawn (main.py:1873 _read_device_env). Handing it a
+     pre-translated index instead freezes a mapping that a respawn can no longer
+     correct. So this entry point must emit the uuid form even when the cache
+     could translate it. */
+  it('passes a cuda-uuid override through even when the card IS visible', () => {
+    (us.readConfigOverrides as any).mockReturnValue({ 'tts.qwen.device': 'cuda-uuid:GPU-1' });
+    (gds.getLastKnownGpuDevices as any).mockReturnValue([{ uuid: 'GPU-1', idx: 1 }]);
+    const st = resolveKnobForSidecarEnv(getKnob('tts.qwen.device')!);
+    expect(st.effective).toBe('cuda-uuid:GPU-1');
+    expect(st.staleReason).toBeUndefined();
+  });
+
+  it('passes a cuda-uuid override through when no card matches, WITHOUT flagging stale', () => {
+    (us.readConfigOverrides as any).mockReturnValue({ 'tts.qwen.device': 'cuda-uuid:GONE' });
+    (gds.getLastKnownGpuDevices as any).mockReturnValue([]);
+    const st = resolveKnobForSidecarEnv(getKnob('tts.qwen.device')!);
+    expect(st.effective).toBe('cuda-uuid:GONE');
+    // staleReason is a UI concept; the sidecar decides liveness for itself.
+    expect(st.staleReason).toBeUndefined();
+  });
+
+  it('is identical to resolveKnob for every non-device-uuid value', () => {
+    (us.readConfigOverrides as any).mockReturnValue({ 'tts.qwen.device': 'cuda:1' });
+    const knob = getKnob('tts.qwen.device')!;
+    expect(resolveKnobForSidecarEnv(knob)).toEqual(resolveKnob(knob));
+  });
+
+  it('still honours an env-locked value', () => {
+    process.env.QWEN_DEVICE = 'cpu';
+    try {
+      const st = resolveKnobForSidecarEnv(getKnob('tts.qwen.device')!);
+      expect(st.effective).toBe('cpu');
+      expect(st.source).toBe('env');
+      expect(st.locked).toBe(true);
+    } finally {
+      delete process.env.QWEN_DEVICE;
+    }
+  });
+});
+```
 
 Append to `server/src/tts/sidecar-env.test.ts`:
 
 ```ts
 import {
   setLastKnownGpuDevices,
-  _resetGpuDeviceListForTests,
+  getLastKnownGpuDevices,
 } from '../gpu/gpu-device-list-state.js';
 
-describe('buildSidecarEnv device-knob resolution against the GPU device cache', () => {
+describe('buildSidecarEnv hands the sidecar a UUID pin verbatim', () => {
   beforeEach(() => {
-    _resetGpuDeviceListForTests();
+    setLastKnownGpuDevices([]);
     (us.readConfigOverrides as ReturnType<typeof vi.fn>).mockReturnValue({});
     delete process.env.QWEN_DEVICE;
   });
 
-  it('translates a cuda-uuid: pin to an index when the cache is warm', () => {
-    (us.readConfigOverrides as ReturnType<typeof vi.fn>).mockReturnValue({
-      'tts.qwen.device': 'cuda-uuid:GPU-1',
+  /* Both cases must agree. Before #1857 the emitted value depended on whether
+     the user had opened Advanced settings during this server session — the warm
+     branch froze a cuda:N that every later respawn re-emitted, so a vanished or
+     renumbered card produced a hard load failure or the wrong card. */
+  for (const [label, cache] of [
+    ['cold cache', [] as { uuid: string; idx: number }[]],
+    ['warm cache', [{ uuid: 'GPU-1', idx: 1 }]],
+  ] as const) {
+    it(`emits the raw cuda-uuid literal with a ${label}`, () => {
+      (us.readConfigOverrides as ReturnType<typeof vi.fn>).mockReturnValue({
+        'tts.qwen.device': 'cuda-uuid:GPU-1',
+      });
+      setLastKnownGpuDevices([...cache]);
+
+      const env = buildSidecarEnv({ modelKey: 'qwen3-tts-0.6b', repoRoot: process.cwd() });
+
+      expect(env.QWEN_DEVICE).toBe('cuda-uuid:GPU-1');
     });
-    setLastKnownGpuDevices([{ uuid: 'GPU-1', idx: 1 }]);
+  }
 
+  it('still emits a plain cuda:N pin unchanged', () => {
+    (us.readConfigOverrides as ReturnType<typeof vi.fn>).mockReturnValue({
+      'tts.qwen.device': 'cuda:1',
+    });
     const env = buildSidecarEnv({ modelKey: 'qwen3-tts-0.6b', repoRoot: process.cwd() });
-
     expect(env.QWEN_DEVICE).toBe('cuda:1');
-  });
-
-  /* CONTRACT, NOT A BUG. With a cold cache resolveKnob can't translate, so the
-     raw 'cuda-uuid:' literal is handed to the sidecar — which resolves it
-     itself in _read_device_env -> _resolve_uuid_to_index (main.py:1873). That
-     Python-side resolution was added FOR this case: the Node cache is
-     necessarily empty at the initial boot spawn, because the only source of
-     the uuid<->idx mapping is the sidecar process that doesn't exist yet.
-     Do not "fix" this by making it assert cuda:N. */
-  it('passes the raw cuda-uuid: literal through when the cache is cold', () => {
-    (us.readConfigOverrides as ReturnType<typeof vi.fn>).mockReturnValue({
-      'tts.qwen.device': 'cuda-uuid:GPU-1',
-    });
-
-    const env = buildSidecarEnv({ modelKey: 'qwen3-tts-0.6b', repoRoot: process.cwd() });
-
-    expect(env.QWEN_DEVICE).toBe('cuda-uuid:GPU-1');
   });
 });
 ```
 
-- [ ] **Step 2: Run the test**
+- [ ] **Step 2: Run tests to verify they fail**
 
-Run: `npm --prefix server run test -- src/tts/sidecar-env.test.ts`
-Expected: PASS, both new tests plus the pre-existing ones.
+Run: `npm --prefix server run test -- src/config/resolver.test.ts src/tts/sidecar-env.test.ts`
+Expected: FAIL. The resolver tests fail with `resolveKnobForSidecarEnv is not a function`. The `warm cache` case in `sidecar-env.test.ts` fails with `expected 'cuda:1' to be 'cuda-uuid:GPU-1'` — that one is the B1 regression test and **must** be red before the fix.
 
-- [ ] **Step 3: Commit**
+- [ ] **Step 3: Split the resolver**
+
+In `server/src/config/resolver.ts`, replace `resolveKnob` (lines 15-53) with a shared implementation plus two entry points:
+
+```ts
+function resolveKnobInner(knob: ConfigKnob, reconcileDeviceUuid: boolean): KnobValueState {
+  if (knob.env) {
+    const raw = process.env[knob.env];
+    if (raw != null && raw.trim() !== '') {
+      const v = parseEnv(knob, raw);
+      if (v != null) {
+        return { key: knob.key, effective: v, source: 'env', locked: true, overridden: false };
+      }
+      const warnKey = `${knob.env}=${raw}`;
+      if (!warnedInvalidEnv.has(warnKey)) {
+        warnedInvalidEnv.add(warnKey);
+        console.warn(
+          `[config] ${knob.env}="${raw}" is not a valid ${knob.type} for ${knob.key} — ignoring env, falling through to override/default.`,
+        );
+      }
+    }
+  }
+  const overrides = readConfigOverrides();
+  if (Object.prototype.hasOwnProperty.call(overrides, knob.key)) {
+    const raw = overrides[knob.key];
+    if (
+      reconcileDeviceUuid &&
+      knob.type === 'device' &&
+      typeof raw === 'string' &&
+      raw.startsWith('cuda-uuid:')
+    ) {
+      const uuid = raw.slice('cuda-uuid:'.length);
+      const card = getLastKnownGpuDevices().find((d) => d.uuid === uuid);
+      if (card) {
+        return { key: knob.key, effective: `cuda:${card.idx}`, source: 'override', locked: false, overridden: true };
+      }
+      return {
+        key: knob.key,
+        effective: raw,
+        source: 'override',
+        locked: false,
+        overridden: true,
+        staleReason: 'uuid_unresolved',
+      };
+    }
+    return { key: knob.key, effective: raw, source: 'override', locked: false, overridden: true };
+  }
+  return { key: knob.key, effective: knob.default, source: 'default', locked: false, overridden: false };
+}
+
+/** Effective value for a READ SITE or the Advanced UI. Reconciles a stored
+    'cuda-uuid:<uuid>' override against the last-known device list, so the UI can
+    show a concrete card and flag a vanished one as staleReason:'uuid_unresolved'. */
+export function resolveKnob(knob: ConfigKnob): KnobValueState {
+  return resolveKnobInner(knob, true);
+}
+
+/** Effective value for the SIDECAR ENV. Deliberately does NOT reconcile a
+    'cuda-uuid:' override to an index (#1857).
+
+    The sidecar resolves the uuid form itself, against LIVE torch enumeration, on
+    every spawn — `_read_device_env` -> `_resolve_uuid_to_index`, main.py:1873.
+    Handing it a pre-translated `cuda:N` instead freezes whatever the Node cache
+    believed at translation time, and `buildOpts` re-emits that frozen value on
+    every respawn (sidecar-supervisor.ts). A card that then vanishes makes
+    `_validate_cuda_index` raise and the engine load fail on every retry; a card
+    that renumbers silently lands on the wrong one. Passing the uuid through
+    keeps the sidecar's live resolution in charge, which degrades a vanished pin
+    to 'auto' with a warning instead.
+
+    It also makes the spawn env DETERMINISTIC: before this split, the emitted
+    value depended on whether the device cache happened to be warm, i.e. on
+    whether the user had opened Advanced settings during this server session. */
+export function resolveKnobForSidecarEnv(knob: ConfigKnob): KnobValueState {
+  return resolveKnobInner(knob, false);
+}
+```
+
+- [ ] **Step 4: Point `buildSidecarEnv` at it**
+
+In `server/src/tts/spawn-sidecar.ts`, update the import and line 474:
+
+```ts
+// import: was  import { resolveKnob } from '../config/resolver.js';
+import { resolveKnobForSidecarEnv } from '../config/resolver.js';
+
+// line 474, inside the restart-sidecar knob loop — was: const st = resolveKnob(knob);
+const st = resolveKnobForSidecarEnv(knob);
+```
+
+**Keep the `resolveKnob` import — do NOT find-replace.** `spawn-sidecar.ts` has
+**three** `resolveKnob` call sites and only line 474 changes:
+
+| Line | Function | Knobs | Change? |
+|---|---|---|---|
+| 119 | `expectedSidecarCeilings` | `sidecar.restartMb`, `sidecar.vramRestartMb` | **no** |
+| 136 | `expectedFreeFloorMb` | `sidecar.vramFreeFloorMb` | **no** |
+| 474 | `buildSidecarEnv` loop | all restart-sidecar knobs | **yes** |
+
+The two ceiling helpers feed `sidecarCeilingMismatch`, which drives
+adopt-versus-recycle decisions. Their knobs are numeric, so the split is
+behaviourally identical for them — meaning a careless find-replace would change
+the declared intent of that code and **no test would catch it**. The import line
+must end up as:
+
+```ts
+import { resolveKnob, resolveKnobForSidecarEnv } from '../config/resolver.js';
+```
+
+Then extend the docblock above the loop (`spawn-sidecar.ts:462-471`) with a fourth paragraph:
+
+```ts
+     Device knobs go through resolveKnobForSidecarEnv, NOT resolveKnob: a
+     'cuda-uuid:' pin is handed to the sidecar verbatim so it resolves against
+     live enumeration on every spawn. See that function's docblock (#1857).
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm --prefix server run test -- src/config/resolver.test.ts src/tts/sidecar-env.test.ts`
+Expected: PASS, including the pre-existing `resolveKnob` reconcile tests at `resolver.test.ts:79-94` — those pin the UI path and must be untouched by this split.
+
+- [ ] **Step 6: Run the wider suites that read device knobs**
+
+Run: `npm --prefix server run test -- src/config src/tts/spawn-windows-hide.test.ts src/routes/config.test.ts src/gpu`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
 
 ```bash
-git add server/src/tts/sidecar-env.test.ts
+git add server/src/config/resolver.ts server/src/config/resolver.test.ts server/src/tts/spawn-sidecar.ts server/src/tts/sidecar-env.test.ts
 git commit -F - <<'EOF'
-test(server): pin buildSidecarEnv device resolution under warm and cold caches
+fix(server): hand the sidecar a device UUID pin verbatim
+
+buildSidecarEnv resolved device knobs through resolveKnob, which
+translates a stored cuda-uuid: override to cuda:N only when the GPU
+device cache is warm — i.e. only if Advanced settings had been opened
+this session. Same config, two different spawn envs, and the warm one
+froze an index that every respawn re-emitted: a card that vanished
+afterwards failed _validate_cuda_index on every retry, and one that
+renumbered landed on the wrong card silently.
+
+Adds resolveKnobForSidecarEnv, which skips the reconcile. The sidecar
+resolves the uuid itself against live enumeration on every spawn and
+degrades a vanished pin to auto with a warning. The UI path keeps its
+translation and its uuid_unresolved badge.
 
 Refs #1857
 
@@ -939,22 +314,17 @@ EOF
 
 ---
 
-### Task 6: `QWEN_CODEC_DEVICE` resolves a UUID pin
+### Task 2: `QWEN_CODEC_DEVICE` resolves a UUID pin
 
-Independent of Tasks 1–5. `tts.qwen.codecDevice` is the fourth and only `type: 'device'` knob whose env var is read with a bare `os.environ.get`, so a card pinned from the UI is stored as `cuda-uuid:<uuid>`, passes `_validate_cuda_index` (because `_parse_device` reads it as family `cuda` with no index), then fails inside torch's `.to()` and gets rolled back to CPU.
+Independent of Task 1. `tts.qwen.codecDevice` is the fourth and only
+`type: 'device'` knob whose env var is read with a bare `os.environ.get`, so a
+card pinned from the UI is stored as `cuda-uuid:<uuid>`, passes
+`_validate_cuda_index` (because `_parse_device` reads it as family `cuda` with no
+index), then fails inside torch's `.to()` and is rolled back to CPU.
 
 **Files:**
-- Modify: `server/tts-sidecar/main.py:2995-2997`
+- Modify: `server/tts-sidecar/main.py` — add helper after `_resolve_codec_device` (ends line 403); change the call site currently at 2995-2997
 - Modify: `server/tts-sidecar/tests/test_device_parse.py`
-
-**Why this task introduces a named helper.** The production read lives inside
-`_load_qwen_model`, which needs real Qwen weights and a GPU to invoke — so a test
-cannot reach it. Asserting on a hand-composed
-`_resolve_codec_device(_read_device_env(...) or "cpu", ...)` in the test would be
-a **placebo**: that expression already returns the right answer today, and would
-pass whether or not `main.py:2996` was ever changed. So the fix extracts the
-one-line expression into `_codec_device_pref()` and has the production line call
-it. The test then exercises the exact function production uses.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -964,7 +334,7 @@ Append to `server/tts-sidecar/tests/test_device_parse.py`:
 def test_codec_device_pref_resolves_uuid(monkeypatch):
     """QWEN_CODEC_DEVICE is a type:'device' knob, so a card picked in Advanced
     Settings is persisted as 'cuda-uuid:<uuid>'. _codec_device_pref is what
-    _load_qwen_model actually calls, so a UUID must never reach torch raw."""
+    _load_qwen_model calls, so a UUID must never reach torch raw."""
     monkeypatch.setenv("QWEN_CODEC_DEVICE", "cuda-uuid:GPU-1")
     monkeypatch.setattr(main, "_enumerate_cuda_devices",
         lambda tm=None: [{"uuid": "GPU-1", "idx": 1, "name": "x", "total_mb": 16000, "free_mb": 14000}])
@@ -972,21 +342,22 @@ def test_codec_device_pref_resolves_uuid(monkeypatch):
     assert main._resolve_codec_device(main._codec_device_pref(), "cuda:0") == "cuda:1"
 
 
-def test_codec_device_pref_unresolvable_uuid_follows_the_model(monkeypatch):
-    """A vanished card degrades to 'auto', which for the codec means "follow
-    the model" -- never a different card, and never a CPU demotion."""
+def test_codec_device_pref_vanished_uuid_falls_back_to_cpu(monkeypatch):
+    """A vanished card must NOT degrade to 'auto' -- for the codec that means
+    "follow the model", i.e. move onto the very card the user was spreading VRAM
+    away from. cpu is the knob's registry default and is VRAM-neutral."""
     monkeypatch.setenv("QWEN_CODEC_DEVICE", "cuda-uuid:GONE")
     monkeypatch.setattr(main, "_enumerate_cuda_devices", lambda tm=None: [])
-    assert main._codec_device_pref() == "auto"
-    assert main._resolve_codec_device(main._codec_device_pref(), "cuda:0") == "cuda:0"
+    assert main._codec_device_pref() == "cpu"
+    # _resolve_codec_device('cpu', ...) is None == "leave the codec where it is"
+    assert main._resolve_codec_device(main._codec_device_pref(), "cuda:0") is None
 
 
-def test_codec_device_pref_unset_still_means_cpu(monkeypatch):
-    """Regression guard on the `or 'cpu'` fallback: unset must stay CPU-only,
-    i.e. _resolve_codec_device returns None (no move attempted)."""
+def test_codec_device_pref_unset_and_empty_mean_cpu(monkeypatch):
     monkeypatch.delenv("QWEN_CODEC_DEVICE", raising=False)
     assert main._codec_device_pref() == "cpu"
-    assert main._resolve_codec_device(main._codec_device_pref(), "cuda:0") is None
+    monkeypatch.setenv("QWEN_CODEC_DEVICE", "   ")
+    assert main._codec_device_pref() == "cpu"
 
 
 def test_codec_device_pref_passes_through_plain_values(monkeypatch):
@@ -1002,33 +373,52 @@ def test_codec_device_pref_passes_through_plain_values(monkeypatch):
 Run: `server/tts-sidecar/.venv/Scripts/python.exe -m pytest server/tts-sidecar/tests/test_device_parse.py -v -k codec_device_pref`
 Expected: all four FAIL with `AttributeError: module 'main' has no attribute '_codec_device_pref'`.
 
-- [ ] **Step 3: Add the helper and route the production read through it**
+- [ ] **Step 3: Add the helper**
 
-In `server/tts-sidecar/main.py`, define the helper immediately after
-`_resolve_codec_device` (i.e. after line 403), so it sits beside the function it
-feeds:
+In `server/tts-sidecar/main.py`, immediately after `_resolve_codec_device` (which
+ends at line 403):
 
 ```python
 def _codec_device_pref() -> str:
     """QWEN_CODEC_DEVICE as a resolved device string, defaulting to 'cpu'.
 
-    Goes through _read_device_env like COQUI_DEVICE / KOKORO_DEVICE /
-    QWEN_DEVICE, because QWEN_CODEC_DEVICE is a type:'device' knob too --
-    PUT /api/config persists a picked card as 'cuda-uuid:<uuid>'. A bare
-    os.environ.get (the #1857 bug) let that literal through _validate_cuda_index
-    untouched, because _parse_device reads 'cuda-uuid:x' as family cuda with NO
-    index and the range check only fires on a concrete index. It then failed
-    inside torch's .to() in _move_codec_to_device and got rolled back to CPU --
-    so a pinned codec silently ran on the wrong device.
+    QWEN_CODEC_DEVICE is a type:'device' knob, so PUT /api/config persists a
+    picked card as 'cuda-uuid:<uuid>'. A bare os.environ.get (the #1857 bug) let
+    that literal through _validate_cuda_index untouched -- _parse_device reads
+    'cuda-uuid:x' as family cuda with NO index, and the range check only fires on
+    a concrete index -- so it failed later inside torch's .to() in
+    _move_codec_to_device and got rolled back to CPU.
 
-    Named rather than inlined at the call site so it is reachable from tests:
-    the call site is inside _load_qwen_model, which needs real weights + a GPU.
+    Deliberately NOT _read_device_env: that degrades an unresolvable pin to
+    'auto', which is right for the three engine knobs but wrong here.
+    _resolve_codec_device('auto', model_device) means "follow the model", so a
+    vanished card would silently move the codec ONTO the model's card -- adding
+    pressure to exactly the card a user pinning the codec elsewhere was trying to
+    protect, with no rollback (that only fires if .to() raises, not if a
+    successful move OOMs a later decode). 'cpu' is this knob's registry default
+    and is VRAM-neutral.
+
+    Named rather than inlined so it is reachable from tests: the call site is
+    inside _load_qwen_model, which needs real weights and a GPU.
     """
-    return _read_device_env("QWEN_CODEC_DEVICE") or "cpu"
+    raw = os.environ.get("QWEN_CODEC_DEVICE")
+    if not raw or not raw.strip():
+        return "cpu"
+    resolved = _resolve_uuid_to_index(raw)
+    if resolved is None:
+        log.warning(
+            "QWEN_CODEC_DEVICE=%s did not match any visible GPU -- leaving the codec on cpu.",
+            raw,
+        )
+        return "cpu"
+    return resolved
 ```
 
-Then replace the call site. **Do not go by line number** — inserting the helper
-above shifts it from 2995-2997 to roughly 3010. Find it by content:
+- [ ] **Step 4: Route the production read through it**
+
+Find the call site by content — it is around line 2995 *before* the helper is
+inserted and shifts down by the helper's length afterwards, so do not go by line
+number:
 
 ```python
         # BEFORE (find this):
@@ -1040,20 +430,29 @@ above shifts it from 2995-2997 to roughly 3010. Find it by content:
         codec_device = _resolve_codec_device(_codec_device_pref(), self._device)
 ```
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [ ] **Step 5: Run tests to verify they pass**
 
 Run: `server/tts-sidecar/.venv/Scripts/python.exe -m pytest server/tts-sidecar/tests/test_device_parse.py -v`
 Expected: PASS, all tests in the file.
 
 Run: `server/tts-sidecar/.venv/Scripts/python.exe -m pytest server/tts-sidecar/tests/test_module_import_order.py -v`
-Expected: PASS — `_read_device_env` is reached at module-import time via `ENGINES = {...}`, and this file guards that ordering.
+Expected: PASS. `_codec_device_pref` is defined at ~404 but calls `_resolve_uuid_to_index` (1858) — safe, because Python resolves names at call time and the only caller is `_load_qwen_model`, which is never reached at module import. This file guards that class of NameError, so run it.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
 git add server/tts-sidecar/main.py server/tts-sidecar/tests/test_device_parse.py
 git commit -F - <<'EOF'
 fix(sidecar): resolve a cuda-uuid: pin for QWEN_CODEC_DEVICE
+
+The one type:'device' knob still read with a bare os.environ.get. A
+pinned card reached torch as a raw 'cuda-uuid:' literal, passed
+_validate_cuda_index (which no-ops when _parse_device finds no concrete
+index), then failed inside .to() and rolled back to CPU.
+
+An unresolvable pin falls back to cpu rather than _read_device_env's
+'auto' — for the codec, 'auto' means follow the model, which would move
+it onto the card a user pinning the codec elsewhere was protecting.
 
 Refs #1857
 
@@ -1066,12 +465,8 @@ EOF
 
 ## Final verification
 
-- [ ] Run the full server suite: `npm run test:server`
-- [ ] Run typecheck: `npm run typecheck` (the repo script — root `tsc --noEmit` **and** `npm --prefix server run typecheck`; a bare `npx tsc -p server/tsconfig.json` only covers the second half)
-- [ ] Run the sidecar device tests: `server/tts-sidecar/.venv/Scripts/python.exe -m pytest server/tts-sidecar/tests/test_device_parse.py server/tts-sidecar/tests/test_module_import_order.py -v`
-- [ ] **Confirm no `gpu/ → routes/` import was introduced.** This repo has **no** cycle checker — `madge` is not a dependency and there is no `import/no-cycle` ESLint rule, so the `gpu/*-gate.ts` pattern is enforced by review alone. Verify by grep instead, which must return nothing:
-  ```bash
-  grep -rn "from '\.\./routes/" server/src/gpu/
-  ```
-  The registration test in Task 2 covers the other half — that routing *around* the cycle didn't leave the provider unregistered.
-- [ ] Open PR with `Closes #1857` in the body, and post the premise correction (the sidecar already resolves `cuda-uuid:` for the three engine knobs; the issue's acceptance criteria are superseded by the spec's).
+- [ ] Full server suite: `npm run test:server`
+- [ ] Typecheck: `npm run typecheck` (root `tsc --noEmit` **and** `npm --prefix server run typecheck`)
+- [ ] Sidecar: `server/tts-sidecar/.venv/Scripts/python.exe -m pytest server/tts-sidecar/tests/test_device_parse.py server/tts-sidecar/tests/test_module_import_order.py -v`
+- [ ] Confirm no other caller was switched by accident: `grep -rn "resolveKnobForSidecarEnv" server/src` should return the resolver definition, its tests, and exactly one call site in `spawn-sidecar.ts`.
+- [ ] Open PR with `Closes #1857` in the body, carrying the premise correction: the sidecar already resolves `cuda-uuid:` for the three engine knobs, the raw literal is the designed input rather than the bug, and the issue's suggested boot warm would have made respawns worse. Link the two Fable review findings that drove the rescope.

--- a/docs/superpowers/plans/2026-07-27-gpu-device-list-boot-warm.md
+++ b/docs/superpowers/plans/2026-07-27-gpu-device-list-boot-warm.md
@@ -20,7 +20,7 @@
   Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
   Claude-Session: https://claude.ai/code/session_01VxtGhVyXqmikbXSpsvuEmg
   ```
-- Server tests: `npx vitest run --config server/vitest.config.ts <path>` from the worktree root.
+- Server tests: `npm --prefix server run test -- <path>` from the worktree root, where `<path>` is relative to `server/` (e.g. `src/gpu/foo.test.ts`, **not** `server/src/gpu/foo.test.ts`). `server/vitest.config.ts` has `include: src/**`, resolved against whatever cwd vitest runs in — so `npx vitest run --config server/vitest.config.ts server/src/...` from the worktree root resolves `src/**` against the *frontend* tree, matches nothing, and exits 1 with "No test files found". Verified by running it.
 - Sidecar tests: `server/tts-sidecar/.venv/Scripts/python.exe -m pytest server/tts-sidecar/tests/<file> -v`.
 - No task requires a GPU. Every test added here runs on a CPU-only box.
 
@@ -110,7 +110,7 @@ describe('setLastKnownGpuDevices no-downgrade rule', () => {
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `npx vitest run --config server/vitest.config.ts server/src/gpu/gpu-device-list-state.test.ts`
+Run: `npm --prefix server run test -- src/gpu/gpu-device-list-state.test.ts`
 Expected: FAIL — `_resetGpuDeviceListForTests` is not exported, and "ignores an empty list when the cache is already warm" returns `[]`.
 
 - [ ] **Step 3: Add the guard and the reset seam**
@@ -142,7 +142,7 @@ export function _resetGpuDeviceListForTests(): void {
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `npx vitest run --config server/vitest.config.ts server/src/gpu/gpu-device-list-state.test.ts`
+Run: `npm --prefix server run test -- src/gpu/gpu-device-list-state.test.ts`
 Expected: PASS, 5 tests.
 
 - [ ] **Step 5: Migrate the three existing empty-reset call sites**
@@ -184,7 +184,7 @@ import — it passes a non-empty list.
 
 - [ ] **Step 6: Run the affected suites**
 
-Run: `npx vitest run --config server/vitest.config.ts server/src/gpu/gpu-device-list-state.test.ts server/src/routes/config.test.ts server/src/routes/gpu-devices.test.ts`
+Run: `npm --prefix server run test -- src/gpu/gpu-device-list-state.test.ts src/routes/config.test.ts src/routes/gpu-devices.test.ts`
 Expected: PASS, all three files green.
 
 - [ ] **Step 7: Commit**
@@ -341,7 +341,7 @@ describe('device-probe-state provider registration', () => {
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `npx vitest run --config server/vitest.config.ts server/src/routes/sidecar-health-record-state.test.ts`
+Run: `npm --prefix server run test -- src/routes/sidecar-health-record-state.test.ts`
 Expected: FAIL — `probeSidecarHealth` takes no arguments (so the `recordState: false` test still sees all three writes), and `probeDeviceProbeStateIfRegistered` is not exported from the gate.
 
 - [ ] **Step 3: Add the opt to `probeSidecarHealth`**
@@ -435,7 +435,7 @@ setDeviceProbeStateProvider(() =>
 
 - [ ] **Step 6: Run tests**
 
-Run: `npx vitest run --config server/vitest.config.ts server/src/routes/sidecar-health-record-state.test.ts server/src/routes/sidecar-health.test.ts`
+Run: `npm --prefix server run test -- src/routes/sidecar-health-record-state.test.ts src/routes/sidecar-health.test.ts`
 Expected: PASS — the four new tests, plus every pre-existing test in the original file unchanged.
 
 **If the new file fails on a mock-resolution error rather than an assertion,
@@ -606,7 +606,7 @@ describe('runGpuDeviceListWarmup', () => {
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `npx vitest run --config server/vitest.config.ts server/src/gpu/warm-device-list.test.ts`
+Run: `npm --prefix server run test -- src/gpu/warm-device-list.test.ts`
 Expected: FAIL — `Cannot find module './warm-device-list.js'`.
 
 - [ ] **Step 3: Write the module**
@@ -744,7 +744,7 @@ export function startGpuDeviceListWarmup(opts: WarmupOpts = {}): void {
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `npx vitest run --config server/vitest.config.ts server/src/gpu/warm-device-list.test.ts`
+Run: `npm --prefix server run test -- src/gpu/warm-device-list.test.ts`
 Expected: PASS, 12 tests.
 
 - [ ] **Step 5: Commit**
@@ -805,7 +805,7 @@ Then put a shortened docblock immediately above `configRouter.get('/', …)`, re
 
 - [ ] **Step 2: Verify the config route still passes**
 
-Run: `npx vitest run --config server/vitest.config.ts server/src/routes/config.test.ts`
+Run: `npm --prefix server run test -- src/routes/config.test.ts`
 Expected: PASS — identical behaviour, warmer just lives elsewhere now.
 
 - [ ] **Step 3: Start the loop at boot**
@@ -836,7 +836,7 @@ and immediately after `registerActiveSupervisor(sidecarSupervisor);` (line 302),
 Run: `npx tsc -p server/tsconfig.json --noEmit`
 Expected: no errors.
 
-Run: `npx vitest run --config server/vitest.config.ts server/src/index.test.ts`
+Run: `npm --prefix server run test -- src/index.test.ts`
 Expected: PASS — `index.test.ts` imports the module but the main-module guard keeps `main()` (and therefore `listenerCallback` and the timer) from running.
 
 - [ ] **Step 5: Commit**
@@ -920,7 +920,7 @@ describe('buildSidecarEnv device-knob resolution against the GPU device cache', 
 
 - [ ] **Step 2: Run the test**
 
-Run: `npx vitest run --config server/vitest.config.ts server/src/tts/sidecar-env.test.ts`
+Run: `npm --prefix server run test -- src/tts/sidecar-env.test.ts`
 Expected: PASS, both new tests plus the pre-existing ones.
 
 - [ ] **Step 3: Commit**

--- a/docs/superpowers/plans/2026-07-27-gpu-device-list-boot-warm.md
+++ b/docs/superpowers/plans/2026-07-27-gpu-device-list-boot-warm.md
@@ -1,0 +1,981 @@
+# GPU device-list boot warm + codec device-knob parity — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Qwen codec honour a `cuda-uuid:` device pin, and warm the Node-side GPU device-list cache from a server-owned boot loop instead of depending on a frontend HTTP request.
+
+**Architecture:** Six tasks. Tasks 1–2 harden the two pieces of shared state a new concurrent writer would otherwise destabilise (the device-list cache, and the sidecar health probe's side effects). Task 3 adds the warm module itself. Task 4 wires it into boot and de-duplicates the existing warmer. Task 5 pins the `buildSidecarEnv` contract under both cache states. Task 6 is the independent sidecar fix and can be done at any point.
+
+**Tech Stack:** TypeScript (Node/Express, ESM, `.js` import specifiers), Vitest for server tests; Python 3.12 + FastAPI for the TTS sidecar, pytest for its tests.
+
+**Spec:** `docs/superpowers/specs/2026-07-27-gpu-device-list-boot-warm-design.md`
+
+## Global Constraints
+
+- Worktree: `C:\Claude\Projects\Audiobook-Generator\.claude\worktrees\fix+1857-gpu-device-cache-boot-warm`, branch `fix/1857-gpu-device-cache-boot-warm`. Run every command from there; never `cd` to the main checkout.
+- Server imports use ESM `.js` specifiers even for TypeScript sources (`./gpu-device-list-state.js`).
+- `gpu/**` must never import from `routes/**` — including type-only imports, which still count as cycle edges. Cross-layer access goes through the registered-provider gates in `gpu/*-gate.ts`.
+- Commit messages follow Conventional Commits with a scope (`fix(server): …`, `test(server): …`, `fix(sidecar): …`). Every commit body ends with:
+  ```
+  Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01VxtGhVyXqmikbXSpsvuEmg
+  ```
+- Server tests: `npx vitest run --config server/vitest.config.ts <path>` from the worktree root.
+- Sidecar tests: `server/tts-sidecar/.venv/Scripts/python.exe -m pytest server/tts-sidecar/tests/<file> -v`.
+- No task requires a GPU. Every test added here runs on a CPU-only box.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `server/src/gpu/gpu-device-list-state.ts` (modify) | Owns the cached uuid↔idx list. Gains the no-downgrade invariant + a test reset seam. |
+| `server/src/gpu/gpu-device-list-state.test.ts` (create) | Pins the no-downgrade invariant. |
+| `server/src/gpu/sidecar-health-gate.ts` (modify) | Zero-import leaf gate. Gains a second provider slot for `devices_state` only. |
+| `server/src/routes/sidecar-health.ts` (modify) | Gains a `recordState` opt to suppress its three cache writes; registers the new provider. |
+| `server/src/gpu/warm-device-list.ts` (create) | Idempotent warm helper + bounded retry loop. |
+| `server/src/gpu/warm-device-list.test.ts` (create) | Covers dedup, retry, stop conditions. |
+| `server/src/routes/config.ts` (modify) | Drops its private warmer, imports the shared one. |
+| `server/src/index.ts` (modify) | Starts the warm loop at boot. |
+| `server/src/tts/sidecar-env.test.ts` (modify) | Pins `buildSidecarEnv` under warm and cold caches. |
+| `server/tts-sidecar/main.py` (modify) | Routes `QWEN_CODEC_DEVICE` through `_read_device_env`. |
+| `server/tts-sidecar/tests/test_device_parse.py` (modify) | Pins codec UUID resolution. |
+
+---
+
+### Task 1: No-downgrade rule in the device-list state module
+
+An empty device list must never overwrite a warm cache — otherwise the boot loop added in Task 3, racing `GET /api/gpu/devices` and `toUuidForm`, can flip resolved UUID pins back to `uuid_unresolved` during a sidecar recycle.
+
+**Files:**
+- Modify: `server/src/gpu/gpu-device-list-state.ts:15-23`
+- Create: `server/src/gpu/gpu-device-list-state.test.ts`
+- Modify: `server/src/routes/config.test.ts:344,350,383,387`
+- Modify: `server/src/routes/gpu-devices.test.ts:10,25`
+
+**Interfaces:**
+- Produces: `setLastKnownGpuDevices(devices: GpuDeviceInfo[]): void` (unchanged signature, new guard), `_resetGpuDeviceListForTests(): void`, `getLastKnownGpuDevices(): GpuDeviceInfo[]` (unchanged).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/src/gpu/gpu-device-list-state.test.ts`:
+
+```ts
+/* Pins the no-downgrade invariant (#1857): once the device list is warm, an
+   empty list never replaces it. Three writers reach this setter — the boot
+   warm loop (gpu/warm-device-list.ts), GET /api/gpu/devices, and toUuidForm on
+   a PUT — and a transient empty from any of them would otherwise unpin every
+   cuda-uuid: assignment until something re-warmed the cache. */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  setLastKnownGpuDevices,
+  getLastKnownGpuDevices,
+  _resetGpuDeviceListForTests,
+} from './gpu-device-list-state.js';
+
+describe('setLastKnownGpuDevices no-downgrade rule', () => {
+  beforeEach(() => {
+    _resetGpuDeviceListForTests();
+  });
+
+  it('stores a non-empty list', () => {
+    setLastKnownGpuDevices([{ uuid: 'GPU-1', idx: 1 }]);
+    expect(getLastKnownGpuDevices()).toEqual([{ uuid: 'GPU-1', idx: 1 }]);
+  });
+
+  it('ignores an empty list when the cache is already warm', () => {
+    setLastKnownGpuDevices([{ uuid: 'GPU-1', idx: 1 }]);
+    setLastKnownGpuDevices([]);
+    expect(getLastKnownGpuDevices()).toEqual([{ uuid: 'GPU-1', idx: 1 }]);
+  });
+
+  it('accepts an empty list when the cache is already empty (no-op)', () => {
+    setLastKnownGpuDevices([]);
+    expect(getLastKnownGpuDevices()).toEqual([]);
+  });
+
+  it('always replaces a warm cache with another non-empty list', () => {
+    setLastKnownGpuDevices([{ uuid: 'GPU-1', idx: 1 }]);
+    setLastKnownGpuDevices([{ uuid: 'GPU-2', idx: 0 }]);
+    expect(getLastKnownGpuDevices()).toEqual([{ uuid: 'GPU-2', idx: 0 }]);
+  });
+
+  it('_resetGpuDeviceListForTests clears a warm cache', () => {
+    setLastKnownGpuDevices([{ uuid: 'GPU-1', idx: 1 }]);
+    _resetGpuDeviceListForTests();
+    expect(getLastKnownGpuDevices()).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run --config server/vitest.config.ts server/src/gpu/gpu-device-list-state.test.ts`
+Expected: FAIL — `_resetGpuDeviceListForTests` is not exported, and "ignores an empty list when the cache is already warm" returns `[]`.
+
+- [ ] **Step 3: Add the guard and the reset seam**
+
+In `server/src/gpu/gpu-device-list-state.ts`, replace the setter and add the reset:
+
+```ts
+/** Store the live device list. An EMPTY list never replaces a warm one
+    (#1857): `_enumerate_cuda_devices` in the sidecar returns [] both for "no
+    CUDA cards" and for "torch isn't imported yet / the probe raised", so a
+    transient empty during a sidecar recycle is indistinguishable from a real
+    one. Three writers reach this setter — the boot warm loop, GET
+    /api/gpu/devices, and toUuidForm — and downgrading here would flip every
+    resolved 'cuda-uuid:' pin to staleReason:'uuid_unresolved' and make
+    buildSidecarEnv emit raw literals after having emitted indices. The
+    tradeoff is deliberate: a genuinely-unplugged card keeps serving its last
+    known mapping (same staleness contract as vram-state.ts, see file header). */
+export function setLastKnownGpuDevices(devices: GpuDeviceInfo[]): void {
+  if (devices.length === 0 && lastKnownGpuDevices.length > 0) return;
+  lastKnownGpuDevices = devices;
+}
+
+/** Test seam — the ONLY way to clear a warm cache, since the setter above
+    deliberately ignores an empty list. */
+export function _resetGpuDeviceListForTests(): void {
+  lastKnownGpuDevices = [];
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run --config server/vitest.config.ts server/src/gpu/gpu-device-list-state.test.ts`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Migrate the three existing empty-reset call sites**
+
+These pass `[]` to mean "reset", which is now a no-op and would make their cold-cache assertions pass for the wrong reason (or fail outright when an earlier test in the file left the cache warm).
+
+In `server/src/routes/config.test.ts`, at lines 344 and 383 change the dynamic import, and at 350 and 387 change the call:
+
+```ts
+// line 344 and line 383 — was: const { setLastKnownGpuDevices } = await import(...)
+const { _resetGpuDeviceListForTests } = await import('../gpu/gpu-device-list-state.js');
+
+// line 350 and line 387 — was: setLastKnownGpuDevices([]);
+_resetGpuDeviceListForTests();
+```
+
+Leave line 370/374 alone — that test sets a non-empty list and is unaffected.
+
+In `server/src/routes/gpu-devices.test.ts`, line 10 and line 25:
+
+```ts
+// line 10
+import {
+  setLastKnownGpuDevices,
+  getLastKnownGpuDevices,
+  _resetGpuDeviceListForTests,
+} from '../gpu/gpu-device-list-state.js';
+
+// line 25, inside beforeEach — was: setLastKnownGpuDevices([]);
+_resetGpuDeviceListForTests();
+```
+
+- [ ] **Step 6: Run the affected suites**
+
+Run: `npx vitest run --config server/vitest.config.ts server/src/gpu/gpu-device-list-state.test.ts server/src/routes/config.test.ts server/src/routes/gpu-devices.test.ts`
+Expected: PASS, all three files green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/src/gpu/gpu-device-list-state.ts server/src/gpu/gpu-device-list-state.test.ts server/src/routes/config.test.ts server/src/routes/gpu-devices.test.ts
+git commit -F - <<'EOF'
+fix(server): never downgrade a warm GPU device list to empty
+
+Refs #1857
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01VxtGhVyXqmikbXSpsvuEmg
+EOF
+```
+
+---
+
+### Task 2: Side-effect-free `devices_state` accessor
+
+The warm loop needs the sidecar's `devices_state` to tell "no CUDA cards" from "torch still importing". The obvious route, `probeSidecarHealthIfRegistered()`, would drag three cache writes (`setLastKnownQwenInstallState`, `setLastKnownVram`, `setLastKnownEngineDevices`) into a boot timer that runs while the supervisor is deciding what to spawn.
+
+**Files:**
+- Modify: `server/src/gpu/sidecar-health-gate.ts:45-58`
+- Modify: `server/src/routes/sidecar-health.ts:235`, `:263-268`, `:331`
+- Modify: `server/src/routes/sidecar-health.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: `probeSidecarHealth(opts?: { recordState?: boolean }): Promise<SidecarHealthResult>`; `type DeviceProbeState = 'pending' | 'ready' | 'error'`; `setDeviceProbeStateProvider(fn: () => Promise<DeviceProbeState | null>): void`; `probeDeviceProbeStateIfRegistered(): Promise<DeviceProbeState | null>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/src/routes/sidecar-health.test.ts`:
+
+```ts
+import { probeSidecarHealth } from './sidecar-health.js';
+import * as vramMod from '../gpu/vram-state.js';
+import * as engineDeviceMod from '../gpu/engine-device-state.js';
+import * as settingsMod from '../workspace/user-settings.js';
+
+describe('probeSidecarHealth recordState opt', () => {
+  function okHealth() {
+    return new Response(
+      JSON.stringify({
+        model_loaded: true,
+        vram_total_mb: 16000,
+        devices: { qwen: 'cuda' },
+        devices_state: 'ready',
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  it('records last-known state by default', async () => {
+    const vramSpy = vi.spyOn(vramMod, 'setLastKnownVram');
+    const devSpy = vi.spyOn(engineDeviceMod, 'setLastKnownEngineDevices');
+    const qwenSpy = vi.spyOn(settingsMod, 'setLastKnownQwenInstallState');
+    fetchMock.mockResolvedValue(okHealth());
+
+    const res = await probeSidecarHealth();
+
+    expect(res.status).toBe('reachable');
+    expect(res.devicesState).toBe('ready');
+    expect(vramSpy).toHaveBeenCalled();
+    expect(devSpy).toHaveBeenCalled();
+    expect(qwenSpy).toHaveBeenCalled();
+  });
+
+  it('performs no state writes when recordState is false, but parses the same result', async () => {
+    const vramSpy = vi.spyOn(vramMod, 'setLastKnownVram');
+    const devSpy = vi.spyOn(engineDeviceMod, 'setLastKnownEngineDevices');
+    const qwenSpy = vi.spyOn(settingsMod, 'setLastKnownQwenInstallState');
+    fetchMock.mockResolvedValue(okHealth());
+
+    const res = await probeSidecarHealth({ recordState: false });
+
+    expect(res.status).toBe('reachable');
+    expect(res.devicesState).toBe('ready');
+    expect(res.vramTotalMb).toBe(16000);
+    expect(vramSpy).not.toHaveBeenCalled();
+    expect(devSpy).not.toHaveBeenCalled();
+    expect(qwenSpy).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run --config server/vitest.config.ts server/src/routes/sidecar-health.test.ts -t "recordState"`
+Expected: FAIL — `probeSidecarHealth` takes no arguments, so the writes still fire.
+
+- [ ] **Step 3: Add the opt to `probeSidecarHealth`**
+
+In `server/src/routes/sidecar-health.ts`, change the signature at line 235 and guard the three writes at 263-268:
+
+```ts
+/** Options for {@link probeSidecarHealth}. */
+export interface ProbeSidecarHealthOpts {
+  /** When false, parse and return exactly as normal but perform NONE of the
+      three last-known-state writes below. Used by the boot-time GPU
+      device-list warm loop (gpu/warm-device-list.ts), which needs
+      `devices_state` while the supervisor is still deciding what to spawn —
+      letting a background timer move Qwen install state there could change
+      which model the first spawn preloads (index.ts seeds it from a DISK
+      probe for exactly that reason). Defaults to true: every other caller,
+      including the /health route the UI polls, still records. */
+  recordState?: boolean;
+}
+
+export async function probeSidecarHealth(
+  opts: ProbeSidecarHealthOpts = {},
+): Promise<SidecarHealthResult> {
+  const { recordState = true } = opts;
+```
+
+and:
+
+```ts
+    const devices = normaliseDevices(body.devices);
+    if (recordState) {
+      setLastKnownQwenInstallState(qwenInstallState);
+      setLastKnownVram({
+        totalMb: typeof body.vram_total_mb === 'number' ? body.vram_total_mb : null,
+      });
+      setLastKnownEngineDevices(devices);
+    }
+```
+
+(Move the `const devices = …` line above the block, as shown — the returned object still uses it.)
+
+- [ ] **Step 4: Add the provider slot to the gate**
+
+Append to `server/src/gpu/sidecar-health-gate.ts`:
+
+```ts
+/** The sidecar's startup device-probe state: 'pending' until torch finishes
+    importing in the background, 'ready' once it has, 'error' when torch is
+    missing or the probe raised. Spelled locally rather than imported from
+    routes/sidecar-health.ts for the same cycle reason as
+    SidecarHealthSnapshot above — a type-only import is still an edge. */
+export type DeviceProbeState = 'pending' | 'ready' | 'error';
+
+let deviceProbeStateProvider: (() => Promise<DeviceProbeState | null>) | null = null;
+
+/** Registered by routes/sidecar-health.ts with a NON-recording probe — the
+    caller (the boot warm loop) must not perturb last-known Qwen/VRAM/device
+    state just by asking whether the device probe has settled. */
+export function setDeviceProbeStateProvider(
+  fn: () => Promise<DeviceProbeState | null>,
+): void {
+  deviceProbeStateProvider = fn;
+}
+
+/** Resolves to the sidecar's device-probe state, or `null` when nothing has
+    registered or the sidecar is unreachable — fail closed (see file header):
+    `null` means "can't tell", and callers must treat it as "keep waiting",
+    never as "settled". */
+export async function probeDeviceProbeStateIfRegistered(): Promise<DeviceProbeState | null> {
+  if (!deviceProbeStateProvider) return null;
+  return deviceProbeStateProvider();
+}
+```
+
+- [ ] **Step 5: Register it**
+
+In `server/src/routes/sidecar-health.ts`, next to line 331:
+
+```ts
+import {
+  setProbeSidecarHealthProvider,
+  setDeviceProbeStateProvider,
+} from '../gpu/sidecar-health-gate.js';
+
+// …at the bottom, beside the existing registration:
+setProbeSidecarHealthProvider(probeSidecarHealth);
+setDeviceProbeStateProvider(() =>
+  probeSidecarHealth({ recordState: false }).then((r) => r.devicesState ?? null),
+);
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `npx vitest run --config server/vitest.config.ts server/src/routes/sidecar-health.test.ts`
+Expected: PASS — the two new tests plus every pre-existing test in the file.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/src/gpu/sidecar-health-gate.ts server/src/routes/sidecar-health.ts server/src/routes/sidecar-health.test.ts
+git commit -F - <<'EOF'
+feat(server): side-effect-free devices_state accessor for the health gate
+
+Refs #1857
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01VxtGhVyXqmikbXSpsvuEmg
+EOF
+```
+
+---
+
+### Task 3: The warm module
+
+**Files:**
+- Create: `server/src/gpu/warm-device-list.ts`
+- Create: `server/src/gpu/warm-device-list.test.ts`
+
+**Interfaces:**
+- Consumes: `setLastKnownGpuDevices`, `getLastKnownGpuDevices`, `_resetGpuDeviceListForTests` (Task 1); `probeDeviceProbeStateIfRegistered`, `DeviceProbeState` (Task 2); `fetchSidecarDevices` from `./fetch-sidecar-devices.js` (existing).
+- Produces: `ensureGpuDeviceListWarm(): Promise<void>`; `runGpuDeviceListWarmup(opts?: WarmupOpts): Promise<void>`; `startGpuDeviceListWarmup(opts?: WarmupOpts): void`; `_resetWarmDeviceListForTests(): void`; `interface WarmupOpts { maxAttempts?: number; attemptDelayMs?: number; log?: (msg: string) => void; delayFn?: (ms: number) => Promise<void> }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/src/gpu/warm-device-list.test.ts`:
+
+```ts
+/* #1857 — the GPU device-list cache had exactly one warmer, GET /api/config,
+   so nothing warmed it until the user opened Advanced settings. These cover
+   the server-owned replacement: dedup, retry, and the two stop conditions. */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('./fetch-sidecar-devices.js', () => ({ fetchSidecarDevices: vi.fn() }));
+vi.mock('./sidecar-health-gate.js', () => ({
+  probeDeviceProbeStateIfRegistered: vi.fn(async () => null),
+}));
+
+import { fetchSidecarDevices } from './fetch-sidecar-devices.js';
+import { probeDeviceProbeStateIfRegistered } from './sidecar-health-gate.js';
+import {
+  ensureGpuDeviceListWarm,
+  runGpuDeviceListWarmup,
+  _resetWarmDeviceListForTests,
+} from './warm-device-list.js';
+import {
+  getLastKnownGpuDevices,
+  _resetGpuDeviceListForTests,
+} from './gpu-device-list-state.js';
+
+const mockFetch = vi.mocked(fetchSidecarDevices);
+const mockState = vi.mocked(probeDeviceProbeStateIfRegistered);
+
+const ONE_CARD = {
+  devices: [{ uuid: 'GPU-1', idx: 1, name: 'x', total_mb: 16000, free_mb: 14000 }],
+  cpu: true,
+};
+const NO_CARDS = { devices: [], cpu: true };
+
+/* delayFn is replaced so the retry loop never actually waits — the tests
+   assert attempt COUNTS, not wall-clock behaviour. */
+const noWait = async () => {};
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockState.mockReset();
+  mockState.mockResolvedValue(null);
+  _resetGpuDeviceListForTests();
+  _resetWarmDeviceListForTests();
+});
+
+describe('ensureGpuDeviceListWarm', () => {
+  it('warms a cold cache from a reachable sidecar', async () => {
+    mockFetch.mockResolvedValue(ONE_CARD);
+    await ensureGpuDeviceListWarm();
+    expect(getLastKnownGpuDevices()).toEqual([{ uuid: 'GPU-1', idx: 1 }]);
+  });
+
+  it('issues no fetch when the cache is already warm', async () => {
+    mockFetch.mockResolvedValue(ONE_CARD);
+    await ensureGpuDeviceListWarm();
+    mockFetch.mockClear();
+    await ensureGpuDeviceListWarm();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('concurrent callers share a single in-flight fetch', async () => {
+    mockFetch.mockResolvedValue(ONE_CARD);
+    await Promise.all([
+      ensureGpuDeviceListWarm(),
+      ensureGpuDeviceListWarm(),
+      ensureGpuDeviceListWarm(),
+    ]);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the cache cold when the sidecar is unreachable', async () => {
+    mockFetch.mockResolvedValue(null);
+    await ensureGpuDeviceListWarm();
+    expect(getLastKnownGpuDevices()).toEqual([]);
+  });
+});
+
+describe('runGpuDeviceListWarmup', () => {
+  it('retries an unreachable sidecar and warms once it answers', async () => {
+    mockFetch.mockResolvedValueOnce(null).mockResolvedValueOnce(null).mockResolvedValue(ONE_CARD);
+    await runGpuDeviceListWarmup({ maxAttempts: 5, delayFn: noWait });
+    expect(getLastKnownGpuDevices()).toEqual([{ uuid: 'GPU-1', idx: 1 }]);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('keeps retrying an empty list while devices_state is pending', async () => {
+    mockFetch.mockResolvedValueOnce(NO_CARDS).mockResolvedValue(ONE_CARD);
+    mockState.mockResolvedValue('pending');
+    await runGpuDeviceListWarmup({ maxAttempts: 5, delayFn: noWait });
+    expect(getLastKnownGpuDevices()).toEqual([{ uuid: 'GPU-1', idx: 1 }]);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops early when devices_state is ready with zero cards', async () => {
+    mockFetch.mockResolvedValue(NO_CARDS);
+    mockState.mockResolvedValue('ready');
+    await runGpuDeviceListWarmup({ maxAttempts: 24, delayFn: noWait });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(getLastKnownGpuDevices()).toEqual([]);
+  });
+
+  it('stops early when devices_state is error', async () => {
+    mockFetch.mockResolvedValue(NO_CARDS);
+    mockState.mockResolvedValue('error');
+    await runGpuDeviceListWarmup({ maxAttempts: 24, delayFn: noWait });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps retrying when no state provider is registered (null)', async () => {
+    mockFetch.mockResolvedValue(NO_CARDS);
+    mockState.mockResolvedValue(null);
+    await runGpuDeviceListWarmup({ maxAttempts: 4, delayFn: noWait });
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+  });
+
+  it('exhausts its budget without throwing', async () => {
+    mockFetch.mockResolvedValue(null);
+    await expect(
+      runGpuDeviceListWarmup({ maxAttempts: 3, delayFn: noWait }),
+    ).resolves.toBeUndefined();
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('swallows a throwing fetch and keeps going', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('boom')).mockResolvedValue(ONE_CARD);
+    await runGpuDeviceListWarmup({ maxAttempts: 3, delayFn: noWait });
+    expect(getLastKnownGpuDevices()).toEqual([{ uuid: 'GPU-1', idx: 1 }]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run --config server/vitest.config.ts server/src/gpu/warm-device-list.test.ts`
+Expected: FAIL — `Cannot find module './warm-device-list.js'`.
+
+- [ ] **Step 3: Write the module**
+
+Create `server/src/gpu/warm-device-list.ts`:
+
+```ts
+/* Server-owned warm for the GPU device-list cache (#1857).
+
+   Until PR #1852 the frontend dispatched fetchConfig() at app boot, so every
+   page load in any view incidentally warmed this cache. That dispatch existed
+   only to hydrate the deleted voices.library.enabled gate; with it gone, all
+   three warmers (GET /api/config, GET /api/gpu/devices, and a PUT device
+   write) are dispatched from src/views/advanced.tsx alone — so nothing warmed
+   the cache until a user opened Advanced settings.
+
+   This does NOT warm before the first spawnSidecar: the only source of the
+   uuid<->idx mapping is the sidecar's own GET /devices, and at the initial
+   boot spawn that process doesn't exist yet. It doesn't need to. The sidecar
+   resolves 'cuda-uuid:<uuid>' itself via _read_device_env ->
+   _resolve_uuid_to_index (main.py), which exists precisely because this cache
+   is cold at spawn time. This loop is for the NODE-side consumers of a
+   resolved device knob, and for the Advanced UI's staleReason reconcile. */
+
+import { fetchSidecarDevices } from './fetch-sidecar-devices.js';
+import { getLastKnownGpuDevices, setLastKnownGpuDevices } from './gpu-device-list-state.js';
+import { probeDeviceProbeStateIfRegistered } from './sidecar-health-gate.js';
+
+/* Sized to outlast a cold torch import, not a single probe. fetchSidecarDevices
+   aborts each attempt at 2s (PROBE_TIMEOUT_MS) and the sidecar's /devices is a
+   sync def whose first call triggers `import torch` on FastAPI's threadpool —
+   so early attempts WILL abort. That's survivable because the aborted client
+   fetch doesn't cancel the server-side import (a running Python thread can't be
+   interrupted by a disconnect), so a later attempt lands on a warm module.
+   Mirrors runCatalogAudit's 24 x 5s, which solves the same "sidecar takes
+   30-60s to come up" problem. */
+const DEFAULT_MAX_ATTEMPTS = 24;
+const DEFAULT_ATTEMPT_DELAY_MS = 5_000;
+
+export interface WarmupOpts {
+  maxAttempts?: number;
+  attemptDelayMs?: number;
+  log?: (msg: string) => void;
+  delayFn?: (ms: number) => Promise<void>;
+}
+
+/* Shared in-flight promise so the boot loop and a concurrent GET /api/config
+   pay ONE sidecar round-trip rather than two. */
+let inFlight: Promise<void> | null = null;
+
+/** Warm the cache if it isn't already. Idempotent, deduped, and NEVER throws —
+    GET /api/config awaits this inline (routes/config.ts), so a throw here would
+    turn a warm failure into a 500 on the Advanced Settings load. fetchSidecarDevices
+    already swallows everything and returns null; the catch is belt-and-braces
+    against that contract changing. */
+export async function ensureGpuDeviceListWarm(): Promise<void> {
+  if (getLastKnownGpuDevices().length > 0) return;
+  if (inFlight) return inFlight;
+  inFlight = (async () => {
+    try {
+      const result = await fetchSidecarDevices();
+      if (result) {
+        setLastKnownGpuDevices(result.devices.map((d) => ({ uuid: d.uuid, idx: d.idx })));
+      }
+    } catch {
+      // leave the cache cold; the retry loop (or the next request) tries again
+    }
+  })().finally(() => {
+    inFlight = null;
+  });
+  return inFlight;
+}
+
+/** Test seam — clears the shared in-flight promise. Distinct from
+    _resetGpuDeviceListForTests(), which clears the cached list itself. */
+export function _resetWarmDeviceListForTests(): void {
+  inFlight = null;
+}
+
+function defaultDelay(ms: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const t = setTimeout(resolve, ms);
+    // Never hold the process open on our own — same contract as the other
+    // boot-time background timers (see startBackupScheduler in index.ts).
+    t.unref?.();
+  });
+}
+
+/** The retry loop. Exported separately from the fire-and-forget starter so
+    tests can await it with an injected delayFn instead of real timers.
+    Never throws — a boot-time warm failing must not affect anything else. */
+export async function runGpuDeviceListWarmup(opts: WarmupOpts = {}): Promise<void> {
+  const {
+    maxAttempts = DEFAULT_MAX_ATTEMPTS,
+    attemptDelayMs = DEFAULT_ATTEMPT_DELAY_MS,
+    log = console.log,
+    delayFn = defaultDelay,
+  } = opts;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await ensureGpuDeviceListWarm();
+      const cards = getLastKnownGpuDevices();
+      if (cards.length > 0) {
+        log(`[gpu] device list warm: ${cards.length} card(s) after ${attempt} attempt(s).`);
+        return;
+      }
+      /* An empty list is ambiguous — the sidecar returns [] both for "no CUDA
+         cards" and for "torch isn't imported yet / the probe raised". Ask the
+         sidecar which it is. Only a SETTLED state ends the loop: 'ready' means
+         torch is up and there genuinely are no cards, 'error' means the probe
+         failed and won't fix itself. 'pending' and null (unregistered provider,
+         or unreachable sidecar) both mean "can't tell yet" — keep waiting. */
+      const state = await probeDeviceProbeStateIfRegistered();
+      if (state === 'ready' || state === 'error') {
+        log(`[gpu] device list warm: sidecar reports no CUDA cards (devices_state=${state}).`);
+        return;
+      }
+    } catch {
+      // fall through to the retry — never let a warm failure escape
+    }
+    if (attempt < maxAttempts) await delayFn(attemptDelayMs);
+  }
+  log(
+    `[gpu] device list warm: gave up after ${maxAttempts} attempt(s) — ` +
+      `sidecar never reported a card list. UUID device pins will resolve sidecar-side.`,
+  );
+}
+
+/** Fire-and-forget starter for the boot path. */
+export function startGpuDeviceListWarmup(opts: WarmupOpts = {}): void {
+  void runGpuDeviceListWarmup(opts);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run --config server/vitest.config.ts server/src/gpu/warm-device-list.test.ts`
+Expected: PASS, 12 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/gpu/warm-device-list.ts server/src/gpu/warm-device-list.test.ts
+git commit -F - <<'EOF'
+feat(server): server-owned GPU device-list warm loop
+
+Refs #1857
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01VxtGhVyXqmikbXSpsvuEmg
+EOF
+```
+
+---
+
+### Task 4: Wire it into boot; de-duplicate the route's private warmer
+
+**Files:**
+- Modify: `server/src/routes/config.ts:20-46`
+- Modify: `server/src/index.ts` (import block, and `listenerCallback` after line 301)
+
+**Interfaces:**
+- Consumes: `ensureGpuDeviceListWarm`, `startGpuDeviceListWarmup` (Task 3).
+- Produces: nothing new.
+
+- [ ] **Step 1: Replace the route's private warmer with the shared one**
+
+In `server/src/routes/config.ts`, delete the local `ensureGpuDeviceListWarm` function **and** its docblock (lines 26-43). The `GET /` handler's `await ensureGpuDeviceListWarm();` call at line 46 stays exactly as it is — it now resolves to the imported helper.
+
+Import changes, precisely:
+
+- **Line 21, keep unchanged.** `import { fetchSidecarDevices, type SidecarDevicesResponse } from '../gpu/fetch-sidecar-devices.js';` — the `PUT` handler still uses both (lines 82 and 101).
+- **Line 22, delete.** `import { getLastKnownGpuDevices, setLastKnownGpuDevices } from '../gpu/gpu-device-list-state.js';` — both bindings become unused once the local function is gone.
+- **Add**, beside the other `../gpu/` imports:
+
+```ts
+import { ensureGpuDeviceListWarm } from '../gpu/warm-device-list.js';
+```
+
+Then put a shortened docblock immediately above `configRouter.get('/', …)`, replacing the deleted one:
+
+```ts
+/* resolveAll() -> resolveKnob() reconciles a stored 'cuda-uuid:<uuid>' override
+   against getLastKnownGpuDevices()'s cache SYNCHRONOUSLY. AdvancedView's mount
+   effect fires fetchConfig() and getGpuDevices() concurrently with no ordering,
+   and this route is a synchronous local computation that routinely resolves
+   BEFORE the sidecar round-trip GET /api/gpu/devices needs — which would
+   mislabel a valid uuid pin as staleReason:'uuid_unresolved' on the first
+   Advanced Settings load after a restart. Warming here (a no-op once anything
+   else has warmed it, including the boot loop) keeps that race closed. See
+   gpu/warm-device-list.ts. */
+```
+
+**Note:** `fetchSidecarDevices` and `SidecarDevicesResponse` are still used by the `PUT` handler at lines 82 and 101 — keep that import. Only the `gpu-device-list-state.js` import becomes unused.
+
+- [ ] **Step 2: Verify the config route still passes**
+
+Run: `npx vitest run --config server/vitest.config.ts server/src/routes/config.test.ts`
+Expected: PASS — identical behaviour, warmer just lives elsewhere now.
+
+- [ ] **Step 3: Start the loop at boot**
+
+In `server/src/index.ts`, add to the import block (near line 48's `initDeviceTotalVram` import):
+
+```ts
+import { startGpuDeviceListWarmup } from './gpu/warm-device-list.js';
+```
+
+and immediately after `registerActiveSupervisor(sidecarSupervisor);` (line 302), inside `listenerCallback`:
+
+```ts
+    /* #1857 — warm the GPU device-list cache from the SERVER, not from a
+       frontend request. Until PR #1852 the store's boot fetchConfig() dispatch
+       warmed it incidentally on every page load; that dispatch existed only for
+       the deleted voices.library.enabled gate, so with it gone nothing warmed
+       the cache until a user opened Advanced settings. Started after the
+       supervisor so the sidecar it polls is already being spawned; the loop
+       retries while the sidecar comes up and stops as soon as it reports a
+       settled devices_state. Fire-and-forget and unref'd — it never blocks boot
+       and never holds the process open. */
+    startGpuDeviceListWarmup();
+```
+
+- [ ] **Step 4: Verify boot wiring compiles and the shutdown suite is unaffected**
+
+Run: `npx tsc -p server/tsconfig.json --noEmit`
+Expected: no errors.
+
+Run: `npx vitest run --config server/vitest.config.ts server/src/index.test.ts`
+Expected: PASS — `index.test.ts` imports the module but the main-module guard keeps `main()` (and therefore `listenerCallback` and the timer) from running.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/routes/config.ts server/src/index.ts
+git commit -F - <<'EOF'
+fix(server): warm the GPU device list at boot, not on first GET /api/config
+
+Refs #1857
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01VxtGhVyXqmikbXSpsvuEmg
+EOF
+```
+
+---
+
+### Task 5: Pin the `buildSidecarEnv` contract under both cache states
+
+The cold-cache case is **not** a bug — the sidecar resolves the literal itself. This test documents that so the next reader doesn't "fix" it.
+
+**Files:**
+- Modify: `server/src/tts/sidecar-env.test.ts`
+
+**Interfaces:**
+- Consumes: `_resetGpuDeviceListForTests` (Task 1).
+
+- [ ] **Step 1: Write the test**
+
+Append to `server/src/tts/sidecar-env.test.ts`:
+
+```ts
+import {
+  setLastKnownGpuDevices,
+  _resetGpuDeviceListForTests,
+} from '../gpu/gpu-device-list-state.js';
+
+describe('buildSidecarEnv device-knob resolution against the GPU device cache', () => {
+  beforeEach(() => {
+    _resetGpuDeviceListForTests();
+    (us.readConfigOverrides as ReturnType<typeof vi.fn>).mockReturnValue({});
+    delete process.env.QWEN_DEVICE;
+  });
+
+  it('translates a cuda-uuid: pin to an index when the cache is warm', () => {
+    (us.readConfigOverrides as ReturnType<typeof vi.fn>).mockReturnValue({
+      'tts.qwen.device': 'cuda-uuid:GPU-1',
+    });
+    setLastKnownGpuDevices([{ uuid: 'GPU-1', idx: 1 }]);
+
+    const env = buildSidecarEnv({ modelKey: 'qwen3-tts-0.6b', repoRoot: process.cwd() });
+
+    expect(env.QWEN_DEVICE).toBe('cuda:1');
+  });
+
+  /* CONTRACT, NOT A BUG. With a cold cache resolveKnob can't translate, so the
+     raw 'cuda-uuid:' literal is handed to the sidecar — which resolves it
+     itself in _read_device_env -> _resolve_uuid_to_index (main.py:1873). That
+     Python-side resolution was added FOR this case: the Node cache is
+     necessarily empty at the initial boot spawn, because the only source of
+     the uuid<->idx mapping is the sidecar process that doesn't exist yet.
+     Do not "fix" this by making it assert cuda:N. */
+  it('passes the raw cuda-uuid: literal through when the cache is cold', () => {
+    (us.readConfigOverrides as ReturnType<typeof vi.fn>).mockReturnValue({
+      'tts.qwen.device': 'cuda-uuid:GPU-1',
+    });
+
+    const env = buildSidecarEnv({ modelKey: 'qwen3-tts-0.6b', repoRoot: process.cwd() });
+
+    expect(env.QWEN_DEVICE).toBe('cuda-uuid:GPU-1');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `npx vitest run --config server/vitest.config.ts server/src/tts/sidecar-env.test.ts`
+Expected: PASS, both new tests plus the pre-existing ones.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/src/tts/sidecar-env.test.ts
+git commit -F - <<'EOF'
+test(server): pin buildSidecarEnv device resolution under warm and cold caches
+
+Refs #1857
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01VxtGhVyXqmikbXSpsvuEmg
+EOF
+```
+
+---
+
+### Task 6: `QWEN_CODEC_DEVICE` resolves a UUID pin
+
+Independent of Tasks 1–5. `tts.qwen.codecDevice` is the fourth and only `type: 'device'` knob whose env var is read with a bare `os.environ.get`, so a card pinned from the UI is stored as `cuda-uuid:<uuid>`, passes `_validate_cuda_index` (because `_parse_device` reads it as family `cuda` with no index), then fails inside torch's `.to()` and gets rolled back to CPU.
+
+**Files:**
+- Modify: `server/tts-sidecar/main.py:2995-2997`
+- Modify: `server/tts-sidecar/tests/test_device_parse.py`
+
+**Why this task introduces a named helper.** The production read lives inside
+`_load_qwen_model`, which needs real Qwen weights and a GPU to invoke — so a test
+cannot reach it. Asserting on a hand-composed
+`_resolve_codec_device(_read_device_env(...) or "cpu", ...)` in the test would be
+a **placebo**: that expression already returns the right answer today, and would
+pass whether or not `main.py:2996` was ever changed. So the fix extracts the
+one-line expression into `_codec_device_pref()` and has the production line call
+it. The test then exercises the exact function production uses.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/tts-sidecar/tests/test_device_parse.py`:
+
+```python
+def test_codec_device_pref_resolves_uuid(monkeypatch):
+    """QWEN_CODEC_DEVICE is a type:'device' knob, so a card picked in Advanced
+    Settings is persisted as 'cuda-uuid:<uuid>'. _codec_device_pref is what
+    _load_qwen_model actually calls, so a UUID must never reach torch raw."""
+    monkeypatch.setenv("QWEN_CODEC_DEVICE", "cuda-uuid:GPU-1")
+    monkeypatch.setattr(main, "_enumerate_cuda_devices",
+        lambda tm=None: [{"uuid": "GPU-1", "idx": 1, "name": "x", "total_mb": 16000, "free_mb": 14000}])
+    assert main._codec_device_pref() == "cuda:1"
+    assert main._resolve_codec_device(main._codec_device_pref(), "cuda:0") == "cuda:1"
+
+
+def test_codec_device_pref_unresolvable_uuid_follows_the_model(monkeypatch):
+    """A vanished card degrades to 'auto', which for the codec means "follow
+    the model" -- never a different card, and never a CPU demotion."""
+    monkeypatch.setenv("QWEN_CODEC_DEVICE", "cuda-uuid:GONE")
+    monkeypatch.setattr(main, "_enumerate_cuda_devices", lambda tm=None: [])
+    assert main._codec_device_pref() == "auto"
+    assert main._resolve_codec_device(main._codec_device_pref(), "cuda:0") == "cuda:0"
+
+
+def test_codec_device_pref_unset_still_means_cpu(monkeypatch):
+    """Regression guard on the `or 'cpu'` fallback: unset must stay CPU-only,
+    i.e. _resolve_codec_device returns None (no move attempted)."""
+    monkeypatch.delenv("QWEN_CODEC_DEVICE", raising=False)
+    assert main._codec_device_pref() == "cpu"
+    assert main._resolve_codec_device(main._codec_device_pref(), "cuda:0") is None
+
+
+def test_codec_device_pref_passes_through_plain_values(monkeypatch):
+    """cpu / auto / cuda:N are unchanged -- no behaviour change for any value
+    that already worked."""
+    for raw, expected in (("cpu", "cpu"), ("auto", "auto"), ("cuda:1", "cuda:1")):
+        monkeypatch.setenv("QWEN_CODEC_DEVICE", raw)
+        assert main._codec_device_pref() == expected
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `server/tts-sidecar/.venv/Scripts/python.exe -m pytest server/tts-sidecar/tests/test_device_parse.py -v -k codec_device_pref`
+Expected: all four FAIL with `AttributeError: module 'main' has no attribute '_codec_device_pref'`.
+
+- [ ] **Step 3: Add the helper and route the production read through it**
+
+In `server/tts-sidecar/main.py`, define the helper immediately after
+`_resolve_codec_device` (i.e. after line 403), so it sits beside the function it
+feeds:
+
+```python
+def _codec_device_pref() -> str:
+    """QWEN_CODEC_DEVICE as a resolved device string, defaulting to 'cpu'.
+
+    Goes through _read_device_env like COQUI_DEVICE / KOKORO_DEVICE /
+    QWEN_DEVICE, because QWEN_CODEC_DEVICE is a type:'device' knob too --
+    PUT /api/config persists a picked card as 'cuda-uuid:<uuid>'. A bare
+    os.environ.get (the #1857 bug) let that literal through _validate_cuda_index
+    untouched, because _parse_device reads 'cuda-uuid:x' as family cuda with NO
+    index and the range check only fires on a concrete index. It then failed
+    inside torch's .to() in _move_codec_to_device and got rolled back to CPU --
+    so a pinned codec silently ran on the wrong device.
+
+    Named rather than inlined at the call site so it is reachable from tests:
+    the call site is inside _load_qwen_model, which needs real weights + a GPU.
+    """
+    return _read_device_env("QWEN_CODEC_DEVICE") or "cpu"
+```
+
+Then replace lines 2995-2997:
+
+```python
+        codec_device = _resolve_codec_device(_codec_device_pref(), self._device)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `server/tts-sidecar/.venv/Scripts/python.exe -m pytest server/tts-sidecar/tests/test_device_parse.py -v`
+Expected: PASS, all tests in the file.
+
+Run: `server/tts-sidecar/.venv/Scripts/python.exe -m pytest server/tts-sidecar/tests/test_module_import_order.py -v`
+Expected: PASS — `_read_device_env` is reached at module-import time via `ENGINES = {...}`, and this file guards that ordering.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/tts-sidecar/main.py server/tts-sidecar/tests/test_device_parse.py
+git commit -F - <<'EOF'
+fix(sidecar): resolve a cuda-uuid: pin for QWEN_CODEC_DEVICE
+
+Refs #1857
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01VxtGhVyXqmikbXSpsvuEmg
+EOF
+```
+
+---
+
+## Final verification
+
+- [ ] Run the full server suite: `npm run test:server`
+- [ ] Run typecheck: `npx tsc -p server/tsconfig.json --noEmit`
+- [ ] Run the sidecar device tests: `server/tts-sidecar/.venv/Scripts/python.exe -m pytest server/tts-sidecar/tests/test_device_parse.py server/tts-sidecar/tests/test_module_import_order.py -v`
+- [ ] Confirm no `gpu/ → routes/` import was introduced: `npx madge --circular --extensions ts server/src` (or the repo's existing cycle check) reports no new cycles.
+- [ ] Open PR with `Closes #1857` in the body, and post the premise correction (the sidecar already resolves `cuda-uuid:` for the three engine knobs; the issue's acceptance criteria are superseded by the spec's).

--- a/docs/superpowers/plans/2026-07-27-gpu-device-list-boot-warm.md
+++ b/docs/superpowers/plans/2026-07-27-gpu-device-list-boot-warm.md
@@ -161,12 +161,14 @@ _resetGpuDeviceListForTests();
 
 Leave line 370/374 alone — that test sets a non-empty list and is unaffected.
 
-In `server/src/routes/gpu-devices.test.ts`, line 10 and line 25:
+In `server/src/routes/gpu-devices.test.ts`, line 10 and line 25. **Drop
+`setLastKnownGpuDevices` from the import** — line 25 is its only use in the file,
+so keeping it would leave an unused binding and fail lint/typecheck.
+`getLastKnownGpuDevices` stays; it is still used at line 87.
 
 ```ts
-// line 10
+// line 10 — was: import { setLastKnownGpuDevices, getLastKnownGpuDevices } from '../gpu/gpu-device-list-state.js';
 import {
-  setLastKnownGpuDevices,
   getLastKnownGpuDevices,
   _resetGpuDeviceListForTests,
 } from '../gpu/gpu-device-list-state.js';
@@ -174,6 +176,11 @@ import {
 // line 25, inside beforeEach — was: setLastKnownGpuDevices([]);
 _resetGpuDeviceListForTests();
 ```
+
+In `server/src/routes/config.test.ts` the setter is imported dynamically inside
+each test, so removing it from the two dynamic imports at 344 and 383 leaves
+nothing dangling. The test at 370/374 keeps its own `setLastKnownGpuDevices`
+import — it passes a non-empty list.
 
 - [ ] **Step 6: Run the affected suites**
 
@@ -203,7 +210,7 @@ The warm loop needs the sidecar's `devices_state` to tell "no CUDA cards" from "
 **Files:**
 - Modify: `server/src/gpu/sidecar-health-gate.ts:45-58`
 - Modify: `server/src/routes/sidecar-health.ts:235`, `:263-268`, `:331`
-- Modify: `server/src/routes/sidecar-health.test.ts`
+- Create: `server/src/routes/sidecar-health-record-state.test.ts`
 
 **Interfaces:**
 - Consumes: nothing from Task 1.
@@ -211,46 +218,97 @@ The warm loop needs the sidecar's `devices_state` to tell "no CUDA cards" from "
 
 - [ ] **Step 1: Write the failing test**
 
-Append to `server/src/routes/sidecar-health.test.ts`:
+Create `server/src/routes/sidecar-health-record-state.test.ts`. **Its own file,
+not appended to `sidecar-health.test.ts`:** asserting "these setters were NOT
+called" requires the state modules to be mocked, and mocking them wholesale
+inside that file would change what every pre-existing test there exercises.
+`vi.spyOn` on the shared file is not an option either — `server/vitest.config.ts`
+sets no `restoreMocks`, so spies would leak across its tests.
 
 ```ts
+/* #1857 — probeSidecarHealth({ recordState: false }) parses identically but
+   performs NONE of its three last-known-state writes, so the boot-time GPU
+   device-list warm loop can read devices_state without moving Qwen install
+   state / VRAM / per-engine device ground truth while the supervisor is still
+   deciding what to spawn. Also pins that sidecar-health.ts actually REGISTERS
+   the non-recording probe with the gate at module init — without that, the
+   warm loop's early exit silently degrades to "always null, always retry". */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../tts/sidecar-supervisor.js', () => ({
+  getActiveSupervisor: vi.fn(() => null),
+  registerActiveSupervisor: vi.fn(),
+  createSidecarSupervisor: vi.fn(),
+}));
+vi.mock('../gpu/capacity-retry.js', () => ({ withCapacityRetry: vi.fn() }));
+/* All three use the importOriginal SPREAD, not a bare factory. vi.mock replaces
+   the module for every importer in this test's graph, and each of these has
+   other live consumers: vram-state also exports getLastKnownVram (analyzer/
+   ollama.ts, routes/ollama-health.ts), engine-device-state also exports
+   getLastKnownEngineDevice + _resetEngineDevicesForTests (gpu/engine-device.ts),
+   and user-settings exports most of the settings surface. A bare factory
+   listing only the setter would kill the import with "does not provide an
+   export named …". Spread first, override the one setter. */
+vi.mock('../gpu/vram-state.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../gpu/vram-state.js')>()),
+  setLastKnownVram: vi.fn(),
+}));
+vi.mock('../gpu/engine-device-state.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../gpu/engine-device-state.js')>()),
+  setLastKnownEngineDevices: vi.fn(),
+}));
+vi.mock('../workspace/user-settings.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../workspace/user-settings.js')>()),
+  setLastKnownQwenInstallState: vi.fn(),
+}));
+
 import { probeSidecarHealth } from './sidecar-health.js';
-import * as vramMod from '../gpu/vram-state.js';
-import * as engineDeviceMod from '../gpu/engine-device-state.js';
-import * as settingsMod from '../workspace/user-settings.js';
+import { probeDeviceProbeStateIfRegistered } from '../gpu/sidecar-health-gate.js';
+import { setLastKnownVram } from '../gpu/vram-state.js';
+import { setLastKnownEngineDevices } from '../gpu/engine-device-state.js';
+import { setLastKnownQwenInstallState } from '../workspace/user-settings.js';
+
+const fetchMock = vi.fn();
+
+function okHealth() {
+  return new Response(
+    JSON.stringify({
+      model_loaded: true,
+      vram_total_mb: 16000,
+      devices: { qwen: 'cuda' },
+      devices_state: 'ready',
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  );
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+  vi.mocked(setLastKnownVram).mockClear();
+  vi.mocked(setLastKnownEngineDevices).mockClear();
+  vi.mocked(setLastKnownQwenInstallState).mockClear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('probeSidecarHealth recordState opt', () => {
-  function okHealth() {
-    return new Response(
-      JSON.stringify({
-        model_loaded: true,
-        vram_total_mb: 16000,
-        devices: { qwen: 'cuda' },
-        devices_state: 'ready',
-      }),
-      { status: 200, headers: { 'Content-Type': 'application/json' } },
-    );
-  }
-
   it('records last-known state by default', async () => {
-    const vramSpy = vi.spyOn(vramMod, 'setLastKnownVram');
-    const devSpy = vi.spyOn(engineDeviceMod, 'setLastKnownEngineDevices');
-    const qwenSpy = vi.spyOn(settingsMod, 'setLastKnownQwenInstallState');
     fetchMock.mockResolvedValue(okHealth());
 
     const res = await probeSidecarHealth();
 
     expect(res.status).toBe('reachable');
     expect(res.devicesState).toBe('ready');
-    expect(vramSpy).toHaveBeenCalled();
-    expect(devSpy).toHaveBeenCalled();
-    expect(qwenSpy).toHaveBeenCalled();
+    expect(setLastKnownVram).toHaveBeenCalled();
+    expect(setLastKnownEngineDevices).toHaveBeenCalled();
+    expect(setLastKnownQwenInstallState).toHaveBeenCalled();
   });
 
   it('performs no state writes when recordState is false, but parses the same result', async () => {
-    const vramSpy = vi.spyOn(vramMod, 'setLastKnownVram');
-    const devSpy = vi.spyOn(engineDeviceMod, 'setLastKnownEngineDevices');
-    const qwenSpy = vi.spyOn(settingsMod, 'setLastKnownQwenInstallState');
     fetchMock.mockResolvedValue(okHealth());
 
     const res = await probeSidecarHealth({ recordState: false });
@@ -258,17 +316,33 @@ describe('probeSidecarHealth recordState opt', () => {
     expect(res.status).toBe('reachable');
     expect(res.devicesState).toBe('ready');
     expect(res.vramTotalMb).toBe(16000);
-    expect(vramSpy).not.toHaveBeenCalled();
-    expect(devSpy).not.toHaveBeenCalled();
-    expect(qwenSpy).not.toHaveBeenCalled();
+    expect(setLastKnownVram).not.toHaveBeenCalled();
+    expect(setLastKnownEngineDevices).not.toHaveBeenCalled();
+    expect(setLastKnownQwenInstallState).not.toHaveBeenCalled();
+  });
+});
+
+describe('device-probe-state provider registration', () => {
+  it('is registered by importing sidecar-health.ts, and does not record state', async () => {
+    fetchMock.mockResolvedValue(okHealth());
+
+    // Not null => sidecar-health.ts called setDeviceProbeStateProvider at init.
+    await expect(probeDeviceProbeStateIfRegistered()).resolves.toBe('ready');
+    expect(setLastKnownVram).not.toHaveBeenCalled();
+  });
+
+  it('resolves null when the sidecar is unreachable, so the warm loop keeps waiting', async () => {
+    fetchMock.mockRejectedValue(new TypeError('fetch failed'));
+
+    await expect(probeDeviceProbeStateIfRegistered()).resolves.toBeNull();
   });
 });
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `npx vitest run --config server/vitest.config.ts server/src/routes/sidecar-health.test.ts -t "recordState"`
-Expected: FAIL — `probeSidecarHealth` takes no arguments, so the writes still fire.
+Run: `npx vitest run --config server/vitest.config.ts server/src/routes/sidecar-health-record-state.test.ts`
+Expected: FAIL — `probeSidecarHealth` takes no arguments (so the `recordState: false` test still sees all three writes), and `probeDeviceProbeStateIfRegistered` is not exported from the gate.
 
 - [ ] **Step 3: Add the opt to `probeSidecarHealth`**
 
@@ -361,13 +435,18 @@ setDeviceProbeStateProvider(() =>
 
 - [ ] **Step 6: Run tests**
 
-Run: `npx vitest run --config server/vitest.config.ts server/src/routes/sidecar-health.test.ts`
-Expected: PASS — the two new tests plus every pre-existing test in the file.
+Run: `npx vitest run --config server/vitest.config.ts server/src/routes/sidecar-health-record-state.test.ts server/src/routes/sidecar-health.test.ts`
+Expected: PASS — the four new tests, plus every pre-existing test in the original file unchanged.
+
+**If the new file fails on a mock-resolution error rather than an assertion,
+re-run once before debugging.** This repo has a recorded intermittent failure
+with `importOriginal`-based mocks that clears on a re-run. A *consistent*
+failure is a real defect; a one-off is the known flake.
 
 - [ ] **Step 7: Commit**
 
 ```bash
-git add server/src/gpu/sidecar-health-gate.ts server/src/routes/sidecar-health.ts server/src/routes/sidecar-health.test.ts
+git add server/src/gpu/sidecar-health-gate.ts server/src/routes/sidecar-health.ts server/src/routes/sidecar-health-record-state.test.ts
 git commit -F - <<'EOF'
 feat(server): side-effect-free devices_state accessor for the health gate
 
@@ -780,6 +859,12 @@ EOF
 
 The cold-cache case is **not** a bug — the sidecar resolves the literal itself. This test documents that so the next reader doesn't "fix" it.
 
+**This task is a characterization test, not a TDD cycle.** Both assertions pass
+against unmodified production code; there is deliberately no "verify it fails"
+step, because there is no behaviour change here to drive. Its value is pinning a
+contract that currently exists only as tribal knowledge — #1857 was filed because
+a reader saw the cold-cache literal and reasonably concluded it was a defect.
+
 **Files:**
 - Modify: `server/src/tts/sidecar-env.test.ts`
 
@@ -942,9 +1027,16 @@ def _codec_device_pref() -> str:
     return _read_device_env("QWEN_CODEC_DEVICE") or "cpu"
 ```
 
-Then replace lines 2995-2997:
+Then replace the call site. **Do not go by line number** — inserting the helper
+above shifts it from 2995-2997 to roughly 3010. Find it by content:
 
 ```python
+        # BEFORE (find this):
+        codec_device = _resolve_codec_device(
+            os.environ.get("QWEN_CODEC_DEVICE", "cpu"), self._device
+        )
+
+        # AFTER:
         codec_device = _resolve_codec_device(_codec_device_pref(), self._device)
 ```
 
@@ -975,7 +1067,11 @@ EOF
 ## Final verification
 
 - [ ] Run the full server suite: `npm run test:server`
-- [ ] Run typecheck: `npx tsc -p server/tsconfig.json --noEmit`
+- [ ] Run typecheck: `npm run typecheck` (the repo script — root `tsc --noEmit` **and** `npm --prefix server run typecheck`; a bare `npx tsc -p server/tsconfig.json` only covers the second half)
 - [ ] Run the sidecar device tests: `server/tts-sidecar/.venv/Scripts/python.exe -m pytest server/tts-sidecar/tests/test_device_parse.py server/tts-sidecar/tests/test_module_import_order.py -v`
-- [ ] Confirm no `gpu/ → routes/` import was introduced: `npx madge --circular --extensions ts server/src` (or the repo's existing cycle check) reports no new cycles.
+- [ ] **Confirm no `gpu/ → routes/` import was introduced.** This repo has **no** cycle checker — `madge` is not a dependency and there is no `import/no-cycle` ESLint rule, so the `gpu/*-gate.ts` pattern is enforced by review alone. Verify by grep instead, which must return nothing:
+  ```bash
+  grep -rn "from '\.\./routes/" server/src/gpu/
+  ```
+  The registration test in Task 2 covers the other half — that routing *around* the cycle didn't leave the provider unregistered.
 - [ ] Open PR with `Closes #1857` in the body, and post the premise correction (the sidecar already resolves `cuda-uuid:` for the three engine knobs; the issue's acceptance criteria are superseded by the spec's).

--- a/docs/superpowers/specs/2026-07-27-gpu-device-list-boot-warm-design.md
+++ b/docs/superpowers/specs/2026-07-27-gpu-device-list-boot-warm-design.md
@@ -134,13 +134,22 @@ B1 is what actually closes the initial-spawn case, at the correct seam.
 
 ### Change 1 — `QWEN_CODEC_DEVICE` parity (`server/tts-sidecar/main.py`)
 
-Replace the bare read at `main.py:2995-2997` with `_read_device_env`:
+Replace the bare read at `main.py:2995-2997` with `_read_device_env`, extracted
+into a named helper beside `_resolve_codec_device`:
 
 ```python
-codec_device = _resolve_codec_device(
-    _read_device_env("QWEN_CODEC_DEVICE") or "cpu", self._device
-)
+def _codec_device_pref() -> str:
+    return _read_device_env("QWEN_CODEC_DEVICE") or "cpu"
+
+# at the call site, main.py:2995-2997:
+codec_device = _resolve_codec_device(_codec_device_pref(), self._device)
 ```
+
+The helper is named rather than inlined for testability: the call site is inside
+`_load_qwen_model`, which needs real Qwen weights and a GPU to invoke, so a test
+asserting on a hand-composed `_resolve_codec_device(_read_device_env(...) or
+"cpu", …)` would pass identically before and after the fix — a placebo. Testing
+`_codec_device_pref()` exercises the function production actually calls.
 
 Behaviour is unchanged for every value that works today:
 

--- a/docs/superpowers/specs/2026-07-27-gpu-device-list-boot-warm-design.md
+++ b/docs/superpowers/specs/2026-07-27-gpu-device-list-boot-warm-design.md
@@ -1,0 +1,419 @@
+# GPU device-list cache: server-owned boot warm + codec device-knob parity
+
+Design for [#1857](https://github.com/dudarenok-maker/Audiobook-Generator/issues/1857).
+Branch `fix/1857-gpu-device-cache-boot-warm`.
+
+## Summary
+
+1. Route `QWEN_CODEC_DEVICE` through `_read_device_env` in the sidecar, so the
+   fourth and last `type: 'device'` knob resolves a `cuda-uuid:` pin like the
+   other three already do.
+2. Warm the Node-side GPU device-list cache from a **server-owned** background
+   loop started at boot, instead of relying on an HTTP request having happened.
+   Two supporting changes fall out of adding a concurrent writer: a no-downgrade
+   rule in the device-list state module (2a), and a definitive stop condition so
+   the loop can tell "no CUDA on this box" from "torch still importing" (2b).
+
+Change 1 is the only misrouting bug. Change 2 closes the structural hole #1857
+names — nothing server-side warms the cache — without claiming to fix a case
+that cannot be fixed from the sidecar's device list.
+
+## Premise correction
+
+#1857's stated harm does not occur, and its acceptance criteria assert a
+behaviour the sidecar was deliberately built not to need. This spec supersedes
+them.
+
+The issue is mechanically correct that with a cold cache `buildSidecarEnv`
+(`server/src/tts/spawn-sidecar.ts:472-480`) injects `String(st.effective)`, so a
+raw `cuda-uuid:<uuid>` literal reaches the sidecar. It is wrong that this
+misroutes the engine.
+
+`main.py:1873` `_read_device_env()` runs every `*_DEVICE` read through
+`_resolve_uuid_to_index()` (`main.py:1858`), which enumerates live torch devices
+and maps `cuda-uuid:<uuid>` → `cuda:N`. All three engine device knobs the issue
+names go through it:
+
+| Knob | Env | Python read site | Resolves UUID |
+|---|---|---|---|
+| `tts.coqui.device` | `COQUI_DEVICE` | `main.py:1124` `_read_device_env` | yes |
+| `tts.kokoro.device` | `KOKORO_DEVICE` | `main.py:1444` `_read_device_env` | yes |
+| `tts.qwen.device` | `QWEN_DEVICE` | `main.py:2860`, `2656`, `6233` `_read_device_env` | yes |
+| `tts.qwen.codecDevice` | `QWEN_CODEC_DEVICE` | `main.py:2996` bare `os.environ.get` | **no** |
+
+That Python-side resolution exists *because* the Node cache is cold at the boot
+spawn. `_enumerate_cuda_devices`'s docstring (`main.py:1843-1847`) says so:
+
+> the Node-side spawn-time cache in `getLastKnownGpuDevices()` is empty before
+> the frontend's first GET `/api/gpu/devices` poll, so `buildSidecarEnv` passes
+> the RAW `'cuda-uuid:...'` string through unresolved on a fresh server boot,
+> not the pre-resolved `'cuda:N'` form a warm cache would produce
+
+So #1857's acceptance bullet — *"a supervisor respawn … passes a translated
+device index, not the raw `cuda-uuid:` literal"* — would pin redundancy, not a
+fix. The raw literal is a supported input at that boundary.
+
+## What is actually broken
+
+### B1. `QWEN_CODEC_DEVICE` does not resolve a UUID pin
+
+`tts.qwen.codecDevice` is `type: 'device'` (`registry.ts:589`), so
+`PUT /api/config` uuid-ifies it on write (`routes/config.ts:100` gates on
+`knob.type === 'device'`), and the frontend offers it the card dropdown
+(`override-row.tsx:366` — "only consumed by `type: 'device'` knobs"). A user
+pinning the codec to a card therefore gets `cuda-uuid:<uuid>` on disk.
+
+At load, `main.py:2996` reads it with a bare `os.environ.get`.
+`_resolve_codec_device` (`main.py:383-403`) lowercases and returns any
+unrecognised string unchanged, so `cuda-uuid:gpu-…` becomes the codec device.
+
+It then passes validation rather than being rejected by it. `_parse_device`
+(`main.py:1801`) lowercases, matches `p.startswith("cuda")`, partitions on `:`,
+finds `"gpu-…"` is not a digit, and returns `("cuda", None)`.
+`_validate_cuda_index` raises only when `index is not None`, so it no-ops. The
+literal therefore reaches `_move_codec_to_device(model, codec_device, torch)`
+(`main.py:3064`) and fails inside torch's `.to()`, which is caught at
+`main.py:431` and rolled back to CPU with `"Could not move Qwen codec to %s (%s)
+-- rolling back to cpu."`.
+
+Impact: the codec ends up on CPU instead of the pinned card. Narrow, but real,
+warned-not-silent, and it hits the **first** spawn as well as respawns — the one
+case no Node-side warming could ever have covered.
+
+**Adjacent latent trap, not fixed here but named so it stays dormant.**
+`_parse_device` classifies `cuda-uuid:<uuid>` as family `cuda` with *no index*.
+Any path that treats `("cuda", None)` as "plain cuda → card 0" and receives a raw
+UUID literal would silently use the **wrong card** rather than fail. Today the
+only consumer at risk, `_engine_env_pin` (`main.py:1898`), is safe solely because
+it routes through `_read_device_env` first. Change 1 makes the codec path the
+fourth caller to depend on that same invariant: *every* `*_DEVICE` read goes
+through `_read_device_env` before `_parse_device` ever sees it.
+
+### B2. Nothing server-side warms the device-list cache
+
+`ensureGpuDeviceListWarm()` has exactly one call site, `GET /api/config`
+(`routes/config.ts:39,46`) — verified by grep on this branch. The other two
+writers of the cache are also request-scoped: `GET /api/gpu/devices`
+(`routes/gpu-devices.ts:23`) and `toUuidForm` on a `PUT /api/config` device
+write (`routes/gpu-uuid.ts:41`).
+
+Before PR #1852 every page load incidentally warmed the cache via a boot
+`fetchConfig()` dispatch. That dispatch existed only to hydrate the deleted
+`voices.library.enabled` gate. With it gone, all three triggers are dispatched
+from `src/views/advanced.tsx` alone.
+
+The defect is structural, not behavioural: an invariant ("device-knob UUID
+resolution works only if an HTTP request happened first") that nothing enforces
+and no test pins. Today's blast radius is small, but by luck rather than design:
+
+- The only `server/src` consumer of a device knob's effective value is
+  `engine-device.ts:36`, which tests `raw.startsWith('cuda')` — satisfied by
+  `'cuda-uuid:…'`. Verified by grep for the three keys across `server/src`.
+- `resolveAll()` ships every device knob's `effective` and `staleReason` to the
+  frontend on `GET /api/config` (`config.ts:65`), `PUT /api/config`
+  (`config.ts:107`) and `POST /api/config/reset` (`config.ts:126`). Only the GET
+  warms. The PUT and reset responses can carry `uuid_unresolved` against a cold
+  cache; in practice `advanced.tsx` has already warmed it on mount, which is
+  precisely the accidental dependency at issue.
+
+The next consumer need not be so lucky, and this is exactly how #1852 unmasked
+the hole.
+
+## Constraint: a pre-spawn warm is not achievable from this data source
+
+#1857 suggests warming "before the first `spawnSidecar`". The only source of the
+uuid↔idx mapping is the sidecar's own `GET /devices` (`main.py:6505`), served by
+`_enumerate_cuda_devices`. At the initial boot spawn the sidecar process does not
+yet exist, so that fetch cannot succeed. The suggestion is unachievable as
+written, and its acceptance bullet ("closes the initial-spawn case too") cannot
+be met by warming.
+
+B1 is what actually closes the initial-spawn case, at the correct seam.
+
+## Design
+
+### Change 1 — `QWEN_CODEC_DEVICE` parity (`server/tts-sidecar/main.py`)
+
+Replace the bare read at `main.py:2995-2997` with `_read_device_env`:
+
+```python
+codec_device = _resolve_codec_device(
+    _read_device_env("QWEN_CODEC_DEVICE") or "cpu", self._device
+)
+```
+
+Behaviour is unchanged for every value that works today:
+
+| `QWEN_CODEC_DEVICE` | Before | After |
+|---|---|---|
+| unset | `"cpu"` → `None` (no move) | `None or "cpu"` → `None` (no move) |
+| `""` | `""` → `p = "cpu"` → `None` | `""` falsy → `"cpu"` → `None` |
+| `cpu` / `auto` / `cuda:N` / `mps` | pass-through | pass-through (`_resolve_uuid_to_index` returns non-`cuda-uuid:` values unchanged) |
+| `cuda-uuid:<visible>` | passes validation, torch `.to()` raises → rolled back to CPU | → `cuda:N`, codec on the pinned card |
+| `cuda-uuid:<vanished>` | passes validation, torch `.to()` raises → rolled back to CPU | → `"auto"` → follows the model's own device |
+
+The vanished-UUID fallback is `"auto"` because that is what `_read_device_env`
+returns for an unresolvable pin, and `_resolve_codec_device('auto', …)` means
+"follow the model" — the codec can never land on a different card than its
+model. This is a strictly better failure mode than today's demotion to CPU via a
+torch exception, and matches how the other three knobs already degrade.
+
+### Change 2 — server-owned warm loop (`server/src/gpu/warm-device-list.ts`, new)
+
+```
+ensureGpuDeviceListWarm(): Promise<void>   // moved from routes/config.ts; idempotent + in-flight-deduped
+startGpuDeviceListWarmup(opts?): void      // bounded retry, fire-and-forget, never throws
+_resetWarmDeviceListForTests(): void       // clears the in-flight promise
+```
+
+Note there are two distinct reset seams, not a duplicate:
+`_resetWarmDeviceListForTests()` here clears this module's shared in-flight
+promise, while `_resetGpuDeviceListForTests()` (Change 2a) clears the cached
+device list in `gpu-device-list-state.ts`.
+
+`ensureGpuDeviceListWarm` returns early when the cache is non-empty, else
+`fetchSidecarDevices()` and store, plus a shared in-flight promise so a boot-loop
+attempt and a concurrent `GET /api/config` pay one round-trip rather than two.
+
+### Change 2a — no-downgrade rule in the state module
+
+`gpu-device-list-state.ts` gains the invariant directly, so it holds for **every**
+writer rather than only the new one:
+
+```ts
+export function setLastKnownGpuDevices(devices: GpuDeviceInfo[]): void {
+  if (devices.length === 0 && lastKnownGpuDevices.length > 0) return; // never downgrade
+  lastKnownGpuDevices = devices;
+}
+export function _resetGpuDeviceListForTests(): void { lastKnownGpuDevices = []; }
+```
+
+Why the setter and not the warm helper: all three writers pass through
+unguarded today. `gpu-devices.ts:20-23` returns early only when `result` is
+`null`, then unconditionally writes `result.devices.map(...)` — so a
+*reachable-but-empty* `GET /api/gpu/devices` clobbers a warm cache. `toUuidForm`
+(`gpu-uuid.ts:41`) does the same. With one request-scoped warmer this was
+unreachable in practice; adding a long-lived background writer that runs
+concurrently with both makes a transient empty — sidecar recycle, torch reload —
+able to flip resolved pins back to `staleReason: 'uuid_unresolved'` and make
+`buildSidecarEnv` emit raw literals after having emitted indices. Guarding only
+`ensureGpuDeviceListWarm` would leave two of three holes open while claiming the
+property.
+
+Cost: exactly three existing call sites use `setLastKnownGpuDevices([])` as a
+reset — `config.test.ts:350`, `config.test.ts:387`, `gpu-devices.test.ts:25` —
+and must move to `_resetGpuDeviceListForTests()`, or they silently stop
+resetting and their cold-cache assertions start passing for the wrong reason.
+(`config.test.ts:374` also calls the setter but with a non-empty list; it is
+unaffected.)
+
+### Change 2b — the loop's stop conditions
+
+`startGpuDeviceListWarmup` polls until one of three things happens: the cache
+holds at least one card, the sidecar definitively reports zero cards, or the
+attempt budget is spent.
+
+**Why an empty response alone does not stop it.** `[]` is ambiguous:
+`_enumerate_cuda_devices` (`main.py:1848-1855`) returns `[]` on any exception and
+whenever `torch.cuda.is_available()` is false — including the window before torch
+finishes importing, which the sidecar reports as `devices_state: 'pending'`
+(`sidecar-health.ts:92-98`).
+
+**How the loop disambiguates.** On an empty response it consults the sidecar's
+own `devices_state` and stops early on `'ready'` **or** `'error'` — respectively
+"torch is up and there are no CUDA cards" and "the device probe failed"
+(`main.py:6271`). Neither resolves itself by retrying. `'pending'` means the
+background torch import is still running (`main.py:5198`) and keeps retrying, as
+does a `null` (unregistered) answer, per the gate module's documented fail-closed
+contract (`sidecar-health-gate.ts:25-31`).
+
+**Reaching `devices_state` without side effects.** The obvious route —
+`probeSidecarHealthIfRegistered()` — is wrong here. The registered implementation
+writes three other caches on every reachable poll:
+`setLastKnownQwenInstallState`, `setLastKnownVram` and `setLastKnownEngineDevices`
+(`sidecar-health.ts:263-268`). Calling it from a boot timer would make this loop
+a writer to all three during the window the supervisor is deciding what to spawn
+— and `index.ts:274` seeds Qwen install state from a *disk* probe precisely
+because the sidecar isn't up yet, while `buildOpts` re-reads
+`getResolvedTtsModelKey()` on every spawn (`index.ts:290-300`). A poll landing
+between those could change which model the first spawn preloads.
+
+Reimplementing a small `/health` fetch instead is also barred:
+`sidecar-health-gate.ts:19-21` requires exactly one source of truth ("nothing
+here copies or reimplements the probe, so it can't drift").
+
+So: give `probeSidecarHealth` an opts parameter — `{ recordState = true }` — that
+suppresses only the three `setLastKnown*` writes, keeping one implementation of
+the probe itself. `sidecar-health-gate.ts` gains a second provider slot:
+
+```ts
+export type DeviceProbeState = 'pending' | 'ready' | 'error';
+export function setDeviceProbeStateProvider(fn: () => Promise<DeviceProbeState | null>): void
+export function probeDeviceProbeStateIfRegistered(): Promise<DeviceProbeState | null>
+```
+
+registered by `routes/sidecar-health.ts` as
+`() => probeSidecarHealth({ recordState: false }).then((r) => r.devicesState ?? null)`.
+The state type is spelled locally rather than imported, for the same
+cycle-avoidance reason the file header already gives for `SidecarHealthSnapshot`
+— a type-only import still counts as an edge. `SidecarHealthSnapshot` itself is
+left untouched.
+
+**Per-attempt timeout.** `fetchSidecarDevices` hardcodes
+`PROBE_TIMEOUT_MS = 2_000` (`fetch-sidecar-devices.ts:13`), sized for a UI
+round-trip. `/devices` is a synchronous `def` (`main.py:6506`), so FastAPI runs
+it on the threadpool and the *first* call triggers `import torch` inside
+`_enumerate_cuda_devices` — far more than 2s on a cold box. Early attempts will
+abort.
+
+That is expected to be tolerable rather than fatal, on the following reasoning:
+an aborted client fetch should not cancel the server-side import, because a
+running Python thread cannot be interrupted by a client disconnect and Starlette
+has no way to reach into `run_in_threadpool`'s worker. A later attempt then lands
+on an already-imported module. **This is reasoning, not a verified fact** — it
+was not checked against this repo's pinned Starlette/uvicorn versions and no test
+covers it. If it is wrong, the loop spends its budget re-triggering work that
+never completes and warms nothing; the fallback is to raise the warm path's own
+timeout above `fetchSidecarDevices`'s shared 2s rather than to change the budget.
+
+The budget is sized to outlast a torch import, not a single probe:
+`maxAttempts: 24`, `attemptDelayMs: 5_000` (≈2 min),
+the same shape as `runCatalogAudit` (`tts/coqui-catalog-audit.ts:52-57`) which
+solves the identical "sidecar takes 30–60s, one shot would miss it" problem.
+`fetchSidecarDevices`'s timeout is left alone — raising it would slow the UI path
+that shares it, for no gain the retry budget doesn't already provide.
+
+Timers are `unref()`'d, per this codebase's existing convention for boot-time
+background timers (`index.ts:304-307`). Exhausting the budget logs one
+informational line that states what was actually observed — sidecar never
+reachable, versus reachable but reporting zero cards — rather than asserting
+"CPU-only", which the loop cannot determine. Neither is a warning: a CPU-only box
+and an autostart-disabled server both land here legitimately.
+
+**`autoStart: false`.** `index.ts:283` branches on `getResolvedAutoStartSidecar()`
+immediately above the insertion point. The warm loop is started unconditionally
+anyway: a no-autostart server may still be pointed at an externally-run sidecar,
+which is exactly a case worth warming.
+
+**Worst-case cost, stated per case.** Sidecar never reachable (no autostart and
+nothing external): 24 fetches that fail fast against a dead URL over two minutes,
+then stop. Zero-card box with a healthy sidecar: polls while `devices_state` is
+`'pending'` — the background torch import, "takes seconds" per `main.py:5198`, so
+a small number of 5s-spaced attempts — then exits on `'ready'`. Box with missing
+or broken torch: exits on `'error'` on the first attempt that reaches `/health`.
+Without Change 2b both of those would pay all 24 round-trips on every boot. GPU
+box: warms on the first attempt after torch is up.
+
+`index.ts` starts it immediately after `void sidecarSupervisor.start()`
+(`index.ts:301`), inside `listenerCallback`. `routes/config.ts` deletes its
+private copy and imports the shared one; the `GET /api/config` call stays, since
+that remains the right freshness point for the Advanced UI.
+
+### Why the boot loop and not an existing poll
+
+Three candidate hook points, two rejected:
+
+- **`routes/sidecar-health.ts`** already feeds `setLastKnownVram`,
+  `setLastKnownEngineDevices` and `setLastKnownQwenInstallState` on every
+  reachable poll (`sidecar-health.ts:263-268`) — the established
+  "last-known state from a reachable poll" pattern, and superficially the
+  obvious home. Rejected: `probeSidecarHealth()` is driven by
+  `GET /api/sidecar/health`, i.e. by the frontend. Hooking there rebuilds the
+  precise accidental dependency #1852 exposed, just on a different route.
+- **`sidecar-supervisor.ts`'s health poll** runs only for *adopted* sidecars —
+  it is the fitness watchdog (`sidecar-supervisor.ts:315-319`) and does not fire
+  for an owned child. Rejected: covers the minority case only.
+- **A dedicated boot-time background warm** — server-owned, fires on every boot
+  with no client, and has a working precedent in `runCatalogAudit`. Chosen.
+
+### Rejected: Node-side `nvidia-smi` enumeration
+
+A pre-spawn warm *is* reachable via `nvidia-smi --query-gpu=index,uuid`, and the
+machinery exists (`gpu/device-total.ts:40-54`). Rejected on correctness: NVML
+indices diverge from torch ordinals under `CUDA_VISIBLE_DEVICES` /
+`CUDA_DEVICE_ORDER`, which this codebase already tracks as a hazard
+(`routes/config.ts:67` `cudaEnvShadow`; `main.py:6031`). It would also introduce
+a second, NVIDIA-only source of truth for `idx` that can disagree with the
+sidecar's under the AMD/ROCm/DirectML profiles the accelerator knob supports. A
+confidently wrong index is worse than a literal the sidecar resolves correctly.
+
+## Testing
+
+- **`server/src/gpu/gpu-device-list-state.test.ts`** (new) — the no-downgrade
+  rule: an empty list over a warm cache is ignored; an empty list over an empty
+  cache is a no-op; a non-empty list always replaces;
+  `_resetGpuDeviceListForTests()` clears.
+- **`server/src/gpu/warm-device-list.test.ts`** (new) — cold cache + reachable
+  sidecar warms it; an already-warm cache issues no fetch; concurrent callers
+  share one fetch; unreachable-then-reachable retries and eventually warms; an
+  empty response with `devices_state: 'pending'` keeps retrying and a later
+  populated response warms; `'ready'` and `'error'` each stop the loop early; an
+  unregistered provider (`null`) keeps retrying; exhausting the attempt budget
+  resolves without throwing.
+- **`server/src/routes/sidecar-health.test.ts`** — `probeSidecarHealth({
+  recordState: false })` returns the same parsed result but performs none of the
+  three `setLastKnown*` writes; the default (`recordState` omitted) still
+  performs all three. Without this the side-effect suppression is unpinned and a
+  later refactor silently reintroduces the boot-time writer.
+- **`server/src/tts/sidecar-env.test.ts`** — at the `buildSidecarEnv` seam: a
+  warm cache plus a `cuda-uuid:` override yields `QWEN_DEVICE=cuda:N`; a **cold**
+  cache yields the raw literal, asserted as the documented contract with a
+  comment citing `main.py:1873`, not as a bug.
+- **`server/tts-sidecar/tests/test_device_parse.py`** —
+  `QWEN_CODEC_DEVICE=cuda-uuid:<uuid>` resolves to `cuda:N`; an unmatched UUID
+  yields `auto`. Follows the file's existing pattern of monkeypatching
+  `main._enumerate_cuda_devices` (lines 92-113).
+
+No GPU is required by any of these; the existing GPU-gated codec smoke test
+(`tests/test_codec_device_smoke.py`) is unchanged.
+
+The `index.ts` insertion needs no test-isolation work: `server/src/index.test.ts`
+imports `index.js`, but the main-module guard at the bottom of `index.ts` —
+`if (invokedHref && import.meta.url === invokedHref)`, comparing
+`import.meta.url` against `pathToFileURL(realpathSync(process.argv[1])).href` —
+keeps `main()` from running on import, so `listenerCallback`, and therefore the
+warm loop's timer, never fires in the server suite. (Both `index.ts:110` and
+`index.test.ts:9` call this the "isMainModule guard"; no such identifier exists,
+the name lives only in those comments. Verified against the code, not the
+comments — a leaked boot timer is this repo's known tinypool worker-exit flake.)
+
+## Out of scope
+
+- Cache staleness after a driver reload or hot-plug. Change 2a makes this
+  explicit rather than incidental: once warm, the list is only ever replaced by
+  another **non-empty** list, from any writer. A box whose cards genuinely
+  disappear mid-run therefore keeps serving the last good mapping indefinitely.
+  That is the same staleness tradeoff `gpu-device-list-state.ts:1-8` already
+  documents against `vram-state.ts`, and it is chosen over the alternative
+  failure — a transient empty during a sidecar recycle silently unpinning every
+  UUID assignment. Genuine hot-unplug handling would need an invalidation signal
+  this design does not add.
+- Re-warming per supervisor respawn. The card inventory does not change across
+  respawns of the same box, and the boot loop's budget covers the window in
+  which the first sidecar becomes reachable.
+- `qa.asr.device` / `SPK_DEVICE`, which also read `os.environ` bare
+  (`main.py:4754`, `4907`). Both are `type: 'string'` in the registry, so
+  `routes/config.ts:100` never writes them a `cuda-uuid:` value and no UUID can
+  reach them. Noted here so the asymmetry is not re-discovered as a bug.
+
+## Acceptance
+
+Replaces #1857's acceptance criteria:
+
+1. `QWEN_CODEC_DEVICE=cuda-uuid:<visible-uuid>` places the Qwen codec on the
+   pinned card on a cold-cache spawn, rather than demoting it to CPU.
+2. Server boot **initiates** the device-list warm with no `GET /api/config`, no
+   `GET /api/gpu/devices`, and no visit to Advanced settings. Stated as
+   "initiates", not "populates": no Node-side work can guarantee completion. The
+   loop has three terminal outcomes — cache warmed, sidecar definitively reported
+   zero cards (`devices_state` `'ready'` or `'error'`), or budget exhausted — and
+   the testable claim is that the loop runs unprompted and that a sidecar
+   reachable with cards inside the budget warms the cache.
+3. A device list that comes back empty never downgrades an already-warm cache —
+   from **any** writer, not only the boot loop.
+4. A zero-card box stops polling as soon as the sidecar reports a settled
+   `devices_state` (`'ready'` or `'error'`), rather than exhausting the retry
+   budget on every boot — and consulting that state does not perturb Qwen
+   install state, VRAM or per-engine device ground truth.
+5. `buildSidecarEnv`'s behaviour under both a warm and a cold cache is pinned by
+   test, with the cold-cache case documented as the sidecar-resolves contract.

--- a/docs/superpowers/specs/2026-07-27-gpu-device-list-boot-warm-design.md
+++ b/docs/superpowers/specs/2026-07-27-gpu-device-list-boot-warm-design.md
@@ -1,28 +1,33 @@
-# GPU device-list cache: server-owned boot warm + codec device-knob parity
+# Device-knob resolution: deterministic sidecar env + codec knob parity
 
 Design for [#1857](https://github.com/dudarenok-maker/Audiobook-Generator/issues/1857).
 Branch `fix/1857-gpu-device-cache-boot-warm`.
 
+> **Revision note.** An earlier version of this spec proposed warming the GPU
+> device-list cache from a server-owned boot loop, as #1857 suggests. Two
+> independent Fable reviews killed that approach — warming makes the *spawn* path
+> strictly worse, and once the spawn path is fixed properly no consumer needs a
+> boot-warmed cache at all. The review trail is preserved in "Rejected: the boot
+> warm" below, because the reasoning is the most useful thing in this document.
+
 ## Summary
 
-1. Route `QWEN_CODEC_DEVICE` through `_read_device_env` in the sidecar, so the
-   fourth and last `type: 'device'` knob resolves a `cuda-uuid:` pin like the
-   other three already do.
-2. Warm the Node-side GPU device-list cache from a **server-owned** background
-   loop started at boot, instead of relying on an HTTP request having happened.
-   Two supporting changes fall out of adding a concurrent writer: a no-downgrade
-   rule in the device-list state module (2a), and a definitive stop condition so
-   the loop can tell "no CUDA on this box" from "torch still importing" (2b).
+Two changes:
 
-Change 1 is the only misrouting bug. Change 2 closes the structural hole #1857
-names — nothing server-side warms the cache — without claiming to fix a case
-that cannot be fixed from the sidecar's device list.
+1. **`buildSidecarEnv` always emits the raw `cuda-uuid:<uuid>` literal** for a
+   device knob, instead of sometimes emitting a translated `cuda:N` depending on
+   whether the cache happens to be warm. The sidecar resolves the literal against
+   live enumeration on every spawn.
+2. **`QWEN_CODEC_DEVICE` resolves a `cuda-uuid:` pin**, with an explicit `cpu`
+   fallback when the pinned card is gone.
+
+Change 1 fixes a nondeterminism bug neither #1857 nor the first draft of this
+spec named. Change 2 fixes the one genuine misrouting.
 
 ## Premise correction
 
 #1857's stated harm does not occur, and its acceptance criteria assert a
-behaviour the sidecar was deliberately built not to need. This spec supersedes
-them.
+behaviour the sidecar was deliberately built not to need.
 
 The issue is mechanically correct that with a cold cache `buildSidecarEnv`
 (`server/src/tts/spawn-sidecar.ts:472-480`) injects `String(st.effective)`, so a
@@ -31,15 +36,15 @@ misroutes the engine.
 
 `main.py:1873` `_read_device_env()` runs every `*_DEVICE` read through
 `_resolve_uuid_to_index()` (`main.py:1858`), which enumerates live torch devices
-and maps `cuda-uuid:<uuid>` → `cuda:N`. All three engine device knobs the issue
-names go through it:
+and maps `cuda-uuid:<uuid>` → `cuda:N`. All three engine device knobs go through
+it, at six call sites:
 
-| Knob | Env | Python read site | Resolves UUID |
+| Knob | Env | Python read sites | Resolves UUID |
 |---|---|---|---|
-| `tts.coqui.device` | `COQUI_DEVICE` | `main.py:1124` `_read_device_env` | yes |
-| `tts.kokoro.device` | `KOKORO_DEVICE` | `main.py:1444` `_read_device_env` | yes |
-| `tts.qwen.device` | `QWEN_DEVICE` | `main.py:2860`, `2656`, `6233` `_read_device_env` | yes |
-| `tts.qwen.codecDevice` | `QWEN_CODEC_DEVICE` | `main.py:2996` bare `os.environ.get` | **no** |
+| `tts.coqui.device` | `COQUI_DEVICE` | `main.py:1124` | yes |
+| `tts.kokoro.device` | `KOKORO_DEVICE` | `main.py:1444` | yes |
+| `tts.qwen.device` | `QWEN_DEVICE` | `main.py:2860`, `2656`, `2669`, `6233` | yes |
+| `tts.qwen.codecDevice` | `QWEN_CODEC_DEVICE` | `main.py:2996` — bare `os.environ.get` | **no** |
 
 That Python-side resolution exists *because* the Node cache is cold at the boot
 spawn. `_enumerate_cuda_devices`'s docstring (`main.py:1843-1847`) says so:
@@ -49,380 +54,223 @@ spawn. `_enumerate_cuda_devices`'s docstring (`main.py:1843-1847`) says so:
 > the RAW `'cuda-uuid:...'` string through unresolved on a fresh server boot,
 > not the pre-resolved `'cuda:N'` form a warm cache would produce
 
-So #1857's acceptance bullet — *"a supervisor respawn … passes a translated
-device index, not the raw `cuda-uuid:` literal"* — would pin redundancy, not a
-fix. The raw literal is a supported input at that boundary.
+So the raw literal is a **supported input** at that boundary — the designed one.
 
 ## What is actually broken
 
-### B1. `QWEN_CODEC_DEVICE` does not resolve a UUID pin
+### B1. `buildSidecarEnv` is nondeterministic
+
+`resolveKnob` (`server/src/config/resolver.ts:35-49`) translates a stored
+`cuda-uuid:` override to `cuda:N` **only when the device cache is warm**. The
+cache is warmed exclusively by request-scoped paths — `GET /api/config`,
+`GET /api/gpu/devices`, and a `PUT /api/config` device write — all dispatched
+from `src/views/advanced.tsx`.
+
+`buildSidecarEnv` reads through that same `resolveKnob`. So the env handed to the
+sidecar depends on **whether the user opened Advanced settings during this server
+session**:
+
+| Cache state | `QWEN_DEVICE` handed to the sidecar |
+|---|---|
+| Cold (nobody opened Advanced) | `cuda-uuid:GPU-…` — sidecar resolves live |
+| Warm (Advanced was opened) | `cuda:1` — frozen at warm time |
+
+Same config, same box, two different spawn envs. Worse, the warm branch is the
+dangerous one, and `buildOpts` re-runs `buildSidecarEnv` on **every respawn**
+(`sidecar-supervisor.ts:234`):
+
+- **Card vanishes after warm** (the documented eGPU "GPU is lost" mode on this
+  dual-GPU box), then a recycle: the sidecar receives `QWEN_DEVICE=cuda:1` with
+  one card visible → `_validate_cuda_index` (`main.py:2602-2612`) raises → the
+  Qwen load fails, and fails again on every retry. The cold-cache path would have
+  degraded to `auto` with a warning and kept generating.
+- **Renumbering without a count change** (driver reload, `CUDA_DEVICE_ORDER`):
+  the frozen index silently lands on the **wrong card**.
+
+This is precisely the failure this spec's own rejected-alternatives section uses
+against `nvidia-smi` enumeration — *a confidently wrong index is worse than a
+literal the sidecar resolves correctly* — applied to a rival data source but not,
+until this revision, to our own cache across time.
+
+### B2. `QWEN_CODEC_DEVICE` does not resolve a UUID pin
 
 `tts.qwen.codecDevice` is `type: 'device'` (`registry.ts:589`), so
 `PUT /api/config` uuid-ifies it on write (`routes/config.ts:100` gates on
-`knob.type === 'device'`), and the frontend offers it the card dropdown
-(`override-row.tsx:366` — "only consumed by `type: 'device'` knobs"). A user
-pinning the codec to a card therefore gets `cuda-uuid:<uuid>` on disk.
+`knob.type === 'device'`) and the frontend offers it the card dropdown
+(`override-row.tsx:366`). A user pinning the codec to a card gets
+`cuda-uuid:<uuid>` on disk.
 
-At load, `main.py:2996` reads it with a bare `os.environ.get`.
-`_resolve_codec_device` (`main.py:383-403`) lowercases and returns any
-unrecognised string unchanged, so `cuda-uuid:gpu-…` becomes the codec device.
+At load, `main.py:2996` reads it with a bare `os.environ.get`. It then *passes*
+validation rather than being rejected by it: `_parse_device` (`main.py:1801`)
+lowercases, matches `p.startswith("cuda")`, partitions on `:`, finds `"gpu-…"` is
+not a digit, and returns `("cuda", None)`. `_validate_cuda_index` raises only when
+`index is not None`, so it no-ops. The literal reaches
+`_move_codec_to_device(model, codec_device, torch)` (`main.py:3064`), fails inside
+torch's `.to()`, and is caught at `main.py:431` and rolled back to CPU with
+`"Could not move Qwen codec to %s (%s) -- rolling back to cpu."`.
 
-It then passes validation rather than being rejected by it. `_parse_device`
-(`main.py:1801`) lowercases, matches `p.startswith("cuda")`, partitions on `:`,
-finds `"gpu-…"` is not a digit, and returns `("cuda", None)`.
-`_validate_cuda_index` raises only when `index is not None`, so it no-ops. The
-literal therefore reaches `_move_codec_to_device(model, codec_device, torch)`
-(`main.py:3064`) and fails inside torch's `.to()`, which is caught at
-`main.py:431` and rolled back to CPU with `"Could not move Qwen codec to %s (%s)
--- rolling back to cpu."`.
-
-Impact: the codec ends up on CPU instead of the pinned card. Narrow, but real,
-warned-not-silent, and it hits the **first** spawn as well as respawns — the one
-case no Node-side warming could ever have covered.
-
-**Adjacent latent trap, not fixed here but named so it stays dormant.**
-`_parse_device` classifies `cuda-uuid:<uuid>` as family `cuda` with *no index*.
-Any path that treats `("cuda", None)` as "plain cuda → card 0" and receives a raw
-UUID literal would silently use the **wrong card** rather than fail. Today the
-only consumer at risk, `_engine_env_pin` (`main.py:1898`), is safe solely because
-it routes through `_read_device_env` first. Change 1 makes the codec path the
-fourth caller to depend on that same invariant: *every* `*_DEVICE` read goes
-through `_read_device_env` before `_parse_device` ever sees it.
-
-### B2. Nothing server-side warms the device-list cache
-
-`ensureGpuDeviceListWarm()` has exactly one call site, `GET /api/config`
-(`routes/config.ts:39,46`) — verified by grep on this branch. The other two
-writers of the cache are also request-scoped: `GET /api/gpu/devices`
-(`routes/gpu-devices.ts:23`) and `toUuidForm` on a `PUT /api/config` device
-write (`routes/gpu-uuid.ts:41`).
-
-Before PR #1852 every page load incidentally warmed the cache via a boot
-`fetchConfig()` dispatch. That dispatch existed only to hydrate the deleted
-`voices.library.enabled` gate. With it gone, all three triggers are dispatched
-from `src/views/advanced.tsx` alone.
-
-The defect is structural, not behavioural: an invariant ("device-knob UUID
-resolution works only if an HTTP request happened first") that nothing enforces
-and no test pins. Today's blast radius is small, but by luck rather than design:
-
-- The only `server/src` consumer of a device knob's effective value is
-  `engine-device.ts:36`, which tests `raw.startsWith('cuda')` — satisfied by
-  `'cuda-uuid:…'`. Verified by grep for the three keys across `server/src`.
-- `resolveAll()` ships every device knob's `effective` and `staleReason` to the
-  frontend on `GET /api/config` (`config.ts:65`), `PUT /api/config`
-  (`config.ts:107`) and `POST /api/config/reset` (`config.ts:126`). Only the GET
-  warms. The PUT and reset responses can carry `uuid_unresolved` against a cold
-  cache; in practice `advanced.tsx` has already warmed it on mount, which is
-  precisely the accidental dependency at issue.
-
-The next consumer need not be so lucky, and this is exactly how #1852 unmasked
-the hole.
-
-## Constraint: a pre-spawn warm is not achievable from this data source
-
-#1857 suggests warming "before the first `spawnSidecar`". The only source of the
-uuid↔idx mapping is the sidecar's own `GET /devices` (`main.py:6505`), served by
-`_enumerate_cuda_devices`. At the initial boot spawn the sidecar process does not
-yet exist, so that fetch cannot succeed. The suggestion is unachievable as
-written, and its acceptance bullet ("closes the initial-spawn case too") cannot
-be met by warming.
-
-B1 is what actually closes the initial-spawn case, at the correct seam.
+Impact: the codec ends up on CPU instead of the pinned card. Warned, not silent,
+and it hits the **first** spawn as well as respawns.
 
 ## Design
 
-### Change 1 — `QWEN_CODEC_DEVICE` parity (`server/tts-sidecar/main.py`)
+### Change 1 — deterministic device env
 
-Replace the bare read at `main.py:2995-2997` with `_read_device_env`, extracted
-into a named helper beside `_resolve_codec_device`:
+`server/src/config/resolver.ts` grows a second entry point that resolves a knob
+*without* the device-uuid reconciliation, sharing one implementation:
+
+```ts
+/** Effective value for the SIDECAR ENV. Deliberately does NOT reconcile a
+    'cuda-uuid:' override to an index — see the docblock for why. */
+export function resolveKnobForSidecarEnv(knob: ConfigKnob): KnobValueState
+```
+
+`buildSidecarEnv` (`spawn-sidecar.ts:474`) calls it instead of `resolveKnob`.
+Every other caller of `resolveKnob` — `resolveAll`, `configValue`, the config
+routes — is untouched, so the Advanced UI keeps seeing translated values and its
+`staleReason: 'uuid_unresolved'` badge keeps working.
+
+Result: the sidecar always receives the UUID form, and resolves it against live
+enumeration on every spawn and respawn. Self-healing across renumbering, and a
+vanished card degrades to `auto` with a warning instead of hard-failing the load.
+
+**The general argument, stated once.** Node's uuid↔idx mapping is *derived from
+the sidecar* — the cache is populated only from the sidecar's own `/devices`
+(`gpu-uuid.ts:41-43`, `gpu-devices.ts:23`) — and the child inherits
+`CUDA_VISIBLE_DEVICES` through `buildSidecarEnv`'s `...process.env` spread, so
+both sides enumerate the same cards in the same order. Node's copy can therefore
+only be *staler* than the sidecar's live view, never better informed. Translating
+in Node is strictly a downgrade: it substitutes an older snapshot for a fresh
+lookup, and there is no scenario in which it can be more correct.
+
+**Version skew can't arise.** A spawned sidecar comes from `repoRoot`, so it is
+always in lockstep with the Node code building its env. The only sidecar that
+could be older is an *adopted* external one (`spawn-sidecar.ts:566`) — and we
+never hand env to a process we didn't spawn.
+
+**This is the opposite of what #1857 asks for, and it is the correct direction.**
+The issue treats the raw literal as the bug; it is the fix.
+
+### Change 2 — `QWEN_CODEC_DEVICE` parity, with a `cpu` fallback
+
+A named helper beside `_resolve_codec_device`, so it is reachable from tests —
+the call site is inside `_load_qwen_model`, which needs real weights and a GPU:
 
 ```python
 def _codec_device_pref() -> str:
-    return _read_device_env("QWEN_CODEC_DEVICE") or "cpu"
-
-# at the call site, main.py:2995-2997:
-codec_device = _resolve_codec_device(_codec_device_pref(), self._device)
+    raw = os.environ.get("QWEN_CODEC_DEVICE")
+    if not raw or not raw.strip():
+        return "cpu"
+    resolved = _resolve_uuid_to_index(raw)
+    if resolved is None:
+        log.warning(
+            "QWEN_CODEC_DEVICE=%s did not match any visible GPU -- leaving the codec on cpu.", raw,
+        )
+        return "cpu"
+    return resolved
 ```
 
-The helper is named rather than inlined for testability: the call site is inside
-`_load_qwen_model`, which needs real Qwen weights and a GPU to invoke, so a test
-asserting on a hand-composed `_resolve_codec_device(_read_device_env(...) or
-"cpu", …)` would pass identically before and after the fix — a placebo. Testing
-`_codec_device_pref()` exercises the function production actually calls.
+**Why this deliberately does not use `_read_device_env`.** That helper degrades an
+unresolvable pin to `"auto"`, which is right for the three engine knobs but wrong
+here: `_resolve_codec_device("auto", model_device)` means "follow the model"
+(`main.py:401-402`), so a vanished card would silently move the codec **onto the
+model's card**. The only reason to pin the codec to a specific card is to spread
+VRAM across cards; degrading that to "share the model's card" adds pressure to
+exactly the card the user was trying to protect. `_move_codec_to_device`'s
+rollback (`main.py:431-437`) only fires if the `.to()` itself raises — a
+*successful* move that eats a tight card's headroom and OOMs a later decode never
+rolls back, and this repo has documented co-residency OOM history on the 8 GB
+card. `cpu` is the knob's registry default and is VRAM-neutral.
 
-Behaviour is unchanged for every value that works today:
+Behaviour, before and after:
 
 | `QWEN_CODEC_DEVICE` | Before | After |
 |---|---|---|
-| unset | `"cpu"` → `None` (no move) | `None or "cpu"` → `None` (no move) |
-| `""` | `""` → `p = "cpu"` → `None` | `""` falsy → `"cpu"` → `None` |
-| `cpu` / `auto` / `cuda:N` / `mps` | pass-through | pass-through (`_resolve_uuid_to_index` returns non-`cuda-uuid:` values unchanged) |
+| unset / `""` | `cpu` → no move | `cpu` → no move |
+| `cpu` / `auto` / `cuda:N` / `mps` | pass-through | pass-through |
 | `cuda-uuid:<visible>` | passes validation, torch `.to()` raises → rolled back to CPU | → `cuda:N`, codec on the pinned card |
-| `cuda-uuid:<vanished>` | passes validation, torch `.to()` raises → rolled back to CPU | → `"auto"` → follows the model's own device |
+| `cuda-uuid:<vanished>` | passes validation, torch `.to()` raises → rolled back to CPU | → `cpu`, with a warning naming the knob |
 
-The vanished-UUID fallback is `"auto"` because that is what `_read_device_env`
-returns for an unresolvable pin, and `_resolve_codec_device('auto', …)` means
-"follow the model" — the codec can never land on a different card than its
-model. This is a strictly better failure mode than today's demotion to CPU via a
-torch exception, and matches how the other three knobs already degrade.
+The vanished row lands on the same device as today; the difference is that it gets
+there deliberately, with an accurate log line, instead of via a torch exception.
 
-### Change 2 — server-owned warm loop (`server/src/gpu/warm-device-list.ts`, new)
+**Adjacent latent trap, named so it stays dormant.** `_parse_device` classifies
+`cuda-uuid:<uuid>` as family `cuda` with *no index*. Any path that treats
+`("cuda", None)` as "plain cuda → card 0" and receives a raw UUID would silently
+use the wrong card. Today's only consumer at risk, `_engine_env_pin`
+(`main.py:1898`), is safe solely because it routes through `_read_device_env`
+first. Change 2 makes the codec path the fourth reader to depend on that
+invariant: *every* `*_DEVICE` read resolves the UUID before `_parse_device` sees
+it.
 
-```
-ensureGpuDeviceListWarm(): Promise<void>   // moved from routes/config.ts; idempotent + in-flight-deduped
-startGpuDeviceListWarmup(opts?): void      // bounded retry, fire-and-forget, never throws
-_resetWarmDeviceListForTests(): void       // clears the in-flight promise
-```
+## Rejected: the boot warm (#1857's own suggestion)
 
-Note there are two distinct reset seams, not a duplicate:
-`_resetWarmDeviceListForTests()` here clears this module's shared in-flight
-promise, while `_resetGpuDeviceListForTests()` (Change 2a) clears the cached
-device list in `gpu-device-list-state.ts`.
+Warming the device-list cache at boot was the first design. It is rejected on
+three independent grounds, two found by review after the design was written.
 
-`ensureGpuDeviceListWarm` returns early when the cache is non-empty, else
-`fetchSidecarDevices()` and store, plus a shared in-flight promise so a boot-loop
-attempt and a concurrent `GET /api/config` pay one round-trip rather than two.
+**It cannot warm before the first spawn anyway.** The only source of the uuid↔idx
+mapping is the sidecar's `GET /devices` (`main.py:6505`). At the initial boot
+spawn that process does not exist. The issue's acceptance bullet — "closes the
+initial-spawn case too" — is unachievable by warming.
 
-### Change 2a — no-downgrade rule in the state module
+**It makes respawns worse, not better.** A warm cache is exactly what turns the
+self-healing raw literal into a frozen `cuda:N` — B1 above. Warming *causes* the
+harm; it does not prevent it.
 
-`gpu-device-list-state.ts` gains the invariant directly, so it holds for **every**
-writer rather than only the new one:
+**Once B1 is fixed, no consumer needs a warm cache without a request.**
+`engine-device.ts:36` tests `raw.startsWith('cuda')`, satisfied by the UUID form.
+`staleReason` and the translated display are only ever surfaced through routes,
+which warm on demand. `buildSidecarEnv` was the one consumer running without a
+request, and Change 1 takes it off the cache deliberately. Request-scoped warming
+turns out to be correct rather than accidental.
 
-```ts
-export function setLastKnownGpuDevices(devices: GpuDeviceInfo[]): void {
-  if (devices.length === 0 && lastKnownGpuDevices.length > 0) return; // never downgrade
-  lastKnownGpuDevices = devices;
-}
-export function _resetGpuDeviceListForTests(): void { lastKnownGpuDevices = []; }
-```
+The cost avoided is real: a long-lived concurrent writer to shared state, up to
+48 fetches over ~3.6 minutes per boot, and — because `/devices` calls
+`mem_get_info` per card (`main.py:1820`) — CUDA primary-context initialisation on
+**every visible card** on every boot, including cards the sidecar will never use.
 
-Why the setter and not the warm helper: all three writers pass through
-unguarded today. `gpu-devices.ts:20-23` returns early only when `result` is
-`null`, then unconditionally writes `result.devices.map(...)` — so a
-*reachable-but-empty* `GET /api/gpu/devices` clobbers a warm cache. `toUuidForm`
-(`gpu-uuid.ts:41`) does the same. With one request-scoped warmer this was
-unreachable in practice; adding a long-lived background writer that runs
-concurrently with both makes a transient empty — sidecar recycle, torch reload —
-able to flip resolved pins back to `staleReason: 'uuid_unresolved'` and make
-`buildSidecarEnv` emit raw literals after having emitted indices. Guarding only
-`ensureGpuDeviceListWarm` would leave two of three holes open while claiming the
-property.
-
-Cost: exactly three existing call sites use `setLastKnownGpuDevices([])` as a
-reset — `config.test.ts:350`, `config.test.ts:387`, `gpu-devices.test.ts:25` —
-and must move to `_resetGpuDeviceListForTests()`, or they silently stop
-resetting and their cold-cache assertions start passing for the wrong reason.
-(`config.test.ts:374` also calls the setter but with a non-empty list; it is
-unaffected.)
-
-### Change 2b — the loop's stop conditions
-
-`startGpuDeviceListWarmup` polls until one of three things happens: the cache
-holds at least one card, the sidecar definitively reports zero cards, or the
-attempt budget is spent.
-
-**Why an empty response alone does not stop it.** `[]` is ambiguous:
-`_enumerate_cuda_devices` (`main.py:1848-1855`) returns `[]` on any exception and
-whenever `torch.cuda.is_available()` is false — including the window before torch
-finishes importing, which the sidecar reports as `devices_state: 'pending'`
-(`sidecar-health.ts:92-98`).
-
-**How the loop disambiguates.** On an empty response it consults the sidecar's
-own `devices_state` and stops early on `'ready'` **or** `'error'` — respectively
-"torch is up and there are no CUDA cards" and "the device probe failed"
-(`main.py:6271`). Neither resolves itself by retrying. `'pending'` means the
-background torch import is still running (`main.py:5198`) and keeps retrying, as
-does a `null` (unregistered) answer, per the gate module's documented fail-closed
-contract (`sidecar-health-gate.ts:25-31`).
-
-**Reaching `devices_state` without side effects.** The obvious route —
-`probeSidecarHealthIfRegistered()` — is wrong here. The registered implementation
-writes three other caches on every reachable poll:
-`setLastKnownQwenInstallState`, `setLastKnownVram` and `setLastKnownEngineDevices`
-(`sidecar-health.ts:263-268`). Calling it from a boot timer would make this loop
-a writer to all three during the window the supervisor is deciding what to spawn
-— and `index.ts:274` seeds Qwen install state from a *disk* probe precisely
-because the sidecar isn't up yet, while `buildOpts` re-reads
-`getResolvedTtsModelKey()` on every spawn (`index.ts:290-300`). A poll landing
-between those could change which model the first spawn preloads.
-
-Reimplementing a small `/health` fetch instead is also barred:
-`sidecar-health-gate.ts:19-21` requires exactly one source of truth ("nothing
-here copies or reimplements the probe, so it can't drift").
-
-So: give `probeSidecarHealth` an opts parameter — `{ recordState = true }` — that
-suppresses only the three `setLastKnown*` writes, keeping one implementation of
-the probe itself. `sidecar-health-gate.ts` gains a second provider slot:
-
-```ts
-export type DeviceProbeState = 'pending' | 'ready' | 'error';
-export function setDeviceProbeStateProvider(fn: () => Promise<DeviceProbeState | null>): void
-export function probeDeviceProbeStateIfRegistered(): Promise<DeviceProbeState | null>
-```
-
-registered by `routes/sidecar-health.ts` as
-`() => probeSidecarHealth({ recordState: false }).then((r) => r.devicesState ?? null)`.
-The state type is spelled locally rather than imported, for the same
-cycle-avoidance reason the file header already gives for `SidecarHealthSnapshot`
-— a type-only import still counts as an edge. `SidecarHealthSnapshot` itself is
-left untouched.
-
-**Per-attempt timeout.** `fetchSidecarDevices` hardcodes
-`PROBE_TIMEOUT_MS = 2_000` (`fetch-sidecar-devices.ts:13`), sized for a UI
-round-trip. `/devices` is a synchronous `def` (`main.py:6506`), so FastAPI runs
-it on the threadpool and the *first* call triggers `import torch` inside
-`_enumerate_cuda_devices` — far more than 2s on a cold box. Early attempts will
-abort.
-
-That is expected to be tolerable rather than fatal, on the following reasoning:
-an aborted client fetch should not cancel the server-side import, because a
-running Python thread cannot be interrupted by a client disconnect and Starlette
-has no way to reach into `run_in_threadpool`'s worker. A later attempt then lands
-on an already-imported module. **This is reasoning, not a verified fact** — it
-was not checked against this repo's pinned Starlette/uvicorn versions and no test
-covers it. If it is wrong, the loop spends its budget re-triggering work that
-never completes and warms nothing; the fallback is to raise the warm path's own
-timeout above `fetchSidecarDevices`'s shared 2s rather than to change the budget.
-
-The budget is sized to outlast a torch import, not a single probe:
-`maxAttempts: 24`, `attemptDelayMs: 5_000` (≈2 min),
-the same shape as `runCatalogAudit` (`tts/coqui-catalog-audit.ts:52-57`) which
-solves the identical "sidecar takes 30–60s, one shot would miss it" problem.
-`fetchSidecarDevices`'s timeout is left alone — raising it would slow the UI path
-that shares it, for no gain the retry budget doesn't already provide.
-
-Timers are `unref()`'d, per this codebase's existing convention for boot-time
-background timers (`index.ts:304-307`). Exhausting the budget logs one
-informational line that states what was actually observed — sidecar never
-reachable, versus reachable but reporting zero cards — rather than asserting
-"CPU-only", which the loop cannot determine. Neither is a warning: a CPU-only box
-and an autostart-disabled server both land here legitimately.
-
-**`autoStart: false`.** `index.ts:283` branches on `getResolvedAutoStartSidecar()`
-immediately above the insertion point. The warm loop is started unconditionally
-anyway: a no-autostart server may still be pointed at an externally-run sidecar,
-which is exactly a case worth warming.
-
-**Worst-case cost, stated per case.** Sidecar never reachable (no autostart and
-nothing external): 24 fetches that fail fast against a dead URL over two minutes,
-then stop. Zero-card box with a healthy sidecar: polls while `devices_state` is
-`'pending'` — the background torch import, "takes seconds" per `main.py:5198`, so
-a small number of 5s-spaced attempts — then exits on `'ready'`. Box with missing
-or broken torch: exits on `'error'` on the first attempt that reaches `/health`.
-Without Change 2b both of those would pay all 24 round-trips on every boot. GPU
-box: warms on the first attempt after torch is up.
-
-`index.ts` starts it immediately after `void sidecarSupervisor.start()`
-(`index.ts:301`), inside `listenerCallback`. `routes/config.ts` deletes its
-private copy and imports the shared one; the `GET /api/config` call stays, since
-that remains the right freshness point for the Advanced UI.
-
-### Why the boot loop and not an existing poll
-
-Three candidate hook points, two rejected:
-
-- **`routes/sidecar-health.ts`** already feeds `setLastKnownVram`,
-  `setLastKnownEngineDevices` and `setLastKnownQwenInstallState` on every
-  reachable poll (`sidecar-health.ts:263-268`) — the established
-  "last-known state from a reachable poll" pattern, and superficially the
-  obvious home. Rejected: `probeSidecarHealth()` is driven by
-  `GET /api/sidecar/health`, i.e. by the frontend. Hooking there rebuilds the
-  precise accidental dependency #1852 exposed, just on a different route.
-- **`sidecar-supervisor.ts`'s health poll** runs only for *adopted* sidecars —
-  it is the fitness watchdog (`sidecar-supervisor.ts:315-319`) and does not fire
-  for an owned child. Rejected: covers the minority case only.
-- **A dedicated boot-time background warm** — server-owned, fires on every boot
-  with no client, and has a working precedent in `runCatalogAudit`. Chosen.
-
-### Rejected: Node-side `nvidia-smi` enumeration
-
-A pre-spawn warm *is* reachable via `nvidia-smi --query-gpu=index,uuid`, and the
-machinery exists (`gpu/device-total.ts:40-54`). Rejected on correctness: NVML
-indices diverge from torch ordinals under `CUDA_VISIBLE_DEVICES` /
-`CUDA_DEVICE_ORDER`, which this codebase already tracks as a hazard
-(`routes/config.ts:67` `cudaEnvShadow`; `main.py:6031`). It would also introduce
-a second, NVIDIA-only source of truth for `idx` that can disagree with the
-sidecar's under the AMD/ROCm/DirectML profiles the accelerator knob supports. A
-confidently wrong index is worse than a literal the sidecar resolves correctly.
+Two further defects the review found in that design, recorded so it is not
+re-proposed unchanged: its stop condition conflated "sidecar reported zero cards"
+with "the fetch timed out", so one aborted `/devices` probe on a GPU box would log
+*"sidecar reports no CUDA cards"* and exit cold. And its no-downgrade rule made
+`staleReason: 'uuid_unresolved'` unreachable for the eGPU-drop case it was named
+for, with no mechanism by which a warm cache could ever learn cards went to zero.
 
 ## Testing
 
-- **`server/src/gpu/gpu-device-list-state.test.ts`** (new) — the no-downgrade
-  rule: an empty list over a warm cache is ignored; an empty list over an empty
-  cache is a no-op; a non-empty list always replaces;
-  `_resetGpuDeviceListForTests()` clears.
-- **`server/src/gpu/warm-device-list.test.ts`** (new) — cold cache + reachable
-  sidecar warms it; an already-warm cache issues no fetch; concurrent callers
-  share one fetch; unreachable-then-reachable retries and eventually warms; an
-  empty response with `devices_state: 'pending'` keeps retrying and a later
-  populated response warms; `'ready'` and `'error'` each stop the loop early; an
-  unregistered provider (`null`) keeps retrying; exhausting the attempt budget
-  resolves without throwing.
-- **`server/src/routes/sidecar-health.test.ts`** — `probeSidecarHealth({
-  recordState: false })` returns the same parsed result but performs none of the
-  three `setLastKnown*` writes; the default (`recordState` omitted) still
-  performs all three. Without this the side-effect suppression is unpinned and a
-  later refactor silently reintroduces the boot-time writer.
-- **`server/src/tts/sidecar-env.test.ts`** — at the `buildSidecarEnv` seam: a
-  warm cache plus a `cuda-uuid:` override yields `QWEN_DEVICE=cuda:N`; a **cold**
-  cache yields the raw literal, asserted as the documented contract with a
-  comment citing `main.py:1873`, not as a bug.
-- **`server/tts-sidecar/tests/test_device_parse.py`** —
-  `QWEN_CODEC_DEVICE=cuda-uuid:<uuid>` resolves to `cuda:N`; an unmatched UUID
-  yields `auto`. Follows the file's existing pattern of monkeypatching
-  `main._enumerate_cuda_devices` (lines 92-113).
+- **`server/src/tts/sidecar-env.test.ts`** — `buildSidecarEnv` emits
+  `QWEN_DEVICE=cuda-uuid:GPU-1` under a **warm** cache and under a **cold** cache.
+  The warm case is the regression test for B1: it fails against today's code.
+- **`server/src/config/resolver.test.ts`** — `resolveKnob` still translates to
+  `cuda:N` against a warm cache and still reports `staleReason: 'uuid_unresolved'`
+  for a vanished pin, i.e. Change 1 did not disturb the UI path.
+- **`server/tts-sidecar/tests/test_device_parse.py`** — `_codec_device_pref()`
+  resolves a visible UUID to `cuda:N`, returns `cpu` for a vanished one, returns
+  `cpu` when unset or empty, and passes `cpu`/`auto`/`cuda:N` through unchanged.
 
-No GPU is required by any of these; the existing GPU-gated codec smoke test
-(`tests/test_codec_device_smoke.py`) is unchanged.
-
-The `index.ts` insertion needs no test-isolation work: `server/src/index.test.ts`
-imports `index.js`, but the main-module guard at the bottom of `index.ts` —
-`if (invokedHref && import.meta.url === invokedHref)`, comparing
-`import.meta.url` against `pathToFileURL(realpathSync(process.argv[1])).href` —
-keeps `main()` from running on import, so `listenerCallback`, and therefore the
-warm loop's timer, never fires in the server suite. (Both `index.ts:110` and
-`index.test.ts:9` call this the "isMainModule guard"; no such identifier exists,
-the name lives only in those comments. Verified against the code, not the
-comments — a leaked boot timer is this repo's known tinypool worker-exit flake.)
+No GPU is required by any of these.
 
 ## Out of scope
 
-- Cache staleness after a driver reload or hot-plug. Change 2a makes this
-  explicit rather than incidental: once warm, the list is only ever replaced by
-  another **non-empty** list, from any writer. A box whose cards genuinely
-  disappear mid-run therefore keeps serving the last good mapping indefinitely.
-  That is the same staleness tradeoff `gpu-device-list-state.ts:1-8` already
-  documents against `vram-state.ts`, and it is chosen over the alternative
-  failure — a transient empty during a sidecar recycle silently unpinning every
-  UUID assignment. Genuine hot-unplug handling would need an invalidation signal
-  this design does not add.
-- Re-warming per supervisor respawn. The card inventory does not change across
-  respawns of the same box, and the boot loop's budget covers the window in
-  which the first sidecar becomes reachable.
-- `qa.asr.device` / `SPK_DEVICE`, which also read `os.environ` bare
-  (`main.py:4754`, `4907`). Both are `type: 'string'` in the registry, so
-  `routes/config.ts:100` never writes them a `cuda-uuid:` value and no UUID can
-  reach them. Noted here so the asymmetry is not re-discovered as a bug.
+- Warming the device-list cache outside a request — see Rejected above.
+- Cache staleness generally. With `buildSidecarEnv` off the cache, a stale entry
+  can only affect what the Advanced UI displays until its next poll.
+- `qa.asr.device` / `qa.speaker.device`, which also read `os.environ` bare
+  (`main.py:4754`, `4907`). Both are `type: 'string'` (`registry.ts:373`, `362`),
+  so `routes/config.ts:100` never writes them a `cuda-uuid:` value. Noted so the
+  asymmetry is not re-discovered as a bug.
 
 ## Acceptance
 
-Replaces #1857's acceptance criteria:
+Replaces #1857's acceptance criteria.
 
-1. `QWEN_CODEC_DEVICE=cuda-uuid:<visible-uuid>` places the Qwen codec on the
-   pinned card on a cold-cache spawn, rather than demoting it to CPU.
-2. Server boot **initiates** the device-list warm with no `GET /api/config`, no
-   `GET /api/gpu/devices`, and no visit to Advanced settings. Stated as
-   "initiates", not "populates": no Node-side work can guarantee completion. The
-   loop has three terminal outcomes — cache warmed, sidecar definitively reported
-   zero cards (`devices_state` `'ready'` or `'error'`), or budget exhausted — and
-   the testable claim is that the loop runs unprompted and that a sidecar
-   reachable with cards inside the budget warms the cache.
-3. A device list that comes back empty never downgrades an already-warm cache —
-   from **any** writer, not only the boot loop.
-4. A zero-card box stops polling as soon as the sidecar reports a settled
-   `devices_state` (`'ready'` or `'error'`), rather than exhausting the retry
-   budget on every boot — and consulting that state does not perturb Qwen
-   install state, VRAM or per-engine device ground truth.
-5. `buildSidecarEnv`'s behaviour under both a warm and a cold cache is pinned by
-   test, with the cold-cache case documented as the sidecar-resolves contract.
+1. `buildSidecarEnv` emits the raw `cuda-uuid:` literal for a device knob under
+   **both** a warm and a cold device cache — the spawn env no longer depends on
+   whether Advanced settings was opened.
+2. A supervisor respawn after the pinned card's index changes still reaches the
+   correct card, because the sidecar re-resolves the UUID on each spawn.
+3. `QWEN_CODEC_DEVICE=cuda-uuid:<visible-uuid>` places the Qwen codec on the
+   pinned card. An unresolvable pin leaves it on `cpu` with a warning naming the
+   knob, never on the model's card.
+4. `GET /api/config` still translates a valid pin to `cuda:N` and still flags a
+   vanished one as `uuid_unresolved` — the UI path is unchanged.

--- a/server/src/config/resolver.test.ts
+++ b/server/src/config/resolver.test.ts
@@ -8,7 +8,12 @@ vi.mock('../gpu/gpu-device-list-state.js', () => ({
   getLastKnownGpuDevices: vi.fn(() => []),
 }));
 
-import { resolveKnob, coerceAndValidate, configValue } from './resolver.js';
+import {
+  resolveKnob,
+  resolveKnobForSidecarEnv,
+  coerceAndValidate,
+  configValue,
+} from './resolver.js';
 import { getKnob } from './registry.js';
 import * as us from '../workspace/user-settings.js';
 import * as gds from '../gpu/gpu-device-list-state.js';
@@ -90,5 +95,65 @@ describe('resolveKnob — device UUID reconcile (Plan 2 §2.1)', () => {
     (gds.getLastKnownGpuDevices as any).mockReturnValue([]);
     const st = resolveKnob(getKnob('tts.qwen.device')!);
     expect(st.staleReason).toBe('uuid_unresolved');
+  });
+});
+
+describe('resolveKnobForSidecarEnv — deliberately does NOT reconcile (#1857)', () => {
+  beforeEach(() => {
+    (gds.getLastKnownGpuDevices as any).mockReturnValue([]);
+    (us.readConfigOverrides as any).mockReturnValue({});
+    delete process.env.QWEN_DEVICE;
+  });
+
+  /* The sidecar resolves 'cuda-uuid:' itself against LIVE enumeration on every
+     spawn (main.py:1873 _read_device_env). Handing it a pre-translated index
+     instead freezes a mapping that buildOpts re-emits on every respawn, which a
+     vanished or renumbered card can no longer correct. So this entry point must
+     emit the uuid form even when the cache COULD translate it. */
+  it('passes a cuda-uuid override through even when the card IS visible', () => {
+    (us.readConfigOverrides as any).mockReturnValue({ 'tts.qwen.device': 'cuda-uuid:GPU-1' });
+    (gds.getLastKnownGpuDevices as any).mockReturnValue([{ uuid: 'GPU-1', idx: 1 }]);
+    const st = resolveKnobForSidecarEnv(getKnob('tts.qwen.device')!);
+    expect(st.effective).toBe('cuda-uuid:GPU-1');
+    expect(st.staleReason).toBeUndefined();
+  });
+
+  it('passes a cuda-uuid override through when no card matches, WITHOUT flagging stale', () => {
+    (us.readConfigOverrides as any).mockReturnValue({ 'tts.qwen.device': 'cuda-uuid:GONE' });
+    (gds.getLastKnownGpuDevices as any).mockReturnValue([]);
+    const st = resolveKnobForSidecarEnv(getKnob('tts.qwen.device')!);
+    expect(st.effective).toBe('cuda-uuid:GONE');
+    // staleReason is a UI concept; the sidecar decides liveness for itself.
+    expect(st.staleReason).toBeUndefined();
+  });
+
+  it('is identical to resolveKnob for a non-uuid device value', () => {
+    (us.readConfigOverrides as any).mockReturnValue({ 'tts.qwen.device': 'cuda:1' });
+    const knob = getKnob('tts.qwen.device')!;
+    expect(resolveKnobForSidecarEnv(knob)).toEqual(resolveKnob(knob));
+  });
+
+  it('is identical to resolveKnob for a non-device knob', () => {
+    (us.readConfigOverrides as any).mockReturnValue({ [KEY]: 0.9 });
+    const knob = getKnob(KEY)!;
+    expect(resolveKnobForSidecarEnv(knob)).toEqual(resolveKnob(knob));
+  });
+
+  it('still honours an env-locked value', () => {
+    process.env.QWEN_DEVICE = 'cpu';
+    try {
+      const st = resolveKnobForSidecarEnv(getKnob('tts.qwen.device')!);
+      expect(st.effective).toBe('cpu');
+      expect(st.source).toBe('env');
+      expect(st.locked).toBe(true);
+    } finally {
+      delete process.env.QWEN_DEVICE;
+    }
+  });
+
+  it('still falls through to the registry default when nothing is set', () => {
+    const st = resolveKnobForSidecarEnv(getKnob('tts.qwen.device')!);
+    expect(st.effective).toBe('auto');
+    expect(st.source).toBe('default');
   });
 });

--- a/server/src/config/resolver.ts
+++ b/server/src/config/resolver.ts
@@ -12,7 +12,7 @@ function parseEnv(knob: ConfigKnob, raw: string): number | boolean | string | nu
 // through to override/default doesn't surprise a deployer who set it.
 const warnedInvalidEnv = new Set<string>();
 
-export function resolveKnob(knob: ConfigKnob): KnobValueState {
+function resolveKnobInner(knob: ConfigKnob, reconcileDeviceUuid: boolean): KnobValueState {
   if (knob.env) {
     const raw = process.env[knob.env];
     if (raw != null && raw.trim() !== '') {
@@ -32,7 +32,12 @@ export function resolveKnob(knob: ConfigKnob): KnobValueState {
   const overrides = readConfigOverrides();
   if (Object.prototype.hasOwnProperty.call(overrides, knob.key)) {
     const raw = overrides[knob.key];
-    if (knob.type === 'device' && typeof raw === 'string' && raw.startsWith('cuda-uuid:')) {
+    if (
+      reconcileDeviceUuid &&
+      knob.type === 'device' &&
+      typeof raw === 'string' &&
+      raw.startsWith('cuda-uuid:')
+    ) {
       const uuid = raw.slice('cuda-uuid:'.length);
       const card = getLastKnownGpuDevices().find((d) => d.uuid === uuid);
       if (card) {
@@ -50,6 +55,40 @@ export function resolveKnob(knob: ConfigKnob): KnobValueState {
     return { key: knob.key, effective: raw, source: 'override', locked: false, overridden: true };
   }
   return { key: knob.key, effective: knob.default, source: 'default', locked: false, overridden: false };
+}
+
+/** Effective value for a READ SITE or the Advanced UI. Reconciles a stored
+    'cuda-uuid:<uuid>' override against the last-known device list, so the UI can
+    show a concrete card and flag a vanished one as staleReason:'uuid_unresolved'. */
+export function resolveKnob(knob: ConfigKnob): KnobValueState {
+  return resolveKnobInner(knob, true);
+}
+
+/** Effective value for the SIDECAR ENV. Deliberately does NOT reconcile a
+    'cuda-uuid:' override to an index (#1857).
+
+    The sidecar resolves the uuid form itself, against LIVE torch enumeration, on
+    every spawn — `_read_device_env` -> `_resolve_uuid_to_index`, main.py:1873.
+    That code exists precisely because this cache is cold at the boot spawn.
+    Handing the sidecar a pre-translated 'cuda:N' instead freezes whatever the
+    Node cache believed at translation time, and the supervisor's buildOpts
+    re-emits that frozen value on EVERY respawn: a card that then vanishes makes
+    _validate_cuda_index raise and the engine load fail on every retry, and a
+    card that renumbers silently lands on the wrong one. Passing the uuid through
+    keeps the sidecar's live resolution in charge, which degrades a vanished pin
+    to 'auto' with a warning instead.
+
+    Node's mapping is DERIVED from the sidecar (the cache is only ever populated
+    from its /devices response) and the child inherits CUDA_VISIBLE_DEVICES via
+    buildSidecarEnv's process.env spread — so our copy can only be staler than
+    the sidecar's live view, never better informed. Translating here is strictly
+    a downgrade.
+
+    It also makes the spawn env DETERMINISTIC. Before this split the emitted
+    value depended on whether the device cache happened to be warm — i.e. on
+    whether the user had opened Advanced Settings during this server session. */
+export function resolveKnobForSidecarEnv(knob: ConfigKnob): KnobValueState {
+  return resolveKnobInner(knob, false);
 }
 
 export function resolveAll(): Record<string, KnobValueState> {

--- a/server/src/tts/sidecar-env.test.ts
+++ b/server/src/tts/sidecar-env.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 vi.mock('../workspace/user-settings.js', () => ({ readConfigOverrides: vi.fn(() => ({})) }));
 import { buildSidecarEnv } from './spawn-sidecar.js';
 import * as us from '../workspace/user-settings.js';
+import { setLastKnownGpuDevices } from '../gpu/gpu-device-list-state.js';
 
 describe('buildSidecarEnv injects resolved restart-sidecar knobs', () => {
   beforeEach(() => {
@@ -149,5 +150,53 @@ describe('buildSidecarEnv injects the accelerator profile + Kokoro ORT providers
     expect(env.CASTWRIGHT_ACCELERATOR_PROFILE).toBe('amd');
     // S0.1 found DirectML can't run the Kokoro model → CPU EP on every OS.
     expect(JSON.parse(env.KOKORO_ORT_PROVIDERS as string)).toEqual(['CPUExecutionProvider']);
+  });
+});
+
+describe('buildSidecarEnv hands the sidecar a UUID device pin verbatim (#1857)', () => {
+  beforeEach(() => {
+    setLastKnownGpuDevices([]);
+    (us.readConfigOverrides as ReturnType<typeof vi.fn>).mockReturnValue({});
+    delete process.env.QWEN_DEVICE;
+  });
+
+  afterEach(() => {
+    setLastKnownGpuDevices([]);
+  });
+
+  /* Both cache states must agree. Before #1857 the emitted value depended on
+     whether the user had opened Advanced Settings during this server session:
+     a warm cache froze a cuda:N that buildOpts re-emitted on every respawn, so
+     a card that later vanished failed _validate_cuda_index on every retry and
+     one that renumbered landed on the wrong card. The sidecar resolves the uuid
+     form itself, live, per spawn — that is the safe branch, so make it the only
+     branch. */
+  for (const [label, cache] of [
+    ['cold cache', [] as { uuid: string; idx: number }[]],
+    ['warm cache', [{ uuid: 'GPU-1', idx: 1 }]],
+  ] as const) {
+    it(`emits the raw cuda-uuid literal with a ${label}`, () => {
+      (us.readConfigOverrides as ReturnType<typeof vi.fn>).mockReturnValue({
+        'tts.qwen.device': 'cuda-uuid:GPU-1',
+      });
+      setLastKnownGpuDevices([...cache]);
+
+      const env = buildSidecarEnv({ modelKey: 'qwen3-tts-0.6b', repoRoot: process.cwd() });
+
+      expect(env.QWEN_DEVICE).toBe('cuda-uuid:GPU-1');
+    });
+  }
+
+  it('still emits a plain cuda:N pin unchanged', () => {
+    (us.readConfigOverrides as ReturnType<typeof vi.fn>).mockReturnValue({
+      'tts.qwen.device': 'cuda:1',
+    });
+    const env = buildSidecarEnv({ modelKey: 'qwen3-tts-0.6b', repoRoot: process.cwd() });
+    expect(env.QWEN_DEVICE).toBe('cuda:1');
+  });
+
+  it('leaves a device knob at its registry default unset', () => {
+    const env = buildSidecarEnv({ modelKey: 'qwen3-tts-0.6b', repoRoot: process.cwd() });
+    expect(env.QWEN_DEVICE).toBeUndefined();
   });
 });

--- a/server/src/tts/spawn-sidecar.ts
+++ b/server/src/tts/spawn-sidecar.ts
@@ -27,7 +27,7 @@ import { WORKSPACE_ROOT } from '../workspace/paths.js';
 import { resolveLogDir, resolveRunDir } from '../app-dirs.js';
 import { formatTimestamp } from '../logger.js';
 import { allKnobs } from '../config/registry.js';
-import { resolveKnob } from '../config/resolver.js';
+import { resolveKnob, resolveKnobForSidecarEnv } from '../config/resolver.js';
 import { readStamp } from '../../tts-sidecar/scripts/venv-migration.mjs';
 // @ts-expect-error — standalone install scripts ship no .d.ts; pure helpers are plain JS.
 import { resolveProfile, ortProviders } from '../../tts-sidecar/scripts/accelerator-profile.mjs';
@@ -468,10 +468,20 @@ export function buildSidecarEnv(opts: BuildSidecarEnvOpts): NodeJS.ProcessEnv {
      explicit registry override for tts.preload.coqui WINS over the
      modelKey-derived PRELOAD_COQUI '0'/'1' set there. tts.preload.kokoro /
      .qwen / .qwenBase17 have no base-block value to win over any more — this
-     loop is their ONLY source (see the buildSidecarEnv docblock above). */
+     loop is their ONLY source (see the buildSidecarEnv docblock above).
+
+     Device knobs resolve through resolveKnobForSidecarEnv, NOT resolveKnob: a
+     'cuda-uuid:' pin is handed to the sidecar VERBATIM so it resolves against
+     live enumeration on every spawn, rather than freezing an index a later
+     respawn can't correct. See that function's docblock (#1857). The two
+     ceiling helpers earlier in this file (expectedSidecarCeilings,
+     expectedFreeFloorMb) deliberately keep using resolveKnob — their knobs are
+     numeric, so the distinction is moot there, and they answer a different
+     question ("what would THIS server configure", for the adopt/recycle
+     mismatch check). */
   for (const knob of allKnobs()) {
     if (knob.apply !== 'restart-sidecar' || !knob.env) continue;
-    const st = resolveKnob(knob);
+    const st = resolveKnobForSidecarEnv(knob);
     if (st.source === 'default') continue;
     // Emit booleans as '1'/'0' — the canonical form every sidecar env reader
     // accepts. Some main.py reads use a bare `== "1"` check that would reject

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -403,6 +403,42 @@ def _resolve_codec_device(pref: str, model_device: str) -> Optional[str]:
     return p
 
 
+def _codec_device_pref() -> str:
+    """QWEN_CODEC_DEVICE as a resolved device string, defaulting to 'cpu'.
+
+    QWEN_CODEC_DEVICE is a type:'device' knob, so PUT /api/config persists a
+    picked card as 'cuda-uuid:<uuid>'. A bare os.environ.get (the #1857 bug) let
+    that literal through _validate_cuda_index untouched -- _parse_device reads
+    'cuda-uuid:x' as family cuda with NO index, and the range check only fires on
+    a concrete index -- so it failed later inside torch's .to() in
+    _move_codec_to_device and got rolled back to CPU. The pinned card was simply
+    ignored.
+
+    Deliberately NOT _read_device_env, which the three ENGINE device knobs use:
+    that helper degrades an unresolvable pin to 'auto', and
+    _resolve_codec_device('auto', model_device) means "follow the model". So a
+    vanished card would silently move the codec ONTO the model's card -- adding
+    pressure to exactly the card a user who pinned the codec elsewhere was trying
+    to protect. _move_codec_to_device's rollback only fires if .to() itself
+    raises, so a SUCCESSFUL move that later OOMs a decode never unwinds. 'cpu' is
+    this knob's registry default and is VRAM-neutral.
+
+    Named rather than inlined at the call site so it is reachable from tests: the
+    call site is inside _load_qwen_model, which needs real weights and a GPU.
+    """
+    raw = os.environ.get("QWEN_CODEC_DEVICE")
+    if not raw or not raw.strip():
+        return "cpu"
+    resolved = _resolve_uuid_to_index(raw)
+    if resolved is None:
+        log.warning(
+            "QWEN_CODEC_DEVICE=%s did not match any visible GPU -- leaving the codec on cpu.",
+            raw,
+        )
+        return "cpu"
+    return resolved
+
+
 def _move_codec_to_device(model: Any, device: str, torch_module: Any) -> None:
     """Move the resolved codec (speech_tokenizer.model) to `device` and
     resync its cached `.device` attribute, so every `.to(self.device)` call
@@ -2992,9 +3028,7 @@ class QwenEngine(Engine):
             ) from e
         _apply_torch_perf_flags(torch)
         _validate_cuda_index(self._device, torch)
-        codec_device = _resolve_codec_device(
-            os.environ.get("QWEN_CODEC_DEVICE", "cpu"), self._device
-        )
+        codec_device = _resolve_codec_device(_codec_device_pref(), self._device)
         if codec_device is not None:
             try:
                 _validate_cuda_index(codec_device, torch)

--- a/server/tts-sidecar/tests/test_device_parse.py
+++ b/server/tts-sidecar/tests/test_device_parse.py
@@ -111,3 +111,40 @@ def test_read_device_env_falls_back_to_auto_when_uuid_unresolved(monkeypatch, ca
     monkeypatch.setenv("QWEN_DEVICE", "cuda-uuid:GONE")
     monkeypatch.setattr(main, "_enumerate_cuda_devices", lambda tm=None: [])
     assert main._read_device_env("QWEN_DEVICE") == "auto"
+
+
+def test_codec_device_pref_resolves_uuid(monkeypatch):
+    """QWEN_CODEC_DEVICE is a type:'device' knob, so a card picked in Advanced
+    Settings is persisted as 'cuda-uuid:<uuid>'. _codec_device_pref is what
+    _load_qwen_model actually calls, so a UUID must never reach torch raw."""
+    monkeypatch.setenv("QWEN_CODEC_DEVICE", "cuda-uuid:GPU-1")
+    monkeypatch.setattr(main, "_enumerate_cuda_devices",
+        lambda tm=None: [{"uuid": "GPU-1", "idx": 1, "name": "x", "total_mb": 16000, "free_mb": 14000}])
+    assert main._codec_device_pref() == "cuda:1"
+    assert main._resolve_codec_device(main._codec_device_pref(), "cuda:0") == "cuda:1"
+
+
+def test_codec_device_pref_vanished_uuid_falls_back_to_cpu(monkeypatch):
+    """A vanished card must NOT degrade to 'auto' -- for the codec that means
+    "follow the model", i.e. move onto the very card the user was spreading VRAM
+    away from. cpu is the knob's registry default and is VRAM-neutral."""
+    monkeypatch.setenv("QWEN_CODEC_DEVICE", "cuda-uuid:GONE")
+    monkeypatch.setattr(main, "_enumerate_cuda_devices", lambda tm=None: [])
+    assert main._codec_device_pref() == "cpu"
+    # _resolve_codec_device('cpu', ...) is None == "leave the codec where it is"
+    assert main._resolve_codec_device(main._codec_device_pref(), "cuda:0") is None
+
+
+def test_codec_device_pref_unset_and_empty_mean_cpu(monkeypatch):
+    monkeypatch.delenv("QWEN_CODEC_DEVICE", raising=False)
+    assert main._codec_device_pref() == "cpu"
+    monkeypatch.setenv("QWEN_CODEC_DEVICE", "   ")
+    assert main._codec_device_pref() == "cpu"
+
+
+def test_codec_device_pref_passes_through_plain_values(monkeypatch):
+    """cpu / auto / cuda:N are unchanged -- no behaviour change for any value
+    that already worked."""
+    for raw, expected in (("cpu", "cpu"), ("auto", "auto"), ("cuda:1", "cuda:1")):
+        monkeypatch.setenv("QWEN_CODEC_DEVICE", raw)
+        assert main._codec_device_pref() == expected


### PR DESCRIPTION
Closes #1857

## The issue's premise was wrong, and its suggested fix would have made things worse

#1857 reports that the GPU device-list cache is never warmed unless Advanced settings is opened, and that this hands the sidecar a raw `cuda-uuid:GPU-…` literal which misroutes the engine. It asks for the cache to be warmed at server boot.

The sidecar resolves that literal itself. `_read_device_env` → `_resolve_uuid_to_index` (`main.py:1873`) maps `cuda-uuid:<uuid>` to a live index on every read, for all three engine device knobs. That code exists *because* the Node cache is necessarily cold at the boot spawn — its docstring says so at `main.py:1843`. The raw literal is the designed input, not the bug.

Warming the cache is what causes harm. A warm cache is what makes `resolveKnob` freeze a `cuda:N` into the spawn env, and `buildOpts` re-runs `buildSidecarEnv` on **every respawn** — so a card that later vanishes makes `_validate_cuda_index` raise and the engine load fail on every retry, and a card that renumbers lands on the wrong one silently. This is the same failure the design rejected `nvidia-smi` enumeration for: a confidently wrong index is worse than a literal the sidecar resolves correctly.

## What this actually fixes

**1. `buildSidecarEnv` was nondeterministic** — named by neither the issue nor the first draft of the spec.

| Cache state | `QWEN_DEVICE` handed to the sidecar |
|---|---|
| Cold (nobody opened Advanced) | `cuda-uuid:GPU-…` — sidecar resolves live, self-healing |
| Warm (Advanced was opened) | `cuda:1` — frozen, re-emitted on every respawn |

Same config, same box, two different spawn envs depending on UI history. New `resolveKnobForSidecarEnv` skips the reconcile, so the sidecar always gets the UUID form. Node's mapping is *derived from* the sidecar's own `/devices`, so it can only ever be staler — translating in Node was strictly a downgrade.

The UI path is untouched: `resolveKnob` keeps its translation and its `staleReason: 'uuid_unresolved'` badge. `expectedSidecarCeilings` / `expectedFreeFloorMb` also keep `resolveKnob` — numeric knobs, different question.

**2. `QWEN_CODEC_DEVICE` ignored a UUID pin.** It is the fourth `type: 'device'` knob and the only one read with a bare `os.environ.get`. A pinned card *passed* `_validate_cuda_index` — `_parse_device` reads `cuda-uuid:x` as family `cuda` with no concrete index, so the range check no-ops — then failed inside `_move_codec_to_device`'s `.to()` and was rolled back to CPU.

An unresolvable pin now falls back to `cpu`, deliberately **not** `_read_device_env`'s `auto`. For the codec `auto` means "follow the model", which would move it onto the very card a user pinning the codec elsewhere was spreading VRAM away from — and the rollback only fires if `.to()` raises, not if a successful move OOMs a later decode.

## What was dropped

An earlier revision of the spec implemented the boot warm as #1857 suggests, plus a no-downgrade rule, a `recordState` option on `probeSidecarHealth`, and a new gate accessor. Two independent Fable reviews killed it:

- Warming is the *cause* of the frozen-index hazard above, not a mitigation.
- The retry loop's stop condition conflated "sidecar reported zero cards" with "the `/devices` fetch timed out", so on a two-GPU box a single 2s abort after `devices_state` flipped to `ready` would log **"sidecar reports no CUDA cards"** and exit with a cold cache.
- The no-downgrade rule made `staleReason: 'uuid_unresolved'` unreachable for the eGPU-drop case it was named for, with no mechanism by which a warm cache could ever learn cards went to zero.

Once `buildSidecarEnv` is off the cache, no consumer needs it warmed without a request — `engine-device.ts` works off the UUID form, and `staleReason` is only surfaced through routes that warm on demand. Request-scoped warming turns out to be correct rather than accidental. The reasoning is preserved in the spec's "Rejected: the boot warm" section.

## Testing

- `resolver.test.ts` — the two entry points diverge exactly on the device-UUID branch; env-locked and default paths unaffected; the pre-existing `resolveKnob` reconcile tests still pin the UI path.
- `sidecar-env.test.ts` — `buildSidecarEnv` emits the raw literal under **both** warm and cold caches. The warm case is the regression test and was red before the fix (`expected 'cuda:1' to be 'cuda-uuid:GPU-1'`).
- `test_device_parse.py` — `_codec_device_pref()` resolves a visible UUID, falls back to `cpu` for a vanished one, and passes `cpu`/`auto`/`cuda:N` through unchanged. Named rather than inlined so it is reachable without weights or a GPU.

Full server suite: 443 files, 5426 tests passing. Typecheck clean. Sidecar `test_device_parse.py` + `test_module_import_order.py` green.

## Not done

No on-box acceptance yet — the behaviour that matters most (a respawn after a real index change reaching the right card) needs the dual-GPU box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
