### PR TITLE
fix(sidecar): cache the clone prompt as a (prompt, language) tuple

### DIFF
--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -5287,7 +5287,7 @@ class QwenEngine(Engine):
         # Warm the in-memory cache + drop any stale 1.7B-native prompt, OUTSIDE
         # the synth lock (mirrors design_voice's post-lock cache handling).
         with self._cache_lock:
-            self._prompt_cache[voice_id] = prompt
+            self._prompt_cache[voice_id] = (prompt, lang)
         self._evict_17b_prompt(voice_id)
         log.info("Cloned + cached Qwen voice '%s' from caller clip.", voice_id)
         return SynthResult(pcm=_float_audio_to_int16_le(wavs[0]), sample_rate=int(sr))

--- a/server/tts-sidecar/tests/test_qwen_clone_voice.py
+++ b/server/tts-sidecar/tests/test_qwen_clone_voice.py
@@ -84,3 +84,70 @@ def test_clone_voice_rejects_missing_body_and_headers(fake_qwen_runtime) -> None
                        headers={"X-Sample-Rate": "24000", "X-Ref-Text": _b64("t")}).status_code == 400
     assert client.post("/qwen/clone-voice", content=_pcm(),
                        headers={"X-Sample-Rate": "24000", "X-Voice-Id": "q"}).status_code == 400
+
+
+def test_clone_voice_cache_entry_survives_a_load_voice_prompt_round_trip(
+    fake_qwen_runtime, monkeypatch
+) -> None:
+    """Regression: clone_voice's post-lock cache warm (main.py ~5290) must
+    store the SAME `(prompt, language)` 2-tuple shape as design_voice's and
+    _load_voice_prompt_17b's writers — _load_voice_prompt (~5508-5510)
+    unconditionally unpacks `prompt, lang = cached`. clone_voice used to
+    stash the bare prompt object instead of a tuple, so the very next
+    /synthesize call against a freshly-cloned voice (still warm, same
+    process) raised `ValueError: not enough values to unpack (expected 2,
+    got 1)` and returned an HTTP 500 — restarting the sidecar 'fixed' it
+    only because that wipes the in-memory cache, proving the on-disk .pt
+    was always fine and the poisoned cache entry was the sole fault.
+
+    The shared fixture's create_voice_clone_prompt fake returns a 2-key
+    dict (fine for the other clone tests in this file), and a 2-key dict
+    happens to unpack into 2 values WITHOUT raising -- which would make a
+    naive version of this test pass even with the bug present. Real
+    qwen_tts create_voice_clone_prompt returns a LIST of
+    VoiceClonePromptItem, normally length 1 (main.py:5908-5911) -- a
+    length-1 list is exactly what reproduces the real
+    ValueError. Patch just this test's create_voice_clone_prompt to return
+    that real shape so the repro is faithful.
+
+    This exercises the real write via the HTTP route (same as clone_voice's
+    other tests above), then calls the real read path directly — no
+    stubbing of _prompt_cache itself, which is the unit under test."""
+    from test_qwen3 import _FakeQwenModel  # noqa: E402  (shared fixture's fake model class)
+
+    class _RealShapedPromptItem:
+        def __init__(self, ref_text: str) -> None:
+            self.ref_text = ref_text
+            self.ref_code = None
+
+    def _real_shaped_create_voice_clone_prompt(self, ref_audio, ref_text, **_kwargs):
+        self.prompt_calls.append((ref_audio, ref_text))
+        return [_RealShapedPromptItem(ref_text)]
+
+    monkeypatch.setattr(
+        _FakeQwenModel, "create_voice_clone_prompt", _real_shaped_create_voice_clone_prompt
+    )
+
+    engine = fake_qwen_runtime["engine"]
+    client = TestClient(main.app)
+    resp = client.post(
+        "/qwen/clone-voice",
+        content=_pcm(),
+        headers={
+            "X-Sample-Rate": "24000",
+            "X-Voice-Id": "qwen-clone-cache",
+            "X-Ref-Text": _b64("hello there this is a sample of my own voice"),
+            "X-Language": "German",
+        },
+    )
+    assert resp.status_code == 200
+
+    # The clone warmed the in-memory cache synchronously (post-lock, same
+    # thread as clone_voice ran on via asyncio.to_thread) — no synth needed
+    # to observe it. This call is exactly _load_voice_prompt's unpack site
+    # (main.py:5510) that raised ValueError before the fix.
+    prompt, lang, cache_hit = engine._load_voice_prompt("qwen-clone-cache")
+    assert cache_hit is True  # in-memory hit, not a disk re-load (the miss
+    # path would also return a valid triple and would silently mask this bug)
+    assert lang == "German"
+    assert isinstance(prompt, list) and len(prompt) == 1


### PR DESCRIPTION
﻿## Summary

Fixes a Critical defect found during the fs-38 Wave 3 on-box acceptance run (register row A1): **every freshly cloned Qwen voice returned HTTP 500 on its first synthesis until the sidecar was restarted** — including the clone wizard's own completion-screen audition, i.e. the first thing a user does after cloning.

`QwenEngine.clone_voice` cached a **bare prompt** where `_prompt_cache` is declared (`main.py:4123`) as `dict[str, tuple[Any, str]]` and every other writer (`:5530`, `:5583`, `:5630`) stores `(prompt, lang)`. `_load_voice_prompt` (`:5510`) unpacks two values and raised `ValueError: not enough values to unpack (expected 2, got 1)`. The 1.7B path failed identically via `_load_voice_prompt_17b` (`:5588`).

The on-disk `.pt` was always correct — only the in-process cache entry was malformed, which is why restarting the sidecar appeared to "fix" it.

One-line source change:

```diff
-            self._prompt_cache[voice_id] = prompt
+            self._prompt_cache[voice_id] = (prompt, lang)
```

An audit of all `_prompt_cache` write sites confirms this was the only one with the wrong shape; the remaining entries at `:4852`, `:4924`, `:5211`, `:5447` are evictions, not writes.

## Test plan

- **New regression test** `server/tts-sidecar/tests/test_qwen_clone_voice.py::test_clone_voice_cache_entry_survives_a_load_voice_prompt_round_trip` — exercises the real `_prompt_cache` round trip (clone write → `_load_voice_prompt` read) and asserts the cache-hit path is taken, not merely that no exception was raised.
- **Verified it fails for the right reason**: with the one-line fix reverted, the test fails with the exact production symptom, `ValueError: not enough values to unpack (expected 2, got 1)` at `main.py:5510`. With the fix applied, it passes.
  - Note: the first draft of this test was a placebo — the shared fixture's fake `create_voice_clone_prompt` returns a 2-key dict, which unpacks into two values without raising, so it passed *with the bug present*. It was rewritten to monkeypatch the real shape (a length-1 list, per the comment at `main.py:5908-5911`).
- `npm run test:sidecar` — **exit code 0** on two independent full runs, no `F`/`E`.
- **Live on-box verification** (2026-07-29, dual-GPU box, real sidecar + real Qwen weights): cloned a brand-new voice and synthesised it **immediately in the same sidecar process** — the exact sequence that previously always 500'd — and got **HTTP 200** with valid audio in 54.8s. Before the fix, three separate cloned voices 500'd on every attempt and only recovered after a sidecar restart.

Closes #1941
