### PR TITLE
test(frontend): pin the #/voices My-voices segment against a focus-dropping unmount

### DIFF
--- a/src/views/voices.restructure.test.tsx
+++ b/src/views/voices.restructure.test.tsx
@@ -5,7 +5,7 @@
    voices.test.tsx, unmodified by this task. */
 
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { act, render, screen, fireEvent, within } from '@testing-library/react';
 import { configureStore } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
 import { castSlice } from '../store/cast-slice';
@@ -13,7 +13,7 @@ import { manuscriptSlice } from '../store/manuscript-slice';
 import { notificationsSlice } from '../store/notifications-slice';
 import { uiSlice } from '../store/ui-slice';
 import { voicesSlice } from '../store/voices-slice';
-import { configSlice, type ConfigState } from '../store/config-slice';
+import { configSlice, fetchConfig, type ConfigState } from '../store/config-slice';
 import { voiceLibrarySlice } from '../store/voice-library-slice';
 import { LibraryView } from './voices';
 import type { BaseVoice, ConfigValues, Voice } from '../lib/types';
@@ -131,6 +131,63 @@ describe('LibraryView restructure — three-way section nav (fs-38 Wave 1 Task 1
     });
     expect(screen.getByRole('button', { name: 'My voices' })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'My voices' }));
+    expect(screen.getByText('No voices in your library yet')).toBeInTheDocument();
+  });
+
+  /* #1835 — the boot race the issue describes, played out end to end: the view
+     mounts before `fetchConfig` resolves, the user clicks "My voices" (so focus
+     is on that button by construction), and the resolved config carries
+     `voices.library.enabled: false`. Under the retired gate that config reply
+     unmounted the focused button, dropping `document.activeElement` to
+     `<body>` and restarting Tab at the top of the document. It is gone (#1833), so
+     the segment is unconditional, no section fallback exists, and both the
+     button and the focus on it survive the same config arrival.
+
+     jsdom does not focus a button on click the way a browser does, so the
+     click's focus side effect is applied explicitly rather than assumed. */
+  it('keeps the focused My-voices segment mounted when config resolves with the retired gate off', () => {
+    const store = makeStore();
+    render(
+      <Provider store={store}>
+        <LibraryView library={library} />
+      </Provider>,
+    );
+
+    const myVoices = screen.getByRole('button', { name: 'My voices' });
+    myVoices.focus();
+    fireEvent.click(myVoices);
+    expect(document.activeElement).toBe(myVoices);
+
+    act(() => {
+      store.dispatch(
+        fetchConfig.fulfilled(
+          {
+            groups: [],
+            descriptors: [],
+            cudaEnvShadow: false,
+            restartPending: false,
+            values: {
+              'voices.library.enabled': {
+                key: 'voices.library.enabled',
+                effective: false,
+                source: 'override',
+                locked: false,
+                overridden: true,
+              },
+            },
+          },
+          'test-request-id',
+          undefined,
+        ),
+      );
+    });
+
+    /* The reported symptom first: an unmount here parks focus on <body>. */
+    expect(document.activeElement).not.toBe(document.body);
+    expect(document.activeElement).toBe(myVoices);
+    /* Same node, not merely a same-named one — a remount would also reset focus. */
+    expect(screen.getByRole('button', { name: 'My voices' })).toBe(myVoices);
+    /* And the section itself did not fall back to In use. */
     expect(screen.getByText('No voices in your library yet')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

#1835 reports that clicking the **My voices** nav segment on `#/voices` can unmount that very button, parking `document.activeElement` on `<body>` so the next Tab restarts at the top of the document.

**The defect is not reachable on `main`.** The unmount trigger the issue names — the segment rendering conditionally on `myVoicesLibraryEnabled` — was deleted with the `voices.library.enabled` flag in `3a71cbf2` (#1833), and the derived `activeSection` masking that #1802 had added went with it. All three segments now render unconditionally, `src/views/voices.tsx` reads nothing from `s.config` at all, and no section fallback remains to fire.

This PR closes the issue by **locking that**, rather than on the reading alone. It adds one regression case to `src/views/voices.restructure.test.tsx` that replays the exact boot race #1835 describes:

1. the view mounts before `fetchConfig` resolves;
2. the user clicks **My voices**, so focus is on that button by construction;
3. `fetchConfig` resolves carrying `voices.library.enabled: false`.

It then asserts focus is still on that same button node — not on `<body>` — and that the section did not fall back to **In use**.

No behaviour changes; `src/views/voices.tsx` is untouched.

## Test plan

- `npx vitest run src/views/voices.restructure.test.tsx` — 5/5 pass.
- **Non-placebo verified.** Temporarily re-gating the segment on the retired config value (`{gateEnabled && <button…>My voices</button>}`) fails the new case at the focus assertion with `AssertionError: expected <body>… not to be <body>…` — the reported symptom itself — and it passes again once the gate is removed. The neighbouring stale-override case fails under the same neutralisation, as it should.
- Full frontend suite green at commit time: 322 files / 4270 tests.
- `npm run verify:fast:branch` green on push (lint, typecheck, config:check, test:hooks, test, build). The first attempt caught a missing `restartPending` field in the `fetchConfig.fulfilled` payload — vitest does not typecheck, so the push gate was the thing that surfaced it.

## Checklist notes

- **Regression plan** — not applicable: single localized test case, no plan doc under `docs/features/` covers this nav segment.
- **Release notes** — deliberately skipped: coverage-only, no user- or operator-visible delta.
- **On-box acceptance** — not applicable: no hardware-dependent behaviour.

Closes #1835
