### PR TITLE
docs(docs): stop recommending .LinkTarget, which is empty on PowerShell 5.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -725,11 +725,14 @@ invalid commit messages sail through, pre-push verify never fires. In that case:
    checkout — the cheap alternative to installing. Frontend tooling resolves via
    root alone, so `server/` is easy to forget and fails the server test legs
    with "vitest not found".
-3. **Verify both.** `ls -d .husky/_ && git config core.hooksPath`, and
-   `fsutil reparsepoint query <link>` (or `(Get-Item $p -Force).LinkTarget`) for
-   each junction — a relative `..` target resolves against the shell's CWD at
-   creation time, not the link's own directory, so an off-by-one silently points
-   at nothing while `ls` still looks plausible.
+3. **Verify both.** `ls -d .husky/_ && git config core.hooksPath`, and for each
+   junction `(Get-Item $p -Force).Target` — a relative `..` target resolves
+   against the shell's CWD at creation time, not the link's own directory, so an
+   off-by-one silently points at nothing while `ls` still looks plausible.
+   **Do not use `.LinkTarget`:** it is PowerShell 6.2+, and on this box's Windows
+   PowerShell 5.1 it reads as empty for a real junction — a check written against
+   it passes vacuously and proves nothing. `.Target` works on both; so does
+   `fsutil reparsepoint query <link>`.
 4. **Never treat hook output as proof of verification in a worktree.** Hook
    output has been observed looking entirely genuine — real timings, real test
    counts — while gating nothing. If it matters, run
@@ -741,10 +744,14 @@ Drop the reparse points **first**, then remove the worktree — `git worktree
 remove` / `Remove-Item -Recurse` can follow a junction and delete the *real*
 `node_modules` in the primary checkout. Use
 `[System.IO.Directory]::Delete($p, $false)` or `(Get-Item $j -Force).Delete()`;
-both remove the link only. `cmd /c rmdir` from the Bash tool **silently no-ops
-and returns 0**, so verify removal with `Test-Path` on both the junction and its
-target rather than trusting an exit code. If a path was converted to a real
-directory by an `npm install`, that one needs `Remove-Item -Recurse -Force`.
+both remove the link only. Gate that on
+`$i.Attributes -band [IO.FileAttributes]::ReparsePoint` — **not** on
+`.LinkTarget`, which is empty on Windows PowerShell 5.1 even for a real junction,
+so the guard skips the delete and the junction survives the teardown. A path
+converted to a real directory by an `npm install` needs
+`Remove-Item -Recurse -Force` instead. `cmd /c rmdir` from the Bash tool
+**silently no-ops and returns 0**, so verify removal with `Test-Path` on both the
+junction and its target rather than trusting an exit code.
 
 ### The two carve-outs
 


### PR DESCRIPTION
## Summary

Found while tearing down the #1902 worktree — the guidance #1902 itself added
does not work on this box's shell.

`(Get-Item $p -Force).LinkTarget` is **PowerShell 6.2+**. On Windows PowerShell
5.1 it reads as an empty string for a genuine junction, so both places the
worktree docs used it were broken:

- **Verification** — "verify the junction resolves with `.LinkTarget`" passes
  vacuously and proves nothing about the link.
- **Teardown** — the guard `if (LinkTarget) { [IO.Directory]::Delete($p,$false) }`
  never fires. The junction survives a teardown that prints no error and reports
  success. This actually happened: after `git worktree remove --force` the
  worktree was deregistered from `git worktree list` while the directory *and*
  the junction were both still on disk. Only a follow-up `Test-Path` caught it.

Verified empirically on the same junction:

```
LinkTarget (PS5.1): ''
Target:              C:\Claude\Projects\Audiobook-Generator\node_modules
IsReparsePoint:      True
```

So: `.Target` to read the destination, `$i.Attributes -band [IO.FileAttributes]::ReparsePoint`
to gate the delete. Both work on 5.1 and 7.x. `fsutil reparsepoint query` was
already correct and stays.

The teardown paragraph also now says plainly what a skipped delete costs — a
junction left pointing into the primary checkout is precisely the state the
junction-first rule exists to prevent.

## Test plan

Docs-only; no runtime surface.

- Reproduced the failure on a real junction created by this session and confirmed
  the three-way reading above
- Confirmed the corrected recipe (`ReparsePoint` gate → `[IO.Directory]::Delete`)
  removed the link, left the primary checkout's `node_modules` intact
  (`Test-Path node_modules/husky/package.json` → True), and allowed the worktree
  directory to be removed

**Checklist steps not applicable:** (1) no regression plan — `CLAUDE.md` is the
record; (2) no paired test — no runtime surface to test; (3) no on-box acceptance;
(5) release notes skipped, internal process doc with no user- or operator-visible
delta; (10) `code-review` gate — docs-only PRs are exempt per Model routing.

Closes #1905
