### PR TITLE
fix(scripts): reject sub-lettered rows and ignore fenced blocks in the register checker

### DIFF
--- a/scripts/check-onbox-register.mjs
+++ b/scripts/check-onbox-register.mjs
@@ -16,6 +16,37 @@ import { readFileSync } from 'node:fs';
 // as "not a group" rather than special-casing two sections whose rows would
 // buy little coverage for a lot of parser fragility.
 
+// ops-44 (issue #1913) added two edge-case behaviours on top of the above: a
+// row heading that looks row-shaped but isn't a strict `<Letter><N>` (e.g. a
+// sub-lettered `### A19b`) is now rejected with a specific error rather than
+// silently uncounted, and both heading scans below are fence-aware so an
+// example `##`/`###` line inside a fenced code block can't be parsed as a
+// real section or row.
+
+// Blanks the contents of fenced code blocks (``` or ~~~) so neither the
+// section split nor the row-heading scan below can mistake an example
+// heading inside a fence for a real one. Toggling is per-delimiter — a line
+// only closes a fence when it starts with the SAME delimiter that opened it,
+// so a `~~~` line inside a ```-fenced block is just content, not a closer.
+function stripFences(text) {
+  const lines = text.split('\n');
+  let openFence = null;
+  return lines
+    .map((line) => {
+      const trimmed = line.trimStart();
+      if (openFence) {
+        if (trimmed.startsWith(openFence)) openFence = null;
+        return '';
+      }
+      if (trimmed.startsWith('```') || trimmed.startsWith('~~~')) {
+        openFence = trimmed.startsWith('```') ? '```' : '~~~';
+        return '';
+      }
+      return line;
+    })
+    .join('\n');
+}
+
 // Splits the document into `## `-level sections: { title, body } from just
 // after each `## Heading` line to just before the next one. Row headings use
 // `### ` (three `#`s), so a regex requiring the space directly after exactly
@@ -74,16 +105,35 @@ function parseGlanceTable(sectionBody) {
 function parseBodyGroups(sections) {
   const groups = new Map();
   const duplicateLetters = new Set();
+  const invalidRowHeadings = [];
   for (const section of sections) {
     const titleMatch = section.title.match(/^Group ([A-Z])\b/);
     if (!titleMatch) continue;
     const letter = titleMatch[1];
     if (groups.has(letter)) duplicateLetters.add(letter);
-    const rowRegex = new RegExp(`^### ${letter}(\\d+)\\b`, 'gm');
-    const numbers = [...section.body.matchAll(rowRegex)].map((m) => Number(m[1]));
+    // A row candidate is a `### ` heading whose text starts with this
+    // section's own letter followed by a digit — anything else (e.g. a
+    // `### Notes` subheading) isn't row-shaped and is never even looked at,
+    // so group sections may legitimately gain non-row subheadings. A
+    // candidate then either parses as a strict `<Letter><N>` (word boundary
+    // right after the digits) or doesn't — e.g. a sub-lettered `A19b`, whose
+    // digits run straight into a trailing letter with no boundary — and is
+    // collected in `invalidRowHeadings` instead of being silently dropped.
+    const candidateRegex = new RegExp(`^### (${letter}\\d[^\\n]*)$`, 'gm');
+    const rowRegex = new RegExp(`^${letter}(\\d+)\\b`);
+    const numbers = [];
+    for (const match of section.body.matchAll(candidateRegex)) {
+      const headingText = match[1];
+      const rowMatch = headingText.match(rowRegex);
+      if (rowMatch) {
+        numbers.push(Number(rowMatch[1]));
+      } else {
+        invalidRowHeadings.push({ letter, headingText });
+      }
+    }
     groups.set(letter, numbers);
   }
-  return { groups, duplicateLetters };
+  return { groups, duplicateLetters, invalidRowHeadings };
 }
 
 // Formats a group's found row numbers for an error message: a single row is
@@ -103,7 +153,7 @@ function formatRowList(letter, numbers) {
 // Runs all checks and returns a list of human-readable error strings — empty
 // when the register is internally coherent.
 export function checkRegister(text) {
-  const sections = splitSections(text);
+  const sections = splitSections(stripFences(text));
   const glanceSection = sections.find((s) => s.title === 'At a glance');
   if (!glanceSection) {
     return ['No "## At a glance" section found — cannot check the register.'];
@@ -115,7 +165,11 @@ export function checkRegister(text) {
     duplicateLetters: duplicateTableLetters,
     malformedLetters,
   } = parseGlanceTable(glanceSection.body);
-  const { groups: bodyGroups, duplicateLetters: duplicateBodyLetters } = parseBodyGroups(sections);
+  const {
+    groups: bodyGroups,
+    duplicateLetters: duplicateBodyLetters,
+    invalidRowHeadings,
+  } = parseBodyGroups(sections);
   const tableLetters = new Set(tableGroups.keys());
   const bodyLetters = new Set(bodyGroups.keys());
   const malformedLetterSet = new Set(malformedLetters);
@@ -127,6 +181,17 @@ export function checkRegister(text) {
   for (const letter of malformedLetterSet) {
     errors.push(
       `The glance-table row for Group ${letter} could not be parsed — expected exactly three cells, the last a bare integer.`,
+    );
+  }
+
+  // Sub-lettered row headings (e.g. `### A19b`) are the body-side mirror of
+  // the malformed-table-row check above — rejected outright rather than
+  // silently uncounted. The register's own convention for a row covering
+  // more than one debt is to annotate the row's title, not sub-letter it
+  // (ops-44, issue #1913).
+  for (const { letter, headingText } of invalidRowHeadings) {
+    errors.push(
+      `Row heading "### ${headingText}" is not a valid row number. Rows are numbered contiguously (${letter}1, ${letter}2, …) — for a row covering more than one debt, annotate its title instead of sub-lettering.`,
     );
   }
 

--- a/scripts/check-onbox-register.mjs
+++ b/scripts/check-onbox-register.mjs
@@ -28,23 +28,43 @@ import { readFileSync } from 'node:fs';
 // heading inside a fence for a real one. Toggling is per-delimiter — a line
 // only closes a fence when it starts with the SAME delimiter that opened it,
 // so a `~~~` line inside a ```-fenced block is just content, not a closer.
+//
+// Also reports whether a fence was left open at EOF, and the (1-based) line
+// it opened on — an unterminated fence blanks everything after it, which
+// must be surfaced as an error rather than silently validating a truncated
+// document (ops-44, issue #1913 review finding: this previously made a
+// stray fence line make the rest of the register invisible to every check
+// below, reporting "no errors" over a truncated read).
+//
+// Residual limitation, deliberately not fixed here: two *balanced* stray
+// fences bracketing a real row still hide that row without leaving anything
+// open at EOF, so this check can't catch it — and the contiguity check (4)
+// only surfaces it when the hidden row isn't the group's highest-numbered
+// one (a hidden top row just looks like a smaller-but-still-contiguous
+// group).
 function stripFences(text) {
   const lines = text.split('\n');
   let openFence = null;
-  return lines
-    .map((line) => {
+  let openFenceLine = null;
+  const stripped = lines
+    .map((line, i) => {
       const trimmed = line.trimStart();
       if (openFence) {
-        if (trimmed.startsWith(openFence)) openFence = null;
+        if (trimmed.startsWith(openFence)) {
+          openFence = null;
+          openFenceLine = null;
+        }
         return '';
       }
       if (trimmed.startsWith('```') || trimmed.startsWith('~~~')) {
         openFence = trimmed.startsWith('```') ? '```' : '~~~';
+        openFenceLine = i + 1;
         return '';
       }
       return line;
     })
     .join('\n');
+  return { text: stripped, unterminatedFenceLine: openFenceLine };
 }
 
 // Splits the document into `## `-level sections: { title, body } from just
@@ -115,12 +135,19 @@ function parseBodyGroups(sections) {
     // section's own letter followed by a digit — anything else (e.g. a
     // `### Notes` subheading) isn't row-shaped and is never even looked at,
     // so group sections may legitimately gain non-row subheadings. A
-    // candidate then either parses as a strict `<Letter><N>` (word boundary
-    // right after the digits) or doesn't — e.g. a sub-lettered `A19b`, whose
-    // digits run straight into a trailing letter with no boundary — and is
+    // candidate then either parses as a strict `<Letter><N>` (whitespace or
+    // end-of-string right after the digits) or doesn't — e.g. a sub-lettered
+    // `A19b`, or dotted sub-numbering like `A2.1` (`\b` alone would accept
+    // both: a non-word character, including `.`, `-`, `(`, `/`, `'`, `+`,
+    // satisfies a word boundary just as well as whitespace does) — and is
     // collected in `invalidRowHeadings` instead of being silently dropped.
-    const candidateRegex = new RegExp(`^### (${letter}\\d[^\\n]*)$`, 'gm');
-    const rowRegex = new RegExp(`^${letter}(\\d+)\\b`);
+    // `[^\r\n]*` (not `[^\n]*`) so a CRLF line ending doesn't leave a raw
+    // `\r` inside the captured heading text. The trailing `\r?` (outside the
+    // capture group, so it isn't included in `headingText`) absorbs a CRLF
+    // line's `\r` before `$` — `$` in multiline mode only matches directly
+    // before `\n`, so without it a CRLF line would fail to match at all.
+    const candidateRegex = new RegExp(`^### (${letter}\\d[^\\r\\n]*)\\r?$`, 'gm');
+    const rowRegex = new RegExp(`^${letter}(\\d+)(?=\\s|$)`);
     const numbers = [];
     for (const match of section.body.matchAll(candidateRegex)) {
       const headingText = match[1];
@@ -153,7 +180,21 @@ function formatRowList(letter, numbers) {
 // Runs all checks and returns a list of human-readable error strings — empty
 // when the register is internally coherent.
 export function checkRegister(text) {
-  const sections = splitSections(stripFences(text));
+  const { text: fenceStrippedText, unterminatedFenceLine } = stripFences(text);
+  const sections = splitSections(fenceStrippedText);
+
+  // An unterminated fence blanks everything after it (stripFences treats an
+  // open fence's remaining lines as still-inside-the-fence content), so
+  // every check below would silently validate a truncated document. Report
+  // it up front and bail before any other check can run against that
+  // truncated read — a partial check here would just produce more wrong
+  // numbers on top of the missing-rows problem itself.
+  if (unterminatedFenceLine !== null) {
+    return [
+      `Unterminated fenced code block opened at line ${unterminatedFenceLine} — everything after it was ignored.`,
+    ];
+  }
+
   const glanceSection = sections.find((s) => s.title === 'At a glance');
   if (!glanceSection) {
     return ['No "## At a glance" section found — cannot check the register.'];
@@ -173,6 +214,13 @@ export function checkRegister(text) {
   const tableLetters = new Set(tableGroups.keys());
   const bodyLetters = new Set(bodyGroups.keys());
   const malformedLetterSet = new Set(malformedLetters);
+  // Mirrors malformedLetterSet: a letter with an invalid row heading (e.g.
+  // `### A2a`/`### A2b` from splitting a row instead of annotating its
+  // title) already gets the rejection message above — suppressing checks 1
+  // and 4 for it avoids also reporting a count/contiguity mismatch that's
+  // just an artifact of the same rejected heading (ops-44, issue #1913
+  // review finding).
+  const invalidRowHeadingLetterSet = new Set(invalidRowHeadings.map((r) => r.letter));
   const errors = [];
 
   // Malformed glance-table rows (wrong cell count, or a non-integer last
@@ -229,8 +277,11 @@ export function checkRegister(text) {
 
   // Check 1: per-group counts (only for groups present on both sides —
   // a group missing from one side is already reported by check 3 above).
+  // A letter with an invalid row heading is skipped — see
+  // invalidRowHeadingLetterSet above.
   for (const letter of tableLetters) {
     if (!bodyLetters.has(letter)) continue;
+    if (invalidRowHeadingLetterSet.has(letter)) continue;
     const tableCount = tableGroups.get(letter);
     const bodyNumbers = bodyGroups.get(letter);
     if (tableCount !== bodyNumbers.length) {
@@ -255,9 +306,11 @@ export function checkRegister(text) {
   }
 
   // Check 4: row numbers within a group are contiguous from 1, no gaps or
-  // duplicates.
+  // duplicates. A letter with an invalid row heading is skipped — see
+  // invalidRowHeadingLetterSet above.
   for (const [letter, numbers] of bodyGroups) {
     if (numbers.length === 0) continue;
+    if (invalidRowHeadingLetterSet.has(letter)) continue;
     const sorted = [...numbers].sort((a, b) => a - b);
     const isContiguous =
       new Set(sorted).size === sorted.length && sorted.every((n, i) => n === i + 1);

--- a/scripts/tests/check-onbox-register.test.mjs
+++ b/scripts/tests/check-onbox-register.test.mjs
@@ -495,3 +495,240 @@ ${bodyE}
     `expected a total-mismatch error, got: ${JSON.stringify(errors)}`,
   );
 });
+
+// --- ops-44 independent-review follow-up (issue #1913 review comment) ---
+
+test('review fix 1: an unterminated fenced code block is reported, not silently swallowed', () => {
+  // Mirrors the review's exact repro: glance table says A = 1, body genuinely
+  // has ### A1 and ### A2, with one stray ``` line inserted before ### A2.
+  // Before the fix this returned [] (exit 0) — the fence blanked ### A2 and
+  // everything after it, so check 1 never saw the mismatch.
+  const text = `# On-box acceptance register
+
+## At a glance
+
+| Group | Setup | Rows |
+|---|---|---|
+| **A** | Setup A | 1 |
+
+**1 owed.** Oldest: **2026-01-01**.
+
+---
+
+## Group A — setup a
+
+### A1 · thing 1
+
+Body text.
+
+\`\`\`
+### A2 · thing 2
+
+Body text.
+
+---
+`;
+  const errors = checkRegister(text);
+  assert.equal(errors.length, 1, `expected exactly one error, got: ${JSON.stringify(errors)}`);
+  assert.match(
+    errors[0],
+    /^Unterminated fenced code block opened at line \d+ — everything after it was ignored\.$/,
+  );
+});
+
+test('review fix 1: the no-fence control case still reports the count mismatch', () => {
+  // Same document as the previous test with the stray fence removed — proves
+  // the fence, not some other change, was what hid the mismatch.
+  const text = `# On-box acceptance register
+
+## At a glance
+
+| Group | Setup | Rows |
+|---|---|---|
+| **A** | Setup A | 1 |
+
+**1 owed.** Oldest: **2026-01-01**.
+
+---
+
+## Group A — setup a
+
+### A1 · thing 1
+
+Body text.
+
+### A2 · thing 2
+
+Body text.
+
+---
+`;
+  const errors = checkRegister(text);
+  assert.ok(
+    errors.some(
+      (e) =>
+        e ===
+        'Group A: glance table says 1, body has 2 rows (A1–A2). Update the table or the body.',
+    ),
+    `expected the Group A count-mismatch error, got: ${JSON.stringify(errors)}`,
+  );
+});
+
+test('review fix 1: a fence opened before "## At a glance" also degrades loudly', () => {
+  // If the whole document (including the "## At a glance" heading itself)
+  // gets swallowed by an unterminated fence, the failure must still be named
+  // as an unterminated fence — not surface as the unrelated "No At a glance
+  // section found" message, which would misdirect the fix.
+  const text = '```\n' + buildRegister();
+  const errors = checkRegister(text);
+  assert.equal(errors.length, 1, `expected exactly one error, got: ${JSON.stringify(errors)}`);
+  assert.equal(
+    errors[0],
+    'Unterminated fenced code block opened at line 1 — everything after it was ignored.',
+  );
+});
+
+test('review fix 2: dotted sub-numbering ("### A2.1") is rejected, not silently counted as row 2', () => {
+  // \b alone (the pre-fix regex) treats "." as a word boundary just like
+  // whitespace, so `### A2.1` and `### A2.2` were both silently counted as
+  // row 2 — producing a phantom "duplicate row 2" contiguity error instead
+  // of the correct invalid-row-heading rejection.
+  const text = `# On-box acceptance register
+
+## At a glance
+
+| Group | Setup | Rows |
+|---|---|---|
+| **A** | Setup A | 4 |
+
+**4 owed.** Oldest: **2026-01-01**.
+
+---
+
+## Group A — setup a
+
+### A1 · thing 1
+
+Body text.
+
+### A2.1 · thing 2 part 1
+
+Body text.
+
+### A2.2 · thing 2 part 2
+
+Body text.
+
+### A3 · thing 3
+
+Body text.
+
+---
+`;
+  const errors = checkRegister(text);
+  assert.ok(
+    errors.some(
+      (e) =>
+        e ===
+        'Row heading "### A2.1 · thing 2 part 1" is not a valid row number. Rows are numbered contiguously (A1, A2, …) — for a row covering more than one debt, annotate its title instead of sub-lettering.',
+    ),
+    `expected the A2.1 rejection, got: ${JSON.stringify(errors)}`,
+  );
+  assert.ok(
+    errors.some(
+      (e) =>
+        e ===
+        'Row heading "### A2.2 · thing 2 part 2" is not a valid row number. Rows are numbered contiguously (A1, A2, …) — for a row covering more than one debt, annotate its title instead of sub-lettering.',
+    ),
+    `expected the A2.2 rejection, got: ${JSON.stringify(errors)}`,
+  );
+  assert.ok(
+    !errors.some((e) => e.includes('are not contiguous')),
+    `did not expect a phantom "duplicate row 2" contiguity error, got: ${JSON.stringify(errors)}`,
+  );
+});
+
+test('review fix 3: an invalid row heading suppresses checks 1 and 4 for that letter, leaving only the rejection messages', () => {
+  // The decision comment's own motivating case: A2 split into A2a/A2b (table
+  // bumped to 3 to "absorb" the split) instead of annotating a single row's
+  // title. Table (3) vs. the one still-valid body row (A1) would otherwise
+  // ALSO report a count mismatch on top of the two rejections. Deliberately
+  // NOT sized so the counts happen to reconcile (unlike the pre-existing
+  // A19b fixture, which dodges this case) — this test fails if fix 3 is
+  // reverted.
+  const text = `# On-box acceptance register
+
+## At a glance
+
+| Group | Setup | Rows |
+|---|---|---|
+| **A** | Setup A | 3 |
+
+**3 owed.** Oldest: **2026-01-01**.
+
+---
+
+## Group A — setup a
+
+### A1 · thing 1
+
+Body text.
+
+### A2a · thing 2 part a
+
+Body text.
+
+### A2b · thing 2 part b
+
+Body text.
+
+---
+`;
+  const errors = checkRegister(text);
+  assert.deepEqual(errors, [
+    'Row heading "### A2a · thing 2 part a" is not a valid row number. Rows are numbered contiguously (A1, A2, …) — for a row covering more than one debt, annotate its title instead of sub-lettering.',
+    'Row heading "### A2b · thing 2 part b" is not a valid row number. Rows are numbered contiguously (A1, A2, …) — for a row covering more than one debt, annotate its title instead of sub-lettering.',
+  ]);
+});
+
+test('review fix 4: CRLF line endings do not leak a raw \\r into the invalid-row-heading message', () => {
+  const text = [
+    '# On-box acceptance register',
+    '',
+    '## At a glance',
+    '',
+    '| Group | Setup | Rows |',
+    '|---|---|---|',
+    '| **A** | Setup A | 1 |',
+    '',
+    '**1 owed.** Oldest: **2026-01-01**.',
+    '',
+    '---',
+    '',
+    '## Group A — setup a',
+    '',
+    '### A1 · thing 1',
+    '',
+    'Body text.',
+    '',
+    '### A19b · sub',
+    '',
+    'Body text.',
+    '',
+    '---',
+    '',
+  ].join('\r\n');
+  const errors = checkRegister(text);
+  assert.ok(
+    errors.some(
+      (e) =>
+        e ===
+        'Row heading "### A19b · sub" is not a valid row number. Rows are numbered contiguously (A1, A2, …) — for a row covering more than one debt, annotate its title instead of sub-lettering.',
+    ),
+    `expected the sub-lettered-row error with no trailing \\r, got: ${JSON.stringify(errors)}`,
+  );
+  assert.ok(
+    !errors.some((e) => e.includes('\r')),
+    `expected no error message to contain a raw \\r, got: ${JSON.stringify(errors)}`,
+  );
+});

--- a/scripts/tests/check-onbox-register.test.mjs
+++ b/scripts/tests/check-onbox-register.test.mjs
@@ -303,6 +303,137 @@ test('fix 5: a single-row count mismatch uses singular grammar and no dash range
   );
 });
 
+test('ops-44: a sub-lettered row heading ("### A19b") is rejected with a clear message, not silently dropped', () => {
+  const text = `# On-box acceptance register
+
+## At a glance
+
+| Group | Setup | Rows |
+|---|---|---|
+| **A** | Setup A | 1 |
+
+**1 owed.** Oldest: **2026-01-01**.
+
+---
+
+## Group A — setup a
+
+### A1 · thing 1
+
+Body text.
+
+### A19b
+
+Body text.
+
+---
+`;
+  const errors = checkRegister(text);
+  assert.ok(
+    errors.some(
+      (e) =>
+        e ===
+        'Row heading "### A19b" is not a valid row number. Rows are numbered contiguously (A1, A2, …) — for a row covering more than one debt, annotate its title instead of sub-lettering.',
+    ),
+    `expected the sub-lettered-row error, got: ${JSON.stringify(errors)}`,
+  );
+});
+
+test('ops-44: a non-row "### " subheading inside a group section is still ignored', () => {
+  const withNotesSubheading = buildRegister().replace(
+    '### A2 · thing 2',
+    '### Notes\n\nSome context that is not a row.\n\n### A2 · thing 2',
+  );
+  assert.deepEqual(checkRegister(withNotesSubheading), []);
+});
+
+test('ops-44: a fenced code block containing "### F2 · ..." does not inflate group F\'s count', () => {
+  const text = `# On-box acceptance register
+
+## At a glance
+
+| Group | Setup | Rows |
+|---|---|---|
+| **F** | Setup F | 1 |
+
+**1 owed.** Oldest: **2026-01-01**.
+
+---
+
+## Group F — setup f
+
+### F1 · thing 1
+
+Body text.
+
+\`\`\`
+### F2 · this is example text inside a fenced block, not a real row
+\`\`\`
+
+---
+`;
+  assert.deepEqual(checkRegister(text), []);
+});
+
+test('ops-44: a fenced code block containing "## Group Z — ..." does not create a phantom group', () => {
+  const text = `# On-box acceptance register
+
+## At a glance
+
+| Group | Setup | Rows |
+|---|---|---|
+| **A** | Setup A | 1 |
+
+**1 owed.** Oldest: **2026-01-01**.
+
+---
+
+## Group A — setup a
+
+### A1 · thing 1
+
+Body text.
+
+\`\`\`
+## Group Z — this line must not create a phantom section
+\`\`\`
+
+More body text after the fence, still part of Group A.
+
+---
+`;
+  assert.deepEqual(checkRegister(text), []);
+});
+
+test('ops-44: "~~~" fences behave the same as ``` fences for both the section split and the row-heading scan', () => {
+  const text = `# On-box acceptance register
+
+## At a glance
+
+| Group | Setup | Rows |
+|---|---|---|
+| **A** | Setup A | 1 |
+
+**1 owed.** Oldest: **2026-01-01**.
+
+---
+
+## Group A — setup a
+
+### A1 · thing 1
+
+Body text.
+
+~~~
+### A2 · this is example text inside a tilde-fenced block, not a real row
+## Group Z — this must not create a phantom section either
+~~~
+
+---
+`;
+  assert.deepEqual(checkRegister(text), []);
+});
+
 test('regression: reproduces the real 2026-07-28 drift (E=5 vs 7 rows, total 31)', () => {
   // Mirrors the actual incident this check exists to catch: the "At a
   // glance" table under-reported Group E (5 instead of the 7 rows actually


### PR DESCRIPTION
## Summary

Closes the last open item from the ops-43 register-checker work. Two parser edge
cases the independent review on #1908 surfaced, both deliberately left out of
that PR because each needed a decision about register convention rather than a
parser change. The decision is recorded on #1913 and the two answers
intentionally differ in shape.

**1. Sub-lettered rows (`### A19b`) are rejected.** One row should mean one
countable unit. Supporting sub-letters would force a rule about whether `A19b`
counts toward the total, and any answer to that makes the total less trustworthy
— which defeats the register's purpose. The existing convention already covers
the motivating case by annotating a multi-debt row's title
(`A2 · … · **two distinct debts**`). Previously such a heading was **silently
uncounted**, surfacing later as a confusing count mismatch with no hint at the
cause; now it says what to do:

> `Row heading "### A19b" is not a valid row number. Rows are numbered contiguously (A1, A2, …) — for a row covering more than one debt, annotate its title instead of sub-lettering.`

Scoped so a `### ` heading that isn't row-shaped at all (`### Notes`) stays
ignored — group sections may legitimately gain non-row subheadings.

**2. Fenced code blocks are parsed around, not rejected.** This reverses the
"just forbid them" option floated when #1913 was filed. Rejecting would
constrain what a future row may contain for the parser's convenience, which is
backwards — E6 already carries several inline commands and a future row could
reasonably want a fenced block. `stripFences()` blanks fenced content before
parsing, so an example `### F2 · …` can't inflate a group's count and an example
`## Group Z — …` can't create a phantom group. Both ``` and `~~~` fences, with
per-delimiter toggling so a mismatched fence type is content, not a closer.

Worth noting the implementation improved on the brief: rather than making the
section split and the row scan fence-aware separately, it applies one
`stripFences()` pass up front, so both inherit it from a single change point
that can't drift apart.

The register has zero fenced blocks today, so half of this is prevention — the
tests are the deliverable for that half.

## Test plan

- `npm run test:hooks` → **719/719 pass** (20 in this file, 5 new)
- `node scripts/check-onbox-register.mjs` against the real register → **exit 0**
- All six acceptance bullets from the decision comment demonstrated against
  scratch copies (the tracked register was never modified) and independently
  re-verified before merge:

| Case | Result |
|---|---|
| real register | `[]` |
| `### A19b` sub-letter | rejected, with the message above |
| `### Notes` non-row heading | ignored |
| fenced `### F2` inside Group F | count not inflated |
| fenced `## Group Z — …` | no phantom group |
| `~~~` fence parity | same as ``` |

- Removal spot-checks: reverting `stripFences` failed exactly the 3 fence tests
  and left the 2 sub-letter tests passing; reverting the sub-letter detection
  failed exactly that test and left the fence tests passing. The new tests pin
  their own behaviour and are isolated from each other.

**Checklist steps not applicable:** (1) no regression plan — the issue body plus
paired tests are the spec for a localized item; (3) no on-box acceptance — no
hardware surface; (5) release notes skipped, contributor-facing tooling with no
user- or operator-visible delta.

Closes #1913
