### PR TITLE
docs(docs): register the #1870 device-pin acceptance debt (A18)

### DIFF
--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -47,7 +47,7 @@ setup rather than repeatedly loading and evicting models.
 
 | Group | Setup | Rows |
 |---|---|---|
-| **A** | The GPU box (single 8 GB for most; the 2-card boot for a few) | 17 |
+| **A** | The GPU box (single 8 GB for most; the 2-card boot for a few) | 18 |
 | **B** | Local Ollama analyzer only, no TTS sidecar | 2 |
 | **C** | One *Ночной дозор* re-analysis session | 3 |
 | **D** | Multi-language TTS render + ASR | 2 |
@@ -56,7 +56,7 @@ setup rather than repeatedly loading and evicting models.
 | — | **Blocked** (hardware absent) | 1 |
 | — | **Unconfirmed** (not debts until substantiated) | 2 |
 
-**30 owed.** Oldest: **2026-06-01** (plans 160, 161, 165).
+**31 owed.** Oldest: **2026-06-01** (plans 160, 161, 165).
 
 ---
 
@@ -251,6 +251,32 @@ evicted.
 "Live GPU acceptance owed: the **audible** difference between a designed variant and
 the base voice can only be confirmed on a real sidecar" (`:48`). Ship notes still a
 placeholder — no shipped date recorded.
+
+### A18 · Device-pin resolution survives a respawn ([#1870](https://github.com/dudarenok-maker/Castwright/pull/1870), closes [#1857](https://github.com/dudarenok-maker/Castwright/issues/1857)) · **2-card boot**
+
+`buildSidecarEnv` now hands the sidecar the raw `cuda-uuid:` literal instead of a
+translated `cuda:N`, so the sidecar re-resolves the pin against live torch
+enumeration on every spawn. Verified by unit tests and CI; **never watched on real
+cards.** The behaviour that matters most is the one no test can reach — a respawn
+after the index actually changes.
+
+- Pin Qwen to a specific card in Advanced settings, restart the server, and force a
+  supervisor respawn (`POST /api/sidecar/restart`, or let a recycle fire). The engine
+  lands on the **pinned** card both times.
+- Then change the enumeration order — swap the cards, or set `CUDA_DEVICE_ORDER` —
+  and confirm a respawn still finds the pinned card by UUID rather than failing
+  `_validate_cuda_index` or landing on the wrong one. **This is the regression the
+  change exists to prevent**, and it was previously reachable only when the user had
+  opened Advanced settings during that server session.
+- Pin `tts.qwen.codecDevice` to a card and confirm the codec is actually placed there.
+  Before #1870 the pin was silently ignored — the literal failed inside torch's
+  `.to()` and rolled back to CPU.
+- Point the codec pin at a card that is **not** present and confirm the sidecar logs
+  `QWEN_CODEC_DEVICE=… did not match any visible GPU` and leaves the codec on **cpu**
+  — not on the model's card, which is what `auto` would have done.
+
+*Needs:* both cards, and the ability to change enumeration order between boots (the
+eGPU is not hot-pluggable, so batch this with A2 step 9 and A3). *Cost:* short.
 
 ---
 


### PR DESCRIPTION
Refs #1857

PR #1870 shipped with on-box acceptance owed and never added a row to the register. That violates the register's own rule — *"Add a row in the same PR that ships the unverified behaviour. Not later."* This is that row, late.

## What is owed

`buildSidecarEnv` now hands the sidecar the raw `cuda-uuid:` literal instead of a translated `cuda:N`, so the sidecar re-resolves the pin against live torch enumeration on every spawn. CI can prove the right string is emitted; it cannot prove the right card is selected.

The debt that matters is the case no test can reach — **a supervisor respawn after the enumeration order actually changes.** That is precisely the regression #1870 exists to prevent, and before it the bad path was reachable only when the user had opened Advanced settings during that server session.

Also owed: that a `tts.qwen.codecDevice` pin now actually places the codec on the pinned card (it was silently ignored before), and that an unresolvable codec pin lands on `cpu` rather than on the model's card.

## Placement

Group A, **2-card boot** — batches naturally with A2 step 9 and A3, which already need both cards in one sitting since the eGPU is not hot-pluggable.

Counts: Group A 17 → 18, total 30 → 31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
