### PR TITLE
fix(frontend): add the missing coquiIdleTtl mock config descriptor

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -8575,6 +8575,18 @@ const MOCK_CONFIG_DESCRIPTORS: import('./types').KnobDescriptor[] = [
     default: 120,
   },
   {
+    key: 'sidecar.coquiIdleTtl',
+    group: 'gpu-lifecycle',
+    label: 'Coqui (XTTS) idle TTL (s)',
+    help: 'Seconds of Coqui inactivity before a VRAM-starved operation may reclaim the resident XTTS model (~3 GB). Unlike the other idle TTLs there is no background watchdog — this only ever fires when another operation would otherwise fail for want of VRAM. Raise it if a mixed-engine book keeps reloading XTTS between chapters (a reload costs ~90s); lower it if renders still fail while an idle Coqui is loaded. Values below 5 fall back to the default (30) to avoid reload thrash.',
+    type: 'integer',
+    min: 0,
+    apply: 'restart-sidecar',
+    risk: 'high',
+    isPrompt: false,
+    default: 30,
+  },
+  {
     key: 'sidecar.asrIdleTtl',
     group: 'gpu-lifecycle',
     label: 'ASR (Whisper) idle TTL (s)',


### PR DESCRIPTION
## Summary

Closes #1927.

`main` has been red since #1924 merged. That PR added the `sidecar.coquiIdleTtl` registry knob (`server/src/config/registry.ts:713-724`) but not the matching descriptor in the mock config surface, and `src/lib/api.config.test.ts` asserts the two key sets mirror each other:

```
    "sidecar.asrIdleTtl",
-   "sidecar.coquiIdleTtl",
    "sidecar.disableMkldnn",
```

Verified on a clean checkout at `main` (`75ced5bb`) before touching anything: **1 failed | 1 passed | 17 skipped**. This branch: **19 passed**, and the full frontend suite is green at **4323 passed** via the pre-commit hook.

The fix is one descriptor mirroring the registry entry's label / help / type / min / default / apply / risk, exactly as its four sibling idle-TTL knobs do. No behaviour change — this surface is what Account → Advanced Settings renders in mock mode.

## Why CI missed it, which is the part worth reading

`verify.yml` scope-filters every leg to what the PR's diff touched. #1924 changed `server/**`, `server/tts-sidecar/**` and `docs/**` but **no `src/**` file**, so the frontend unit-test leg never ran. The breakage sat latent on `main` and only surfaced when the next branch to touch a frontend file hit its pre-commit hook.

So a **server-side** registry change can break a **frontend** test, and the scope filter has no way to know. The generalisable gap: `src/lib/api.config.test.ts` mirrors `server/src/config/registry.ts`, but nothing makes a change to the latter trigger the leg that runs the former. #1927 records that for a follow-up — worth fixing properly rather than relying on the next frontend PR to trip over it.

## What was NOT wrong

Everything else about the knob was wired correctly, so this is a single missed mirror rather than a half-finished feature:

- `server/.env.example:643` — `COQUI_IDLE_TTL=30` ✅
- `docs/wiki/Advanced-Settings.md` §9 — the table row is present ✅
- `server/src/config/registry.ts` — the knob itself ✅

## Test plan

- `npx vitest run src/lib/api.config.test.ts` — 19 passed (1 failing before).
- Full frontend suite via pre-commit — 323 files, 4323 passed.
- `npm run verify:fast:branch` via pre-push — lint, typecheck, config:check, test:hooks, test, build all green.

No release-notes entry: this is an internal correctness fix with no user- or operator-visible delta — the knob already rendered from the real registry in non-mock mode, which is every shipped install.