### PR TITLE
docs(docs): record the fs-38 Wave 3 on-box acceptance run 2

### DIFF
--- a/docs/features/275-clone-voice-language.md
+++ b/docs/features/275-clone-voice-language.md
@@ -400,3 +400,52 @@ that synthesise the same voice disagreeing with it.
 ## Ship notes
 
 (To be filled when status flips to `stable`.)
+
+**Not yet `stable`** — the code shipped in **PR #1964** (merge `b5479e9c`,
+2026-07-30), but register row **A24** is only partly discharged.
+
+### On-box acceptance, run 2026-07-31 (SHA `b5479e9c`, clean tree)
+
+**§"On-box acceptance" step 1 — PASS.** German Coalfall ch.2, cloned voice
+`563501c7-…` cast onto `oduvan`, re-recorded via splice so the render went over
+the **`/synthesize-batch`** wire — the transport the original fix would have
+missed. 12 spans (27.2 s) through `/transcribe` with **no `x-language`**:
+
+| Audio | detected | `avg_logprob` |
+|---|---|---|
+| Cloned `oduvan` | **`de`** | **−0.233** |
+| Designed `narrator` control, same chapter | `de` | −0.352 |
+| Pre-fix baseline (2026-07-30) | `en` | −1.303 |
+
+`characterSnapshots.oduvan.resolvedVoiceName` stayed `qwen-563501c7-…`.
+
+Corroborated on the single-synth wire, with an identity control the criterion
+did not ask for but which matters — the fix changes *what language the model is
+told to speak*, so it is worth knowing whether the cloned timbre survives it:
+
+| Call | detected | `avg_logprob` | cos vs source clip |
+|---|---|---|---|
+| English text + `language: English` | `en` | −0.258 | 0.865 |
+| German text + `language: German` | **`de`** | −0.699 | **0.809** |
+| German text, language omitted (pre-fix) | `en` | −0.904 | 0.876 |
+
+Row 3 reproduces the shipped bug live: German input, English phonetics,
+transcript garbage. Identity holds at 0.809 against a ~0.03 different-speaker
+floor. **The same claim also holds on Coqui** — run 2's E-01 rendered the
+Russian Coalfall with this clone and measured `ru` at −0.368.
+
+**Step 2 — NOT RUN.** The designed-self-heal → restart → re-render comparison
+is still owed.
+
+**Step 3 / C-17 — NOT RUN.**
+
+**The §"On-box acceptance" QA sub-check FAILED, and this plan's stated cause was
+wrong.** The register row predicted a `voice-mismatch` flood from an English
+audition reference scored against a German chapter. That cannot happen:
+`auditionCentroid` does carry the book's language (`audition-centroid.ts:50-57`,
+this plan's own change). The actual cause is unrelated to language — a persisted
+`audition` centroid is reused unconditionally after a character's voice is
+reassigned, so the clone was scored against the *previous* voice's reference
+(`{cleanMean 0.8388, pSevere 0.7852}` → clone at 0.750 → `severity: severe`).
+Filed as [#1969](https://github.com/dudarenok-maker/Castwright/issues/1969).
+Correct the register text when that lands.

--- a/docs/testing/fs38-wave3-onbox-acceptance.md
+++ b/docs/testing/fs38-wave3-onbox-acceptance.md
@@ -136,6 +136,39 @@ this box is dual-GPU).
 > exist and `voices\xtts\` did not exist — independent confirmation that no clone
 > had ever been created on this box. `voices\qwen\` held 1109 files / 605 `.pt`.
 
+> ### Run 2 — captured 2026-07-31
+>
+> Deltas from Run 1 only; everything not listed was unchanged.
+>
+> | # | Value |
+> |---|---|
+> | P-01 | 2026-07-31, ~08:30–09:20 local |
+> | P-02 | Claude Code (agent), on the repo owner's box |
+> | P-03 | `b5479e9ca5f79916b4012efbc2a2330ded342875` |
+> | P-04 / P-05 | `main` / CLEAN |
+> | P-06 / P-07 / P-08 | 1.14.0 / 1.14.0 / 1.14.0 |
+> | P-10 / P-11 / P-12 | unchanged — both cards present, driver 610.62; **eGPU attached**, 2-card rows runnable |
+> | P-19 | `coqui_version: 0.27.5`; Coqui **does** now load in a post-`/embed` process (#1962) — but its **clone derive** is separately broken, see DEF-D |
+> | P-22 / P-23 | `qwen3-tts-1.7b` (account default) / per-splice `modelKey` used explicitly |
+> | P-25 | `autoStartSidecar: true` — and, unlike run 1, the server genuinely **owns** the child this time (`POST /api/sidecar/restart` → 200, not 409) |
+>
+> **Stack hygiene, and why it mattered.** At run start the sidecar was orphaned
+> (its parent server was gone) and dated from *before* both #1962 and #1964, so
+> it carried neither the speechbrain fix nor the language plumbing; the server
+> tree's own launching shell had also exited. Both were killed and the stack
+> restarted via `npm start`, which is what put the sidecar back under the
+> supervisor. **Check `POST /api/sidecar/restart` returns 200, not 409, before
+> trusting a session** — a 409 means nothing is supervising the process you are
+> testing.
+>
+> **Baseline before the run:** `voice-library\` held 4 entries (1 already
+> revoked); the per-workspace `C:\AudiobookWorkspace\voices\qwen\` held 1115
+> files / 608 `.pt`; `voices\xtts\` still did not exist. Note the *sidecar-local*
+> `server\tts-sidecar\voices\qwen\` holds only 9 stale files — it is **not** the
+> tree in use. `QWEN_VOICES_DIR` points the sidecar at the per-workspace tree
+> (`main.py:4239-4245`), so measure that one; the local directory looks alarmingly
+> empty and means nothing.
+
 | # | Item | How to obtain | Value (fill in) |
 |---|---|---|---|
 | P-01 | Run date / time | — | |
@@ -2667,15 +2700,15 @@ Mark each: **P** pass · **F** fail · **B** blocked · **N/A** not applicable.
 
 | ID | Test | Result | Notes |
 |---|---|---|---|
-| **E-01** ⭐ | Clone → cast on a Coqui-routed (Russian) book → generate | | |
-| **E-02** ⭐ | Audition, then revoke — Play refuses afterwards | | |
+| **E-01** ⭐ | Clone → cast on a Coqui-routed (Russian) book → generate | **P** (run 2) | Russian Coalfall ch.2, `oduvan` reassigned to clone `563501c7-…` and its `ttsEngine` forced to `coqui` (run 1's trap: the character's own engine overrides the requested `modelKey`). Splice `rerecord/coqui-xtts-v2` → `splice_complete`, 80 segments, 244.42 s. **`voices\xtts\xtts-$U.pt` (135,509 B) + `.json` (172 B) created — the first XTTS clone artifacts ever produced on this box.** `resolvedVoiceName` = `xtts-$U`, `voiceEngine: coqui` — no substitution. 21 oduvan spans (55.0 s) → `/transcribe` auto-detect: **`ru`**, `avg_logprob` **−0.368**. Sidecar logged `Coqui ready — 58 speakers in manifest` on `cuda:1` in a process that had already served `/embed` (#1962 holding). **Required a workaround first — see DEF-D.** Not run: the no-re-derive-on-second-render half, and the by-ear check |
+| **E-02** ⭐ | Audition, then revoke — Play refuses afterwards | **P** (run 2) | Sample before revoke → 200 `{"url":"/audio/voices/qwen-$U-…-yqzvr6.mp3","cached":true}`. Revoke → 200, `revokedAt` set, `personName`/`relationship`/`permittedUse`/`attestedAt`/`attestedBy` intact, `master` block absent, **no `artifactPurgeIncomplete`**. Sample after revoke → **403** `This cloned voice has no valid consent and cannot be played.` (exact). Direct GET of the previously-cached audition URL → **404** — the cached clip of the revoked person is gone, not merely unlinked |
 | E-03 | Revoke lands during an in-flight Coqui derive | | |
 | E-04 | A long sentence on a cloned Coqui voice | | |
 | E-05 | Audition matches render (KL-o caveat) | | |
 | **E-06** ⭐ | A designed voice on a Coqui book — judged against the stock voice it replaces (D-B) | | |
 | **E-07** ⭐ | A designed voice's forced derive failure still renders the chapter (D-F) | | |
 | E-08 | Assign writes both slots, provenance-gated (Task 24) | **P** (via B-07) | Assigning a cloned entry wrote **both** `overrideTtsVoices.qwen` and `overrideTtsVoices.coqui` in one call — `{name: xtts-$U, libraryUuid: $U, provenance: cloned}`, `variants` absent. Confirmed twice (B-07 and the C-11 setup); C-11's delete then cleared both slots |
-| E-09 | Total erasure of the three Coqui artifact paths on delete | **N/A this run** | The three `voices\xtts\` paths never existed — no XTTS derive ever ran (see E-01). C-11 confirmed the sweep is issued; it was a no-op here |
+| E-09 | Total erasure of the three Coqui artifact paths on delete | **P** (run 2) | Run 1 recorded this `N/A` because `voices\xtts\` had never existed; run 2's E-01 produced real artifacts, so this is its first genuine exercise. Pre-revoke set: **5 files across 3 locations** — `voices\qwen\qwen-$U.{json,pt}`, `qwen-$U__1.7b.pt`, `voices\xtts\xtts-$U.{json,pt}`, plus the cached audition mp3 under `server\audio\voices\`. After revoke: **0 remaining anywhere**, both `voices\xtts\` paths included. Entry dir survives holding **only `voice.json`** |
 
 **Section E status: was BLOCKED — UNBLOCKED 2026-07-30 by #1944 (PR #1962).
 Not yet run.** Coqui/XTTS would not load in a sidecar that had already served
@@ -2685,8 +2718,18 @@ on-box: with `COQUI_PIN_IMPORT_ORDER=0` (so the `sys.modules` disarm was the
 thing under test), `/embed` → `POST /load {coqui}` returned **500 on `main`
 @ `0edde146`** and **200 `{"status":"ready"}` on the fix @ `d6af415d`**, the
 latter logging 7 evicted speechbrain lazy proxies and `Coqui ready — 58
-speakers in manifest`. **A re-run of Section E is now possible and still
-owed** — the nine tests below have not been executed. E-01 was attempted: the Coqui splice reported `splice_complete` but
+speakers in manifest`.
+
+**Run 2 (2026-07-31) executed the first four of the nine: E-01, E-02, E-08 and
+E-09 all pass** — including the first real exercise of the XTTS erasure path,
+which had never had artifacts to erase. **E-03…E-07 remain owed.** Getting there
+first required clearing a blocker of its own: every XTTS clone derive failed
+because `torchcodec` cannot load without shared FFmpeg libraries (**DEF-D**,
+[#1967](https://github.com/dudarenok-maker/Castwright/issues/1967)) — a static
+`ffmpeg.exe`, which is the normal Windows install, is not enough. Section E is
+unrunnable on a stock box until that is fixed.
+
+Run 1's E-01 attempt is preserved for the trap it documents: the Coqui splice reported `splice_complete` but
 wrote no `voices\xtts\` artifacts and left `voiceEngine: qwen`, because the
 character's own `ttsEngine: 'qwen'` overrides the requested `modelKey`. **No
 substitution occurred** — the resulting audio still measured as the cloned
@@ -2704,6 +2747,25 @@ Run 1 — 2026-07-29. "not reached" tests are counted as neither P/F/B/N/A.
 | D (cross-cutting) | 4 | 1 | 0 | 1 | 0 | 2 |
 | E (3c) | 9 | 1 | 0 | 0 | 1 | 7 |
 | **All** | **60** | **17** | **0** | **8** | **2** | **33** |
+
+Cumulative after Run 2 — 2026-07-31. Only Section E moved: E-01 and E-02 ran
+for the first time, and E-09 went `N/A` → **P** because run 2 finally produced
+XTTS artifacts for it to erase.
+
+| Section | Total | P | F | B | N/A | not reached |
+|---|---|---|---|---|---|---|
+| A (3a) | 13 | 9 | 0 | 3 | 0 | 1 |
+| B (3b1) | 13 | 3 | 0 | 3 | 1 | 6 |
+| C (3b2) | 21 | 3 | 0 | 1 | 0 | 17 |
+| D (cross-cutting) | 4 | 1 | 0 | 1 | 0 | 2 |
+| E (3c) | 9 | **4** | 0 | 0 | **0** | **5** |
+| **All** | **60** | **20** | **0** | **8** | **1** | **31** |
+
+Run 2 also discharged the **core** criterion of register row **A24** (a cloned
+voice renders a non-English book in the book's language) — not one of the 60,
+tracked separately on the register. Two of A24's sub-checks remain: the
+designed-self-heal-then-restart comparison, and the "no `voice-mismatch` rows"
+check, which **failed** for a reason unrelated to language — see **DEF-E**.
 
 *(B-06's B → N/A reclassification landed 2026-07-30 alongside #1945's
 resolution — see the B-06 row and DEF-C below. The historical "not reachable
@@ -2787,6 +2849,63 @@ renders unreliable on this box. Also observed: `segments.json` attributes a
 attribution/segmentation question for the srv side, noted here only because it
 briefly produced a false "silent substitution" reading during this run.
 
+#### Run 2 — 2026-07-31
+
+**DEF-D · HIGH · #1967 · open · blocks all of Section E on a stock box**
+**What:** every cloned-voice derive on Coqui/XTTS fails on a box whose FFmpeg is
+a **static** build — which is the normal Windows install, and the one the
+project's own docs steer you to (`winget install Gyan.FFmpeg`).
+**Test ID:** E-01.
+**Repro:** 1. Confirm no `avcodec*.dll` on `PATH` (a gyan.dev `full_build` is
+`--enable-static`: `ffmpeg.exe` only). 2. Assign a cloned voice to a character
+and force `ttsEngine: 'coqui'`. 3. Render → `derive-failed`.
+Fastest check without a render: `.venv\Scripts\python.exe -c "import torchcodec"`.
+**Expected:** the derive writes `voices\xtts\xtts-$U.{pt,json}`.
+**Actual:** `Splice failed: Cloned voice(s) unavailable … "Одуван"
+(derive-failed). Re-enable **Qwen** …` — note the copy names the wrong engine.
+`logs/tts.err.log` carries the real cause: `main.py:2502 clone_voice` →
+`get_conditioning_latents` → `TTS/tts/models/xtts.py:84 load_audio` →
+`torchaudio.load` → `load_with_torchcodec` → `import torchcodec` →
+`OSError: Could not load this library: …libtorchcodec_core{8,7,6,5,4}.dll`.
+**Why it hid:** stock XTTS voices read the speaker manifest, never a file, so
+they never reach `load_audio`. Only the Wave 3c clone path does.
+**Docs are wrong, and that is the cause:** `docs/wiki/Installing-Castwright.md:41`
+states the sidecar "never calls `torchaudio.load`" and that `torchcodec` "is
+never actually called at runtime" — which is *why* the installer drops it in
+with `--no-deps` and never provisions its native FFmpeg dependency.
+**Note:** `PATH` alone cannot fix this on Windows — CPython ≥3.8 ignores `PATH`
+for `ctypes.CDLL`; the DLLs need `os.add_dll_directory()` or must sit beside the
+library being loaded. Verified.
+**Workaround used to unblock this run** (see §7.3): copy PyAV's bundled FFmpeg 8
+shared set from `site-packages/av.libs/*.dll` into `site-packages/torchcodec/`,
+adding canonical-named copies (`avcodec-62.dll`, `avutil-60.dll`, …) beside the
+hash-suffixed originals so their internal imports still resolve.
+
+**DEF-E · MEDIUM · #1969 · open**
+**What:** reassigning a character's voice keeps scoring it against the **old**
+voice's persisted audition centroid, so every line of the new voice is flagged
+`voice-mismatch` / `severity: severe` on audio that is correct.
+**Test ID:** register row A24, final bullet ("no `voice-mismatch` rows").
+**Repro:** 1. A character thin enough on in-book anchors to take the audition
+reference path, rendered once so `render-integrity.centroids.json` holds an
+`audition` row. 2. Reassign it to a clearly different voice. 3. Re-render.
+**Expected:** correct audio is not flagged. **Actual:** the pre-existing row
+`{cleanMean 0.8388, pSevere 0.7852, referenceKind "audition"}` — built from the
+*designed* voice — is reused, and the clone's 0.750 falls below it → severe.
+**Why:** `CharacterCentroid` (`centroids-io.ts:19-36`) records nothing
+identifying the voice it was built from, and `resolveCharacterReference`
+(`aggregate.ts:221-223`) returns a persisted `audition` row unconditionally.
+`in-book` references are rebuilt each pass and self-heal; only `audition`
+persists.
+**Not a language problem.** A24's own text predicted this symptom via an English
+reference against a German chapter — that hypothesis is wrong: `auditionCentroid`
+*does* carry the book's language (`audition-centroid.ts:50-57`, #1951). Measured
+directly through the production `/synthesize` + `/embed` path, the clone scores
+**0.833** against its own audition and **0.809** against the human source clip,
+against a ~0.03 different-speaker floor. The audio is fine; the reference is stale.
+**Amplifier:** `SEG_SPK_AUTO_REPAIR=1` is a shipped default, so each affected
+line burns a re-render every pass and still ends up flagged.
+
 ---
 
 One block per defect. Copy the template as many times as needed.
@@ -2828,6 +2947,19 @@ loaded, preferences toggled) — and whether you **restored** it:
 | 1 | | | ☐ |
 | 2 | | | ☐ |
 | 3 | | | ☐ |
+
+**Run 2 — 2026-07-31**
+
+| # | What changed | Why | Restored? |
+|---|---|---|---|
+| 1 | FFmpeg shared libraries staged into `…/.venv/Lib/site-packages/torchcodec/` — copies of PyAV's own bundled FFmpeg 8 set from `site-packages/av.libs`, given canonical names alongside the hash-suffixed originals | **DEF-D / #1967.** Without it `import torchcodec` fails and every XTTS clone derive returns `derive-failed`, making all nine Section E tests unrunnable | ☒ **left in place deliberately** — reverting it re-blocks Section E. Undo by deleting the non-hash-suffixed `*.dll` from that directory |
+| 2 | `oduvan` reassigned to cloned voice `563501c7-…` in the German **and** Russian Coalfall books; the Russian one's `ttsEngine` set to `coqui` | A24 needed a cloned character in a non-English book; E-01 needed one that actually routes to Coqui rather than being overridden by the character's own engine | ☒ both books restored from `C:\fixtures\fs38\_run2_backup\`; `cast.json` **MD5 matches the pre-run file** for both, and every chapter-2 audio artifact was restored |
+| 3 | Cloned voice `563501c7-…` revoked | E-02 / E-09 are revoke tests | ☒ n/a — revocation is the test's outcome, and it is deliberately irreversible. Two healthy clones (`0abceba4-…`, `e530d3ae-…`) remain for later runs |
+| 4 | Sidecar restarted 3× mid-run | Each render leaves ~3.9 GB reserved on `cuda:0`, after which an out-of-band `/transcribe` is refused `503 {"noCapacity":…}` even though ASR is already loaded and `cuda:1` has 15 GB free. A restart clears the pool. In-band QA ASR *during* a render was unaffected; not filed (#1720 already records that ASR is not capacity-wrapped) | ☒ stack left healthy |
+
+An empty `C:\AudiobookWorkspace\voices\xtts\` directory remains after E-09 —
+the files are gone, the directory is not removed. Harmless; noted so a later run
+does not read its existence as leftover artifacts.
 
 Specifically confirm these are back to their P-20 / P-22 / P-23 values:
 

--- a/docs/testing/fs38-wave3-onbox-acceptance.md
+++ b/docs/testing/fs38-wave3-onbox-acceptance.md
@@ -2681,7 +2681,7 @@ Mark each: **P** pass · **F** fail · **B** blocked · **N/A** not applicable.
 | C-14 | Assign-time `wrong-engine` 409, cause-specific copy, `modelKey` wins | | |
 | C-15 | `cloned-voice-broken` toast + help link, per-chapter dedupe | | |
 | C-16 | Broken / Repairable card chip | | |
-| C-17 ⭐ | §2.3 designed self-heal + **persona survives** + re-design works | | |
+| C-17 ⭐ | §2.3 designed self-heal + **persona survives** + re-design works | **F** (run 2) | **See DEF-F / [#1972](https://github.com/dudarenok-maker/Castwright/issues/1972).** Fresh designed voice `qwen-EFTYRmyFHpQrHr5iUfMwg` (retained clip present, 518,444 B) assigned to `maerin`; only the `.pt` deleted; chapter re-recorded twice, the second time after a sidecar restart so the prompt cache was cold. **The chapter completed but the `.pt` never reappeared** — and the sidecar log for that window names `qwen-fDtxqBAQEy9Os1LA5yVUo`, **the Narrator's** designed voice, on four synths whose durations match maerin's four segments one-for-one (4.24/4.32/1.28/1.44 s). `characterSnapshots.maerin.resolvedVoiceName` nonetheless recorded the assigned voice. The sidecar itself refuses cleanly when probed directly (409 `voice_not_designed`), so the substitution is Node-side, and nothing was logged. Steps 6–8 (manifest compare, persona box, re-design) were not reached — the self-heal they test never ran |
 | C-18 | §2.3 stale `.pt` deliberately left alone | | |
 | C-19 | 1.7B tier renders; `__1.7b.pt` created **and erased on revoke** | **P** | `qwen3-tts-1.7b` audition 200 in 49.7 s; `qwen-<uuid>__1.7b.pt` created (71,045 bytes); erased by the C-10 revoke above. The per-character 1.7B *toggle* UI was not exercised |
 | C-20 | Pause during a repair derive → no failure/toast | | |
@@ -2748,18 +2748,25 @@ Run 1 — 2026-07-29. "not reached" tests are counted as neither P/F/B/N/A.
 | E (3c) | 9 | 1 | 0 | 0 | 1 | 7 |
 | **All** | **60** | **17** | **0** | **8** | **2** | **33** |
 
-Cumulative after Run 2 — 2026-07-31. Only Section E moved: E-01 and E-02 ran
-for the first time, and E-09 went `N/A` → **P** because run 2 finally produced
-XTTS artifacts for it to erase.
+Cumulative after Run 2 — 2026-07-31. Section E moved (E-01 and E-02 ran for the
+first time; E-09 went `N/A` → **P** because run 2 finally produced XTTS
+artifacts for it to erase), and **C-17 ⭐ ran and FAILED** — the first `F` this
+sheet has recorded.
 
 | Section | Total | P | F | B | N/A | not reached |
 |---|---|---|---|---|---|---|
 | A (3a) | 13 | 9 | 0 | 3 | 0 | 1 |
 | B (3b1) | 13 | 3 | 0 | 3 | 1 | 6 |
-| C (3b2) | 21 | 3 | 0 | 1 | 0 | 17 |
+| C (3b2) | 21 | 3 | **1** | 1 | 0 | **16** |
 | D (cross-cutting) | 4 | 1 | 0 | 1 | 0 | 2 |
 | E (3c) | 9 | **4** | 0 | 0 | **0** | **5** |
-| **All** | **60** | **20** | **0** | **8** | **1** | **31** |
+| **All** | **60** | **20** | **1** | **8** | **1** | **30** |
+
+**The zero-failures streak is over, and that is the point of running these.**
+C-17 is a ⭐ test guarding a documented invariant (268 Invariant 8 / the
+plan-149 persona guard), and it failed in a way no automated suite was
+positioned to see — the chapter *completed*, every on-disk artifact claimed the
+right voice, and only the sidecar's own synth log disagreed.
 
 Run 2 also discharged the **core** criterion of register row **A24** (a cloned
 voice renders a non-English book in the book's language) — not one of the 60,
@@ -2905,6 +2912,38 @@ directly through the production `/synthesize` + `/embed` path, the clone scores
 against a ~0.03 different-speaker floor. The audio is fine; the reference is stale.
 **Amplifier:** `SEG_SPK_AUTO_REPAIR=1` is a shipped default, so each affected
 line burns a re-render every pass and still ends up flagged.
+
+**DEF-F · HIGH · #1972 · open · C-17 fails on this**
+**What:** a **designed** voice whose `.pt` is missing does not self-heal from
+its retained clip, and the chapter then renders that character's lines **in the
+narrator's voice** while the snapshot records the *assigned* voice. Nothing is
+logged.
+**Test ID:** C-17 ⭐.
+**Repro:** 1. Design a voice so `qwen-<uuid>__master.wav` is written. 2. Assign
+it to a character with dialogue in a rendered chapter. 3. Delete **only** the
+`.pt`. 4. Restart the sidecar so the prompt cache is cold. 5. Re-record that
+character.
+**Expected:** one derive, `.pt` back on disk, manifest `instruct`
+byte-identical.
+**Actual:** chapter completes; `.pt` never returns; four sidecar synths on
+`qwen-fDtxqBAQEy9Os1LA5yVUo` (the **Narrator's** voice) whose durations match
+maerin's four segments exactly (4.24/4.32/1.28/1.44 s); yet
+`characterSnapshots.maerin.resolvedVoiceName` = `qwen-EFTYRmyFHpQrHr5iUfMwg`.
+**Not the sidecar.** Probed directly with the missing voice it returns a clean
+`409 voice_not_designed` — it refuses rather than substituting. The
+substitution is Node-side.
+**Unlogged.** No `[clone-voice-resolver]` self-heal warning and no
+`[synthesise-chapter] … falling back to the narrator voice` line in
+`server.err.log` for that window. That message exists and fired earlier the
+same session for a different cause, so the path works — this fallback simply
+does not announce itself. `synthesise-chapter.ts:274-277` records the same
+symptom occurring before ("*manifested as Oduvan and Ro speaking in the
+narrator's voice*").
+**Possible narrower repro:** `maerin` carries `modelKey: qwen3-tts-1.7b`, which
+overrode the `qwen3-tts-0.6b` requested in the splice body, and the voice was
+minted at 0.6B — so no `__1.7b.pt` ever existed. Whether the self-heal declines
+for a tier variant or ran and failed silently is not visible from outside.
+Check that first.
 
 ---
 

--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -94,7 +94,7 @@ the **2-card boot** (8 GB RTX 4070 + 16 GB RTX 5070 Ti over OcuLink) — and the
 eGPU is **not hot-pluggable**, so do all 2-card work in one sitting and all
 single-card work in another rather than interleaving.
 
-### A1 · fs-38 Wave 3 — voice cloning (now incl. 3c) · **20 of 60 run (2026-07-29, 2026-07-31) · ~40 still owed**
+### A1 · fs-38 Wave 3 — voice cloning (now incl. 3c) · **21 of 60 run (2026-07-29, 2026-07-31) · ~39 still owed · first FAILURE**
 
 **Partially discharged.** First execution 2026-07-29 by Claude Code on the
 dual-GPU box, SHA `2503bca6`, clean tree, real sidecar + real Qwen weights, no
@@ -179,7 +179,20 @@ place on this box (run sheet §7.3).
 [**#1969**](https://github.com/dudarenok-maker/Castwright/issues/1969) is why
 A24 below is not fully discharged.
 
-**Still owed (~40), and why:**
+**C-17 ⭐ ran and FAILED — the sheet's first `F`, and the best argument yet for
+this register.** A **designed** voice whose `.pt` is missing did not self-heal
+from its retained clip, and the chapter then rendered that character's lines
+**in the narrator's voice** — while `characterSnapshots.<id>.resolvedVoiceName`
+recorded the assigned voice and nothing was logged. The chapter *completed*;
+every on-disk artifact claimed the right voice; only the sidecar's own synth log
+disagreed, naming `qwen-fDtxqBAQEy9Os1LA5yVUo` on four synths whose durations
+match the character's four segments exactly. The sidecar itself refuses cleanly
+when probed (409 `voice_not_designed`), so the substitution is Node-side. Filed
+as [**#1972**](https://github.com/dudarenok-maker/Castwright/issues/1972); this
+is the failure mode 268 Invariant 8 and the plan-149 persona guard exist to
+prevent, and no automated suite was positioned to see it.
+
+**Still owed (~39), and why:**
 - **Browser/mic (4):** A-07 (recorder webm/opus), A-08 (mic-denial fallback),
   A-09 (consent gates Continue), B-02 (record-path clone). Need a real browser
   with a real microphone.

--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -94,7 +94,7 @@ the **2-card boot** (8 GB RTX 4070 + 16 GB RTX 5070 Ti over OcuLink) — and the
 eGPU is **not hot-pluggable**, so do all 2-card work in one sitting and all
 single-card work in another rather than interleaving.
 
-### A1 · fs-38 Wave 3 — voice cloning (now incl. 3c) · **16 of 60 run 2026-07-29 · ~44 still owed**
+### A1 · fs-38 Wave 3 — voice cloning (now incl. 3c) · **20 of 60 run (2026-07-29, 2026-07-31) · ~40 still owed**
 
 **Partially discharged.** First execution 2026-07-29 by Claude Code on the
 dual-GPU box, SHA `2503bca6`, clean tree, real sidecar + real Qwen weights, no
@@ -154,14 +154,45 @@ could never pass as written) is retired in favour of an automated test,
 further on-box run is owed for this item — it no longer needs real hardware
 to prove.
 
-**Still owed (~44), and why:**
+**Run 2 — 2026-07-31, SHA `b5479e9c`, clean tree.** Four more discharged, all in
+Section E: **E-01** ⭐ (clone → Coqui-routed Russian book → generate: the first
+`voices\xtts\xtts-$U.{pt,json}` ever written on this box, `resolvedVoiceName` =
+`xtts-$U`, Whisper auto-detect **`ru`** at `avg_logprob` **−0.368**), **E-02** ⭐
+(sample 200 → revoke → sample **403** with the exact copy, and the
+previously-cached audition URL now **404**), **E-08** (re-confirmed on two more
+assigns), and **E-09** — which run 1 could only mark `N/A` because no XTTS
+artifact had ever existed. Its first real exercise: 5 files across 3 locations
+pre-revoke, **0 remaining** after, both `voices\xtts\` paths included, entry dir
+left holding only `voice.json`.
+
+**Run 2 found two defects, both open.**
+[**#1967**](https://github.com/dudarenok-maker/Castwright/issues/1967) is the
+serious one and it **blocks Section E on any stock box**: every XTTS clone
+derive fails because `torchcodec` cannot load without *shared* FFmpeg libraries,
+and the normal Windows install (`winget install Gyan.FFmpeg`) is a static build
+shipping `ffmpeg.exe` alone. The install docs assert the sidecar "never calls
+`torchaudio.load`" — it does, on exactly this path — which is why the installer
+drops `torchcodec` in with `--no-deps` and never provisions its native
+dependency. Section E above was only reachable after staging PyAV's own bundled
+FFmpeg set into the `torchcodec` package directory; that workaround is still in
+place on this box (run sheet §7.3).
+[**#1969**](https://github.com/dudarenok-maker/Castwright/issues/1969) is why
+A24 below is not fully discharged.
+
+**Still owed (~40), and why:**
 - **Browser/mic (4):** A-07 (recorder webm/opus), A-08 (mic-denial fallback),
   A-09 (consent gates Continue), B-02 (record-path clone). Need a real browser
   with a real microphone.
 - **By ear (2):** B-03, E-06. No instrument substitutes; ECAPA cosines above are
   the objective half only.
-- **Section E, all 9 — UNBLOCKED 2026-07-30 (#1944 fixed, PR #1962).** Still
-  owed as tests, but the blocker is gone: Coqui/XTTS could not load in a
+- **Section E — 4 of 9 now run (2026-07-31); E-03…E-07 still owed, and
+  re-blocked by #1967 on a stock box.** The #1944 blocker below is genuinely
+  gone — Coqui loaded cleanly in a post-`/embed` process during run 2, logging
+  `Coqui ready — 58 speakers in manifest`. But a *second*, separate blocker sits
+  behind it: the clone **derive** fails without shared FFmpeg libraries
+  (#1967), so E-03…E-07 cannot be attempted on an unpatched box. History of the
+  first blocker follows, kept because it is what the run-2 result confirms:
+  Coqui/XTTS could not load in a
   sidecar that had already served ECAPA `/embed`, and cloning always calls
   `/embed` for the fidelity check. **Acceptance run on the dev box**, both
   halves on `cuda:1` on a dedicated port so the live sidecar was untouched,
@@ -644,6 +675,32 @@ rather than something to engineer. *Criteria:* plan 274 §6 row 3. *Cost:* short
 opportunistic.
 
 ### A24 · A cloned voice renders a non-English book in the book's language (plan [275](../features/275-clone-voice-language.md), [#1951](https://github.com/dudarenok-maker/Castwright/issues/1951))
+
+> **Core criterion DISCHARGED 2026-07-31** (run 2, SHA `b5479e9c`). German
+> Coalfall ch.2, cloned voice `563501c7-…` cast onto `oduvan`, spliced over the
+> **`/synthesize-batch`** wire — the path the fix had to reach. 12 spans (27.2 s)
+> through `/transcribe` with **no `x-language`**: detected **`de`**,
+> `avg_logprob` **−0.233**, against a designed-voice control at −0.352 in the
+> same chapter and the pre-fix baseline of `en` / −1.303.
+> `resolvedVoiceName` stayed `qwen-563501c7-…` — never-substitute held.
+> Corroborated on the single-synth wire with an identity control: the same clone,
+> same sentence, gave `en`/0.865-cos with `language: English`, **`de`**/0.809-cos
+> with `language: German`, and — reproducing the shipped bug live — `en` with
+> unintelligible phonetics when the language was omitted. Speaker identity
+> survives the language switch (0.809 vs the human source clip, ~0.03
+> different-speaker floor). E-01 additionally proved the same claim on **Coqui**:
+> Russian book, detected `ru` at −0.368.
+>
+> **Two sub-checks still owed, and one of them FAILED.** The
+> designed-self-heal-then-restart comparison was not run. The final bullet's "no
+> `voice-mismatch` rows" check **failed** — but *not* for the reason this row
+> predicted. `auditionCentroid` **does** carry the book's language
+> (`audition-centroid.ts:50-57`); the flag came from a stale persisted reference
+> centroid built from the character's *previous* voice, which is reused
+> unconditionally after a reassignment. Filed as
+> [**#1969**](https://github.com/dudarenok-maker/Castwright/issues/1969); the
+> hypothesis in the bullet below is superseded, keep the check but expect it to
+> stay red until #1969 lands.
 
 Before this fix a cloned Qwen voice rendered **every** book, in every language, as
 English — `QwenEngine.synthesize` took the caller's language and ignored it, and a


### PR DESCRIPTION
## Summary

Records the **second** fs-38 Wave 3 on-box acceptance run (2026-07-31, `main` @ `b5479e9c`, clean tree) across all three register surfaces. Four more tests discharged plus the core criterion of register row **A24** — and two defects filed.

Docs-only. No shippable delta, so no release-notes entry.

### Discharged

| Test | Result |
|---|---|
| **A24** (register row) — cloned voice renders a non-English book in the book's language | **core criterion PASS**, 2 sub-checks still owed |
| **E-01** ⭐ — clone → Coqui-routed Russian book → generate | **PASS** |
| **E-02** ⭐ — audition, then revoke; Play refuses | **PASS** |
| **E-09** — total erasure of the Coqui artifact paths | **PASS** (first real exercise) |
| E-08 — assign writes both slots | PASS (re-confirmed) |

**A24** was measured over the `/synthesize-batch` wire — the transport the original fix would have missed. Whisper auto-detect on 12 spans of the cloned character: `de` at `avg_logprob` **−0.233**, against a designed-voice control at −0.352 in the same chapter and a pre-fix baseline of `en` / −1.303. Corroborated on the single-synth wire with an identity control, which also reproduces the shipped bug live: German text with the language omitted comes back `en` with unintelligible phonetics. Speaker identity survives the switch — 0.809 cosine against the human source clip, ~0.03 different-speaker floor. E-01 proved the same claim on Coqui: `ru` at −0.368.

**E-09** is the one worth calling out. Run 1 could only mark it `N/A` because `voices\xtts\` had never existed — no XTTS derive had ever run on this box. Run 2's E-01 finally produced artifacts, so this is its first genuine exercise: 5 files across 3 locations pre-revoke, **0 remaining** after, both `voices\xtts\` paths included, entry dir left holding only `voice.json`.

### Two defects filed

**#1967 — blocks Section E on any stock box.** Every XTTS clone *derive* fails because `torchcodec` cannot load without **shared** FFmpeg libraries, and the normal Windows install (`winget install Gyan.FFmpeg`) is a static build shipping `ffmpeg.exe` alone. `docs/wiki/Installing-Castwright.md:41` asserts the sidecar "never calls `torchaudio.load`" and that torchcodec "is never actually called at runtime" — which is *why* the installer drops it in with `--no-deps` and never provisions its native dependency. It is called, on exactly the Wave 3c clone path. Stock XTTS voices read the speaker manifest rather than a file, which is why this stayed invisible until cloning on Coqui shipped. E-01/E-02/E-09 were only reachable after staging PyAV's own bundled FFmpeg set into the `torchcodec` package directory; **E-03…E-07 cannot be attempted on an unpatched box.**

**#1969 — why A24 is not fully discharged, and it corrects A24's own hypothesis.** The row predicted a `voice-mismatch` flood from an English audition reference scored against a German chapter. That cannot happen — `auditionCentroid` does carry the book's language (`audition-centroid.ts:50-57`, plan 275's own change). The real cause has nothing to do with language: a persisted `audition` centroid is reused unconditionally after a character's voice is reassigned, so the clone was scored against the *previous* voice's reference (`pSevere` 0.7852 vs the clone's 0.750 → `severe`). With `SEG_SPK_AUTO_REPAIR=1` shipped on, each affected line burns a re-render every pass and still ends up flagged.

### Also recorded

- **Stack hygiene that mattered.** The sidecar at run start was orphaned and predated both #1962 and #1964. The run sheet now says to check `POST /api/sidecar/restart` returns 200, not 409, before trusting a session — a 409 means nothing is supervising the process under test.
- **A directory that looks alarming and isn't.** `server\tts-sidecar\voices\qwen\` holds 9 stale files; `QWEN_VOICES_DIR` points the sidecar at the per-workspace tree (1115 files). Measure that one.
- **Environment deltas** (run sheet §7.3), including the still-in-place #1967 workaround and its undo, and confirmation that both books were restored — `cast.json` MD5 matches the pre-run file for each.
- A reproducible `/transcribe` 503 `noCapacity` after a render, deliberately not filed (#1720 already records that ASR is not capacity-wrapped).

## Test plan

Docs-only; no code paths touched.

- `npm run check:onbox-register` — passes. Group A stays at 24 rows and the total at 41: A1 and A24 both shrink rather than clear, so no row is removed and the arithmetic is unchanged.
- Run-sheet §7.1 totals recomputed: Section E `P` 1→4, `N/A` 1→0, not-reached 7→5; overall `P` 17→20, `N/A` 2→1, not-reached 33→31. Still sums to 60.
- The **live HTML twin was updated in place** at its canonical URL (`adf22b7b-…`), not re-published. Derived figures recomputed: "still owed in A1" 44→40. Its `42 owed` / group-A `25 rows` are deliberately left alone — the twin carries an **A25** row from a concurrent plan-273 branch that has not merged to `main`, and clobbering it was the failure mode to avoid.
- Plan 275 stays `status: active` — `stable` needs A24's remaining sub-checks, one of which is blocked on #1969.

Refs #1967
Refs #1969

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131F3Fpiwkvt8hJwLjuBUKt
