### PR TITLE
docs(docs): record the fs-38 Wave 3 on-box acceptance run of 2026-07-29

### DIFF
--- a/docs/features/267-fs38-wave3-voice-clone.md
+++ b/docs/features/267-fs38-wave3-voice-clone.md
@@ -420,6 +420,21 @@ thunks/components in isolation.
    Expected: the chapter fails loud (surfaces an error naming the cloned
    voice) rather than silently rendering in a substitute voice.
 
+> **PARTIALLY DISCHARGED 2026-07-29** — first on-box run, SHA `2503bca6`. Item
+> **(a) is now settled**: the ECAPA cosine reads sane and is genuinely computed
+> (three distinct values; two clones of the *same* fixture gave
+> 0.8914416029109107 vs 0.8812903511976901 — similar but not identical, so not a
+> mock constant), and a cloned voice renders recognisably in a real book
+> (Coalfall ch.3, `resolvedVoiceName` = the clone's storage key, `asr.verdict:
+> ok`, WER 0; `/embed` similarity to the human source: audition **0.822**,
+> in-book segments **0.564**/**0.706**, against a designed-voice control of
+> **0.158**). The *by-ear* half of (a) is still owed — a human must listen.
+> Item **(b) is still owed.** The run also found a Critical defect on shipped
+> `main` — every fresh clone 500'd on its first synthesis (#1941, fixed in PR
+> #1942, verified live). Full results in
+> [`docs/testing/fs38-wave3-onbox-acceptance.md`](../testing/fs38-wave3-onbox-acceptance.md) §7;
+> remaining debt in register row A1.
+>
 > **Owed — on-box live-GPU acceptance (spec §8), not yet run.** Steps 8/9
 > above are describable from the automated suite's mocked seams but have not
 > been walked on real hardware: (a) a real recorded/uploaded sample renders

--- a/docs/features/268-fs38-wave3b2-resolver.md
+++ b/docs/features/268-fs38-wave3b2-resolver.md
@@ -329,6 +329,22 @@ only exercises the frontend/store seams.
    `-preview`/`__master.wav` siblings are all gone from disk; the entry no
    longer appears anywhere in the library.
 
+> **PARTIALLY DISCHARGED 2026-07-29** — first on-box run, SHA `2503bca6`. Item
+> **(c) is now settled and passed** (run-sheet C-10 ⭐): after a real revoke, the
+> base `.pt`, the sidecar manifest, `__1.7b.pt`, **the entry-dir `master.wav`**
+> and both cached audition mp3s were all gone, a wildcard sweep of the storage
+> key returned **0 files**, the response carried **no `artifactPurgeIncomplete`**,
+> and the entry + `voice.json` survived with `revokedAt` stamped and the rest of
+> consent intact. C-11 (delete) also passed, including the 409-with-usage guard
+> and the cast-reference cascade clearing **both** engine slots.
+> Items **(a) and (b) remain owed** — (a) needs a full-chapter render, which is
+> currently blocked on this box by the side-11 host-memory leak (use the
+> per-character splice path as a partial substitute). The ⭐ concurrency and
+> atomicity tests (C-01, C-08, C-12, C-17) were **not reached** and remain the
+> highest-risk unproven behaviour in this plan. See
+> [`docs/testing/fs38-wave3-onbox-acceptance.md`](../testing/fs38-wave3-onbox-acceptance.md) §7
+> and register row A1.
+>
 > **Owed — on-box live-GPU acceptance, not yet run.** (a) a real revoked
 > voice fails a live render loud, exactly as described in step 2 above; (b) a
 > voice re-derives identically after a real base-model bump (step 3, but

--- a/docs/features/271-fs38-wave3c-xtts.md
+++ b/docs/features/271-fs38-wave3c-xtts.md
@@ -369,6 +369,32 @@ that routes to Coqui today).
 
 ## Owed on-box acceptance
 
+> **ATTEMPTED 2026-07-29 — BLOCKED, none of E-1…E-7 discharged.** First on-box
+> run, SHA `2503bca6`. Coqui/XTTS **cannot load in a sidecar that has already
+> served ECAPA `/embed`** (`ImportError: Lazy import of
+> LazyModule(…speechbrain.integrations.k2_fsa)` → `RuntimeError: Failed to import
+> coqui-tts`, surfaced as a bare 500); a freshly-started sidecar returns a clean
+> 409 instead. Since cloning **always** calls `/embed` for the fidelity check,
+> the natural clone→render-on-Coqui sequence trips it. Filed as **#1944**, which
+> also covers two secondary defects: `/health` reports
+> `coqui_package_installed: true` from a spec probe that never imports (this is
+> how the run was mis-scoped as unblocked), and the `RuntimeError` text blames a
+> missing PyTorch when torch is installed and Qwen is rendering on GPU in the
+> same process.
+>
+> E-01 was attempted: the Coqui splice reported `splice_complete` but wrote **no
+> `voices\xtts\` artifacts** and left `characterSnapshots.wren.voiceEngine` as
+> `qwen`, because the character's own `ttsEngine: 'qwen'` overrides the requested
+> `modelKey`. To retry, flip the target character's engine to coqui (or use the
+> Russian Coalfall twin) **and** start from a sidecar that has never called
+> `/embed`. **Reassuringly, no silent substitution occurred** — the resulting
+> audio still measured as the cloned speaker (0.66 / 0.61 vs the human source),
+> so the never-substitute guarantee held even on the path that failed to reach
+> XTTS. E-08 (dual-slot provenance-gated assign) **did pass**, exercised from the
+> Qwen side via run-sheet B-07. Details in
+> [`docs/testing/fs38-wave3-onbox-acceptance.md`](../testing/fs38-wave3-onbox-acceptance.md) §7
+> and register row A1.
+
 None of the items below can be settled from a CI box — they need either a
 real GPU running the real sidecar, a real coqui-tts version bump, or a human
 ear. Tracked here rather than silently dropped; **not a merge blocker** per

--- a/docs/testing/fs38-wave3-onbox-acceptance.md
+++ b/docs/testing/fs38-wave3-onbox-acceptance.md
@@ -93,6 +93,47 @@ all three plans:
 meaningful against a recorded environment (VRAM/capacity behaviour especially —
 this box is dual-GPU).
 
+> ### Run 1 — captured 2026-07-29
+>
+> | # | Value |
+> |---|---|
+> | P-01 | 2026-07-29, ~13:40–16:10 local |
+> | P-02 | Claude Code (agent), on the repo owner's box |
+> | P-03 | `2503bca68d387bd155d337cef6746d8cfb812ac6` |
+> | P-04 | `main` |
+> | P-05 | CLEAN at run start |
+> | P-06 / P-07 / P-08 | 1.14.0 / 1.14.0 / 1.14.0 |
+> | P-09 | `engines: ["coqui","kokoro","qwen"]`, `devices_state: ready`, `poisoned: false` |
+> | P-10 | `0, NVIDIA GeForce RTX 4070 Laptop GPU, 8585 MB`, uuid `1831b67f-…` |
+> | P-11 | `1, NVIDIA GeForce RTX 5070 Ti, 17094 MB`, uuid `73e7270e-…` — **eGPU attached**, 2-card rows runnable |
+> | P-12 | 610.62 |
+> | P-13 / P-14 | Qwen weights present, `install_state: ready` / 1.7B-Base present |
+> | P-15 | `whisper_package_installed: true`; `faster-whisper-base` cached |
+> | P-16 | ECAPA `spkrec-ecapa-voxceleb` cached; `spk_device: cpu`; `/embed` returns dim 192 |
+> | P-17 | **`C:\AudiobookWorkspace`** |
+> | P-18 | `env` |
+> | P-19 | `coqui_package_installed: true`, `coqui_weights_present: true`, `coqui_version: 0.27.5` — **but see #1944: this field does not mean Coqui can actually load** |
+> | P-20 | `SEG_CAPACITY_ADMISSION=1` |
+> | P-21 | unset → local (Ollama present with `qwen36-cw-*` / `gemma4-cw-*`) |
+> | P-22 | `qwen3-tts-1.7b` |
+> | P-23 | unset at run start |
+> | P-24 | no pin; both GPUs idle, `resident: []` |
+> | P-25 | `autoStartSidecar: true` |
+>
+> **Deviation from §3's probes:** `server/.env` sets `LAN_HTTPS=1`, so the server
+> listens on **`https://localhost:8443`**, not `http://localhost:8080`. Every
+> `curl` in this sheet needs `curl.exe -k https://localhost:8443`. The sidecar is
+> unchanged at `http://localhost:9000`.
+>
+> **Fixtures:** built from public-domain LibriVox recordings (two distinct
+> narrators) and left at `C:\fixtures\fs38\` — F-1…F-9 plus `F8b-twospeaker`.
+> F-8 was regenerated at `volume=+6dB` rather than the sheet's `-8dB`, which
+> landed at −41.7 dBFS, only 3.3 dB above the −45 dBFS fatal-silence floor.
+>
+> **Baseline before the run:** `C:\AudiobookWorkspace\voice-library\` did not
+> exist and `voices\xtts\` did not exist — independent confirmation that no clone
+> had ever been created on this box. `voices\qwen\` held 1109 files / 605 `.pt`.
+
 | # | Item | How to obtain | Value (fill in) |
 |---|---|---|---|
 | P-01 | Run date / time | — | |
@@ -2531,31 +2572,31 @@ Mark each: **P** pass · **F** fail · **B** blocked · **N/A** not applicable.
 
 | ID | Test | Result | Notes |
 |---|---|---|---|
-| A-01 | Clean ≥8 s clip → candidate + transcript | | |
-| A-02 | <4 s → 400 duration message | | |
-| A-03 | Near-silent → 400 | | |
-| A-04 | 4–8 s → warns, proceeds | | |
-| A-05 | Clipping → warns, proceeds | | |
-| A-06 | >60 s → capped, not rejected | | |
-| A-07 | Browser recorder (webm/opus) end to end | | |
-| A-08 | Mic denied → Upload fallback | | |
-| A-09 | Consent gates Continue | | |
-| A-10 | Write-time consent guard; nothing persisted | | |
-| A-11 | `/revoke` stamps `revokedAt` | | |
-| A-12 | Sample route 403s a revoked voice | | |
+| A-01 | Clean ≥8 s clip → candidate + transcript | **P** | 202; real Whisper transcript; 20.0 s; 24000 Hz; `qualityWarnings` []; `master.wav`+`candidate.json`; header `52 49 46 46 … 57 41 56 45` |
+| A-02 | <4 s → 400 duration message | **P** | 400, `Sample too short (2.0s) — need at least 4s.` exact; no candidate dir created |
+| A-03 | Near-silent → 400 | **P** | 400, `Sample is silent or too quiet — record closer to the mic.` exact |
+| A-04 | 4–8 s → warns, proceeds | **P** | 202; exactly one warning, `Sample is a little short (6.0s) — 8s+ clones better.` |
+| A-05 | Clipping → warns, proceeds | **P** | 202; `Audio is clipping — lower the input level or move back from the mic.` |
+| A-06 | >60 s → capped, not rejected | **P** | 202; `durationSeconds` 60 not 90; `master.wav` **2,880,044 bytes — delta 0**; no length warning |
+| A-07 | Browser recorder (webm/opus) end to end | **B** | needs a real browser + real microphone |
+| A-08 | Mic denied → Upload fallback | **B** | needs a browser with mic permission blocked |
+| A-09 | Consent gates Continue | **B** | wizard UI; needs a browser |
+| A-10 | Write-time consent guard; nothing persisted | **P** | 422 consent message; missing `candidateId` 400; unknown 404; lib entries 0→0; `.pt` 605→605; candidate NOT consumed |
+| A-11 | `/revoke` stamps `revokedAt` | **P** | 200; `revokedAt` set, `personName`/`relationship`/`permittedUse`/`attestedAt`/`attestedBy` unchanged; entry dir + `voice.json` survive; `master` now absent; unknown uuid → 404 |
+| A-12 | Sample route 403s a revoked voice | **P** | 403 `This cloned voice has no valid consent and cannot be played.` exact; healthy control 200 `cached:true` |
 | A-13 | Voice library unconditionally available | | |
 
 #### Section B — 3b1 (13)
 
 | ID | Test | Result | Notes |
 |---|---|---|---|
-| B-01 | Wizard happy path (Upload) → ready cloned entry | | |
-| B-02 | Wizard happy path (Record) | | |
-| B-03 | Audition **sounds like the person** | | |
-| B-04 | ECAPA cosine is a real number, not a mock constant | | |
-| B-05 | Fidelity-unavailable is advisory, not fatal | | |
-| B-06 | Low-fidelity clip warns but still saves | | |
-| B-07 | Assign to a character | | |
+| B-01 | Wizard happy path (Upload) → ready cloned entry | **P** (route + disk) | 200; `$U` = `0abceba4-5eba-4d8f-8bdf-46bee14c931d`; baseModel `Qwen/Qwen3-TTS-12Hz-0.6B-Base`; entry dir `voice.json`+`master.wav`; `qwen-$U.{pt,json}`; `.pt` 605→606; candidate consumed; manifest `clone:true`, `designModel:null`, `refText`=transcript; no `preview.mp3` (expected). **UI assertions (completion screen, card badge) still owed** — driven via the API, not the wizard |
+| B-02 | Wizard happy path (Record) | **B** | needs a real browser + microphone |
+| B-03 | Audition **sounds like the person** | **B** | requires a human listener. Objective half done: `/embed` cosine audition-vs-source **0.822**, designed-voice control **0.158**. A/B kit left at `C:\fixtures\fs38\_EARCHECK\` |
+| B-04 | ECAPA cosine is a real number, not a mock constant | **P** | Three distinct finite values in [-1,1]: F-1 **0.8914416029109107**, F-1 again **0.8812903511976901** (similar, not byte-identical → computed, not stubbed), two-speaker mix **0.7727**. `cloneFidelityUnavailable` absent. A 4th clone post-fix scored 0.8916 on an independent speaker |
+| B-05 | Fidelity-unavailable is advisory, not fatal | **B** | no way to fail `/embed` independently of the clone path — the sheet's own caveat |
+| B-06 | Low-fidelity clip warns but still saves | **B — not reachable as written** | See **#1945**. The cosine scores clone-vs-source *faithfulness*, so degrading the source degrades the clone equally: clean 0.891, band-limited **0.881** (not lower), two speakers 0.773. Nothing realistic nears `CLONE_FIDELITY_MIN = 0.3`; **the advisory-warning path has never fired on hardware** |
+| B-07 | Assign to a character | **P** | 200 `{updated:1, written:["qwen","coqui"]}`; qwen slot `{name:qwen-$U, libraryUuid:$U, provenance:cloned}`; **`variants` map dropped** (had a `whisper` variant); `voiceUuid` unchanged; **coqui slot also written** `{name:xtts-$U,…}` per Task 24; all 13 characters diffed — only the target changed |
 | B-08 | Cast sample plays in the cloned voice | | |
 | B-09 | Chapter renders, consistent across lines | | |
 | B-10 | Consistent across chapters | | |
@@ -2568,7 +2609,7 @@ Mark each: **P** pass · **F** fail · **B** blocked · **N/A** not applicable.
 | ID | Test | Result | Notes |
 |---|---|---|---|
 | **C-01** ⭐ | **Revoke lands mid-derive**: `revokedAt` survives, chapter fails, no `.pt` survives | | |
-| C-02 | Revoked → fails loud, names the voice, **zero audio, zero GPU** | | |
+| C-02 | Revoked → fails loud, names the voice, **zero audio, zero GPU** | **B** | needs a full-chapter render — blocked by the side-11 leak (see §7.2 BLOCKER-1) |
 | C-03 | Broken voice not in this chapter doesn't fail it | | |
 | C-04 | Title-beat narrator path is gated | | |
 | C-05 | Orphaned-characterId narrator path is gated | | |
@@ -2576,8 +2617,8 @@ Mark each: **P** pass · **F** fail · **B** blocked · **N/A** not applicable.
 | C-07 | Base-model bump → same re-derive | | |
 | C-08 ⭐ | **Transient** failure → Broken but **not bricked**; restart + re-run succeeds | | |
 | C-09 | **Permanent** 4xx → persists `failed` (terminal) | | |
-| C-10 ⭐ | **Total erasure on revoke**, incl. the entry-dir recording | | |
-| C-11 | Delete also removes the entry dir + clears cast refs | | |
+| C-10 ⭐ | **Total erasure on revoke**, incl. the entry-dir recording | **P** | Pre-state 7 artifacts / 3 locations (`.pt`, `.json`, `__1.7b.pt`, `master.wav`, `voice.json`, 2 cached mp3s). After revoke: 200 with **no `artifactPurgeIncomplete`**; every GONE-table row gone; **wildcard sweep 0 files**; sample cache 0. Survives: entry dir + `voice.json`, `revokedAt` set, rest of consent intact, `master` block absent |
+| C-11 | Delete also removes the entry dir + clears cast refs | **P** | Unconfirmed DELETE → **409** with `usage:[{bookId, bookTitle, characterId, characterName}]`, nothing erased. `?confirm=1` → 200 `{deleted:true}`; artifacts 2→0; **entry dir removed**; the referencing character's **qwen *and* coqui** slots both cleared |
 | C-12 | Atomic `.pt`: kill mid-write leaves no truncated `.pt` | | |
 | C-13 | `wrong-engine` diagnosed distinctly at render time | | |
 | C-14 | Assign-time `wrong-engine` 409, cause-specific copy, `modelKey` wins | | |
@@ -2585,7 +2626,7 @@ Mark each: **P** pass · **F** fail · **B** blocked · **N/A** not applicable.
 | C-16 | Broken / Repairable card chip | | |
 | C-17 ⭐ | §2.3 designed self-heal + **persona survives** + re-design works | | |
 | C-18 | §2.3 stale `.pt` deliberately left alone | | |
-| C-19 | 1.7B tier renders; `__1.7b.pt` created **and erased on revoke** | | |
+| C-19 | 1.7B tier renders; `__1.7b.pt` created **and erased on revoke** | **P** | `qwen3-tts-1.7b` audition 200 in 49.7 s; `qwen-<uuid>__1.7b.pt` created (71,045 bytes); erased by the C-10 revoke above. The per-character 1.7B *toggle* UI was not exercised |
 | C-20 | Pause during a repair derive → no failure/toast | | |
 | C-21 | Partial erasure is reported, not claimed as success | | |
 
@@ -2593,10 +2634,10 @@ Mark each: **P** pass · **F** fail · **B** blocked · **N/A** not applicable.
 
 | ID | Test | Result | Notes |
 |---|---|---|---|
-| D-01 | Concurrent multi-book render sharing a cloned voice | | |
-| D-02 | Full-book render with a cloned character | | |
-| D-03 | Server + sidecar restart → still renders (cache-independent) | | |
-| D-04 | Splice / QA-repair surface plain text (expected, KL-i) | | |
+| D-01 | Concurrent multi-book render sharing a cloned voice | | not reached |
+| D-02 | Full-book render with a cloned character | **B** | blocked by side-11 (§7.2 BLOCKER-1). **Partially substituted:** a per-character re-record of a cloned character into a real chapter succeeded — `splice_complete`, 58 segments, `resolvedVoiceName` = the clone's key, `asr.verdict: ok`, WER 0 |
+| D-03 | Server + sidecar restart → still renders (cache-independent) | **P** (incidentally) | Proven repeatedly while isolating #1941: the on-disk `.pt` survived 6 stack restarts and rendered correctly each time from a cold cache. Not run as the sheet's scripted steps |
+| D-04 | Splice / QA-repair surface plain text (expected, KL-i) | | not reached |
 
 #### Section E — 3c: cloned + designed voices on Coqui XTTS v2 (9)
 
@@ -2609,21 +2650,90 @@ Mark each: **P** pass · **F** fail · **B** blocked · **N/A** not applicable.
 | E-05 | Audition matches render (KL-o caveat) | | |
 | **E-06** ⭐ | A designed voice on a Coqui book — judged against the stock voice it replaces (D-B) | | |
 | **E-07** ⭐ | A designed voice's forced derive failure still renders the chapter (D-F) | | |
-| E-08 | Assign writes both slots, provenance-gated (Task 24) | | |
-| E-09 | Total erasure of the three Coqui artifact paths on delete | | |
+| E-08 | Assign writes both slots, provenance-gated (Task 24) | **P** (via B-07) | Assigning a cloned entry wrote **both** `overrideTtsVoices.qwen` and `overrideTtsVoices.coqui` in one call — `{name: xtts-$U, libraryUuid: $U, provenance: cloned}`, `variants` absent. Confirmed twice (B-07 and the C-11 setup); C-11's delete then cleared both slots |
+| E-09 | Total erasure of the three Coqui artifact paths on delete | **N/A this run** | The three `voices\xtts\` paths never existed — no XTTS derive ever ran (see E-01). C-11 confirmed the sweep is issued; it was a no-op here |
+
+**Section E status: BLOCKED, not failed — see #1944.** Coqui/XTTS will not load in
+a sidecar that has already served ECAPA `/embed`, and cloning always calls
+`/embed`. A fresh sidecar returns a clean 409 `voice_not_designed`; a used one a
+bare 500. E-01 was attempted: the Coqui splice reported `splice_complete` but
+wrote no `voices\xtts\` artifacts and left `voiceEngine: qwen`, because the
+character's own `ttsEngine: 'qwen'` overrides the requested `modelKey`. **No
+substitution occurred** — the resulting audio still measured as the cloned
+speaker (0.66 / 0.61 vs source), so the never-substitute guarantee held.
 
 #### Totals
 
-| Section | Total | P | F | B | N/A |
-|---|---|---|---|---|---|
-| A (3a) | 13 | | | | |
-| B (3b1) | 13 | | | | |
-| C (3b2) | 21 | | | | |
-| D (cross-cutting) | 4 | | | | |
-| E (3c) | 9 | | | | |
-| **All** | **60** | | | | |
+Run 1 — 2026-07-29. "not reached" tests are counted as neither P/F/B/N/A.
+
+| Section | Total | P | F | B | N/A | not reached |
+|---|---|---|---|---|---|---|
+| A (3a) | 13 | 9 | 0 | 3 | 0 | 1 |
+| B (3b1) | 13 | 3 | 0 | 4 | 0 | 6 |
+| C (3b2) | 21 | 3 | 0 | 1 | 0 | 17 |
+| D (cross-cutting) | 4 | 1 | 0 | 1 | 0 | 2 |
+| E (3c) | 9 | 1 | 0 | 0 | 1 | 7 |
+| **All** | **60** | **17** | **0** | **9** | **1** | **33** |
+
+**Zero failures** — but that is not an acceptance signal: 33 tests were never
+reached and 9 are blocked, including all of the highest-risk ⭐ set except C-10.
+The one Critical defect this run found (#1941) was discovered *outside* the
+scripted steps, while populating an artifact set for C-10.
 
 ### 7.2 Defects found
+
+#### Run 1 — 2026-07-29
+
+**DEF-A · CRITICAL · #1941 · fixed in PR #1942 · verified live**
+**What:** every freshly cloned Qwen voice returns HTTP 500 on its first
+synthesis until the sidecar is restarted — including the wizard's own
+completion-screen audition.
+**Test ID:** found outside the scripted steps, while populating artifacts for C-10.
+**Repro:** 1. `POST /api/voice-library/clone` (200, `.pt` correct on disk).
+2. `POST /api/voice-library/{uuid}/sample` → **500**. 3. Restart the sidecar;
+the *identical* request → **200**.
+**Expected:** the audition plays. **Actual:** `ValueError: not enough values to
+unpack (expected 2, got 1)` at `main.py:5510`.
+**Evidence:** `clone_voice` (`main.py:5290`) cached a bare `prompt` where
+`_prompt_cache` is `dict[str, tuple[Any, str]]` (`:4123`) and the three other
+writers store `(prompt, lang)`. Three separate clones reproduced it; post-fix a
+new clone synthesised immediately in-process (200, 54.8 s).
+**Severity:** blocker.
+
+**DEF-B · MAJOR · #1943 — consent record cannot name the real attester.**
+`voice-library.ts:1036` hardcodes `attestedBy: consentDraft.personName`, so for
+`family-with-permission` and `guardian-of-minor` the record names the wrong
+party — a guardian's attestation is stored as the *minor* attesting to their own
+voice being cloned. The wizard has no attester field, and
+`voice-library.test.ts:2435` asserts the incorrect behaviour. Needs a product
+decision, so filed rather than fixed in-run.
+
+**DEF-C · MINOR · #1945 — the clone-fidelity advisory has never fired.** B-06's
+fixture recipe cannot lower a metric that scores clone-vs-source faithfulness.
+See the B-06 row above for the three measurements.
+
+**DEF-D · MAJOR · #1944 — Coqui/XTTS unloadable after ECAPA, and `/health` lies
+about it.** Blocks all of Section E. `coqui_package_installed: true` comes from
+a spec probe that never imports.
+
+**Not defects (recorded so they are not re-filed).** (1) `ASR_DEVICE` and
+`ASR_COMPUTE_TYPE` must agree — setting the device to `cpu` while
+`ASR_COMPUTE_TYPE=int8_float16` stays pinned 500s every `/transcribe`.
+`_compute_type()` is correct; the pairing is simply unenforced. (2) `npm start`
+looks like it spawns two sidecars but does not — the venv `python.exe` is a
+launcher that re-execs the base interpreter as a child; one process holds :9000.
+(3) `npm run stop` reported `[GONE] tts pid=… (already exited)` for a pid
+matching neither live process across several restarts — pid tracking drifts;
+minor, unfiled.
+
+**Pre-existing, not caused by this wave:** the **side-11 host-memory leak**
+(committed memory peaked at 29,395 MB, sidecar recycled 3×) makes full-chapter
+renders unreliable on this box. Also observed: `segments.json` attributes a
+13.4 s ch.3 span to `wren` whose ASR transcript is plainly narration — an
+attribution/segmentation question for the srv side, noted here only because it
+briefly produced a false "silent substitution" reading during this run.
+
+---
 
 One block per defect. Copy the template as many times as needed.
 
@@ -2679,19 +2789,35 @@ Specifically confirm these are back to their P-20 / P-22 / P-23 values:
 
 > **fs-38 Wave 3 (3a + 3b1 + 3b2) is:  ☐ ACCEPTED  ☐ ACCEPTED WITH DEFECTS  ☐ REJECTED**
 >
+> **Run 1 (2026-07-29) reaches NONE of these — the run is INCOMPLETE.**
+>
 > Accept only if **every ⭐ test passed** and there are **zero blocker defects**.
 > "Accepted with defects" requires each open defect to be filed, linked, and
 > explicitly judged non-blocking above.
 
 **Rationale (2–3 sentences):**
 
-_____________________________________________________________________________
+16 of 60 tests were executed (15 pass, 1 blocked); of the ⭐ set only **C-10**
+passed, so the acceptance bar is not met and cannot be met until Section E is
+unblocked (#1944) and the remaining ⭐ tests C-01 / C-08 / C-12 / C-17 are run.
+The run did establish the wave's central claim — a cloned voice renders inside a
+real book as the cloned speaker, measured via the production `/embed` (audition
+vs human source **0.822**, in-book segments **0.564** / **0.706**, designed-voice
+control **0.158**) with `asr.verdict: ok` and WER 0 — and it found one Critical
+defect on shipped `main` (#1941, fixed in PR #1942, verified live): every fresh
+clone 500'd on its first synthesis, i.e. the wizard's own completion audition
+failed for every user until a sidecar restart.
 
-_____________________________________________________________________________
+Two environment blockers, not fs-38 defects, gate the remainder: the **side-11
+host-memory leak** makes any full-chapter render unreliable (blocks C-02, D-02,
+D-04 — use the per-character splice path instead), and **Coqui/XTTS will not
+load in a sidecar that has already served ECAPA `/embed`** (#1944), which blocks
+all of Section E. `/health` reports Coqui available regardless, which is how this
+run was mis-scoped as unblocked.
 
-**Tester:** ______________________   **Date:** ______________________
+**Tester:** Claude Code (agent), on the repo owner's dual-GPU box   **Date:** 2026-07-29
 
-**Git SHA accepted (from P-03):** ______________________________________
+**Git SHA accepted (from P-03):** none — `2503bca6` was **tested, not accepted**
 
 ---
 

--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -94,23 +94,115 @@ the **2-card boot** (8 GB RTX 4070 + 16 GB RTX 5070 Ti over OcuLink) — and the
 eGPU is **not hot-pluggable**, so do all 2-card work in one sitting and all
 single-card work in another rather than interleaving.
 
-### A1 · fs-38 Wave 3 — voice cloning (now incl. 3c) · **60 tests, entirely unexecuted**
+### A1 · fs-38 Wave 3 — voice cloning (now incl. 3c) · **16 of 60 run 2026-07-29 · ~44 still owed**
 
-The run sheet `docs/testing/fs38-wave3-onbox-acceptance.md` is complete and has
-never been run — every `Result:` line still reads `☐ P ☐ F ☐ B ☐ N/A`, §7.1's
-tables blank. PR #1837 shipped the template (3a/3b1/3b2, 51 tests); Wave 3c
-added **Section E** (9 tests, cloned + designed voices on Coqui XTTS v2) —
-also unexecuted.
+**Partially discharged.** First execution 2026-07-29 by Claude Code on the
+dual-GPU box, SHA `2503bca6`, clean tree, real sidecar + real Qwen weights, no
+mock mode. **16 tests executed: 15 pass, 1 blocked.** Results are recorded in
+the run sheet `docs/testing/fs38-wave3-onbox-acceptance.md` (§2 preconditions
+filled, per-test `Result:` lines and §7.1 completed for the tests run). PR #1837
+shipped the template (3a/3b1/3b2, 51 tests); Wave 3c added **Section E** (9
+tests) — Section E remains entirely unrun, see the blockers below.
 
-Starred, highest-risk: **C-01** revoke mid-derive leaves no live `.pt` and
-`revokedAt` survives · **C-08** a transient failure does not brick a voice ·
-**C-10** revoke does total erasure including the original recording · **C-17**
+**The run found one Critical defect, now fixed.** Every freshly cloned Qwen
+voice returned HTTP 500 on its first synthesis until the sidecar restarted —
+including the clone wizard's own completion-screen audition, i.e. the first
+thing a user does after cloning. `clone_voice` cached a bare prompt where
+`_load_voice_prompt` unpacks a `(prompt, language)` tuple
+(`ValueError: not enough values to unpack`). Filed as **#1941**, fixed in
+**PR #1942**, verified live on-box (clone → immediate synth in the same process
+now returns 200). *This is the case for this register existing:* the feature's
+central path was broken on shipped `main`, and no automated suite could see it
+because unit tests mock the engine and no pytest exercised clone→synth in one
+process against the real cache.
+
+**Discharged (do not re-run):** A-01…A-06 (ingest + the full quality-gate tier
+set — including the 60s truncation landing at 2,880,044 bytes, delta 0), A-10
+(write-time consent guard: 422/400/404, nothing written), A-11 (`/revoke`
+stamps `revokedAt`, rest of consent intact, entry survives), A-12 (sample route
+403s a revoked clone, healthy control 200), B-01 (route + on-disk half —
+UI assertions still owed), B-04 (ECAPA cosine is real: three distinct finite
+values, two clones of the same fixture gave 0.8914 vs 0.8813 — not a mock
+constant), B-07 (assign writes both qwen **and** coqui slots per Task 24, drops
+the stale `variants` map, leaves `voiceUuid` untouched; all 13 characters
+diffed, only the target changed), **C-10** ⭐ (total erasure on revoke — 7
+artifacts across 3 locations all gone including both cached mp3s and the
+original recording; wildcard sweep 0 files; entry + `voice.json` survive with
+`revokedAt`), **C-11** (409-with-usage then `{deleted:true}`, entry dir removed,
+both cast slots cascade-cleared), C-19 first half (1.7B tier renders a cloned
+voice; its erasure is covered by C-10).
+
+**Also proven — the wave's central claim, measured not asserted.** A cloned
+voice renders inside a real book: `wren`'s segments re-recorded into Coalfall
+ch.3, `characterSnapshots.wren.resolvedVoiceName` = the clone's storage key,
+segments carrying `asr.verdict: ok` / **WER 0**. Speaker identity via the
+production `/embed`: 20s audition vs human source **0.822**; in-book segments
+**0.564** and **0.706**; designed-voice control **0.158**. The by-ear
+confirmation (B-03, E-06) is still owed — a human must listen.
+
+**Still owed (~44), and why:**
+- **Browser/mic (4):** A-07 (recorder webm/opus), A-08 (mic-denial fallback),
+  A-09 (consent gates Continue), B-02 (record-path clone). Need a real browser
+  with a real microphone.
+- **By ear (2):** B-03, E-06. No instrument substitutes; ECAPA cosines above are
+  the objective half only.
+- **Section E, all 9 — BLOCKED by #1944.** Coqui/XTTS cannot load in a sidecar
+  that has already served ECAPA `/embed`, and cloning always calls `/embed` for
+  the fidelity check. A fresh sidecar returns a clean 409; a used one a bare
+  500. Note `/health` reports `coqui_package_installed: true` regardless, which
+  is how this row was previously scoped as unblocked — treat that field with
+  suspicion when planning.
+- **C-02, D-02 and any full-book work — BLOCKED by the side-11 host-memory
+  leak.** Two full-chapter render attempts died: one at the QA gate (ASR could
+  not get VRAM alongside Kokoro), one with `recycle-storm` after the sidecar
+  recycled 3× (committed memory peaked at 29,395 MB). The sidecar's own log
+  names it: *"expected for the variable-shape leak; the restart ceiling is the
+  real guard"*. **Workaround that works today:** the per-character re-record
+  (splice) path renders one character's lines without the full-chapter memory
+  churn — that is how the central claim above was proven.
+- **B-06 — cannot pass as written, see #1945.** The clone-fidelity cosine scores
+  clone-vs-source *faithfulness*, so degrading the source degrades the clone
+  equally and the number does not fall (measured: clean 0.891, band-limited
+  0.881, two speakers overlaid 0.773). The advisory-warning path has therefore
+  **never fired on real hardware**.
+- **The rest of Section C (18) and Section D (3):** not reached. C-08/C-12
+  (deliberate mid-write sidecar kills) and C-01/E-03 (revoke racing an in-flight
+  derive) are untouched and remain the highest-risk unproven behaviour here.
+
+**Two findings that are NOT defects, recorded so they are not re-filed.** (1)
+`ASR_DEVICE` and `ASR_COMPUTE_TYPE` in `server/.env` must agree — flipping the
+device to `cpu` while `ASR_COMPUTE_TYPE=int8_float16` remains pinned makes every
+`/transcribe` 500. `_compute_type()` is correct; nothing enforces the pairing.
+(2) `npm start` appears to launch two sidecars but does not — the venv
+`python.exe` is a launcher that re-execs the base interpreter as a child. Only
+one holds :9000. Separately, `npm run stop` repeatedly reported
+`[GONE] tts pid=… (already exited)` for a pid matching neither live process, so
+its pid tracking drifts across restarts — minor, unfiled.
+
+**Also opened by this run:** #1943 (consent record cannot name the real
+attester — `attestedBy` is overwritten with `personName`, which inverts
+`guardian-of-minor`).
+
+Starred, highest-risk — **C-10 is now discharged (passed 2026-07-29)**; the rest
+remain: **C-01** revoke mid-derive leaves no live `.pt` and `revokedAt` survives ·
+**C-08** a transient failure does not brick a voice · **C-17**
 designed-voice self-heal preserves persona · **C-12** a killed mid-write leaves
 no truncated `.pt` · **E-01** clone → cast on Coqui → generate · **E-02**
 audition-then-revoke refuses Play on the Coqui path · **E-06** the one place
 D-B's synthetic-clip-vs-catalogue quality question can actually be judged, by
 ear · **E-07** a forced designed-derive failure still renders the chapter
 (fail-soft, the opposite policy from cloned's fail-loud).
+
+**E-01 was attempted and is blocked, not failed.** A Coqui splice reported
+`splice_complete` but wrote no `voices\xtts\` artifacts and left
+`characterSnapshots.wren.voiceEngine` as `qwen` — the character's own
+`ttsEngine: 'qwen'` overrides the requested `modelKey`. To attempt Section E,
+first flip the target character's engine to coqui (or use the Russian Coalfall
+twin, which routes there natively), **and** start from a sidecar that has never
+called `/embed` (#1944). Reassuringly, the post-splice audio still measured as
+the cloned speaker (0.66 / 0.61 vs source), so **no silent substitution
+occurred** — the never-substitute guarantee held even on the path that failed to
+reach XTTS.
 
 C-08 and C-12 deliberately kill the sidecar mid-write — nothing else in flight.
 D-01 deliberately runs two concurrent book renders sharing one cloned voice.
@@ -120,7 +212,19 @@ E-03 deliberately races a revoke against an in-flight Coqui derive.
 Coalfall fixture with ≥2 speaking characters/chapter, the 9 audio fixtures in §4,
 and (for Section E) a Coqui-capable sidecar plus a non-English (e.g. Russian)
 book fixture that actually routes to Coqui.
-*Plans:* 267, 268, 271 — all `status: active`, Ship notes empty. *Cost:* multi-hour.
+*Prerequisites confirmed present on the box 2026-07-29:* Qwen 0.6B/1.7B-Base +
+VoiceDesign, `faster-whisper-base`, ECAPA `spkrec-ecapa-voxceleb`, coqui-tts
+0.27.5 + xtts_v2 weights, both GPUs (the eGPU was attached, so 2-card rows are
+runnable), and Coalfall already imported and analysed in 7 languages incl. the
+Russian twin. **The §4 audio fixtures now exist** at `C:\fixtures\fs38\` —
+public-domain LibriVox, two distinct narrators, F-1…F-9 built and verified
+against the `clone-quality.ts` thresholds — so a follow-up session does not need
+to rebuild them. Note the box runs `LAN_HTTPS=1`, so the server is on
+`https://localhost:8443`, **not** the `http://localhost:8080` the run sheet's
+§3 probes assume.
+*Plans:* 267, 268, 271 — all `status: active`, Ship notes now record this
+partial run. *Cost:* multi-hour; the 2026-07-29 session spent roughly half its
+time on the three environment blockers above rather than on tests.
 
 **Six checks added by the post-32 follow-up campaign, same box/setup as
 above — batch them into the same session:**


### PR DESCRIPTION
﻿## Summary

Records the **first execution** of the fs-38 Wave 3 on-box acceptance sheet, which had never been run (register row A1 read "60 tests, entirely unexecuted"). Run 2026-07-29 on the dual-GPU box, SHA `2503bca6`, clean tree, real sidecar + real Qwen weights, no mock mode.

**16 of 60 tests executed: 15 pass, 1 blocked, zero failures.** Row A1 is **partially discharged, not cleared** — per the register's own rule, a row comes out only when the acceptance was run and the outcome recorded, so it now states what was proven, what remains, and why.

### Proven

- **The wave's central claim, measured rather than asserted.** A cloned voice renders inside a real book as the cloned speaker: `characterSnapshots.resolvedVoiceName` = the clone's storage key, `asr.verdict: ok`, WER 0. Speaker identity via the production `/embed` — audition vs human source **0.822**, in-book segments **0.564** / **0.706**, designed-voice control **0.158**.
- **C-10 ⭐ total erasure on revoke** — 7 artifacts across 3 locations gone including both cached mp3s and the original recording, wildcard sweep 0 files, no `artifactPurgeIncomplete`, entry + consent survive with `revokedAt`.
- **C-11 delete** — 409-with-usage, then entry dir removed and both cast slots cascade-cleared.
- **B-07 assign** — writes both qwen and coqui slots (Task 24), drops the stale `variants` map, leaves `voiceUuid` untouched; all 13 characters diffed, only the target changed.
- The full 3a quality-gate tier set, the write-time consent guard, and `/revoke` + revoked-play refusal.

### Found

One **Critical** defect on shipped `main`: every freshly cloned Qwen voice returned HTTP 500 on its first synthesis until the sidecar restarted — i.e. the clone wizard's own completion-screen audition failed for every user, every time. Filed **#1941**, fixed in **PR #1942**, verified live. This is the case for the register existing: no automated suite could see it, because unit tests mock the engine and no pytest exercised clone→synth in one process against the real cache.

Also filed: **#1943** (consent record cannot name the real attester — `attestedBy` is overwritten with `personName`, inverting `guardian-of-minor`), **#1944** (Coqui/XTTS unloadable in a sidecar that has already served ECAPA `/embed`, while `/health` reports it available — blocks all of Section E), **#1945** (the clone-fidelity advisory has never fired; B-06's fixture recipe cannot lower a clone-vs-source metric).

### Still owed

~44 tests, now itemised in A1 with reasons: browser/mic (4), by-ear (2), all of Section E (blocked by #1944), C-02/D-02 (blocked by the pre-existing side-11 host-memory leak — full-chapter renders recycle; the per-character splice path is the workaround), and the unreached remainder of Sections C and D, which still contains the highest-risk ⭐ tests C-01, C-08, C-12 and C-17.

## Test plan

Documentation only — no runtime change, so no paired automated test applies. `npm run check:onbox-register` passes (exit 0), which is the mechanical guard on this file's internal arithmetic. The register's row counts are unchanged because A1 remains a row; only its content changed.

Per CLAUDE.md this is a doc-only PR (`docs/**` only), so it takes the doc-only CI fast-path and is exempt from the `code-review` gate.

Refs #624
