### PR TITLE
docs(docs): register E7 and fill plan 269 ship notes

### DIFF
--- a/docs/features/269-ffmpeg-version-floor.md
+++ b/docs/features/269-ffmpeg-version-floor.md
@@ -206,4 +206,26 @@ Requires a box where ffmpeg can be swapped — see the on-box register row.
 
 ## Ship notes
 
-_Pending._
+**Shipped 2026-07-27** in [#1881](https://github.com/dudarenok-maker/Castwright/pull/1881),
+merge commit `c7ceee9b`.
+
+`status:` stays **`active`**, not `stable` — the plan does **not** move to
+`archive/` yet, because its on-box acceptance
+([register row E6](../testing/onbox-acceptance-register.md)) is still owed.
+Every assertion this plan ships drives a **mocked `spawnSync`**; no test has
+met a real ffmpeg binary of any version. Per the Before-shipping checklist, a
+row comes out only when the acceptance was actually run on the box, or the repo
+owner confirms it was exercised for real — "tests pass, so it's presumably
+fine" never removes it.
+
+Post-merge steps completed: `npm run wiki:sync` ran 2026-07-28 (0 added, 48
+changed, 0 removed) and the published
+[Installing Castwright](https://github.com/dudarenok-maker/Castwright/wiki/Installing-Castwright)
+page was verified to show "ffmpeg 6.0 or newer on PATH" and "validated on
+Ubuntu 24.04+". Until that ran, the wizard's outdated-ffmpeg card linked to a
+page that still said only "ffmpeg on PATH" with no floor.
+
+Deferred by design: [#1880](https://github.com/dudarenok-maker/Castwright/issues/1880)
+(ops-36) — the golden-audio assembly tier asserts a 20-LU loudness band and
+fixture-derived durations, not output bytes, so the ffmpeg version stamp #1877
+asked about would have implied a comparison that test does not make.

--- a/docs/features/270-openapi-setup-surface.md
+++ b/docs/features/270-openapi-setup-surface.md
@@ -163,6 +163,12 @@ by an `it.each(['detecting', 'bootstrapping'])` regression test.
 This is the single best illustration of why the issue was worth doing: the
 drift was invisible, tested, and shipping.
 
+**On-box acceptance owed** — [register row E7](../testing/onbox-acceptance-register.md).
+The regression test pins the card, but it mocks `fetch`; no automated test has
+ever driven this component from a real bootstrap job, which is exactly how the
+bug survived. Proving the fix needs a box with no venv and the patience for a
+~2 GB, multi-minute install — the duration is the point.
+
 ## Known limitations
 
 - **The route-coverage assertion is a literal, not derived from the routers.**

--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -512,6 +512,50 @@ Expect the documented one-update lag — a user updating *from* a pre-ops-35 rel
 their old `update.js`, so the constraint applies from the update *after* that. That is not
 a bug to report.
 
+**Why every step above is owed:** all of ops-35's automated coverage drives the floor through
+a **mocked `spawnSync`** (`server/src/diagnostics/ffmpeg.test.ts` stubs `node:child_process`;
+`scripts/tests/ffmpeg-version.test.mjs` feeds the parser canned banner strings). Not one
+assertion has met a real ffmpeg binary of any version. The parser is well covered against a
+corpus of real-world banner shapes, but "the preflight exits 1 on a genuinely old build" and
+"Re-check re-probes a genuinely upgraded one" are both unproven.
+
+---
+
+### E7 · fe-57 venv-bootstrap progress card — the fix nothing automated can prove ([#1883](https://github.com/dudarenok-maker/Castwright/issues/1883), plan [270](../features/270-openapi-setup-surface.md))
+
+`src/components/venv-bootstrap.tsx` declared `status: 'installing'` — a value
+`server/src/tts/venv-bootstrap.ts` **never emits** (its states are `detecting` /
+`bootstrapping` / `installed` / `error`; `'installing'` is the sibling ollama/coqui/kokoro
+vocabulary, copied here by mistake). So the in-progress branch was dead in production: through
+a real multi-minute venv bootstrap the card never rendered and the user saw the idle
+"Set up the voice engine runtime" button the whole time. **The suite stayed green because the
+component's own tests mocked `'installing'` too** — a placebo over a wire value the server
+cannot produce.
+
+The fix is now typed against the generated contract, so that class of drift is a compile
+error, and an `it.each(['detecting','bootstrapping'])` regression pins the card. **But every
+one of those tests mocks `fetch`.** No automated test has ever driven this component from a
+real bootstrap job, which is precisely how the bug survived in the first place.
+
+Needs a box with **no** `server/tts-sidecar/.venv` (delete it, or a fresh clone). Any machine,
+no GPU. ~2 GB download, several minutes — that duration is the point.
+
+Observe:
+
+1. Setup Wizard → voice-engine step with the venv absent → the "Set up the voice engine
+   runtime" button.
+2. Click it. **Within ~1.5 s the progress card must appear** — spinner, "Setting up the voice
+   engine runtime…", and a live `job.step` line. Before this fix, nothing happened here.
+3. Watch the step text **change** as the job advances (`Starting venv bootstrap…` → pip
+   output). This proves the poll loop and the card are wired to the same job, not just that a
+   card rendered once.
+4. Let it finish → the green "Voice engine runtime ready" card, and `onBootstrapped` refetches
+   so the parent's status flips without a reload.
+5. **The `detecting` window is brief** — if you miss it, that is fine; step 2 covers the
+   pre-terminal render. Do not report a missed `detecting` frame as a failure.
+6. Failure path, if cheap to induce (e.g. no Python 3.12 on PATH): the red "Setup failed" card
+   with the server's message, and a working "Try again".
+
 ---
 
 ## Group F — a real Android device


### PR DESCRIPTION
## Summary

Follow-through owed by #1881 (ops-35) and #1897 (fe-57). Docs only — no runtime surface.

**New register row E7 — a gap #1897 left.** That PR fixed a user-visible bug (the venv-bootstrap progress card was dead in production: `venv-bootstrap.tsx` checked for `status: 'installing'`, which `venv-bootstrap.ts` never emits) and added **no on-box row**, which Before-shipping step 3 requires. The regression test pins the card but mocks `fetch` — nothing automated has ever driven that component from a real bootstrap job, which is exactly how the bug survived tested and green. E7 says what to observe: the card must appear within ~1.5 s of the click, and the step text must *change* as the job advances — that proves the poll loop and the card share a job, rather than that a card rendered once.

**E6 now states why it's owed**, rather than leaving it to be inferred: every ffmpeg-floor assertion drives a **mocked `spawnSync`** (`ffmpeg.test.ts` stubs `node:child_process`; `ffmpeg-version.test.mjs` feeds canned banner strings). The parser is well covered against real-world banner shapes, but *"preflight exits 1 on a genuinely old build"* and *"Re-check re-probes a genuinely upgraded one"* are both unproven.

**Plan 269 Ship notes filled** — shipped 2026-07-27 in #1881, merge `c7ceee9b`. `status:` stays **`active`** and it does **not** move to `archive/`: E6 is still owed, and per the checklist a row comes out only when the acceptance is actually run or the repo owner confirms it was exercised for real — never because tests pass. Also records the completed `npm run wiki:sync` (0 added / 48 changed / 0 removed, published page verified to show the 6.0 floor and Ubuntu 24.04+) and the deliberately deferred #1880.

## Test plan

Docs-only — no tests apply, and per CONTRIBUTING.md's doc-only fast-path every `verify.yml` leg's scope condition is false, so the battery completes green without running anything.

Verified by inspection: E7 renders as its own `### E7 ·` heading under Group E; plan 270 links to it; plan 269's Ship notes cite the real merge SHA (`c7ceee9b`) and the real wiki-sync result.

No release-notes entry — this is process bookkeeping with no shippable delta, which the Before-shipping checklist allows when stated rather than silently omitted.

Refs #1877, #1883
