### PR TITLE
fix(ops): make forceRerunTriggers survive a dot-prefixed checkout

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,15 +216,22 @@ creates worktrees at `../wt-<slug>`, but the Agent tool's `isolation:
 dot-prefixed directory. picomatch's globstar refuses to cross a dot-prefixed
 path segment unless `{ dot: true }` is passed, and vitest passes no options
 when it builds its `forceRerunTriggers` matchers. Until ops-33/#1868 that
-meant **every** trigger silently matched nothing from an agent worktree, so
-`npx vitest run --changed <base>` under-selected — and the failure mode was
-`0 tests found, exit 0`, which reads as success. The trigger patterns now
-carry an explicit dot-segment alternative, and
-`src/test/force-rerun-triggers.test.ts` +
+meant every **glob** trigger silently matched nothing from an agent worktree,
+so `npx vitest run --changed <base>` under-selected — and the failure mode was
+`0 tests found, exit 0`, which reads as success. (Vitest also appends resolved
+`setupFiles` as absolute paths; those carry no wildcard and were never
+affected.) The trigger patterns now carry an explicit dot-segment alternative,
+and `src/test/force-rerun-triggers.test.ts` +
 `server/src/force-rerun-triggers.test.ts` pin that at a synthetic dotted root
-so a regression can't pass CI (which always runs from a clean path). If you
-are measuring anything `--changed`-related and the numbers look impossibly
-low, check those tests first.
+so a regression can't pass CI, which always runs from a clean path. If you are
+measuring anything `--changed`-related and the numbers look impossibly low,
+check those tests first.
+
+The tolerance is exactly **one** dot segment deep. A checkout nested under a
+second dotted parent — say a `.claude/worktrees/` tree inside `~/.local/src/` —
+still misses. No such path exists on the current boxes, and if one appears the
+`this checkout` case in both trigger tests goes red rather than under-selecting
+silently, so the failure is loud.
 
 ## Commit convention
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,6 +210,22 @@ manually):
   time they will race on `state.json`. Set `WORKSPACE_DIR=…` in each
   worktree's `.env.local` if you need fully isolated book stores.
 
+**`vitest --changed` and dot-prefixed worktree paths.** `scripts/wt-new.mjs`
+creates worktrees at `../wt-<slug>`, but the Agent tool's `isolation:
+"worktree"` puts them under `.claude/worktrees/<branch>` — inside a
+dot-prefixed directory. picomatch's globstar refuses to cross a dot-prefixed
+path segment unless `{ dot: true }` is passed, and vitest passes no options
+when it builds its `forceRerunTriggers` matchers. Until ops-33/#1868 that
+meant **every** trigger silently matched nothing from an agent worktree, so
+`npx vitest run --changed <base>` under-selected — and the failure mode was
+`0 tests found, exit 0`, which reads as success. The trigger patterns now
+carry an explicit dot-segment alternative, and
+`src/test/force-rerun-triggers.test.ts` +
+`server/src/force-rerun-triggers.test.ts` pin that at a synthetic dotted root
+so a regression can't pass CI (which always runs from a clean path). If you
+are measuring anything `--changed`-related and the numbers look impossibly
+low, check those tests first.
+
 ## Commit convention
 
 The history is a tool, not a log. Tag every commit by area so

--- a/docs/release-notes-next.md
+++ b/docs/release-notes-next.md
@@ -404,12 +404,19 @@ history at cut time.
 - **`vitest --changed` no longer under-selects to zero from an agent worktree** (ops-33, #1868).
   picomatch's globstar refuses to cross a dot-prefixed path segment unless `{ dot: true }` is passed,
   and vitest passes no options when it builds its `forceRerunTriggers` matchers. Agent worktrees live
-  under `.claude/worktrees/…`, so from one, **every** trigger matched nothing and
+  under `.claude/worktrees/…`, so from one, every **glob** trigger matched nothing and
   `npx vitest run --changed <base>` selected zero tests — reporting `0 tests found, exit 0`, which
-  reads as success. Measured on an identical `package.json`-only diff: **322 test files selected from
-  a non-dotted checkout, 0 from a dotted one, 322 after the fix.** All 9 triggers across
-  `vitest.config.ts`, `server/vitest.config.ts` and `server/vitest.config.slow.ts` now carry an
-  explicit dot-segment alternative.
+  reads as success. (Vitest also appends resolved `setupFiles` as absolute paths, which carry no
+  wildcard and were never affected.) Measured in a single dotted checkout on an identical
+  `package.json`-only diff, swapping only the configs: **frontend 1 → 323 test files, server 0 → 446,
+  slow tier 0 → 10.** All 10 triggers across `vitest.config.ts`, `server/vitest.config.ts` and
+  `server/vitest.config.slow.ts` now carry an explicit dot-segment alternative, and
+  `server/vitest.config.ts` gained a trigger for `vitest.config.slow.ts` — the
+  `{vitest,vite}.config.ts` brace never matched it, so a slow-config-only diff selected zero tests
+  from the suite that holds its own guard.
+  - The dot tolerance is exactly **one** segment deep; a checkout nested under a second dotted parent
+    still misses. Known bound, and a loud one — the trigger tests' `this checkout` case goes red there
+    rather than under-selecting silently.
   - **CI was never affected** — GitHub runners check out to `/home/runner/work/Castwright/Castwright`,
     which has no dot segment, and `verify.yml` holds the repo's only three `--changed` invocations. The
     cost landed entirely on local verification, which is where essentially all non-trivial work in this

--- a/docs/release-notes-next.md
+++ b/docs/release-notes-next.md
@@ -398,3 +398,24 @@ history at cut time.
     `server/src/parsers/adm-zip-pin.test.ts` guards the block, since deleting it reinstalls a vulnerable
     0.5.x with no error (epub2's declared `^0.5.10` is satisfied) and the 27 existing parser cases return
     byte-identical results on both versions, so they cannot detect the regression.
+
+## 🧪 Test gates
+
+- **`vitest --changed` no longer under-selects to zero from an agent worktree** (ops-33, #1868).
+  picomatch's globstar refuses to cross a dot-prefixed path segment unless `{ dot: true }` is passed,
+  and vitest passes no options when it builds its `forceRerunTriggers` matchers. Agent worktrees live
+  under `.claude/worktrees/…`, so from one, **every** trigger matched nothing and
+  `npx vitest run --changed <base>` selected zero tests — reporting `0 tests found, exit 0`, which
+  reads as success. Measured on an identical `package.json`-only diff: **322 test files selected from
+  a non-dotted checkout, 0 from a dotted one, 322 after the fix.** All 9 triggers across
+  `vitest.config.ts`, `server/vitest.config.ts` and `server/vitest.config.slow.ts` now carry an
+  explicit dot-segment alternative.
+  - **CI was never affected** — GitHub runners check out to `/home/runner/work/Castwright/Castwright`,
+    which has no dot segment, and `verify.yml` holds the repo's only three `--changed` invocations. The
+    cost landed entirely on local verification, which is where essentially all non-trivial work in this
+    repo happens.
+  - This is why the regression tests assert a **synthetic dotted root** rather than only the real
+    checkout path: CI always runs from a clean path, so a regression that dropped the dot-tolerant half
+    would pass CI unnoticed and break only on developer machines — exactly how #1868 survived. It cost
+    real time twice before being fixed: once masquerading as the bug under investigation in #1848, and
+    again in #1873, whose own trigger tests hit it and had to route around it with a synthetic root.

--- a/docs/superpowers/specs/2026-07-27-force-rerun-triggers-dot-segments-design.md
+++ b/docs/superpowers/specs/2026-07-27-force-rerun-triggers-dot-segments-design.md
@@ -1,0 +1,101 @@
+# Design — make `forceRerunTriggers` survive a dot-prefixed checkout (ops-33, #1868)
+
+**Date:** 2026-07-27
+**Issue:** [#1868](https://github.com/dudarenok-maker/Castwright/issues/1868) (ops-33)
+**Branch:** `fix/ops-force-rerun-triggers` (worktree `C:\Claude\Projects\wt-force-rerun-triggers`, cut from `main` @ `7b0cc955`)
+**Status:** draft — awaiting review
+
+## Problem
+
+`vitest run --changed <base>` narrows a run to tests whose module graph touches the diff. Files with no module-graph edge — the manifest, the test configs, `openapi.yaml`, the injected setup file — are covered instead by `forceRerunTriggers`: a changed file matching one of those globs forces a full run.
+
+picomatch's `**` refuses to cross a **dot-prefixed path segment** unless `{ dot: true }` is passed. Vitest passes no options at either call site — `cli-api…js:11495` (`pm(forceRerunTriggers)`, the `--changed` path) and `:12916` (`pm.isMatch`, the watch path). Claude-Code-harness worktrees live under `.claude/worktrees/…`, so from one, **every** trigger silently matches nothing.
+
+The failure mode is `0 tests found, exit 0` — it reads as success.
+
+### Measured
+
+`vitest list --changed HEAD` against a single-file dirty tree; vitest 4.1.9, picomatch 4.0.4, Windows:
+
+| checkout | dirty file | test files selected |
+|---|---|---|
+| `C:\Claude\Projects\wt-force-rerun-triggers` (non-dotted) | `package.json` | **322** |
+| `…\.claude\worktrees\ops33-probe` (dotted) | `package.json` | **0** |
+| dotted, with the dot-tolerant pattern applied | `package.json` | **322** |
+
+## Relationship to ops-30 / #1873
+
+ops-30 (#1848) was a *different* defect in the same arrays — a wildcard-bearing segment followed by `/**` matches nothing anywhere. It was fixed and closed by PR #1873 (merged 2026-07-27), which pinned the extension to `.ts` and gave `server/vitest.config.slow.ts` its own explicit array. **That work is done and is not revisited here.**
+
+#1873 is, however, the second recorded incident of ops-33 costing time. Its two new test files — `src/test/force-rerun-triggers.test.ts` and `server/src/force-rerun-triggers.test.ts` — both hit this bug and route around it with a synthetic `/repo/…` root, carrying the comment:
+
+> picomatch's `**` refuses to cross a dot-prefixed path segment (its default `dot: false`) — this checkout happens to live under `.claude/worktrees/...`, so matching the file's REAL on-disk absolute path would spuriously fail here regardless of the trigger patterns.
+
+The first incident was #1848 itself, where the confounder produced the same "No test files found" symptom as the bug under investigation and forced the measurement to be taken from a throwaway non-dotted checkout.
+
+## Corrections to the issue's premises
+
+Recorded because #1868 will be closed by this work and its text is otherwise the record.
+
+1. **"Key files" lists three configs carrying `forceRerunTriggers`.** At filing time `server/vitest.config.slow.ts` carried none — it inherited vitest's defaults. #1873 has since given it an explicit array, so the issue's claim is now true by accident rather than by observation.
+2. **The workaround is cheaper than the issue assumes.** #1868 calls an in-pattern fix "possible but ugly … would need to be repeated in all three configs". The measured form is a single brace alternative, and it is *generic* — it tolerates any dot segment rather than hard-coding `.claude`, so it does not encode the harness's directory layout.
+3. **A Windows-specific failure mode was hypothesised and disproved.** `findChangedFiles` ends in `resolve(options.root, file)`, which on Windows appears to yield backslash paths that picomatch 4 (which, unlike v3, does *not* auto-detect Windows) would never match. It does not: vitest bundles `pathe`, so paths stay forward-slashed. The 322-file run at a Windows root is the proof. No platform-specific handling is needed in the configs — but see the test design below, where `path.resolve` *does* yield backslashes and must be normalised.
+
+## Design
+
+### 1. Pattern form
+
+Every trigger becomes `{**/X,**/.*/**/X}`. The first alternative covers a clean root (Windows or posix, including the CI runner path); the second names a dot segment literally, which is the only thing that lets the leading `**` reach past it without `{ dot: true }`.
+
+The trailing `/**` is dropped — the new form matches the target file directly.
+
+| file | triggers today (post-#1873) | count |
+|---|---|---|
+| `vitest.config.ts` | `package.json`, `{vitest,vite}.config.ts`, `src/test/setup.ts`, `openapi.yaml` | 4 |
+| `server/vitest.config.ts` | `package.json`, `{vitest,vite}.config.ts`, `openapi.yaml` | 3 |
+| `server/vitest.config.slow.ts` | `package.json`, `vitest.config.slow.ts` | 2 |
+
+All 9 are rewritten. Nested braces (`{**/{vitest,vite}.config.ts,…}`) are verified during implementation before being committed.
+
+### 2. Tests — extend, do not add
+
+The two files #1873 created are the right home; this change removes their need to work around the bug.
+
+`realFileAsAbsPath` currently returns one synthetic path. It becomes a set of **three root shapes**, each asserted per covered file:
+
+| shape | example | why |
+|---|---|---|
+| synthetic clean | `/repo/package.json` | preserves #1873's existing intent — the CI/production shape |
+| synthetic dotted | `/repo/.claude/worktrees/x/package.json` | **pins ops-33 regardless of where the suite runs.** Essential: in CI the real path is non-dotted, so a dot regression would otherwise pass CI unnoticed |
+| real on-disk | `resolve(REPO_ROOT, rel)`, forward-slash normalised | proves the mechanism works *where this suite is actually executing* — passes from a dotted worktree only once the patterns are dot-tolerant |
+
+The existing `existsSync` guard stays, so a covered file going missing still fails.
+
+The synthetic-root comments in both files are rewritten: they currently describe the dot limitation as accepted, which stops being true.
+
+### 3. Documentation
+
+- CONTRIBUTING.md worktree section: one note that `--changed` was dot-sensitive, that this is now covered by the trigger patterns, and that `npm run wt-new` creates worktrees at `../wt-<slug>` (non-dotted) while harness `isolation: "worktree"` agents land under `.claude/worktrees/`.
+- Config comments updated to name both failure modes rather than only ops-30's.
+
+### 4. Release notes
+
+`docs/release-notes-next.md` (technical register) only. No `RELEASE_NOTES.md` line — nothing a Castwright user sees changes. Stated explicitly in the PR body rather than silently omitted.
+
+## Acceptance
+
+- A `package.json`-only diff selects the full suite from a `.claude/worktrees/…` checkout (measured 0 → 322).
+- The same diff still selects the full suite at a non-dotted root, and a config-only diff still does too (no ops-30 regression).
+- Both server configs behave the same way, including `slow`.
+- The extended tests fail if any trigger loses its dot-tolerant alternative.
+- `npm run verify:fast:branch` green.
+
+## Risks
+
+- **Concurrent session.** PR #1873 touched these exact files and its cleanup deleted an earlier branch and worktree of this work mid-session. Mitigation: commit and push early so the branch survives another prune, and re-check `main` before opening the PR.
+
+## Out of scope
+
+- Reporting upstream to vitest (`{ dot: true }`). Listed as a "consider" on both issues; not a repo change and should not gate this PR — worth a follow-up issue.
+- Moving harness worktrees out of `.claude/` — not repo-controllable.
+- Any change to `verify.yml` or to ops-30's fix.

--- a/docs/superpowers/specs/2026-07-27-force-rerun-triggers-dot-segments-design.md
+++ b/docs/superpowers/specs/2026-07-27-force-rerun-triggers-dot-segments-design.md
@@ -15,13 +15,25 @@ The failure mode is `0 tests found, exit 0` — it reads as success.
 
 ### Measured
 
-`vitest list --changed HEAD` against a single-file dirty tree; vitest 4.1.9, picomatch 4.0.4, Windows:
+`vitest list --changed HEAD` against a single-file dirty tree; vitest 4.1.9, picomatch 4.0.5, Windows.
+
+First pass, taken against `main` @ `0bf1f411` (before #1873 added a test file, so the suite total was 322):
 
 | checkout | dirty file | test files selected |
 |---|---|---|
 | `C:\Claude\Projects\wt-force-rerun-triggers` (non-dotted) | `package.json` | **322** |
 | `…\.claude\worktrees\ops33-probe` (dotted) | `package.json` | **0** |
 | dotted, with the dot-tolerant pattern applied | `package.json` | **322** |
+
+Confirmed afterwards in a **single** dotted checkout with only the configs swapped between `main` @ `7b0cc955` and this branch — the cleaner comparison, since it varies one thing:
+
+| config | `main` | this branch |
+|---|---|---|
+| `vitest.config.ts` | 1 | **323** |
+| `server/vitest.config.ts` | 0 | **446** |
+| `server/vitest.config.slow.ts` | 0 | **10** |
+
+323 is the full frontend suite post-#1873 (`vitest list --filesOnly` → 323). The lone `1` on `main` is the new test file itself, selected via its real import edge to `vitest.config.ts`.
 
 ## Relationship to ops-30 / #1873
 
@@ -52,10 +64,10 @@ The trailing `/**` is dropped — the new form matches the target file directly.
 | file | triggers today (post-#1873) | count |
 |---|---|---|
 | `vitest.config.ts` | `package.json`, `{vitest,vite}.config.ts`, `src/test/setup.ts`, `openapi.yaml` | 4 |
-| `server/vitest.config.ts` | `package.json`, `{vitest,vite}.config.ts`, `openapi.yaml` | 3 |
+| `server/vitest.config.ts` | `package.json`, `{vitest,vite}.config.ts`, `openapi.yaml`, **`vitest.config.slow.ts`** (added, see Amendments #1) | 4 |
 | `server/vitest.config.slow.ts` | `package.json`, `vitest.config.slow.ts` | 2 |
 
-All 9 are rewritten. Nested braces (`{**/{vitest,vite}.config.ts,…}`) are verified during implementation before being committed.
+All 10 are rewritten. Nested braces (`{**/{vitest,vite}.config.ts,…}`) are verified during implementation before being committed.
 
 ### 2. Tests — extend, do not add
 
@@ -93,6 +105,18 @@ The synthetic-root comments in both files are rewritten: they currently describe
 ## Risks
 
 - **Concurrent session.** PR #1873 touched these exact files and its cleanup deleted an earlier branch and worktree of this work mid-session. Mitigation: commit and push early so the branch survives another prune, and re-check `main` before opening the PR.
+
+## Amendments after independent review
+
+The Opus review pass on PR #1879 returned no HIGH/CRITICAL findings and confirmed the core fix and the tests' non-placebo status by mutation. Seven findings were folded in:
+
+1. **`server/vitest.config.ts` gained a `vitest.config.slow.ts` trigger.** The `{vitest,vite}.config.ts` brace never matched `vitest.config.slow.ts`, and nothing else created an edge (`SLOW_FILES` has no importers; the guard test reaches both configs by runtime-computed dynamic import). So a slow-config-only diff selected **zero** tests from the suite that holds its own guard — the guard could have been reverted with CI green. Trigger count is therefore **10**, not 9.
+2. **Both tests now cover `vite.config.ts`.** Narrowing the brace to `vitest.config.ts` previously left every assertion green while dropping coverage for the vite build config. Mutation-verified: 3 cases go red.
+3. **The one-segment bound is now documented** in the config comment, CONTRIBUTING.md and the release notes. Two dot segments still miss — a known bound, and a loud one: the `this checkout` case goes red rather than under-selecting.
+4. **Negative controls use real files** (`src/main.tsx`, `tsconfig.json`, `apps/android/pubspec.yaml`) with their own `existsSync` guards, replacing `src/App.tsx`, which does not exist in this repo. Three shapes instead of one, so a widening to a suffix glob is caught, not just a bare globstar.
+5. **Measured numbers corrected** — see the two tables above; the original single figure conflated a pre-#1873 total with a post-#1873 one. picomatch is 4.0.5, not 4.0.4.
+6. **"every trigger" softened to "every glob trigger".** Vitest appends resolved `setupFiles` as absolute paths, which carry no wildcard and cross dot segments fine, so one implicit trigger always worked. This does not affect the measured zero-selection result — a `package.json`-only diff never touches the setup file.
+7. **`absPathUnder` derives nesting** via `relative(REPO_ROOT, base)` instead of comparing identity against `SERVER_ROOT`, which would have silently re-introduced the earlier finding-11 bug the moment a third base was added.
 
 ## Out of scope
 

--- a/server/src/force-rerun-triggers.test.ts
+++ b/server/src/force-rerun-triggers.test.ts
@@ -27,7 +27,7 @@
 import { describe, it, expect } from 'vitest';
 import picomatch from 'picomatch';
 import { existsSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { relative, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 const SERVER_ROOT = resolve(__dirname, '..');
@@ -76,30 +76,50 @@ const ROOT_SHAPES = [
   { shape: 'this checkout', root: toPosix(REPO_ROOT) },
 ];
 
-/* Confirms `relFromRoot` (relative to `base`) names a real file, then builds
+/* Confirms `relFromBase` (relative to `base`) names a real file, then builds
    the absolute path to check under the given synthetic/real repo root.
 
    The composed path reflects `base`'s real nesting under the repo — finding
-   11 of the ops-30 review: this used to return `/repo/${relFromRoot}`
+   11 of the ops-30 review: this used to return `/repo/${relFromBase}`
    regardless of `base`, so "server package.json" actually asserted against
    `/repo/package.json`, not `/repo/server/package.json`. Every trigger
    starts with a leading globstar segment, so nested paths match in reality
    either way, which is why the bug never failed a test — but the test wasn't
-   proving what its own label claimed. */
-function absPathUnder(root: string, base: string, relFromRoot: string): string {
-  expect(existsSync(resolve(base, relFromRoot))).toBe(true);
-  return base === SERVER_ROOT ? `${root}/server/${relFromRoot}` : `${root}/${relFromRoot}`;
+   proving what its own label claimed.
+
+   The nesting is derived rather than compared against SERVER_ROOT: an
+   identity check re-introduces exactly that bug the moment a third base is
+   added (it would silently fall through to the repo-root branch). */
+function absPathUnder(root: string, base: string, relFromBase: string): string {
+  expect(existsSync(resolve(base, relFromBase))).toBe(true);
+  return [root, toPosix(relative(REPO_ROOT, base)), relFromBase].filter(Boolean).join('/');
 }
 
 const MAIN_COVERED = [
   { rel: 'package.json', file: 'server package.json', base: SERVER_ROOT },
   { rel: 'vitest.config.ts', file: 'this config file', base: SERVER_ROOT },
+  /* The slow config is NOT matched by the `{vitest,vite}.config.ts` brace —
+     it needs its own trigger, and this suite is where its guard lives. */
+  { rel: 'vitest.config.slow.ts', file: 'the slow-tier config', base: SERVER_ROOT },
+  /* Pins the `vite` half of the brace. Without a case for it, narrowing the
+     trigger to `vitest.config.ts` would leave every assertion green while
+     silently dropping coverage for the vite build config. */
+  { rel: 'vite.config.ts', file: 'the vite build config', base: REPO_ROOT },
   { rel: 'openapi.yaml', file: 'the API contract', base: REPO_ROOT },
 ];
 
 const SLOW_COVERED = [
   { rel: 'package.json', file: 'server package.json', base: SERVER_ROOT },
   { rel: 'vitest.config.slow.ts', file: 'this config file', base: SERVER_ROOT },
+];
+
+/* Real files that must NOT match. More than one shape, so widening a dead
+   trigger to something like `**` + a suffix glob is caught rather than only
+   the crudest `**`. */
+const NOT_COVERED = [
+  { rel: 'src/index.ts', file: 'an ordinary server source file', base: SERVER_ROOT },
+  { rel: 'tsconfig.json', file: 'a JSON file that is not a manifest', base: REPO_ROOT },
+  { rel: 'apps/android/pubspec.yaml', file: 'a YAML file that is not the contract', base: REPO_ROOT },
 ];
 
 const crossProduct = (covered: typeof MAIN_COVERED) =>
@@ -116,8 +136,8 @@ describe('server/vitest.config.ts forceRerunTriggers', () => {
   /* Guards against "fixing" a dead trigger by widening it to something that
      matches everything — that would force a full run on every diff and
      quietly undo the point of --changed. */
-  it.each(ROOT_SHAPES)('does not match an ordinary source file from $shape', ({ root }) => {
-    expect(matchesTrigger(mainTriggers, `${root}/server/src/index.ts`)).toBe(false);
+  it.each(crossProduct(NOT_COVERED))('does not match $file from $shape', ({ rel, base, root }) => {
+    expect(matchesTrigger(mainTriggers, absPathUnder(root, base, rel))).toBe(false);
   });
 });
 
@@ -129,7 +149,7 @@ describe('server/vitest.config.slow.ts forceRerunTriggers', () => {
     },
   );
 
-  it.each(ROOT_SHAPES)('does not match an ordinary source file from $shape', ({ root }) => {
-    expect(matchesTrigger(slowTriggers, `${root}/server/src/index.ts`)).toBe(false);
+  it.each(crossProduct(NOT_COVERED))('does not match $file from $shape', ({ rel, base, root }) => {
+    expect(matchesTrigger(slowTriggers, absPathUnder(root, base, rel))).toBe(false);
   });
 });

--- a/server/src/force-rerun-triggers.test.ts
+++ b/server/src/force-rerun-triggers.test.ts
@@ -1,19 +1,29 @@
-/* Regression coverage for ops-30/#1848: vitest's documented default
-   `forceRerunTriggers` entry for config files — a brace-alternation with a
-   wildcarded extension, followed by a trailing wildcard suffix — matches
-   NOTHING under picomatch 4. A wildcard inside that path segment kills the
-   trailing-wildcard-suffix-also-matches-the-file behaviour. verify.yml runs
-   BOTH server/vitest.config.ts and server/vitest.config.slow.ts with
-   `--changed`; the main config re-lists (and previously inherited the dead
-   copy of) vitest's defaults, and the slow config set no override at all —
-   which means it fell back to vitest's own broken default. Either way, a
-   config-only diff could silently select zero tests and merge unexercised.
+/* Regression coverage for the two independent ways these configs'
+   `forceRerunTriggers` have silently matched nothing:
+
+   ops-30/#1848 — vitest's documented default entry for config files (a
+   brace-alternation with a wildcarded extension, followed by a trailing
+   wildcard suffix) matches NOTHING under picomatch 4: a wildcard inside a
+   path segment kills the trailing-wildcard-suffix-also-matches-the-file
+   behaviour. verify.yml runs BOTH server/vitest.config.ts and
+   server/vitest.config.slow.ts with `--changed`; the main config re-listed
+   the dead copy of vitest's defaults, and the slow config set no override at
+   all, so it fell back to vitest's own broken default.
+
+   ops-33/#1868 — picomatch's `**` refuses to cross a dot-prefixed path
+   segment unless `{ dot: true }` is passed, and vitest passes no options
+   when it builds these matchers. Claude-Code-harness worktrees live under
+   `.claude/worktrees/…`, so every entry matched nothing whenever the suite
+   ran from one.
+
+   Either way the consequence is the same and it reads as success: a
+   config-only diff selects zero tests, exits 0, and merges unexercised.
 
    This imports the REAL forceRerunTriggers array from each config module
-   (not a re-declared copy) and checks it against the absolute path of every
-   file that config documents as needing full-rerun coverage — the same
-   shape vitest itself uses when matching. A regression back to the broken
-   glob, or a covered file going missing, fails this test. */
+   (not a re-declared copy) and checks it against every file that config
+   documents as needing full-rerun coverage, at three checkout shapes. A
+   regression to either broken glob, or a covered file going missing, fails
+   this test. */
 import { describe, it, expect } from 'vitest';
 import picomatch from 'picomatch';
 import { existsSync } from 'node:fs';
@@ -42,45 +52,84 @@ function matchesTrigger(triggers: string[], absPath: string): boolean {
   return triggers.some((pattern) => picomatch(pattern)(absPath));
 }
 
-/* Confirms `relFromRoot` (relative to `root`) names a real file, then
-   returns a SYNTHETIC absolute path (fixed `/repo/...` root, forward
-   slashes) for the picomatch check. picomatch's `**` refuses to cross a
-   dot-prefixed path segment (its default `dot: false`) — this checkout
-   happens to live under `.claude/worktrees/...`, so matching the file's
-   REAL on-disk absolute path would spuriously fail here regardless of the
-   trigger patterns. A CI/production checkout has no such dot segment; the
-   synthetic root keeps the assertion about the patterns, not about where
-   this worktree sits.
+/* Vitest normalises to forward slashes (it resolves through `pathe`) before
+   consulting these patterns, but node's `path.resolve` does not. Without
+   this, the real-checkout assertion below would fail on Windows for reasons
+   that have nothing to do with the patterns. */
+const toPosix = (p: string): string => p.replace(/\\/g, '/');
 
-   The synthetic path reflects `root`'s real nesting under the repo (`/repo`
-   for REPO_ROOT, `/repo/server` for SERVER_ROOT) — finding 11 (ops-30
-   review): this used to always return `/repo/${relFromRoot}` regardless of
-   `root`, so "server package.json" actually asserted against
-   `/repo/package.json`, not `/repo/server/package.json`. Both trigger
-   patterns start with a leading globstar segment, so nested paths match in
-   reality either way, which is why the bug never failed a test — but the
-   test wasn't proving what its own label claimed. */
-function realFileAsAbsPath(root: string, relFromRoot: string): string {
-  expect(existsSync(resolve(root, relFromRoot))).toBe(true);
-  const syntheticRoot = root === SERVER_ROOT ? '/repo/server' : '/repo';
-  return `${syntheticRoot}/${relFromRoot}`;
+/* Every covered file is asserted at all three shapes.
+
+   The dot-prefixed shape is the ops-33 pin, and it is REQUIRED even though
+   CI never runs from such a path: without it, dropping the dot-tolerant half
+   of a trigger would pass CI unnoticed and break only on developer machines
+   — which is precisely how #1868 survived as long as it did.
+
+   The real on-disk shape proves the mechanism works where this suite is
+   actually executing, not merely in the abstract. Before #1868 was fixed
+   that assertion could not be made at all: this suite runs from
+   `.claude/worktrees/…` often enough that it would have failed for reasons
+   unrelated to the patterns. */
+const ROOT_SHAPES = [
+  { shape: 'a clean checkout', root: '/repo' },
+  { shape: 'a dot-prefixed checkout', root: '/repo/.claude/worktrees/wt' },
+  { shape: 'this checkout', root: toPosix(REPO_ROOT) },
+];
+
+/* Confirms `relFromRoot` (relative to `base`) names a real file, then builds
+   the absolute path to check under the given synthetic/real repo root.
+
+   The composed path reflects `base`'s real nesting under the repo — finding
+   11 of the ops-30 review: this used to return `/repo/${relFromRoot}`
+   regardless of `base`, so "server package.json" actually asserted against
+   `/repo/package.json`, not `/repo/server/package.json`. Every trigger
+   starts with a leading globstar segment, so nested paths match in reality
+   either way, which is why the bug never failed a test — but the test wasn't
+   proving what its own label claimed. */
+function absPathUnder(root: string, base: string, relFromRoot: string): string {
+  expect(existsSync(resolve(base, relFromRoot))).toBe(true);
+  return base === SERVER_ROOT ? `${root}/server/${relFromRoot}` : `${root}/${relFromRoot}`;
 }
 
+const MAIN_COVERED = [
+  { rel: 'package.json', file: 'server package.json', base: SERVER_ROOT },
+  { rel: 'vitest.config.ts', file: 'this config file', base: SERVER_ROOT },
+  { rel: 'openapi.yaml', file: 'the API contract', base: REPO_ROOT },
+];
+
+const SLOW_COVERED = [
+  { rel: 'package.json', file: 'server package.json', base: SERVER_ROOT },
+  { rel: 'vitest.config.slow.ts', file: 'this config file', base: SERVER_ROOT },
+];
+
+const crossProduct = (covered: typeof MAIN_COVERED) =>
+  covered.flatMap((entry) => ROOT_SHAPES.map((rootShape) => ({ ...entry, ...rootShape })));
+
 describe('server/vitest.config.ts forceRerunTriggers', () => {
-  it.each([
-    { relFromRoot: 'package.json', label: 'server package.json', root: SERVER_ROOT },
-    { relFromRoot: 'vitest.config.ts', label: 'this config file', root: SERVER_ROOT },
-    { relFromRoot: 'openapi.yaml', label: 'the API contract', root: REPO_ROOT },
-  ])('covers $label so a config-only diff still forces a full --changed run', ({ relFromRoot, root }) => {
-    expect(matchesTrigger(mainTriggers, realFileAsAbsPath(root, relFromRoot))).toBe(true);
+  it.each(crossProduct(MAIN_COVERED))(
+    'covers $file from $shape so a config-only diff still forces a full --changed run',
+    ({ rel, base, root }) => {
+      expect(matchesTrigger(mainTriggers, absPathUnder(root, base, rel))).toBe(true);
+    },
+  );
+
+  /* Guards against "fixing" a dead trigger by widening it to something that
+     matches everything — that would force a full run on every diff and
+     quietly undo the point of --changed. */
+  it.each(ROOT_SHAPES)('does not match an ordinary source file from $shape', ({ root }) => {
+    expect(matchesTrigger(mainTriggers, `${root}/server/src/index.ts`)).toBe(false);
   });
 });
 
 describe('server/vitest.config.slow.ts forceRerunTriggers', () => {
-  it.each([
-    { relFromRoot: 'package.json', label: 'server package.json' },
-    { relFromRoot: 'vitest.config.slow.ts', label: 'this config file' },
-  ])('covers $label so a config-only diff still forces a full --changed run', ({ relFromRoot }) => {
-    expect(matchesTrigger(slowTriggers, realFileAsAbsPath(SERVER_ROOT, relFromRoot))).toBe(true);
+  it.each(crossProduct(SLOW_COVERED))(
+    'covers $file from $shape so a config-only diff still forces a full --changed run',
+    ({ rel, base, root }) => {
+      expect(matchesTrigger(slowTriggers, absPathUnder(root, base, rel))).toBe(true);
+    },
+  );
+
+  it.each(ROOT_SHAPES)('does not match an ordinary source file from $shape', ({ root }) => {
+    expect(matchesTrigger(slowTriggers, `${root}/server/src/index.ts`)).toBe(false);
   });
 });

--- a/server/vitest.config.slow.ts
+++ b/server/vitest.config.slow.ts
@@ -73,9 +73,21 @@ export default defineConfig({
        trailing-wildcard-suffix-also-matches-the-file behaviour (ops-30/
        #1848) — so a change to THIS file would silently select zero of the
        slow suite's 10 files. Set explicitly (`.ts` extension, not `.*`) so
-       it, and package.json, still force a full run. Not extended from the
-       main config's list — see the header comment: no mergeConfig, this
-       file stands alone. */
-    forceRerunTriggers: ['**/package.json/**', '**/vitest.config.slow.ts/**'],
+       it, and package.json, still force a full run.
+
+       The second alternative in each entry — the one naming a dot segment
+       explicitly — guards a second, unrelated picomatch failure: the
+       globstar will not cross a dot-prefixed path segment unless
+       `{ dot: true }` is passed, and vitest passes no options when it builds
+       these matchers, so without it every entry dies when the suite runs
+       from a `.claude/worktrees/…` checkout (ops-33/#1868). Full write-up in
+       the root vitest.config.ts.
+
+       Not extended from the main config's list — see the header comment: no
+       mergeConfig, this file stands alone. */
+    forceRerunTriggers: [
+      '{**/package.json,**/.*/**/package.json}',
+      '{**/vitest.config.slow.ts,**/.*/**/vitest.config.slow.ts}',
+    ],
   },
 });

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -83,11 +83,17 @@ export default defineConfig({
     hookTimeout: 30_000,
     /* Setting this key REPLACES vitest's defaults rather than extending them,
        so the first two entries re-list them — same note the root
-       vitest.config.ts has always carried. The config-file entry pins `.ts`
-       (not vitest's own `.*`): under picomatch 4 a wildcard inside that path
-       segment kills the trailing-`/**`-also-matches-the-file behaviour, so
-       vitest's documented default matches NOTHING here and a config-only
-       diff silently selected zero tests — ops-30/#1848. This is load-bearing,
+       vitest.config.ts has always carried. Every entry is a brace
+       alternation of two halves, each guarding a different picomatch
+       failure; the full write-up lives in the root vitest.config.ts. In
+       short: the pinned `.ts` with no trailing globstar suffix is
+       ops-30/#1848 (a wildcard inside a path segment kills the
+       trailing-globstar-also-matches-the-file behaviour, so vitest's own
+       documented default matches NOTHING), and the second alternative — the
+       one naming a dot segment explicitly — is ops-33/#1868 (picomatch's
+       globstar will not cross a dot-prefixed segment without `{ dot: true }`,
+       which vitest never passes, so every entry dies when the suite runs
+       from a `.claude/worktrees/…` checkout). This is load-bearing,
        measured on a clean tree: with them stripped, a root-manifest diff
        makes `cd server && vitest run --changed` report "No test files found"
        and exit 0 — a release-cut version bump would run ZERO server tests
@@ -100,9 +106,9 @@ export default defineConfig({
        `--changed` would otherwise skip the pin on the openapi-only diff it
        exists to catch. */
     forceRerunTriggers: [
-      '**/package.json/**',
-      '**/{vitest,vite}.config.ts/**',
-      '**/openapi.yaml/**',
+      '{**/package.json,**/.*/**/package.json}',
+      '{**/{vitest,vite}.config.ts,**/.*/**/{vitest,vite}.config.ts}',
+      '{**/openapi.yaml,**/.*/**/openapi.yaml}',
     ],
     pool: 'forks',
     /* Vitest 4 removed `poolOptions`; `poolOptions.forks.maxForks` is now the

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -108,6 +108,16 @@ export default defineConfig({
     forceRerunTriggers: [
       '{**/package.json,**/.*/**/package.json}',
       '{**/{vitest,vite}.config.ts,**/.*/**/{vitest,vite}.config.ts}',
+      /* vitest.config.slow.ts needs its OWN entry: the brace above matches
+         `vitest.config.ts`, not `vitest.config.slow.ts`. Without this, a
+         slow-config-only diff selects zero tests from THIS suite — which is
+         where force-rerun-triggers.test.ts lives, so the guard protecting the
+         slow config could itself be reverted with CI green. (The slow config's
+         own trigger does fire, but it selects only the 10 slow files, and the
+         guard is not one of them. Nothing creates a module-graph edge either:
+         SLOW_FILES has no importers, and the guard reaches both configs via a
+         runtime-computed dynamic import that vite cannot record as a dep.) */
+      '{**/vitest.config.slow.ts,**/.*/**/vitest.config.slow.ts}',
       '{**/openapi.yaml,**/.*/**/openapi.yaml}',
     ],
     pool: 'forks',

--- a/src/test/force-rerun-triggers.test.ts
+++ b/src/test/force-rerun-triggers.test.ts
@@ -63,20 +63,33 @@ const ROOT_SHAPES = [
 const COVERED = [
   { rel: 'package.json', file: 'root package.json' },
   { rel: 'vitest.config.ts', file: 'this config file' },
+  /* Pins the `vite` half of the brace. Without a case for it, narrowing the
+     trigger to `vitest.config.ts` would leave every assertion green while
+     silently dropping coverage for the vite build config — plugins, the `@`
+     alias, build options. */
+  { rel: 'vite.config.ts', file: 'the vite build config' },
   { rel: 'src/test/setup.ts', file: 'the injected test-setup file' },
   { rel: 'openapi.yaml', file: 'the API contract' },
 ];
 
-const CASES = COVERED.flatMap((covered) =>
-  ROOT_SHAPES.map((rootShape) => ({ ...covered, ...rootShape })),
-);
+/* Real files that must NOT match. More than one shape, so widening a dead
+   trigger to something like `**` plus a suffix glob is caught rather than
+   only the crudest `**`. */
+const NOT_COVERED = [
+  { rel: 'src/main.tsx', file: 'an ordinary source file' },
+  { rel: 'tsconfig.json', file: 'a JSON file that is not a manifest' },
+  { rel: 'apps/android/pubspec.yaml', file: 'a YAML file that is not the contract' },
+];
+
+const crossProduct = (files: typeof COVERED) =>
+  files.flatMap((entry) => ROOT_SHAPES.map((rootShape) => ({ ...entry, ...rootShape })));
 
 describe('vitest.config.ts forceRerunTriggers', () => {
   it.each(COVERED)('$file is a real file, so the trigger covers something', ({ rel }) => {
     expect(existsSync(resolve(REPO_ROOT, rel))).toBe(true);
   });
 
-  it.each(CASES)(
+  it.each(crossProduct(COVERED))(
     'covers $file from $shape so a config-only diff still forces a full --changed run',
     ({ rel, root }) => {
       expect(matchesTrigger(`${root}/${rel}`)).toBe(true);
@@ -86,7 +99,11 @@ describe('vitest.config.ts forceRerunTriggers', () => {
   /* Guards against "fixing" a dead trigger by widening it to something that
      matches everything — that would force a full run on every diff and
      quietly undo the point of --changed. */
-  it.each(ROOT_SHAPES)('does not match an ordinary source file from $shape', ({ root }) => {
-    expect(matchesTrigger(`${root}/src/App.tsx`)).toBe(false);
+  it.each(NOT_COVERED)('$file is a real file, so the negative control is honest', ({ rel }) => {
+    expect(existsSync(resolve(REPO_ROOT, rel))).toBe(true);
+  });
+
+  it.each(crossProduct(NOT_COVERED))('does not match $file from $shape', ({ rel, root }) => {
+    expect(matchesTrigger(`${root}/${rel}`)).toBe(false);
   });
 });

--- a/src/test/force-rerun-triggers.test.ts
+++ b/src/test/force-rerun-triggers.test.ts
@@ -1,19 +1,28 @@
-/* Regression coverage for ops-30/#1848: vitest's documented default
-   `forceRerunTriggers` entry for config files — a brace-alternation with a
-   wildcarded extension, followed by a trailing wildcard suffix — matches
-   NOTHING under picomatch 4. A wildcard inside that path segment kills the
-   trailing-wildcard-suffix-also-matches-the-file behaviour. Both
-   vitest.config.ts and server/vitest.config.ts re-list vitest's defaults
-   (setting forceRerunTriggers replaces rather than extends them), so both
-   silently inherited the dead pattern. Consequence: `vitest run --changed
-   <base>` (verify.yml) selected ZERO tests for a config-only diff, which
-   could merge without exercising the change.
+/* Regression coverage for the two independent ways this suite's
+   `forceRerunTriggers` have silently matched nothing:
+
+   ops-30/#1848 — vitest's documented default entry for config files (a
+   brace-alternation with a wildcarded extension, followed by a trailing
+   wildcard suffix) matches NOTHING under picomatch 4: a wildcard inside a
+   path segment kills the trailing-wildcard-suffix-also-matches-the-file
+   behaviour. Both vitest.config.ts and server/vitest.config.ts re-list
+   vitest's defaults (setting forceRerunTriggers replaces rather than extends
+   them), so both silently inherited the dead pattern.
+
+   ops-33/#1868 — picomatch's `**` refuses to cross a dot-prefixed path
+   segment unless `{ dot: true }` is passed, and vitest passes no options
+   when it builds these matchers. Claude-Code-harness worktrees live under
+   `.claude/worktrees/…`, so every entry matched nothing whenever the suite
+   ran from one.
+
+   Either way the consequence is the same and it reads as success:
+   `vitest run --changed <base>` (verify.yml) selects ZERO tests and exits 0,
+   so the change merges without being exercised.
 
    This imports the REAL forceRerunTriggers array (not a re-declared copy)
-   and checks it against the absolute path of every file this suite's config
-   documents as needing full-rerun coverage — the same shape vitest itself
-   uses when matching. A regression back to the broken glob, or a covered
-   file going missing, fails this test. */
+   and checks it against every file this suite's config documents as needing
+   full-rerun coverage, at three checkout shapes. A regression to either
+   broken glob, or a covered file going missing, fails this test. */
 import { describe, it, expect } from 'vitest';
 import picomatch from 'picomatch';
 import { existsSync } from 'node:fs';
@@ -27,26 +36,57 @@ function matchesTrigger(absPath: string): boolean {
   return triggers.some((pattern) => picomatch(pattern)(absPath));
 }
 
-/* Confirms `relFromRoot` names a real file, then returns a SYNTHETIC
-   absolute path (fixed `/repo/...` root, forward slashes) for the picomatch
-   check. picomatch's `**` refuses to cross a dot-prefixed path segment
-   (its default `dot: false`) — this checkout happens to live under
-   `.claude/worktrees/...`, so matching the file's REAL on-disk absolute
-   path would spuriously fail here regardless of the trigger patterns. A
-   CI/production checkout has no such dot segment; the synthetic root keeps
-   the assertion about the patterns, not about where this worktree sits. */
-function realFileAsAbsPath(relFromRoot: string): string {
-  expect(existsSync(resolve(REPO_ROOT, relFromRoot))).toBe(true);
-  return `/repo/${relFromRoot}`;
-}
+/* Vitest normalises to forward slashes (it resolves through `pathe`) before
+   consulting these patterns, but node's `path.resolve` does not. Without
+   this, the real-checkout assertion below would fail on Windows for reasons
+   that have nothing to do with the patterns. */
+const toPosix = (p: string): string => p.replace(/\\/g, '/');
+
+/* Every covered file is asserted at all three shapes.
+
+   The dot-prefixed shape is the ops-33 pin, and it is REQUIRED even though
+   CI never runs from such a path: without it, dropping the dot-tolerant half
+   of a trigger would pass CI unnoticed and break only on developer machines
+   — which is precisely how #1868 survived as long as it did.
+
+   The real on-disk shape proves the mechanism works where this suite is
+   actually executing, not merely in the abstract. Before #1868 was fixed
+   that assertion could not be made at all: this suite runs from
+   `.claude/worktrees/…` often enough that it would have failed for reasons
+   unrelated to the patterns. */
+const ROOT_SHAPES = [
+  { shape: 'a clean checkout', root: '/repo' },
+  { shape: 'a dot-prefixed checkout', root: '/repo/.claude/worktrees/wt' },
+  { shape: 'this checkout', root: toPosix(REPO_ROOT) },
+];
+
+const COVERED = [
+  { rel: 'package.json', file: 'root package.json' },
+  { rel: 'vitest.config.ts', file: 'this config file' },
+  { rel: 'src/test/setup.ts', file: 'the injected test-setup file' },
+  { rel: 'openapi.yaml', file: 'the API contract' },
+];
+
+const CASES = COVERED.flatMap((covered) =>
+  ROOT_SHAPES.map((rootShape) => ({ ...covered, ...rootShape })),
+);
 
 describe('vitest.config.ts forceRerunTriggers', () => {
-  it.each([
-    { relFromRoot: 'package.json', label: 'root package.json' },
-    { relFromRoot: 'vitest.config.ts', label: 'this config file' },
-    { relFromRoot: 'src/test/setup.ts', label: 'the injected test-setup file' },
-    { relFromRoot: 'openapi.yaml', label: 'the API contract' },
-  ])('covers $label so a config-only diff still forces a full --changed run', ({ relFromRoot }) => {
-    expect(matchesTrigger(realFileAsAbsPath(relFromRoot))).toBe(true);
+  it.each(COVERED)('$file is a real file, so the trigger covers something', ({ rel }) => {
+    expect(existsSync(resolve(REPO_ROOT, rel))).toBe(true);
+  });
+
+  it.each(CASES)(
+    'covers $file from $shape so a config-only diff still forces a full --changed run',
+    ({ rel, root }) => {
+      expect(matchesTrigger(`${root}/${rel}`)).toBe(true);
+    },
+  );
+
+  /* Guards against "fixing" a dead trigger by widening it to something that
+     matches everything — that would force a full run on every diff and
+     quietly undo the point of --changed. */
+  it.each(ROOT_SHAPES)('does not match an ordinary source file from $shape', ({ root }) => {
+    expect(matchesTrigger(`${root}/src/App.tsx`)).toBe(false);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -34,18 +34,34 @@ export default defineConfig({
        setup change forces a FULL run. The first two entries below are vitest's
        built-in defaults (package.json + the vite/vitest config files) — they
        must be re-listed because setting this key replaces the defaults rather
-       than extending them. The config-file entry pins the extension to `.ts`
-       (not vitest's own `.*`): under picomatch 4 a wildcard inside that path
-       segment kills the trailing-`/**`-also-matches-the-file behaviour, so
-       vitest's documented default matches NOTHING here and a config-only diff
-       silently selected zero tests — ops-30/#1848.
+       than extending them.
+
+       Every entry is a brace alternation of two halves, each load-bearing
+       against a DIFFERENT picomatch failure. (The globs are spelled out in
+       the array below rather than quoted here: a comment cannot contain a
+       star immediately followed by a slash without ending itself.)
+
+         1. The extension is pinned to `.ts`, and no entry carries a trailing
+            globstar suffix. Under picomatch 4 a wildcard inside a path
+            segment kills the trailing-globstar-also-matches-the-file
+            behaviour, so vitest's own documented config-file default matches
+            NOTHING and a config-only diff silently selected zero tests —
+            ops-30/#1848.
+         2. The second alternative in each entry names a dot segment
+            explicitly. picomatch's globstar refuses to cross a dot-prefixed
+            path segment unless `{ dot: true }` is passed, and vitest passes
+            no options when it builds these matchers. Claude-Code-harness
+            worktrees live under `.claude/worktrees/…`, so without that half
+            EVERY entry matches nothing when the suite runs from one —
+            silently, as "0 tests found, exit 0" — ops-33/#1868.
+
        Shared fixtures/mocks need NO entry: tests import them statically, so
        the module graph already covers them.
        See docs/features/118-ci-cost-round-2.md. */
     forceRerunTriggers: [
-      '**/package.json/**',
-      '**/{vitest,vite}.config.ts/**',
-      '**/src/test/setup.ts',
+      '{**/package.json,**/.*/**/package.json}',
+      '{**/{vitest,vite}.config.ts,**/.*/**/{vitest,vite}.config.ts}',
+      '{**/src/test/setup.ts,**/.*/**/src/test/setup.ts}',
       /* Tests that pin a value against the contract (e.g. the clone-transcript
          cap in api.clone-voice.test.ts) read openapi.yaml at RUNTIME, so they
          have no module-graph edge to it and `vitest --changed` — which CI uses
@@ -53,7 +69,7 @@ export default defineConfig({
          the drift they exist to catch. Every api-types import is `import
          type`, erased at transform time, so regenerating the types doesn't
          create an edge either. */
-      '**/openapi.yaml/**',
+      '{**/openapi.yaml,**/.*/**/openapi.yaml}',
     ],
     /* One retry to absorb transient jsdom/timer flakes inside a single
        verify run instead of forcing a full pre-push re-execution. See

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -52,8 +52,18 @@ export default defineConfig({
             path segment unless `{ dot: true }` is passed, and vitest passes
             no options when it builds these matchers. Claude-Code-harness
             worktrees live under `.claude/worktrees/…`, so without that half
-            EVERY entry matches nothing when the suite runs from one —
-            silently, as "0 tests found, exit 0" — ops-33/#1868.
+            every glob entry here matches nothing when the suite runs from
+            one — silently, as "0 tests found, exit 0" — ops-33/#1868.
+            (Vitest also appends resolved `setupFiles` as ABSOLUTE paths,
+            which carry no wildcard and so cross dot segments regardless;
+            that one implicit trigger was never affected.)
+
+            The tolerance is exactly ONE dot segment deep — a path with two,
+            e.g. a dotted checkout nested under a dotted parent, still misses.
+            That is a known bound, not an oversight: no such path exists here,
+            and if one ever did, the `this checkout` case in
+            src/test/force-rerun-triggers.test.ts goes RED rather than
+            under-selecting silently.
 
        Shared fixtures/mocks need NO entry: tests import them statically, so
        the module graph already covers them.


### PR DESCRIPTION
## Summary

picomatch's globstar refuses to cross a **dot-prefixed path segment** unless `{ dot: true }` is passed, and vitest passes no options when it builds its `forceRerunTriggers` matchers — `cli-api…js:11495` for `--changed`, `:12916` for watch. Agent worktrees live under `.claude/worktrees/…`, so from one, every **glob** trigger matched nothing and `npx vitest run --changed <base>` selected zero tests. The failure mode is `0 tests found, exit 0`, which reads as success.

All 10 triggers across `vitest.config.ts`, `server/vitest.config.ts` and `server/vitest.config.slow.ts` now carry an explicit dot-segment alternative — `{**/X,<dot-segment alternative>}`. The trailing `/**` suffix is dropped everywhere, so the form is now identical for literal and wildcard-bearing segments.

**CI was never affected.** GitHub runners check out to `/home/runner/work/Castwright/Castwright`, which has no dot segment, and `verify.yml` holds the repo's only three `--changed` invocations (lines 261, 300, 301). The cost landed entirely on local verification — which is where essentially all non-trivial work in this repo happens, per CLAUDE.md "Parallel agents".

This bug cost real time twice before being fixed: once in #1848, where it produced the same "No test files found" symptom as the bug under investigation and forced the measurement to be taken from a throwaway non-dotted checkout; and again in #1873, whose own trigger tests hit it and had to route around it with a synthetic root.

### Relationship to ops-30 / #1873

ops-30 (#1848) was a *different* defect in the same arrays — a wildcard-bearing segment followed by `/**` matches nothing anywhere. It was fixed by #1873 and is not revisited here; this PR layers dot-tolerance on top of that work and extends the two test files #1873 created rather than adding new ones.

### Corrections to the issue's premises

- #1868's "Key files" listed three configs carrying `forceRerunTriggers`; at filing time `server/vitest.config.slow.ts` carried none and inherited vitest's defaults. #1873 has since given it an explicit array.
- #1868 called an in-pattern fix "possible but ugly … repeated in all three configs". The measured form is a single brace alternative and is generic — it tolerates any dot segment rather than hard-coding `.claude`.
- A Windows-specific failure was hypothesised and **disproved**: `findChangedFiles` ends in `resolve(root, file)`, which looks like it yields backslash paths picomatch 4 would never match (unlike v3 it does not auto-detect Windows). It does not — vitest resolves through `pathe`, so paths stay forward-slashed. This *does* bite in the tests, where `path.resolve` is the real node one, hence the explicit normalisation there.

### Upstream

Reported as vitest-dev/vitest#10835, discharging the third acceptance box. Note this is **not** the ops-30 default-pattern problem — that was already reported as vitest-dev/vitest#10421 and fixed by vitest-dev/vitest#10420 (merged 2026-05-23); our installed 4.1.9 still ships the old form. The dot bug survives that fix regardless.

## Test plan

Both existing trigger tests gain a **three-shape matrix** — clean checkout, dot-prefixed checkout, and the real on-disk path (forward-slash normalised) — plus negative controls over three real files so a dead trigger can't be "fixed" by widening it to match everything. **40 → 71 cases.**

The synthetic dotted shape is load-bearing: CI always runs from a clean path, so a regression dropping the dot-tolerant half would otherwise pass CI unnoticed and break only on developer machines — exactly how #1868 survived.

**Not placebos** — each guard was mutation-tested, and each reddens only its own cases:

| mutation | result |
|---|---|
| revert a trigger to `'**/package.json/**'` | 1 red (`'root package.json'` from `'a dot-prefixed checkout'`), 18 green |
| narrow the brace to `vitest.config.ts` (drop `vite`) | 3 red — all `'the vite build config'` shapes |
| remove the new `vitest.config.slow.ts` trigger | 3 red — all `'the slow-tier config'` shapes |
| widen a trigger to `**` | red (negative controls) |

**End-to-end**, `vitest list --changed HEAD` on an identical `package.json`-only diff, measured in one real `.claude/worktrees/…` checkout with the configs swapped between `main` and this branch:

| config | `main` | this branch |
|---|---|---|
| `vitest.config.ts` | 1 | **323** |
| `server/vitest.config.ts` | 0 | **446** |
| `server/vitest.config.slow.ts` | 0 | **10** |

(The lone `1` on `main` is the new test file itself, pulled in by its real import edge to `vitest.config.ts`.)

Also verified from a non-dotted checkout that a `package.json`-only diff and a config-only diff each still select the full suite — no ops-30 regression.

- `npm run test` / `npm run test:server` — green (5464 server tests via the pre-commit gate)
- `npm run typecheck`, `npm run lint`, `npm run build` — re-run **uncached**, all green
- `npm run verify:fast:branch` — exit 0

## Independent review

An Opus review pass ran on the full branch diff before merge (the `code-review` skill is not model-invocable, so a subagent was substituted). **No HIGH or CRITICAL findings**; it confirmed the core fix by replaying the matching empirically and confirmed the tests are not placebos by mutation. Seven findings were folded in as a second commit — all gaps in the *guard*, not the fix:

1. **`server/vitest.config.ts` gained a `vitest.config.slow.ts` trigger** (the most consequential). The `{vitest,vite}.config.ts` brace never matched `vitest.config.slow.ts`, and nothing else created an edge — `SLOW_FILES` has no importers, and the guard test reaches both configs by runtime-computed dynamic import. So a slow-config-only diff selected **zero** tests from the very suite that holds its guard: the guard could have been reverted with CI green. Verified before fixing.
2. **Both tests now cover `vite.config.ts`** — narrowing the brace previously left every assertion green while dropping coverage for the vite build config.
3. **The one-segment dot bound is documented.** Two dot segments still miss. Known bound, and a loud one — the `this checkout` case goes red there rather than under-selecting silently.
4. **Negative controls use real files** with their own `existsSync` guards, replacing `src/App.tsx`, which does not exist in this repo.
5. **Measured numbers corrected** — the original single figure conflated a pre-#1873 suite total with a post-#1873 one; picomatch is 4.0.5, not 4.0.4.
6. **"every trigger" softened to "every glob trigger"** — vitest appends resolved `setupFiles` as absolute paths, which carry no wildcard and cross dot segments fine, so one implicit trigger always worked. Does not affect the measured zero-selection result.
7. **`absPathUnder` derives nesting** via `relative(REPO_ROOT, base)` rather than an identity check against `SERVER_ROOT`, which would have re-introduced the earlier finding-11 bug the moment a third base was added.

## Notes

Release notes: `docs/release-notes-next.md` only (technical register). No `RELEASE_NOTES.md` line — nothing a Castwright user sees changes. Called out here rather than silently omitted, per the Before-shipping checklist.

No on-box acceptance is owed: this is pure test-selection tooling with no hardware surface, and the behaviour is proven by direct measurement above.

Design of record: `docs/superpowers/specs/2026-07-27-force-rerun-triggers-dot-segments-design.md`.

Closes #1868
