### PR TITLE
fix(server): make the openapi setup-parity test line-ending agnostic

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,6 +22,11 @@ src/lib/api-types.ts text eol=lf
 # on a clean tree (the generator emits LF, the checkout is CRLF). Pin to LF.
 .env.example text eol=lf
 
+# openapi.yaml is read as text at runtime by the parity test and is the input to
+# `npm run openapi:types`. With core.autocrlf=true on Windows, it materialises as
+# CRLF and breaks line-anchored matching in schemaBlock() (#1952). Pin to LF.
+openapi.yaml text eol=lf
+
 # Binary files we never want autocrlf to touch.
 *.png binary
 *.jpg binary

--- a/docs/features/270-openapi-setup-surface.md
+++ b/docs/features/270-openapi-setup-surface.md
@@ -171,6 +171,12 @@ bug survived. Proving the fix needs a box with no venv and the patience for a
 
 ## Known limitations
 
+- **The parity matching must stay line-ending agnostic.** `openapi.yaml` is
+  pinned to LF in `.gitattributes` (#1952 / cross-OS Windows runner),
+  but the test defensively tolerates both LF and CRLF via regex anchors
+  (`\r?\n`) in `schemaBlock()` and the next-sibling scan. This prevents a
+  future `.gitattributes` edit from silently breaking the Windows leg of
+  `verify.yml`.
 - **The route-coverage assertion is a literal, not derived from the routers.**
   It catches a path being removed from `openapi.yaml`, but a brand-new route
   mounted without a description would still pass. Deriving the expected set by

--- a/server/src/routes/openapi-setup-parity.test.ts
+++ b/server/src/routes/openapi-setup-parity.test.ts
@@ -10,7 +10,18 @@
    force-rerun-triggers.test.ts:108), so the ops-30/#1848 pin-inertness trap is
    already closed for this file. Mirrors the string-match mechanism
    voice-library.test.ts:1761 already uses against this same file — no YAML
-   parser, no new dependency. */
+   parser, no new dependency.
+
+   **Line-ending agnostic:** The parity matching must tolerate both LF and CRLF
+   because GitHub's Windows runner (core.autocrlf=true) checks out with CRLF,
+   and string-based anchor matching can fail if the test depends on one ending
+   only. openapi.yaml is pinned to LF in .gitattributes (#1952) to ensure fresh
+   clones on all CI runners receive LF. But the pin cannot reach a worktree where
+   the file already materialises as CRLF — git will not rewrite an unchanged blob
+   on pull, and core.autocrlf normalises on comparison, so an existing checkout
+   keeps CRLF indefinitely. The test-side tolerance covers everyone else: regex
+   anchors use \r?\n instead of literal \n, both in the schema anchor and the
+   sibling scan. */
 import { describe, it, expect, beforeAll } from 'vitest';
 import { readFile } from 'node:fs/promises';
 /* Type-only imports — fully erased at runtime, so they add no module-graph
@@ -31,13 +42,13 @@ beforeAll(async () => {
 
 /** The text of one `components.schemas` entry: from its own anchor up to (but
     not including) the next sibling schema at the same 4-space indent. */
-function schemaBlock(schemaName: string): string {
-  const anchor = `\n    ${schemaName}:\n`;
-  const start = yaml.indexOf(anchor);
-  expect(start, `schema ${schemaName} not found in openapi.yaml`).toBeGreaterThan(-1);
-  const bodyStart = start + anchor.length;
-  const rest = yaml.slice(bodyStart);
-  const next = /\n {4}[A-Za-z][A-Za-z0-9]*:\n/.exec(rest);
+function schemaBlock(src: string, schemaName: string): string {
+  const anchor = new RegExp(`\\r?\\n {4}${schemaName}:\\r?\\n`);
+  const match = anchor.exec(src);
+  expect(match, `schema ${schemaName} not found in openapi.yaml`).not.toBeNull();
+  const bodyStart = match!.index + match![0].length;
+  const rest = src.slice(bodyStart);
+  const next = /\r?\n {4}[A-Za-z][A-Za-z0-9]*:\r?\n/.exec(rest);
   return rest.slice(0, next ? next.index : undefined);
 }
 
@@ -56,16 +67,16 @@ function extractEnum(block: string): string[] {
 
 /** A top-level schema whose OWN `type: string` carries the enum directly
     (BlockerCause, BlockerActionKind). */
-function schemaEnum(schemaName: string): string[] {
-  return extractEnum(schemaBlock(schemaName));
+function schemaEnum(src: string, schemaName: string): string[] {
+  return extractEnum(schemaBlock(src, schemaName));
 }
 
 /** A union openapi.yaml describes inline on one property of a bigger schema
     rather than as its own named component — everything Tasks 2-3 added
     (RuntimeStatus.process, EngineStatus.state, EngineRecommendation.engine,
     VenvDetectResult.state, VenvBootstrapJob.status). */
-function propertyEnum(schemaName: string, propertyName: string): string[] {
-  const block = schemaBlock(schemaName);
+function propertyEnum(src: string, schemaName: string, propertyName: string): string[] {
+  const block = schemaBlock(src, schemaName);
   const idx = block.indexOf(`${propertyName}:`);
   expect(idx, `property ${propertyName} not found on schema ${schemaName}`).toBeGreaterThan(-1);
   return extractEnum(block.slice(idx));
@@ -73,8 +84,8 @@ function propertyEnum(schemaName: string, propertyName: string): string[] {
 
 /** Every `/api/setup/*` path key under `paths:` (2-space indent). Keeps
     `{id}`-style params literal, matching app.ts's `:id` param 1:1 in prose. */
-function describedSetupPaths(): string[] {
-  return [...yaml.matchAll(/^ {2}(\/api\/setup\/\S*):$/gm)].map((m) => m[1]);
+function describedSetupPaths(src: string): string[] {
+  return [...src.matchAll(/^ {2}(\/api\/setup\/\S*):$/gm)].map((m) => m[1]);
 }
 
 /* Each map is `satisfies Record<TheServerUnion, 1>`, which is what makes this
@@ -128,42 +139,42 @@ const VENV_BOOTSTRAP_JOB_STATUSES = {
 
 const SERVER_UNIONS: Record<
   string,
-  { source: string; members: readonly string[]; read: () => string[] }
+  { source: string; members: readonly string[]; read: (src: string) => string[] }
 > = {
   BlockerCause: {
     source: 'server/src/routes/setup-readiness.ts',
     members: Object.keys(BLOCKER_CAUSES),
-    read: () => schemaEnum('BlockerCause'),
+    read: (src: string) => schemaEnum(src, 'BlockerCause'),
   },
   BlockerActionKind: {
     source: 'server/src/routes/setup-readiness.ts',
     members: Object.keys(BLOCKER_ACTION_KINDS),
-    read: () => schemaEnum('BlockerActionKind'),
+    read: (src: string) => schemaEnum(src, 'BlockerActionKind'),
   },
   RuntimeProcessState: {
     source: 'server/src/tts/models-status.ts',
     members: Object.keys(RUNTIME_PROCESS_STATES),
-    read: () => propertyEnum('RuntimeStatus', 'process'),
+    read: (src: string) => propertyEnum(src, 'RuntimeStatus', 'process'),
   },
   EngineHealthState: {
     source: 'server/src/tts/engine-health.ts',
     members: Object.keys(ENGINE_HEALTH_STATES),
-    read: () => propertyEnum('EngineStatus', 'state'),
+    read: (src: string) => propertyEnum(src, 'EngineStatus', 'state'),
   },
   VoiceEngineId: {
     source: 'server/src/tts/voice-engine-registry.ts',
     members: Object.keys(VOICE_ENGINE_IDS),
-    read: () => propertyEnum('EngineRecommendation', 'engine'),
+    read: (src: string) => propertyEnum(src, 'EngineRecommendation', 'engine'),
   },
   VenvBootstrapState: {
     source: 'server/src/tts/venv-bootstrap.ts',
     members: Object.keys(VENV_BOOTSTRAP_STATES),
-    read: () => propertyEnum('VenvDetectResult', 'state'),
+    read: (src: string) => propertyEnum(src, 'VenvDetectResult', 'state'),
   },
   VenvBootstrapJobStatus: {
     source: 'server/src/tts/venv-bootstrap.ts',
     members: Object.keys(VENV_BOOTSTRAP_JOB_STATUSES),
-    read: () => propertyEnum('VenvBootstrapJob', 'status'),
+    read: (src: string) => propertyEnum(src, 'VenvBootstrapJob', 'status'),
   },
 };
 
@@ -172,7 +183,7 @@ describe('openapi.yaml describes the /api/setup/* surface accurately', () => {
     '%s matches its TypeScript union',
     (name, { source, members, read }) => {
       expect(
-        read(),
+        read(yaml),
         `openapi.yaml's ${name} disagrees with this test's exhaustive map. ` +
           `The authority is ${source}; if you just changed that union, typecheck ` +
           `will have failed here too — update openapi.yaml to match.`,
@@ -189,7 +200,7 @@ describe('openapi.yaml describes the /api/setup/* surface accurately', () => {
        it from server/src/app.ts's mounts is the honest fix; recorded as a
        known limitation in plan 270 rather than overclaimed here.
        Mounted via setupReadinessRouter, modelsStatusRouter, venvBootstrapRouter. */
-    expect(describedSetupPaths().sort()).toEqual([
+    expect(describedSetupPaths(yaml).sort()).toEqual([
       '/api/setup/complete',
       '/api/setup/models-status',
       '/api/setup/readiness',
@@ -199,5 +210,33 @@ describe('openapi.yaml describes the /api/setup/* surface accurately', () => {
       '/api/setup/venv/bootstrap/{id}/recheck',
       '/api/setup/venv/detect',
     ]);
+  });
+
+  it('reads a CRLF checkout identically (Windows core.autocrlf=true, #1952)', () => {
+    /* Normalise yaml to LF first, then derive both test copies from that.
+       On a Windows checkout that already gave CRLF, deriving both from the same
+       normalized LF version keeps the test non-vacuous — without this, comparing
+       a raw CRLF checkout against a derived CRLF copy would be comparing a value
+       to itself, and the test would pass trivially on the one platform it's for. */
+    const lf = yaml.replace(/\r\n/g, '\n');
+    const crlf = lf.replace(/\n/g, '\r\n');
+    for (const [name, { read }] of Object.entries(SERVER_UNIONS)) {
+      expect(read(crlf), `${name} differs between LF and CRLF`).toEqual(read(lf));
+    }
+    expect(describedSetupPaths(crlf), 'describedSetupPaths differs between LF and CRLF').toEqual(
+      describedSetupPaths(lf),
+    );
+
+    /* Block-level assertions: enum comparison alone cannot see an over-extended
+       block (where the sibling scan fails to find the next schema boundary and
+       returns the rest of the file). Compare the actual blocks to lock the sibling
+       scan's line-ending tolerance. Use mid-file schemas so bounded and unbounded
+       slices visibly differ. */
+    expect(schemaBlock(crlf, 'RuntimeStatus').replace(/\r/g, '')).toEqual(
+      schemaBlock(lf, 'RuntimeStatus'),
+    );
+    expect(schemaBlock(crlf, 'EngineStatus').replace(/\r/g, '')).toEqual(
+      schemaBlock(lf, 'EngineStatus'),
+    );
   });
 });


### PR DESCRIPTION
## Summary

`Cross-OS Verify` has been red on `main` since the 2026-07-29 cron run ([30423665833](https://github.com/dudarenok-maker/Castwright/actions/runs/30423665833)): the `windows-latest` leg failed 7 tests in `server/src/routes/openapi-setup-parity.test.ts`, every one reporting `schema <Name> not found in openapi.yaml: expected -1 to be greater than -1`. macOS and the Ubuntu PR battery were green.

`schemaBlock()` anchored on an LF-only literal — `` `\n    ${schemaName}:\n` `` — and `.gitattributes` declares `* text=auto` without pinning `openapi.yaml`, so GitHub's Windows runner (`core.autocrlf=true` by default) materialises the file with CRLF and every `indexOf` returns `-1`. Measured against the real file:

```
LF   indexOf('\n    BlockerCause:\n'):  308668
CRLF indexOf('\n    BlockerCause:\n'):  -1
```

The sibling route-coverage test survived because JS `$` under `/m` matches before `\r` as well as `\n` — which is why the count was 7 and not 8.

The test landed on 2026-07-27 (fe-57 / #1883). PR CI runs on Ubuntu only and `cross-os.yml` runs twice weekly, so the first Windows execution was the cron two days later; local Windows boxes carry `core.autocrlf=false`, so it passes there too.

Two-part fix, deliberately belt-and-braces:

1. **`.gitattributes` pins `openapi.yaml text eol=lf`** — closes the class for every consumer of the file, not just this test. Three other tests read it at runtime (`server/src/routes/voice-library.test.ts:2604`, `src/lib/api.clone-voice.test.ts:126` and `:155`); they are safe today only because their anchors carry no embedded newline, so the exposure was latent rather than absent. Checkout-only rule — the file is already LF in the index, so it produces no diff to `openapi.yaml`.
2. **The test's matching is line-ending agnostic** — `schemaBlock()` anchors via `\r?\n` regex instead of an LF literal, and the helpers take the yaml source as a parameter so a CRLF copy can be fed through them. This keeps the test standing on its own rather than depending on a `.gitattributes` rule a future edit could remove.

Also updated plan 270's "Known limitations" to record the constraint.

## Test plan

- New regression test `reads a CRLF checkout identically (Windows core.autocrlf=true, #1952)` runs every union's reader plus `describedSetupPaths()` over a CRLF copy and asserts identical results. It normalises to LF *first* and derives both copies from that — comparing a derived CRLF copy against the raw checkout would compare a value to itself on a CRLF checkout, i.e. go vacuous on exactly the platform it exists for.
- Fail-before proven by reverting only the `\r?\n` anchor to the LF-only literal: `1 failed | 8 passed`, `schema BlockerCause not found in openapi.yaml: expected null not to be null`. Restored: `9 passed`.
- `npm run typecheck` clean (frontend + server). The `satisfies Record<TheUnion, 1>` chain the file is built on is untouched.
- Pre-push `npm run verify:fast:branch` green, including the full `test:server` leg (451 files, 5927 tests).

**Release notes:** skipped — test/CI-only, no user- or operator-visible delta.
**On-box acceptance:** not applicable; no hardware-dependent behaviour.

Closes #1952

## Review findings folded

The mandatory `code-review` pass proved by mutation that the regression test locked only half the fix: reverting the anchor to LF-only failed the suite, but reverting the *sibling scan* to LF-only left it 9/9 green. An LF-only sibling scan on CRLF input makes `next` null, so `schemaBlock()` returns the rest of the file instead of one schema — today invisible only because `extractEnum` takes the first `enum:` and `propertyEnum` finds the property inside its own schema first, so bounded and unbounded happen to agree. Break that coincidence and the test reports a wrong parity verdict instead of failing.

Fixed by adding block-level assertions (`RuntimeStatus`, `EngineStatus` — mid-file, so bounded and unbounded slices differ). Comparing enums cannot see an over-extended block; comparing the blocks can. All three mutation states now behave: sibling scan reverted → fails, anchor reverted → fails, both restored → 9 passed.

Two findings deliberately not actioned: interpolating a schema name into `new RegExp` is no longer a literal match (every `components.schemas` key in the file is `[A-Za-z][A-Za-z0-9]*`, and the sibling scan already could not recognise anything else as a sibling, so it is latent-only); and the observation that the `.gitattributes` pin cannot reach a worktree where the file is *already* CRLF, since git will not rewrite an unchanged blob and `text` normalises on comparison. That last one is the sharpest statement of why both halves are needed and is now recorded in the test file's header comment.
