### PR TITLE
docs(docs): correct the acceptance register's glance table and resync the artifact

### DIFF
--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -71,13 +71,13 @@ setup rather than repeatedly loading and evicting models.
 | **B** | Local Ollama analyzer only, no TTS sidecar | 2 |
 | **C** | One *Ночной дозор* re-analysis session | 3 |
 | **D** | Multi-language TTS render + ASR | 2 |
-| **E** | Not the GPU box (a phone, a Mac, a browser) | 5 |
+| **E** | Not the GPU box (a phone, a Mac, a browser) | 7 |
 | **F** | A real Android device, optionally + a head unit | 1 |
 | **G** | GitHub Actions itself (no physical hardware — the runner IS the prerequisite) | 1 |
 | — | **Blocked** (hardware absent) | 1 |
 | — | **Unconfirmed** (not debts until substantiated) | 2 |
 
-**31 owed.** Oldest: **2026-06-01** (plans 160, 161, 165).
+**35 owed.** Oldest: **2026-06-01** (plans 160, 161, 165).
 
 ---
 


### PR DESCRIPTION
## Summary

First exercise of the acceptance-recording gate added in #1902 — and it found
drift on both surfaces immediately.

**The markdown's own glance table disagreed with its body.** Group E listed 5
rows against a body containing 7 (E6 ffmpeg floor and E7 venv-bootstrap were
appended without updating the table), and the total read **31 owed** against a
body totalling **35** (A19 + B2 + C3 + D2 + E7 + F1 + G1). A19 and G1 had made
it into the table but not the sum. Both numbers are mechanically derivable from
the body, so this is a correction, not a judgement call.

**The HTML twin was further behind still** — 18 rows in group A, no group G at
all, and no E6/E7. It has been republished **to its existing URL**
(`adf22b7b-…`, the one now pinned in the register's header) rather than
re-published fresh, with the derived stat strip recomputed: 35 owed, 7 groups,
oldest debt 06-01.

Content that had never reached the artifact and now does: the **E1 Pinokio Node-pin
one-update lag** (a tester seeing the bundled Node version after the first Update
has found documented behaviour, not a defect), the **E6 shadowed-`PATH` trap** the
upgrade hint exists to pre-empt, the **E7 placebo-test note** (the suite stayed
green because the component's tests mocked a wire value the server cannot emit),
and the **G1 caveat** that its second debt does not strictly require the Actions
runner.

## Test plan

Docs-only; no runtime surface.

- Recounted the body directly: A1–A19 (19), B1–B2, C1–C3, D1–D2, E1–E7 (7), F1,
  G1 → **35**, matching the corrected total
- Verified the artifact republished to the **same UUID** rather than minting a new
  one, and that its group counts, stat strip and row set now match the markdown
- Verified every group anchor in the artifact's glance table resolves

**Checklist steps not applicable:** (1) no regression plan — this file *is* the
record; (2) no paired test — no behaviour; (3) this PR *is* the step-3 bookkeeping;
(5) release notes skipped, internal doc accuracy with no user- or operator-visible
delta; (10) `code-review` gate — docs-only PRs are exempt per Model routing.

## Note

No acceptance was *run* here and no row was discharged — this only corrects how
the existing debt is counted and displayed. All 35 rows remain owed.

Closes #1903
