### PR TITLE
docs(docs): correct two inaccurate claims in the ops-40 rule set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,8 +141,11 @@ thread pollutes both. The issue-comment handoff lets an implementation thread
 ### The trivial bar
 
 **One definition, three uses.** Clearing this bar is what lets a change skip the
-worktree + branch, skip the subagent, and skip the design thread. Nothing else
-does.
+worktree, skip the subagent, and skip the design thread. Nothing else does.
+
+Clearing it skips the worktree, the subagent, and the design thread — it does
+**not** skip the branch or the PR, which `main`'s required status checks make
+unavoidable for every change (see Branching workflow → The two carve-outs).
 
 A change is trivial when **nothing can break and nothing needs review**:
 
@@ -179,8 +182,9 @@ opportunistically fix.** Judgement stays in the main thread:
    narrowly scoped: one finding, one fix, one paired test, briefed from the
    report. Not "and while you're there."
 4. **Doesn't clear it → file it** and move on: a GitHub issue in the same round,
-   plus the thin `docs/BACKLOG.md` row, per "The backlog". A finding parked only
-   in a plan's "suggested follow-ups" is a finding being lost.
+   labelled and boarded per "The backlog" — plus a `docs/BACKLOG.md` row *only*
+   if it is `type:feature`, since chores and bugs never render there. A finding
+   parked only in a plan's "suggested follow-ups" is a finding being lost.
 
 **The fix-now bar.** All four must hold:
 
@@ -412,9 +416,12 @@ which is the **canonical detail home** — What / Acceptance / Key files /
 Depends on / Benefit live in the issue, not in BACKLOG.md. The `<prefix>-<n>`
 ID stays the durable cross-reference for code/commits/plans; the issue `#NN`
 is the GitHub-native auto-close hook. A numeric `Priority` field on the board
-drives intra-tier ordering. **Bugs are GitHub issues with the `bug`
-label and stay off `docs/BACKLOG.md`** (still out-of-band — the user files
-them as they hit them). The label taxonomy, issue forms, and the full
+drives intra-tier ordering. **`docs/BACKLOG.md` renders `type:feature` issues
+only.** `npm run backlog:sync` filters to `type:feature` with board Status not
+`Done`; **`type:chore` issues and `bug` issues never appear there** — they live
+on the board's "Bugs & Chores" view, which is their complete home. So a chore
+needs no BACKLOG row, and its absence is not drift. (Bugs remain out-of-band
+besides: the user files them as they hit them.) The label taxonomy, issue forms, and the full
 convention live in [CONTRIBUTING.md "Issues"](CONTRIBUTING.md#issues); plan
 [241](docs/features/archive/241-github-projects-kanban-board.md) is the rationale
 (supersedes [166](docs/features/archive/166-github-issues-backlog-integration.md)).
@@ -428,9 +435,12 @@ When you ship a backlog item:
    plan is now `stable`, move it to `docs/features/archive/`.
 
 When you discover a new outstanding item (e.g. a "Suggested follow-up"
-added to a plan), file a Backlog-item issue (it gets `area:`/`moscow:`/`type:`
-labels) **and** add the thin row to `docs/BACKLOG.md` linking it, in the same
-round — the backlog is only useful while it stays current.
+added to a plan), file a Backlog-item issue in the same round — it gets
+`area:`/`moscow:`/`type:` labels and is auto-added to the board by
+`.github/workflows/add-to-project.yml`. **If it is `type:feature`, also
+re-run `npm run backlog:sync`** so its row lands in `docs/BACKLOG.md`; a
+`type:chore` or `bug` issue is complete at the board and needs no row (see
+above). The backlog is only useful while it stays current.
 
 ## Planning-mode behaviour
 
@@ -757,11 +767,18 @@ junction and its target rather than trusting an exit code.
 
 ### The two carve-outs
 
-**Trivial changes may go direct to `main`** — same [trivial
+**Trivial changes may skip the worktree** — same [trivial
 bar](#the-trivial-bar) as the Execution model's, no separate definition. Nothing
 can break, nothing needs review, and you would not want a `code-review` pass on
-it. **Announce it in the end-of-turn summary** so the user can redirect to a
-branch if they disagree. This should be rare; when in doubt, branch.
+it. Commit on a branch in the primary checkout, PR it, merge. **Announce the
+shortcut in the end-of-turn summary** so the user can redirect if they disagree.
+This should be rare; when in doubt, take the worktree.
+
+**Note what this carve-out does NOT buy: landing on `main` directly.** That path
+does not exist here — `main`'s rulesets apply `required_status_checks`, so a
+pushed commit with no passing checks is rejected outright. Every change reaches
+`main` through a PR regardless of how trivial it is. What the bar actually
+skips is the worktree, the subagent, and the design thread.
 
 **Git-ignored artifacts are produced in the primary checkout, not a worktree.**
 `brand/`, `mockups/`, marketing captures, and anything else outside version


### PR DESCRIPTION
## Summary

Closes out the ops-40 rule rollout by correcting two claims in `CLAUDE.md` that
are factually wrong about this repo. Both had already misled a session into
planning work that wasn't owed, which is how they were found.

**1. The trivial carve-out cannot land on `main`.** #1902 wrote that trivial
changes "may go direct to `main`". Verified against the actual rulesets:

```
main — block force-push & deletion [branch] active
  → deletion, non_fast_forward, required_status_checks
main — require PR issue link      [branch] active
  → required_status_checks
```

A directly-pushed commit has no passing checks, so it is rejected. **Every**
change reaches `main` through a PR regardless of how trivial. Reworded to state
what the bar actually buys — skipping the worktree, the subagent, and the design
thread — and to name the `main` constraint outright so the misreading can't
recur. The trivial-bar section compounded it with "skip the worktree + branch";
now "skip the worktree".

**2. `docs/BACKLOG.md` renders `type:feature` only.** "The backlog" said to file
an issue **and** add a BACKLOG row for every discovered item, noting only that
bugs are excluded. But `scripts/backlog-sync.mjs:129` filters to `type:feature`
with board Status not `Done`, and the file's own generated header says chores
and bugs "live on the board's Bugs & Chores view instead and **never appear
here**."

The concrete cost: after filing #1913 (`type:chore`) I read CLAUDE.md, concluded
a BACKLOG row was owed, and reported the file as stale. A dry-run proved
otherwise — **#1913 appears nowhere in the sync output**, while the sync *would*
have swept in unrelated board drift (an fe-39/fe-54 re-bucketing from another
session) that I could not have attributed. Now states the filter, that a chore
is complete at the board, and that its absence is **not** drift. Same correction
applied to the Incidental-findings deferral step, which repeated the claim.

## Test plan

Docs-only; no runtime surface.

- Verified claim 1 against `gh api repos/.../rulesets` — output quoted above
- Verified claim 2 two ways: read the filter in `scripts/backlog-sync.mjs`
  (`state === 'OPEN' && status !== 'Done'` over `type:feature` only) and ran
  `npm run backlog:sync` in dry-run, confirming zero occurrences of `1913` and
  zero `ops-4x` entries in its proposed output
- Confirmed `#the-trivial-bar` still resolves (2 references, heading intact)
- `git diff --stat` → `CLAUDE.md` only, nothing else touched

**Checklist steps not applicable:** (1) no regression plan — `CLAUDE.md` is the
record; (2) no paired test — no runtime surface; (3) no on-box acceptance;
(5) release notes skipped, internal process doc with no user- or
operator-visible delta; (10) `code-review` gate — docs-only PRs are exempt per
Model routing.

## Note

No BACKLOG row is filed for this issue either — `ops-45` is `type:chore`, which
is exactly the case this PR documents as needing none.

Closes #1914
