### PR TITLE
test(server,docs): cover the clone-fidelity advisory and retire B-06

### DIFF
--- a/docs/testing/fs38-wave3-onbox-acceptance.md
+++ b/docs/testing/fs38-wave3-onbox-acceptance.md
@@ -416,7 +416,7 @@ Prepare these **before** starting. Put them somewhere stable, e.g.
 | F-5 | **Clipped / too-loud clip** | ≥8 s with >0.5 % of samples at/above −0.1 dBFS | `ffmpeg -i F-1 -af "volume=25dB" -t 10 clipped-10s.wav` | A-05 | |
 | F-6 | **Over-cap clip (>60 s)** | ~90 s | `ffmpeg -i F-1 -filter_complex "aloop=loop=8:size=2e9" -t 90 long-90s.wav` | A-06 | |
 | F-7 | **Browser-recorder capture (webm/opus)** | Produced live by the in-app recorder — `VoiceRecorder` builds the Blob as `type: 'audio/webm'` (`src/components/voices/voice-recorder.tsx:19`) | Nothing to pre-make; produced during A-07. Keep a copy if you can, for re-use. | A-07, B-02 | |
-| F-8 | **Low-fidelity clip** | A clip that will score a *low* ECAPA cosine against its own clone — e.g. F-1 heavily noised or band-limited: `ffmpeg -i F-1 -af "highpass=f=800,lowpass=f=2000,volume=-8dB" lowfi.wav` | Advisory warning fires below `CLONE_FIDELITY_MIN = 0.3` (`server/src/tts/clone-fidelity.ts:16`). ⚠️ Not guaranteed to trip on the first try — iterate the filter until the persisted `cloneCosine` is < 0.30. | B-06 | |
+| F-8 | **Degraded-source clip** | A clip that noticeably degrades vs. F-1, for the B-04 relative-cosine sanity check — e.g. F-1 band-limited: `ffmpeg -i F-1 -af "highpass=f=800,lowpass=f=2000,volume=+6dB" lowfi.wav`. **Use `+6dB`, not `-8dB`**: the sheet originally specified `-8dB`, which lands at −41.7 dBFS RMS, only 3.3 dB above the −45 dBFS fatal-silence floor in `clone-quality.ts:10` — it risks rejection as silent rather than testing anything; this run used `+6dB` instead. Does **not** drive the clone-fidelity advisory warning (#1945): that cosine compares the clone against its OWN, equally-degraded source, so it barely moves — see B-06. | B-04 | |
 | F-9 | **A second, different speaker's clean clip** | ≥8 s | Any second voice. | D-01 (two books, two voices), C-03 | |
 
 ### 4.1 The book to render
@@ -901,7 +901,7 @@ the real path. The mock path (`src/mocks/`) is only reachable with
    (Get-Content "$WS\voice-library\$U\voice.json" -Raw | ConvertFrom-Json).sampleMeta.qualityChecks
    ```
 2. Clone the **same** fixture a second time under a different name and read its cosine.
-3. Clone the **low-fidelity** fixture F-8 and read its cosine (this doubles as B-06 setup).
+3. Clone the **degraded-source** fixture F-8 and read its cosine. This is a *relative* sanity check only — it does **not** set up B-06 (#1945: degrading the source can't trip the clone-fidelity advisory, since the cosine compares the clone against that same degraded source).
 4. Confirm the sidecar actually served `/embed` — check `logs\tts.log` around the clone timestamp.
 
 **Expected**
@@ -911,7 +911,8 @@ the real path. The mock path (`src/mocks/`) is only reachable with
   values — proof it is being computed, not stubbed. Two *identical* values to
   full float precision across different clones is the mock-constant smell:
   investigate before passing.
-- F-8's cosine is **materially lower** than F-1's.
+- F-8's cosine is **materially lower** than F-1's — but not below `CLONE_FIDELITY_MIN`
+  (#1945: a same-source comparison, so it stays well above the catastrophe-only backstop).
 - `cloneFidelityUnavailable` is **absent** when `/embed` is reachable.
 
 **Record:** F-1 cosine run 1 = ______ run 2 = ______ · F-8 cosine = ______
@@ -951,26 +952,41 @@ still works. Practical options, in order of preference:
 
 ---
 
-#### B-06 — A low-fidelity clip surfaces the advisory warning but still saves
+#### B-06 — Clone-fidelity advisory warning fires below the threshold, non-blocking (N/A — covered by automated test)
 
-**Proves:** the advisory-not-blocking design — `CLONE_FIDELITY_MIN = 0.3`
-(`clone-fidelity.ts:16`).
+**Formerly:** run the wizard against a deliberately degraded fixture (F-8),
+iterating its filter until the persisted `cloneCosine` dropped below
+`CLONE_FIDELITY_MIN = 0.3`.
 
-**Preconditions:** fixture F-8, iterated until its cosine lands **below 0.30**
-(see B-04 step 3).
+**Retired 2026-07-30 (#1945):** that instruction cannot work. The advisory
+cosines the clone's audition preview against its OWN master clip, so
+degrading the source degrades both sides of the comparison together — the
+on-box run-1 measurements (see the results table below) show the cosine
+essentially unmoved by a band-limited source (clean 0.891/0.881 vs.
+band-limited **0.881**, not lower). **Disposition:** `CLONE_FIDELITY_MIN`
+stays at `0.3` as a documented catastrophe-only backstop — it fires when a
+clone comes out sounding like a *different speaker* (a designed-voice control
+measured **0.158**), not on source-quality degradation, which is already
+gated separately by `clone-quality.ts`. See `clone-fidelity.ts`'s header
+comment for the full rationale.
 
-**Steps**
-1. Run the wizard to Save with F-8.
-2. Read `sampleMeta.qualityChecks` on the persisted entry.
+**Automated coverage (replaces this manual step):**
+`server/src/routes/voice-library.clone-fidelity.test.ts`. It drives the real
+`POST /api/voice-library/clone` route and stubs the `/embed` boundary
+(`embedSegment`, `tts/embed-client.ts`) directly, rather than trying to
+synthesise audio that scores low:
+- vectors scoring **above** `CLONE_FIDELITY_MIN` persist **no**
+  `cloneFidelityWarning`;
+- vectors scoring **below** it persist **both** `cloneCosine` and
+  `cloneFidelityWarning`, and the clone still **saves** (200, `ready`) —
+  proving the warning is non-blocking.
 
-**Expected**
-- The clone **saves** (200) — the warning never blocks.
-- The completion screen shows the advisory line, beginning
-  `This clone sounds only loosely like the sample (similarity 0.NN).`
-- `voice.json` carries both `cloneCosine` (< 0.30) and `cloneFidelityWarning`.
-- The card still appears in My voices and is assignable.
+Both assertions compare against the live `CLONE_FIDELITY_MIN` constant, not a
+hardcoded number, so the test fails if the threshold is ever moved past
+either injected cosine.
 
-**Result:** ☐ P ☐ F ☐ B ☐ N/A  **Notes:**
+**Result:** ☐ P ☐ F ☐ B ☒ N/A  **Notes:** superseded by automated coverage —
+see `server/src/routes/voice-library.clone-fidelity.test.ts` (#1945).
 
 ---
 
@@ -2595,7 +2611,7 @@ Mark each: **P** pass · **F** fail · **B** blocked · **N/A** not applicable.
 | B-03 | Audition **sounds like the person** | **B** | requires a human listener. Objective half done: `/embed` cosine audition-vs-source **0.822**, designed-voice control **0.158**. A/B kit left at `C:\fixtures\fs38\_EARCHECK\` |
 | B-04 | ECAPA cosine is a real number, not a mock constant | **P** | Three distinct finite values in [-1,1]: F-1 **0.8914416029109107**, F-1 again **0.8812903511976901** (similar, not byte-identical → computed, not stubbed), two-speaker mix **0.7727**. `cloneFidelityUnavailable` absent. A 4th clone post-fix scored 0.8916 on an independent speaker |
 | B-05 | Fidelity-unavailable is advisory, not fatal | **B** | no way to fail `/embed` independently of the clone path — the sheet's own caveat |
-| B-06 | Low-fidelity clip warns but still saves | **B — not reachable as written** | See **#1945**. The cosine scores clone-vs-source *faithfulness*, so degrading the source degrades the clone equally: clean 0.891, band-limited **0.881** (not lower), two speakers 0.773. Nothing realistic nears `CLONE_FIDELITY_MIN = 0.3`; **the advisory-warning path has never fired on hardware** |
+| B-06 | Clone-fidelity advisory warning | **N/A — retired, automated** | Originally found **B — not reachable as written**: See **#1945**. The cosine scores clone-vs-source *faithfulness*, so degrading the source degrades the clone equally: clean 0.891, band-limited **0.881** (not lower), two speakers 0.773. Nothing realistic nears `CLONE_FIDELITY_MIN = 0.3`; **the advisory-warning path has never fired on hardware**. Resolved 2026-07-30: threshold kept as a catastrophe-only backstop (fires on a wrong-speaker clone — 0.158 datapoint); manual step replaced by `server/src/routes/voice-library.clone-fidelity.test.ts`. See DEF-C below |
 | B-07 | Assign to a character | **P** | 200 `{updated:1, written:["qwen","coqui"]}`; qwen slot `{name:qwen-$U, libraryUuid:$U, provenance:cloned}`; **`variants` map dropped** (had a `whisper` variant); `voiceUuid` unchanged; **coqui slot also written** `{name:xtts-$U,…}` per Task 24; all 13 characters diffed — only the target changed |
 | B-08 | Cast sample plays in the cloned voice | | |
 | B-09 | Chapter renders, consistent across lines | | |
@@ -2669,11 +2685,15 @@ Run 1 — 2026-07-29. "not reached" tests are counted as neither P/F/B/N/A.
 | Section | Total | P | F | B | N/A | not reached |
 |---|---|---|---|---|---|---|
 | A (3a) | 13 | 9 | 0 | 3 | 0 | 1 |
-| B (3b1) | 13 | 3 | 0 | 4 | 0 | 6 |
+| B (3b1) | 13 | 3 | 0 | 3 | 1 | 6 |
 | C (3b2) | 21 | 3 | 0 | 1 | 0 | 17 |
 | D (cross-cutting) | 4 | 1 | 0 | 1 | 0 | 2 |
 | E (3c) | 9 | 1 | 0 | 0 | 1 | 7 |
-| **All** | **60** | **17** | **0** | **9** | **1** | **33** |
+| **All** | **60** | **17** | **0** | **8** | **2** | **33** |
+
+*(B-06's B → N/A reclassification landed 2026-07-30 alongside #1945's
+resolution — see the B-06 row and DEF-C below. The historical "not reachable
+as written" finding is preserved in the row's Notes.)*
 
 **Zero failures** — but that is not an acceptance signal: 33 tests were never
 reached and 9 are blocked, including all of the highest-risk ⭐ set except C-10.
@@ -2708,9 +2728,17 @@ voice being cloned. The wizard has no attester field, and
 `voice-library.test.ts:2435` asserts the incorrect behaviour. Needs a product
 decision, so filed rather than fixed in-run.
 
-**DEF-C · MINOR · #1945 — the clone-fidelity advisory has never fired.** B-06's
-fixture recipe cannot lower a metric that scores clone-vs-source faithfulness.
-See the B-06 row above for the three measurements.
+**DEF-C · MINOR · #1945 — the clone-fidelity advisory has never fired ·
+resolved 2026-07-30, doc/test-only.** B-06's fixture recipe asked an operator
+to trip a threshold that cannot move by degrading the source — both sides of
+the clone-vs-source cosine degrade together. **Disposition:**
+`CLONE_FIDELITY_MIN = 0.3` is kept as a documented catastrophe-only backstop
+(it fires on a wrong-speaker clone — the 0.158 datapoint below; see the B-06
+row above for the three measurements), not recalibrated or deleted. B-06 is
+retired in favour of automated coverage —
+`server/src/routes/voice-library.clone-fidelity.test.ts`, which stubs the
+`/embed` boundary directly and asserts both sides of the threshold. See
+`clone-fidelity.ts`'s header comment for the full rationale.
 
 **DEF-D · MAJOR · #1944 — Coqui/XTTS unloadable after ECAPA, and `/health` lies
 about it.** Blocks all of Section E. `coqui_package_installed: true` comes from

--- a/docs/testing/fs38-wave3-onbox-acceptance.md
+++ b/docs/testing/fs38-wave3-onbox-acceptance.md
@@ -127,8 +127,10 @@ this box is dual-GPU).
 >
 > **Fixtures:** built from public-domain LibriVox recordings (two distinct
 > narrators) and left at `C:\fixtures\fs38\` — F-1…F-9 plus `F8b-twospeaker`.
-> F-8 was regenerated at `volume=+6dB` rather than the sheet's `-8dB`, which
-> landed at −41.7 dBFS, only 3.3 dB above the −45 dBFS fatal-silence floor.
+> F-8 was regenerated at `volume=+6dB` rather than the sheet's then-published
+> `-8dB`, which landed at −41.7 dBFS, only 3.3 dB above the −45 dBFS
+> fatal-silence floor. The fixture table now specifies `+6dB`, so a fresh run
+> follows the corrected recipe directly.
 >
 > **Baseline before the run:** `C:\AudiobookWorkspace\voice-library\` did not
 > exist and `voices\xtts\` did not exist — independent confirmation that no clone
@@ -911,8 +913,14 @@ the real path. The mock path (`src/mocks/`) is only reachable with
   values — proof it is being computed, not stubbed. Two *identical* values to
   full float precision across different clones is the mock-constant smell:
   investigate before passing.
-- F-8's cosine is **materially lower** than F-1's — but not below `CLONE_FIDELITY_MIN`
-  (#1945: a same-source comparison, so it stays well above the catastrophe-only backstop).
+- F-8's cosine lands **close to** F-1's — record the delta, do not expect a drop.
+  #1945 measured F-1 at 0.8914 and 0.8813 (two clones of the *same* fixture) and
+  band-limited F-8 at 0.881 — a ~0.01 gap, i.e. **inside** the spread between two
+  clones of one fixture. The cosine scores a clone against its own source, so
+  degrading the source degrades the clone equally and the number barely moves.
+  A materially *lower* value here is the surprise worth investigating, not the
+  expected result. (Nothing realistic approaches `CLONE_FIDELITY_MIN`, which is a
+  catastrophe-only backstop — see the retired B-06 below.)
 - `cloneFidelityUnavailable` is **absent** when `/embed` is reachable.
 
 **Record:** F-1 cosine run 1 = ______ run 2 = ______ · F-8 cosine = ______

--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -140,6 +140,20 @@ production `/embed`: 20s audition vs human source **0.822**; in-book segments
 **0.564** and **0.706**; designed-voice control **0.158**. The by-ear
 confirmation (B-03, E-06) is still owed — a human must listen.
 
+**Resolved without on-box acceptance — B-06 (#1945, 2026-07-30).** B-06's own
+measurement was already conclusive: the clone-fidelity cosine scores
+clone-vs-source *faithfulness*, so degrading the source degrades the clone
+equally and the number does not fall (measured: clean 0.891, band-limited
+0.881, two speakers overlaid 0.773; a genuinely different speaker measured
+0.158). **Disposition:** `CLONE_FIDELITY_MIN = 0.3` is kept as a documented
+catastrophe-only backstop, not recalibrated or deleted — see
+`server/src/tts/clone-fidelity.ts`'s header comment. B-06's manual step (which
+could never pass as written) is retired in favour of an automated test,
+`server/src/routes/voice-library.clone-fidelity.test.ts`, which stubs the
+`/embed` boundary directly and asserts both sides of the threshold in CI. No
+further on-box run is owed for this item — it no longer needs real hardware
+to prove.
+
 **Still owed (~44), and why:**
 - **Browser/mic (4):** A-07 (recorder webm/opus), A-08 (mic-denial fallback),
   A-09 (consent gates Continue), B-02 (record-path clone). Need a real browser
@@ -160,11 +174,6 @@ confirmation (B-03, E-06) is still owed — a human must listen.
   real guard"*. **Workaround that works today:** the per-character re-record
   (splice) path renders one character's lines without the full-chapter memory
   churn — that is how the central claim above was proven.
-- **B-06 — cannot pass as written, see #1945.** The clone-fidelity cosine scores
-  clone-vs-source *faithfulness*, so degrading the source degrades the clone
-  equally and the number does not fall (measured: clean 0.891, band-limited
-  0.881, two speakers overlaid 0.773). The advisory-warning path has therefore
-  **never fired on real hardware**.
 - **The rest of Section C (18) and Section D (3):** not reached. C-08/C-12
   (deliberate mid-write sidecar kills) and C-01/E-03 (revoke racing an in-flight
   derive) are untouched and remain the highest-risk unproven behaviour here.

--- a/server/src/routes/voice-library.clone-fidelity.test.ts
+++ b/server/src/routes/voice-library.clone-fidelity.test.ts
@@ -99,6 +99,22 @@ function postClone(candidateId: string) {
 }
 
 describe('POST /api/voice-library/clone — clone-fidelity advisory (#1945)', () => {
+  /* ── CLONE_FIDELITY_MIN pin ──────────────────────────────────────────────
+     #1945 weighed three options and chose "keep 0.3 as a catastrophe-only
+     backstop" over recalibrating upward (~0.6) — rejected because, with about
+     four datapoints and short-clip embeddings measured at 0.56-0.71, a higher
+     threshold risks false-warning on legitimate clones.
+
+     Without this pin that decision is enforced NOWHERE: the cases below inject
+     0.9 and 0.0, so they only fail if the constant moves above 0.9 or below 0.
+     A change to 0.6 — the exact option that was rejected — would keep the whole
+     suite green and land silently. Same idiom as render-integrity's CUTOFFS pin
+     in score.test.ts. If you are deliberately recalibrating, update #1945's
+     disposition and this pin together. */
+  it('pins CLONE_FIDELITY_MIN at its deliberated value', () => {
+    expect(CLONE_FIDELITY_MIN).toBe(0.3);
+  });
+
   it('persists NO warning when the embed boundary scores the clone above CLONE_FIDELITY_MIN', async () => {
     // Two near-aligned (not identical) unit vectors -> cosine 0.9, comfortably
     // above the current 0.3 threshold but not an unreachable 1.0 ceiling, so

--- a/server/src/routes/voice-library.clone-fidelity.test.ts
+++ b/server/src/routes/voice-library.clone-fidelity.test.ts
@@ -1,0 +1,143 @@
+/* #1945 — replaces the impossible-to-trip B-06 manual acceptance step
+   (docs/testing/fs38-wave3-onbox-acceptance.md) with an automated test.
+
+   B-06 asked an operator to degrade the clone's SOURCE clip until the
+   advisory clone-fidelity cosine (assessCloneFidelity, tts/clone-fidelity.ts)
+   dropped below CLONE_FIDELITY_MIN. That can't work: the metric cosines the
+   clone's audition preview against its OWN master clip, so degrading the
+   source degrades both sides of the comparison together and the cosine barely
+   moves (on-box: clean 0.891/0.881 vs. band-limited-source 0.881 — *not
+   lower*; see #1945's implementation-brief comment). The threshold is being
+   KEPT as a documented catastrophe-only backstop (fires on a wrong-speaker
+   clone, e.g. the on-box 0.158 datapoint), not recalibrated or deleted — see
+   clone-fidelity.ts's file-header comment for the full rationale.
+
+   This test proves the backstop is actually WIRED UP end-to-end through the
+   real POST /api/voice-library/clone route, stubbing the boundary the brief
+   specifies — `embedSegment` (tts/embed-client.ts) — rather than the
+   assessCloneFidelity function itself (already stubbed a level up in
+   voice-library.test.ts) or trying to synthesise audio that scores low. Both
+   assertions compare against the live CLONE_FIDELITY_MIN constant, not a
+   hardcoded number, so the test fails if the threshold is later moved past
+   either injected cosine — proof it is wired to the threshold, not to a
+   string. */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import express, { type Express } from 'express';
+import request from 'supertest';
+
+const { deriveMock, decodeMock, embedSegmentMock } = vi.hoisted(() => ({
+  deriveMock: vi.fn(),
+  decodeMock: vi.fn(),
+  embedSegmentMock: vi.fn(),
+}));
+vi.mock('../tts/derive-engine-artifact.js', () => ({ deriveEngineArtifact: deriveMock }));
+vi.mock('../tts/embed-client.js', () => ({ embedSegment: embedSegmentMock }));
+vi.mock('../tts/mp3.js', async (orig) => {
+  const actual = (await orig()) as Record<string, unknown>;
+  return { ...actual, decodeAudioToPcm: decodeMock };
+});
+
+let dir: string;
+let app: Express;
+let CLONE_FIDELITY_MIN: number;
+
+beforeEach(async () => {
+  dir = mkdtempSync(join(tmpdir(), 'cw-voicelib-fidelity-'));
+  process.env.WORKSPACE_DIR = dir;
+  process.env.VOICE_SAMPLE_AUDIO_DIR = join(dir, 'audio-voices');
+  vi.resetModules();
+
+  const [{ voiceLibraryRouter }, cloneFidelityMod] = await Promise.all([
+    import('./voice-library.js'),
+    import('../tts/clone-fidelity.js'),
+  ]);
+  CLONE_FIDELITY_MIN = cloneFidelityMod.CLONE_FIDELITY_MIN;
+
+  app = express();
+  app.use(express.json());
+  app.use('/api/voice-library', voiceLibraryRouter);
+
+  deriveMock.mockReset();
+  deriveMock.mockResolvedValue({ previewPcm: Buffer.from([1, 2, 3, 4]), sampleRate: 24_000, baseModel: 'qwen3-0.6b' });
+  embedSegmentMock.mockReset();
+  decodeMock.mockReset();
+  decodeMock.mockResolvedValue(Buffer.from([0, 0, 0, 0]));
+});
+
+afterEach(() => {
+  delete process.env.WORKSPACE_DIR;
+  delete process.env.VOICE_SAMPLE_AUDIO_DIR;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+async function seedCandidate(candidateId: string) {
+  const { writeCandidate } = await import('../workspace/clone-candidate.js');
+  await writeCandidate(
+    candidateId,
+    {
+      sampleRate: 24000,
+      durationSeconds: 12,
+      transcript: 'my own voice sample',
+      transcriptSource: 'whisper',
+      captureMethod: 'upload',
+    },
+    Buffer.from('RIFFfake-wav-bytes'),
+  );
+}
+
+function postClone(candidateId: string) {
+  return request(app)
+    .post('/api/voice-library/clone')
+    .send({
+      candidateId,
+      consent: { personName: 'Mum', relationship: 'family-with-permission', permittedUse: 'personal' },
+    });
+}
+
+describe('POST /api/voice-library/clone — clone-fidelity advisory (#1945)', () => {
+  it('persists NO warning when the embed boundary scores the clone above CLONE_FIDELITY_MIN', async () => {
+    // Two near-aligned (not identical) unit vectors -> cosine 0.9, comfortably
+    // above the current 0.3 threshold but not an unreachable 1.0 ceiling, so
+    // the assertion below still catches a threshold raised past this value.
+    embedSegmentMock
+      .mockResolvedValueOnce(Float32Array.from([1, 0, 0]))
+      .mockResolvedValueOnce(Float32Array.from([0.9, Math.sqrt(1 - 0.9 * 0.9), 0]));
+
+    await seedCandidate('cand-above');
+    const res = await postClone('cand-above');
+
+    expect(res.status).toBe(200);
+    expect(res.body.provenance).toBe('cloned');
+    const cosine = res.body.sampleMeta.qualityChecks.cloneCosine as number;
+    expect(cosine).toBeGreaterThanOrEqual(CLONE_FIDELITY_MIN);
+    expect(cosine).toBeCloseTo(0.9, 5);
+    expect(res.body.sampleMeta.qualityChecks.cloneFidelityWarning).toBeUndefined();
+  });
+
+  it('persists a warning AND still saves the clone when the embed boundary scores below CLONE_FIDELITY_MIN', async () => {
+    // Orthogonal vectors -> cosine 0, well below any sane threshold.
+    embedSegmentMock
+      .mockResolvedValueOnce(Float32Array.from([1, 0, 0]))
+      .mockResolvedValueOnce(Float32Array.from([0, 1, 0]));
+
+    await seedCandidate('cand-below');
+    const res = await postClone('cand-below');
+
+    // Non-blocking: the clone still saves as a ready, cloned entry.
+    expect(res.status).toBe(200);
+    expect(res.body.provenance).toBe('cloned');
+    expect(res.body.engines.qwen.status).toBe('ready');
+
+    const cosine = res.body.sampleMeta.qualityChecks.cloneCosine as number;
+    expect(cosine).toBeLessThan(CLONE_FIDELITY_MIN);
+    expect(res.body.sampleMeta.qualityChecks.cloneFidelityWarning).toMatch(/loosely/i);
+
+    // The candidate is consumed either way — the warning doesn't block cleanup.
+    const { readCandidate } = await import('../workspace/clone-candidate.js');
+    expect(await readCandidate('cand-below')).toBeNull();
+  });
+});

--- a/server/src/tts/clone-fidelity.ts
+++ b/server/src/tts/clone-fidelity.ts
@@ -12,7 +12,22 @@ import { cosineToCentroid } from '../audio/render-integrity/score.js';
 
 /* Starting value — calibrated on-box against the golden fixture (srv-36
    centroid distributions cluster clean same-speaker cosines well above this).
-   Deliberately conservative so only a clearly-off clone warns. */
+   Deliberately conservative so only a clearly-off clone warns.
+
+   What this compares (#1945): the clone's audition preview against its OWN
+   master clip — the SAME source on both sides. That makes it a detector for
+   a clone that reproduces the WRONG SPEAKER, not for a poor-quality source;
+   source quality is already gated separately, before this check ever runs,
+   by clone-quality.ts. Degrading the source clip therefore can't lower this
+   cosine — both sides of the comparison degrade together. On-box numbers
+   (#1945): clean clone vs. its own source measured 0.891/0.881; a
+   band-limited source (F-8) measured 0.881 — not lower; two speakers
+   overlaid measured 0.773; a different designed voice entirely measured
+   0.158. So 0.3 is a coherent catastrophe-only backstop: it fires when a
+   clone comes out sounding like a different speaker, and stays silent
+   otherwise. See server/src/routes/voice-library.clone-fidelity.test.ts for
+   the automated coverage that replaced the (impossible) manual B-06 step of
+   trying to trip this by degrading the source. */
 export const CLONE_FIDELITY_MIN = 0.3;
 
 export interface CloneFidelity {


### PR DESCRIPTION
## Summary

Run-sheet test **B-06** asked the operator to trip the clone-fidelity advisory by degrading a source clip — iterating fixture F-8 "until the persisted `cloneCosine` is < 0.30". That cannot work in principle. `assessCloneFidelity` cosines the clone's **own audition preview** against its **master clip**, so it measures how faithfully the clone reproduces its source, not the source's audio quality. Degrading the source produces an equally-degraded clone and the cosine does not fall. Measured on-box: clean 0.891, band-limited **0.881** (not lower), two speakers overlaid 0.773 — while a genuinely *different* designed voice scored 0.158.

The disposition here is: **keep `CLONE_FIDELITY_MIN = 0.3` and replace the impossible manual test with an automated one.**

Recalibrating upward was considered and rejected — with ~4 datapoints, and short-clip embeddings measured at 0.56–0.71 during the same run, a higher threshold risks false-warning on legitimate clones. Deleting the advisory was rejected too: it is the only automatic signal that a clone came out sounding like someone else, and 0.158 shows it does fire for that.

So `0.3` is a coherent **catastrophe-only backstop**, and what was actually defective is the run-sheet instruction. Changes:

- **`clone-fidelity.ts`** — comment-only. States plainly what the metric compares and why a source-degradation fixture cannot lower it (source quality is gated separately in `clone-quality.ts`), with the measured numbers. The missing "what does this actually compare" note is how B-06 came to be written.
- **New test** — drives the real `/clone` route, stubbing only the `embedSegment` boundary so the real threshold comparison runs. Both directions asserted against the live imported `CLONE_FIDELITY_MIN`, not a hardcoded number.
- **F-8 fixture** — recipe corrected to `+6dB`. The published `volume=-8dB` lands at −41.7 dBFS RMS, only 3.3 dB above the −45 dBFS fatal-silence floor, so it risked rejection as silent rather than testing anything. Repointed at B-04, its actual remaining consumer.
- **B-06** — retired as `N/A — covered by automated test`, naming the new test. The historical "not reachable as written" finding is preserved in the row's notes rather than deleted. Register totals updated.
- **On-box register** — B-06 removed from A1's still-owed list and recorded as an outcome with the three measurements. The live HTML twin was updated in place via the URL recorded in the register header (verified: same artifact, no second register minted).

No instruction to trip the advisory by degrading a source clip survives anywhere in `docs/`.

Closes #1945

## Test plan

- [x] `npm run test:server` — green
- [x] `npm run typecheck` — clean
- [x] `npm run check:onbox-register` — green
- [x] **Red phase observed in both directions**: raising `CLONE_FIDELITY_MIN` to 0.95 (above the injected 0.9) failed the above-threshold case; lowering it to −1 (below the injected 0) failed the below-threshold case. The threshold edit was reverted and `git diff` confirmed clean before the green run. The constant is unchanged at `0.3`.
- [x] Below-threshold case asserts the clone **still saves** — the advisory is non-blocking, which was never proven before.

**Release notes deliberately skipped** — this is a test-scoping and docs change with no user- or operator-visible runtime delta, so neither `docs/release-notes-next.md` nor `RELEASE_NOTES.md` gets an entry. Flagging explicitly rather than omitting silently.

### Folded in after independent review

Two findings, both confirmed and both fixed in `9a04d845`:

1. **B-04 had inherited B-06's dead end.** The first draft edited `fs38-wave3-onbox-acceptance.md:914` to append "but not below `CLONE_FIDELITY_MIN`" while leaving "F-8's cosine is **materially lower** than F-1's" intact — which this PR's own measurements falsify. F-1 scored 0.8914 and 0.8813 across two clones of the *same* fixture; band-limited F-8 scored 0.881. That 0.01 gap is *inside* the same-fixture spread. An operator running B-04 would see 0.89 vs 0.88, read that line, and mark it failed — the identical dead-end loop, relocated rather than removed. Now states the real expectation: the cosine barely moves, record the delta, and a materially lower value is the surprise worth investigating.

2. **Nothing pinned `CLONE_FIDELITY_MIN = 0.3`.** The injected cosines are 0.9 and 0.0, so the cases only fail if the constant leaves that range — meaning a recalibration to ~0.6, the exact option this issue weighed and rejected, would have kept the entire suite green and landed silently. Added an explicit pin, same idiom as render-integrity's `CUTOFFS` pin in `score.test.ts`, with a comment tying it to #1945's disposition.

Reported, not fixed (pre-existing, outside this branch's scope): stale `voice-library.ts` line references at `fs38-wave3-onbox-acceptance.md:892` and `:928`, and a long-standing disagreement between the register's "16 executed / 44 owed" framing and the run sheet's own 27/33 tally.

### Reviewer note on the register arithmetic

The headline figures ("~44 still owed", glance-table "40 owed") were deliberately **not** moved, and the review confirmed that conclusion while correcting half my reasoning. The glance-table 40 is a count of **register rows** (A 23 + B 2 + C 3 + D 2 + E 8 + F 1 + G 1), not of tests — so my stated rationale "both count not-yet-executed items" is not true of that figure, even though the answer is unchanged (A1 is one row and is still owed). A1's "~44" is 60 − 16, and B-06 was already inside the 16 executed, so removing its still-owed bullet without decrementing is right.
