### PR TITLE
docs(docs): design and plan the cast.json write-lock sweep

### DIFF
--- a/docs/superpowers/plans/2026-07-31-cast-json-write-lock.md
+++ b/docs/superpowers/plans/2026-07-31-cast-json-write-lock.md
@@ -1,0 +1,1065 @@
+# cast.json write lock — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Serialise every cast.json read-modify-write behind a per-book lock, so
+two concurrent writers can no longer silently discard each other's mutation.
+
+**Architecture:** A thin named wrapper (`withCastLock` / `withCastLocks`) over the
+existing `withKeyLock` promise-chain mutex, applied at 30 of the 35
+`writeJsonAtomic(castJsonPath(…))` sites plus 2 delete sites. The lock always
+encloses the **read** as well as the write — wrapping only the write buys
+nothing. A third key class (`library-voice:<uuid>`) closes the delete-vs-assign
+race, under a stated global lock order.
+
+**Tech Stack:** TypeScript, Node 20, Express, Vitest (node env), real-fs
+integration tests.
+
+**Design of record:** [`docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md`](../specs/2026-07-31-cast-json-write-lock-design.md).
+Read it before Task 1. Section references below (§3.1, §5, §10.2 …) point at it.
+
+**Tickets:** `Closes #1981`, `Closes #2000`, `Closes #2001`. `Refs #2006`, `Refs #2015`.
+
+## Global Constraints
+
+- **Base branch:** cut after `fix/server-1933-assign-readiness` merges, or rebase
+  onto it. It rewrites 208 lines of `voice-library.ts` and shifts the assign
+  read/write by +138/+178. **Cite symbols, never line numbers, in code comments.**
+- **Global lock order: `design` → `library-voice` → `cast`.** Never acquire an
+  earlier class while holding a later one. Every acquisition site names its
+  position in a comment.
+- **Lock the innermost read-through-write, never the caller.** One level only.
+  A locked function must not call another locked function on the same book.
+- **The read goes inside the lock**, and so does every decision derived from it.
+- **Two or more books → `withCastLocks`**, never nested `withCastLock`s.
+- **Every outcome test pins a single module registry** — no `vi.resetModules()`
+  between the two concurrent writers in a spec. This is **hygiene, not a
+  detector**: a partitioned lock does not contend, so it loses a mutation and the
+  outcome test goes *red*. Pinning avoids a confusing false failure. Do not add a
+  `chains.size` accessor for this — §10.3 explains why it cannot work.
+- **Task 6 must include one cross-module outcome spec** — two *different*
+  modules' write sites racing on one book. A spec that races a site against
+  itself uses one import and one key, so it can never catch cross-site key
+  derivation drift. This is the only shape that can.
+- **Rule 2 has exactly four sanctioned carve-outs** (spec §4): `promote-voice`'s
+  `realVoiceId`, `cast-design.ts`'s idempotency guards, `cast-add-from-roster`'s
+  target read, `ensureCharacterVoiceUuid`'s series branch. Anything else left
+  outside its lock is the failure mode, not a narrowing.
+- **Every lock is mutation-verified**: revert the lock at that site, re-run,
+  paste the failing output into the task's commit message. A test that was never
+  seen red proves nothing.
+- **Do not touch** `analysis.ts`'s 5 write sites (deferred, #2015) or the three
+  clone-consent gates in `voices.ts` / `single-design.ts` / `qwen-voice.ts`
+  (deferred, #2006). Deleting or "improving" them is out of scope.
+- Commit convention: `<type>(<scope>): <subject>`. Scope is `server` for all
+  code tasks.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `server/src/workspace/cast-lock.ts` | **New.** The three named lock wrappers + the lock-order rule in its header. Sole owner of key derivation. |
+| `server/src/workspace/cast-lock.test.ts` | **New.** Primitive unit tests: sorted acquisition, dedupe, release-on-throw, waiter ordering. |
+| `server/src/workspace/cast-lock.race.test.ts` | **New.** The outcome harness — two overlapping RMWs, both mutations must survive. The reference for every later site test. |
+| `server/src/workspace/file-lock.ts` | Modify — #2001 map-cleanup fix. |
+| `server/src/tts/design-lock.ts` | Modify — same fix, cleanup only. **Do not touch acquire/release/ordering**: `ensureCharacterVoiceUuid`'s series branch still depends on it (§5.1). |
+| `server/src/routes/chapters-restructure.ts` | Modify — same fix; re-derive the safety argument, its control flow differs. |
+| 14 route modules + `voice-library-usage.ts` | Modify — apply the lock per §5. |
+| `server/src/workspace/cast-lock.guard.test.ts` | **New.** Static guard: no unlocked `writeJsonAtomic(castJsonPath(` / `rm(castJsonPath(`. |
+
+---
+
+### Task 1: The race harness, red before anything is locked
+
+Lands the spike as a committed test **before any site is converted**, so the
+200/200 figure the spec leans on is reproducible rather than quoted.
+
+**Files:**
+- Create: `server/src/workspace/cast-lock.race.test.ts`
+
+**Interfaces:**
+- Consumes: `readJson`, `writeJsonAtomic` from `./state-io.js`.
+- Produces: `assignVoice(castPath, characterId, voice)` and
+  `readVoices(castPath)` — the RMW shape every later task's test reuses.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+/* The outcome harness for the cast.json lock sweep. Two overlapping
+   read-modify-writes, each touching a DIFFERENT character: both mutations must
+   survive. Deliberately ONE module registry — no vi.resetModules() between the
+   two writers, because a partitioned lock behaves exactly like no lock and would
+   make this pass vacuously (design §10.3). */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readJson, writeJsonAtomic } from './state-io.js';
+
+interface Cast {
+  characters: Array<{ id: string; voice?: string }>;
+}
+
+let dir: string;
+let castPath: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'cast-lock-race-'));
+  castPath = join(dir, 'cast.json');
+  await writeJsonAtomic(castPath, {
+    characters: [{ id: 'alice' }, { id: 'bob' }],
+  } satisfies Cast);
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+/** One handler-shaped RMW: read the whole cast, mutate one character, write it
+    all back. This is the shape of all 35 cast.json writers. */
+export async function assignVoice(
+  path: string,
+  characterId: string,
+  voice: string,
+): Promise<void> {
+  const cast = await readJson<Cast>(path);
+  const characters = [...(cast?.characters ?? [])];
+  const i = characters.findIndex((c) => c.id === characterId);
+  characters[i] = { ...characters[i], voice };
+  await writeJsonAtomic(path, { ...cast, characters });
+}
+
+export async function readVoices(path: string): Promise<Record<string, string | undefined>> {
+  const cast = await readJson<Cast>(path);
+  return Object.fromEntries((cast?.characters ?? []).map((c) => [c.id, c.voice]));
+}
+
+describe('cast.json concurrent read-modify-write', () => {
+  it('loses a mutation when two writers overlap unlocked', async () => {
+    await Promise.all([
+      assignVoice(castPath, 'alice', 'a'),
+      assignVoice(castPath, 'bob', 'b'),
+    ]);
+    const v = await readVoices(castPath);
+    /* Documents the defect. Task 2 replaces this with the both-survive
+       assertion once the lock exists. */
+    expect(v.alice === 'a' && v.bob === 'b').toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and confirm it passes — i.e. the race is real**
+
+Run: `cd server && npx vitest run src/workspace/cast-lock.race.test.ts`
+Expected: PASS. A pass here means a mutation *was* lost, which is the defect.
+
+- [ ] **Step 3: Prove it is not flaky**
+
+Run: `cd server && npx vitest run src/workspace/cast-lock.race.test.ts --repeat=20`
+Expected: 20/20 PASS. The spec's claim is 200/200; if any run fails, stop and
+report — the whole test strategy depends on this interleave being deterministic.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/src/workspace/cast-lock.race.test.ts
+git commit -m "test(server): pin the cast.json lost-update race before locking anything"
+```
+
+---
+
+### Task 2: `cast-lock.ts` — the three wrappers
+
+**Files:**
+- Create: `server/src/workspace/cast-lock.ts`
+- Create: `server/src/workspace/cast-lock.test.ts`
+- Modify: `server/src/workspace/cast-lock.race.test.ts`
+
+**Interfaces:**
+- Consumes: `withKeyLock` from `./file-lock.js`, `castJsonPath` from `./paths.js`.
+- Produces:
+  - `withCastLock<T>(bookDir: string, fn: () => Promise<T>): Promise<T>`
+  - `withCastLocks<T>(bookDirs: string[], fn: () => Promise<T>): Promise<T>`
+  - `withLibraryVoiceLock<T>(voiceUuid: string, fn: () => Promise<T>): Promise<T>`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { withCastLock, withCastLocks } from './cast-lock.js';
+
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+describe('withCastLocks', () => {
+  it('acquires in the same order regardless of argument order', async () => {
+    const order: string[] = [];
+    const track = (tag: string) => async () => {
+      order.push(tag);
+      await settle();
+    };
+    await withCastLocks(['/w/b', '/w/a'], track('first'));
+    await withCastLocks(['/w/a', '/w/b'], track('second'));
+    /* Both calls lock /w/a then /w/b — sorted, so AB/BA cannot arise. */
+    expect(order).toEqual(['first', 'second']);
+  });
+
+  it('dedupes a repeated book instead of self-deadlocking', async () => {
+    /* A non-reentrant mutex acquired twice on one key wedges forever.
+       library-cast-override can legitimately pass source === target. */
+    const done = await Promise.race([
+      withCastLocks(['/w/same', '/w/same'], async () => 'ran'),
+      new Promise((r) => setTimeout(() => r('DEADLOCK'), 1000)),
+    ]);
+    expect(done).toBe('ran');
+  });
+
+  it('releases when the critical section throws', async () => {
+    await expect(
+      withCastLock('/w/x', async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+    /* A leaked lock would hang this second acquisition. */
+    const after = await Promise.race([
+      withCastLock('/w/x', async () => 'ok'),
+      new Promise((r) => setTimeout(() => r('LEAKED'), 1000)),
+    ]);
+    expect(after).toBe('ok');
+  });
+
+  it('runs waiters in FIFO order', async () => {
+    const seen: number[] = [];
+    await Promise.all(
+      [1, 2, 3].map((n) =>
+        withCastLock('/w/fifo', async () => {
+          seen.push(n);
+          await settle();
+        }),
+      ),
+    );
+    expect(seen).toEqual([1, 2, 3]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd server && npx vitest run src/workspace/cast-lock.test.ts`
+Expected: FAIL — `Cannot find module './cast-lock.js'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+/* Per-book cast.json write lock.
+ *
+ * cast.json carries every character's voice assignment and is the most-written
+ * file in the workspace. Its writers are all read-modify-write: read the whole
+ * file, change one character, write it all back. Two of those overlapping means
+ * both read before either writes, and the later atomic rename wins outright —
+ * the earlier mutation is gone, silently. Measured at 200/200 trials
+ * (cast-lock.race.test.ts). An `await`-free window does NOT prevent this: the
+ * read is itself the yield point.
+ *
+ * THE RULES (design §4 — keep these in sync with CLAUDE.md):
+ *
+ *   1. Lock the innermost read-through-write, never the caller. One level only.
+ *      A locked function must not call another locked function on the same book.
+ *   2. The read goes inside the lock, and so does every decision derived from
+ *      it. Wrapping only the write buys nothing at all.
+ *   3. Two or more books -> withCastLocks, never nested withCastLocks.
+ *   4. Global lock order: design -> library-voice -> cast. Never acquire an
+ *      earlier class while holding a later one. The DELETE library-voice path
+ *      holds `library-voice:<uuid>` across clearLibraryVoiceReferences, which
+ *      takes a cast lock per book — so POST /assign must take library-voice
+ *      BEFORE its cast lock, not after. The other order is an AB/BA cycle on a
+ *      mutex with no timeout and no diagnostic: both requests hang forever.
+ *
+ * WHAT THIS DOES NOT COVER: it protects one read-modify-write. It does not make
+ * a validate-then-write safe when the validation and the write are in different
+ * scopes (#2006), and it does not cover analysis.ts, whose merge base is read
+ * once at the start of a run and replayed for minutes (#2015).
+ *
+ * Key derivation lives here and ONLY here. A site that derived the key slightly
+ * differently would get a second mutex that never contends with the first, and
+ * every test would still pass.
+ */
+import { castJsonPath } from './paths.js';
+import { withKeyLock } from './file-lock.js';
+
+/** Hold the cast.json lock for one book across a read-modify-write. */
+export function withCastLock<T>(bookDir: string, fn: () => Promise<T>): Promise<T> {
+  return withKeyLock(castJsonPath(bookDir), fn);
+}
+
+/** Hold the cast.json lock for several books at once.
+ *
+ *  Dedupes, then sorts. Sorting makes AB/BA deadlock impossible by
+ *  construction — argument order is caller-determined at the two-book routes.
+ *  Deduping matters because library-cast-override can legitimately receive the
+ *  same book twice (its guard rejects same-book AND same-character only), and a
+ *  promise-chain mutex acquired twice on one key never releases. */
+export function withCastLocks<T>(bookDirs: string[], fn: () => Promise<T>): Promise<T> {
+  const keys = [...new Set(bookDirs.map(castJsonPath))].sort();
+  const chained = keys.reduceRight<() => Promise<T>>(
+    (next, key) => () => withKeyLock(key, next),
+    fn,
+  );
+  return chained();
+}
+
+/** Hold the library-voice lock for one voice uuid.
+ *
+ *  Sits between `design` and `cast` in the global order (rule 4). Taken by the
+ *  DELETE /voice-library/:voiceUuid path across scan -> clear -> erase, and by
+ *  POST /:voiceUuid/assign around its own RMW — both sides must take it or it
+ *  serialises nothing. */
+export function withLibraryVoiceLock<T>(voiceUuid: string, fn: () => Promise<T>): Promise<T> {
+  return withKeyLock(`library-voice:${voiceUuid}`, fn);
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd server && npx vitest run src/workspace/cast-lock.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Flip the race harness to the both-survive assertion**
+
+In `cast-lock.race.test.ts`, add a second `it` beside the existing one:
+
+```ts
+import { withCastLock } from './cast-lock.js';
+
+it('keeps both mutations when the writers hold the cast lock', async () => {
+  const bookDir = dir; // castJsonPath(dir) === castPath for this fixture
+  await Promise.all([
+    withCastLock(bookDir, () => assignVoice(castPath, 'alice', 'a')),
+    withCastLock(bookDir, () => assignVoice(castPath, 'bob', 'b')),
+  ]);
+  const v = await readVoices(castPath);
+  expect(v).toEqual({ alice: 'a', bob: 'b' });
+});
+```
+
+Confirm `castJsonPath(dir)` really equals `castPath` for the fixture; if
+`castJsonPath` appends a subdirectory, build the fixture at that path instead.
+**Do not** hand-roll the key in the test — that would defeat the point of Task 2.
+
+- [ ] **Step 6: Run both, then mutation-verify**
+
+Run: `cd server && npx vitest run src/workspace/cast-lock.race.test.ts`
+Expected: PASS (2 tests).
+
+Now revert: temporarily change `withCastLock` to `(bookDir, fn) => fn()`, re-run.
+Expected: the both-survive test FAILS. Paste that output into the commit message,
+then restore.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/src/workspace/cast-lock.ts server/src/workspace/cast-lock.test.ts server/src/workspace/cast-lock.race.test.ts
+git commit -m "feat(server): add the per-book cast.json write lock"
+```
+
+---
+
+### Task 3: #2001 — the lock helpers' map cleanup has never run
+
+**Files:**
+- Modify: `server/src/workspace/file-lock.ts`
+- Modify: `server/src/tts/design-lock.ts`
+- Modify: `server/src/routes/chapters-restructure.ts`
+- Modify: `server/src/workspace/cast-lock.test.ts`
+
+**Interfaces:** no signature changes. Behaviour only.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `cast-lock.test.ts`:
+
+```ts
+import { __chainsSizeForTest } from './file-lock.js';
+
+it('drops the map entry once the last holder settles', async () => {
+  const before = __chainsSizeForTest();
+  await withCastLock('/w/cleanup', async () => 'done');
+  expect(__chainsSizeForTest()).toBe(before);
+});
+```
+
+Add the accessor to `file-lock.ts`:
+
+```ts
+/** Test-only: the number of live chain entries. Used to pin the cleanup in
+ *  Task 3 — NOT a partition detector (design §10.3 explains why that idea was
+ *  rejected). */
+export function __chainsSizeForTest(): number {
+  return chains.size;
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd server && npx vitest run src/workspace/cast-lock.test.ts -t "drops the map entry"`
+Expected: FAIL — received 1, expected 0. The cleanup is dead code today.
+
+- [ ] **Step 3: Fix all three helpers**
+
+In `file-lock.ts`, hold a reference to the promise actually stored:
+
+```ts
+export async function withKeyLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const prior = chains.get(key) ?? Promise.resolve();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  /* `mine` is what goes in the map. The old code compared against `gate`, which
+     is never what was stored, so this delete never ran and the map grew one
+     entry per key for the process lifetime. */
+  const mine = prior.then(() => gate, () => gate);
+  chains.set(key, mine);
+  await prior.catch(() => undefined);
+  try {
+    return await fn();
+  } finally {
+    release();
+    if (chains.get(key) === mine) chains.delete(key);
+  }
+}
+```
+
+Apply the same shape to `withDesignLock` (`design-lock.ts`) and `withBookLock`
+(`chapters-restructure.ts`). In `chapters-restructure.ts` the comparison
+currently re-allocates a third promise inline (`bookWriteLock.get(bookId) ===
+prev.then(() => next)`) — replace it with the stored reference.
+
+**In `design-lock.ts`, change the cleanup and nothing else.** Do not touch
+acquisition, release or ordering: `ensureCharacterVoiceUuid`'s series branch
+still depends on that lock for its same-book double-mint guarantee (spec §5.1).
+
+**In `chapters-restructure.ts`, re-derive the safety argument rather than
+assuming it.** Its `await prev` sits *inside* the `try` and it omits the
+`.catch()` swallow, so its control flow differs from `file-lock.ts`. State in the
+commit message why the change is safe there.
+
+Correct the three comments that claim the cleanup already works.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd server && npx vitest run src/workspace/ src/routes/chapters-restructure.test.ts`
+Expected: PASS, no regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/workspace/file-lock.ts server/src/tts/design-lock.ts server/src/routes/chapters-restructure.ts server/src/workspace/cast-lock.test.ts
+git commit -m "fix(server): make the promise-chain lock helpers actually free their map entries"
+```
+
+---
+
+### Task 4: `POST /:voiceUuid/assign` — the filed defect (#1981)
+
+**Files:**
+- Modify: `server/src/routes/voice-library.ts` (the `POST /:voiceUuid/assign` handler)
+- Modify: `server/src/routes/voice-library.test.ts`
+
+**Interfaces:**
+- Consumes: `withCastLock`, `withLibraryVoiceLock` (Task 2).
+
+- [ ] **Step 1: Write the failing test**
+
+In `voice-library.test.ts`, in a describe that does **not** call
+`vi.resetModules()` between the two requests:
+
+```ts
+it('keeps both assignments when two /assign calls for one book overlap', async () => {
+  /* Two different characters, one book. Unlocked, the later write replays a
+     snapshot taken before the earlier one landed and drops it. */
+  await Promise.all([
+    request(app).post(`/api/voice-library/${uuidA}/assign`)
+      .send({ bookId, characterId: 'alice' }),
+    request(app).post(`/api/voice-library/${uuidB}/assign`)
+      .send({ bookId, characterId: 'bob' }),
+  ]);
+
+  const cast = await readJson<CastJson>(castJsonPath(bookDir));
+  const byId = Object.fromEntries((cast?.characters ?? []).map((c) => [c.id, c]));
+  expect(byId.alice.overrideTtsVoices?.qwen?.libraryUuid).toBe(uuidA);
+  expect(byId.bob.overrideTtsVoices?.qwen?.libraryUuid).toBe(uuidB);
+});
+```
+
+Note `supertest`'s `Request` is lazy — `.send()` alone never dispatches. Inside
+`Promise.all` it is awaited, so this is fine; do not restructure it into a form
+that only builds the requests.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd server && npx vitest run src/routes/voice-library.test.ts -t "two /assign calls"`
+Expected: FAIL — one character's `libraryUuid` is `undefined`.
+
+- [ ] **Step 3: Apply the hoist and both locks**
+
+Three changes to the handler:
+
+1. **Hoist the manifest read** out of the RMW window. It depends only on
+   `entry.provenance`, `voiceUuid` and `located.state` — all in hand once the
+   book is located. Move the `readJson` of `qwenVoiceSidecarPath(...)` and the
+   `sidecarLanguageName` call to just after the `located` null-check, keeping
+   only the warning-**string** construction (which needs `character.name`, and is
+   synchronous) at its current site.
+
+2. **Wrap the RMW.** The cast `readJson` through `writeJsonAtomic` — including
+   the character lookup, the 404, the clone-capable 409 and the
+   `nextCharacters` build — goes inside `withCastLock(located.bookDir, …)`.
+   Early `return res.status(...)` inside the callback is fine; the lock releases
+   when the callback settles.
+
+3. **Wrap that in `withLibraryVoiceLock(voiceUuid, …)`, outside the cast lock.**
+   Order matters and is not arbitrary: the DELETE path holds the library-voice
+   key across `clearLibraryVoiceReferences`, which takes cast locks per book. Take
+   them the other way round here and the two paths deadlock permanently.
+
+Rewrite the invariant comment. It must say **the lock is the guarantee**, and
+that the `await`-free window is now only a best-effort narrowing of unmeasured
+size kept as insurance against a future writer that forgets to lock. Delete the
+claim that a zero-`await` window is "effectively atomic" — it never was.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd server && npx vitest run src/routes/voice-library.test.ts`
+Expected: PASS, no regressions.
+
+- [ ] **Step 5: Mutation-verify**
+
+Remove the `withCastLock` wrapper only, re-run the new test, confirm it goes red,
+paste the output into the commit message, restore.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/routes/voice-library.ts server/src/routes/voice-library.test.ts
+git commit -m "fix(server): serialise the voice-library assign cast.json read-modify-write"
+```
+
+---
+
+### Task 5: `DELETE /:voiceUuid` — close the erase-vs-assign race
+
+**Files:**
+- Modify: `server/src/routes/voice-library.ts` (the `DELETE /:voiceUuid` handler)
+- Modify: `server/src/workspace/voice-library-usage.ts`
+- Modify: `server/src/routes/voice-library.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('does not leave a dangling reference when an assign races a voice delete', async () => {
+  /* The scan passes book B, then an assign plants a reference in B, then the
+     artifacts are erased — leaving a character pointing at a libraryUuid whose
+     files are gone. */
+  await Promise.all([
+    request(app).delete(`/api/voice-library/${uuid}?confirm=1`),
+    request(app).post(`/api/voice-library/${uuid}/assign`)
+      .send({ bookId, characterId: 'alice' }),
+  ]);
+
+  const cast = await readJson<CastJson>(castJsonPath(bookDir));
+  const alice = cast?.characters?.find((c) => c.id === 'alice');
+  const stillReferenced = alice?.overrideTtsVoices?.qwen?.libraryUuid === uuid;
+  const artifactsGone = !existsSync(qwenVoicePtPath(`qwen-${uuid}`));
+  /* Either the assign lost (no reference) or it won (artifacts still there).
+     Never both. */
+  expect(stillReferenced && artifactsGone).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd server && npx vitest run src/routes/voice-library.test.ts -t "dangling reference"`
+Expected: FAIL — reference present and artifacts erased.
+
+- [ ] **Step 3: Wrap scan → clear → erase in the library-voice lock**
+
+Wrap from `scanLibraryVoiceUsage` through `clearLibraryVoiceReferences` and
+`eraseLibraryVoiceArtifacts` in `withLibraryVoiceLock(voiceUuid, …)`. Task 4
+already made `/assign` take the same key, which is what makes this bite.
+
+In `voice-library-usage.ts`, `clearLibraryVoiceReferences` takes a
+`withCastLock` per book **inside** its loop and **re-reads** the cast in there —
+`walkConfirmedCasts()` yields an already-read `cast`, which is stale by the time
+the body writes.
+
+Do **not** change what the walker yields. `clearLibraryVoiceReferences` uses only
+`bookDir` and `cast.characters`, so it can ignore the yielded `cast` entirely and
+re-read `castJsonPath(bookDir)` inside its own lock. That leaves the walker's
+signature and `scanLibraryVoiceUsage` (read-only, same walker) untouched.
+
+This is `library-voice` → `cast`, matching rule 4.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd server && npx vitest run src/routes/voice-library.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Mutation-verify, then commit**
+
+```bash
+git add server/src/routes/voice-library.ts server/src/workspace/voice-library-usage.ts server/src/routes/voice-library.test.ts
+git commit -m "fix(server): hold a library-voice lock across voice delete scan, clear and erase"
+```
+
+---
+
+### Task 6: Class 1 — the mechanical single-book sites
+
+**Files (16 sites across 10 modules):**
+- `cast-aliases.ts` ×3, `cast-create.ts`, `cast-merge.ts`, `cast-series-patch.ts`,
+  `cast-design.ts` ×2, `voice-style.ts` ×2, `voice-override-linked.ts`,
+  `book-state.ts` (the cast write in the save handler),
+  `qwen-voice.ts` (`DELETE emotion-variant`), `cast-add-from-roster.ts`,
+  `voice-library.ts` (`DELETE /assign`)
+- Plus each module's colocated `*.test.ts`
+
+`voice-library.ts`'s `POST /assign` (Task 4), `voice-library-usage.ts` (Task 5)
+and `qwen-voice.ts`'s `promote-voice` (Task 7) are **not** in this task.
+
+- [ ] **Step 1: Write one failing test per module, plus the cross-module spec**
+
+Use the Task 4 shape: two concurrent requests to that route, each touching a
+different character, assert both survive. One module registry per spec file.
+
+**Additionally, one cross-module spec — this is a required deliverable.** Race
+two *different* modules' write sites against the same book, e.g. `cast-aliases`'s
+alias split concurrent with `voice-style`'s style write; assert both survive.
+Every other spec here races a site against itself, which uses one import and one
+key and therefore cannot detect a key mismatch *between* sites. This is the only
+test in the suite that can. Put it in `server/src/workspace/cast-lock.race.test.ts`
+alongside the primitive harness, not in either route's spec.
+
+- [ ] **Step 2: Run them and confirm each fails**
+
+Run: `cd server && npx vitest run src/routes/cast-aliases.test.ts src/routes/cast-create.test.ts src/routes/cast-merge.test.ts src/routes/cast-series-patch.test.ts src/routes/cast-design.test.ts src/routes/voice-style.test.ts src/routes/voice-override-linked.test.ts src/routes/book-state.test.ts src/routes/qwen-voice.test.ts src/routes/cast-add-from-roster.test.ts`
+Expected: each new test FAILS.
+
+- [ ] **Step 3: Wrap each read..write span**
+
+Exemplar — `cast-aliases.ts`, which every other site in this task mirrors:
+
+```ts
+return withCastLock(bookDir, async () => {
+  const cast = await readJson<CastFile>(castJsonPath(bookDir));
+  if (!cast?.characters?.length) {
+    return res.status(409).json({ error: 'Book has no cast on disk yet. …' });
+  }
+  // … findIndex, 404s, build nextCharacters …
+  await writeJsonAtomic(castJsonPath(bookDir), { characters: nextCharacters });
+  return res.status(200).json({ /* … */ });
+});
+```
+
+Per-site notes:
+
+- **`cast-merge.ts`** — the span is long and contains a
+  `writeJsonAtomic(manuscriptEditsJsonPath(...))`. Leave that inner write where
+  it is; it is a different file and the cast lock does not cover it.
+- **`cast-design.ts`** — both sites already re-read a `fresh` cast immediately
+  before writing. Lock from that `fresh` read through the write, not from the
+  earlier read. Deleting the re-read is fine once the lock is in place, but if
+  you keep it, the lock must still enclose it.
+
+  Known and accepted: the two idempotency `continue` guards (`:268`, `:269`) are
+  evaluated against the *first* read, before the LLM persona generation at
+  `:273`, so they stay stale and two concurrent runs can each generate a persona
+  with the second overwriting the first. That is a sanctioned carve-out
+  (spec §4), already recorded in §12 — **do not try to fix it here**, and do not
+  extend the lock upward to cover the generation.
+- **`book-state.ts`** — **the one site in this task that is not a wrap.** There is
+  no cast read at the call site:
+
+  ```ts
+  const guarded = await preserveDesignedVoices(bookDir, body.patch);
+  await writeJsonAtomic(castJsonPath(bookDir), await denormaliseCastReusedVoices(guarded));
+  ```
+
+  The read is inside `preserveDesignedVoices` (`book-state.ts:128-130`), and it
+  feeds `rejectForeignCloneKeys` (`:135`) and `preserveClonedSlotsOnCastWrite`
+  (`:140`) — both **clone-consent guards**. Wrapping only these two lines locks
+  the write while the consent checks still read stale data, which is rule 2's
+  named failure mode dressed as a conversion. **Lock must enclose the
+  `preserveDesignedVoices` call and the write together.** Both `await`s go
+  inside.
+- **`cast-add-from-roster.ts`** — reads **both** books but writes only the
+  source. Lock the **source** only. Do not use `withCastLocks`: it would widen a
+  lock over a second book for a read-only consultation. The target read is a
+  check-then-act and is a documented residual, not something to fix here.
+- **`voice-override-linked.ts`** and **`cast-series-patch.ts`** — long spans; make
+  sure the read at the top is inside, not just the write at the bottom.
+
+  Both are also **cross-book check-then-act**, and that part is out of scope.
+  `voice-override-linked` derives `canonicalVoiceId`, `sourceTokens`, the
+  `inGroup` predicate and the whole `writes` list from the *source* book's
+  snapshot and then writes *other* books via `applyToBook`;
+  `cast-series-patch` derives `sourceChar` and `targets` from the source read
+  plus `scanSeriesCharactersForBookId`. Lock each per-book read..write span.
+  Do **not** attempt to make the cross-book derivation consistent — that is
+  #2006.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cd server && npm run test:server`
+Expected: PASS.
+
+- [ ] **Step 5: Mutation-verify each site**
+
+For each of the 10 modules: remove that module's `withCastLock`, re-run its spec,
+confirm red, restore. Record the list in the commit message. **A site whose test
+stays green with the lock removed is a placebo — stop and investigate rather than
+moving on.**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/routes/
+git commit -m "fix(server): serialise the single-book cast.json read-modify-writes"
+```
+
+---
+
+### Task 7: `promote-voice` — narrow the lock, do not wrap the span
+
+**Files:**
+- Modify: `server/src/routes/qwen-voice.ts` (`promote-voice`)
+- Modify: `server/src/routes/qwen-voice.test.ts`
+
+This site is called out separately because the obvious conversion is wrong. Its
+read..write span contains a `stat`, four `rm`s, three `rename`s, a `copyFile`,
+and a **sidecar `fetch` with no `AbortSignal` and no timeout**. Wrapping the span
+puts a network round-trip inside the hottest lock in the product: a hung sidecar
+would stall every cast write for that book for minutes.
+
+- [ ] **Step 1: Write the failing test**
+
+Concurrent `promote-voice` and a `/assign` on a different character of the same
+book; assert both survive.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd server && npx vitest run src/routes/qwen-voice.test.ts -t "promote"`
+Expected: FAIL.
+
+- [ ] **Step 3: Re-read under a narrow lock**
+
+The top-of-handler read is load-bearing throughout the span — `realVoiceId` comes
+from `character.voiceUuid` and drives the 400 gate, the `stat` 409, the `rm`s,
+the `rename`s, the `copyFile` and the evict payload; and `delete qwenSlot.variants`
+mutates that same object *in place* before it is written. So the lock body is
+given exactly. Replace the tail of the handler with:
+
+```ts
+/* Narrow by design. The artifact moves and the sidecar evict above stay OUTSIDE
+   this lock: that fetch has no AbortSignal, so a hung sidecar would otherwise
+   stall every cast write for this book. Global order: no other lock is held
+   here (cast is last — see cast-lock.ts rule 4). */
+await withCastLock(located.bookDir, async () => {
+  const fresh = await readJson<CastFile>(castJsonPath(located.bookDir));
+  const freshChar = fresh?.characters?.find((c) => c.id === characterId);
+  if (!fresh || !freshChar) return; // deleted mid-promotion — artifacts already moved
+  const freshSlot = freshChar.overrideTtsVoices?.qwen;
+  staleVariantIds = Object.values(freshSlot?.variants ?? {})
+    .map((v) => v?.name)
+    .filter((n): n is string => !!n);
+  if (freshSlot) delete freshSlot.variants;
+  await writeJsonAtomic(castJsonPath(located.bookDir), fresh);
+});
+/* Teardown stays outside: filesystem work, and holding the lock across it
+   reintroduces exactly the stall this narrowing avoids. */
+for (const variantId of staleVariantIds) {
+  await tearDownEmotionVariant(variantId);
+}
+```
+
+Three things are deliberate and must not be "corrected":
+
+- `staleVariantIds` is re-derived from `fresh`, not from the top-of-handler read.
+  Hoist its declaration (`let staleVariantIds: string[] = []`) above the lock.
+- **`realVoiceId` stays pinned to the pre-lock read.** By the time the lock is
+  taken the artifacts have already been renamed to it, so re-deriving it from
+  `fresh` would name files that do not exist. A concurrent write changing
+  `voiceUuid` mid-promotion is a sanctioned residual (spec §4 carve-out, §12).
+- The early `return` on a deleted character is a no-op, not a 404 — the response
+  has not been sent yet at this point, and the artifacts have already moved.
+
+- [ ] **Step 4: Run, mutation-verify, commit**
+
+Run: `cd server && npx vitest run src/routes/qwen-voice.test.ts`
+
+```bash
+git add server/src/routes/qwen-voice.ts server/src/routes/qwen-voice.test.ts
+git commit -m "fix(server): re-read cast.json under a narrow lock in promote-voice"
+```
+
+---
+
+### Task 8: Class 2 — multi-book sites, plus the `library-cast-override` same-book bug
+
+**Files:**
+- Modify: `cast-link-prior.ts` (2 sites), `cast-not-linked-to.ts` (4 sites),
+  `library-cast-override.ts` (2 sites), plus their `*.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Two: (a) two concurrent two-book operations with the books in **opposite**
+argument order — must complete, not deadlock; (b) the `library-cast-override`
+same-book case below.
+
+```ts
+it('does not lose the source merge when source and target are the same book', async () => {
+  /* Its guard rejects same-book AND same-character only, so same-book with two
+     different characters is reachable — and broken with no concurrency at all:
+     two independent reads of one file, two arrays derived from separate
+     snapshots, two writes to the same path. nextTargetCharacters does not
+     contain mergedSource, so the second write discards the first. */
+  await request(app).post('/api/library-cast-override')
+    .send({ sourceBookId: bookId, sourceCharacterId: 'alice',
+            targetBookId: bookId, targetCharacterId: 'bob' })
+    .expect(200);
+
+  const cast = await readJson<CastFile>(castJsonPath(bookDir));
+  const byId = Object.fromEntries((cast?.characters ?? []).map((c) => [c.id, c]));
+  expect(byId.alice.overrideTtsVoices).toBeDefined(); // the merge that got dropped
+  expect(byId.bob.overrideTtsVoices).toBeDefined();
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Expected: the same-book test FAILS today even single-threaded.
+
+- [ ] **Step 3: Apply `withCastLocks` and fix same-book**
+
+Wrap each handler's read..write span in `withCastLocks([a.bookDir, b.bookDir], …)`.
+
+In `library-cast-override.ts`, add a same-book branch: one read, both merges
+applied to that single array, one write. `withCastLocks` dedupes so it will not
+deadlock, but dedupe alone leaves the data loss — it just puts a lock around it.
+
+- [ ] **Step 4: Run, mutation-verify, commit**
+
+```bash
+git add server/src/routes/cast-link-prior.ts server/src/routes/cast-not-linked-to.ts server/src/routes/library-cast-override.ts server/src/routes/
+git commit -m "fix(server): lock multi-book cast writes in sorted order and fix the same-book merge"
+```
+
+---
+
+### Task 9: Class 3 — `voices.ts`'s two fan-out branches
+
+**Files:**
+- Modify: `server/src/routes/voices.ts` (`forEachMatchingCastCharacter`)
+- Modify: `server/src/routes/voices.test.ts`
+
+Both branches write, and **both need locking**:
+
+- `:816-829`, the workspace/series walk (write at `:828`) — live for every
+  **series** book. `cast-design.ts` and `single-design.ts` pass `seriesFilter`
+  *and* `job.bookDir`, so the `onlyBookDir` fast path is bypassed for them.
+  Three more callers never pass `onlyBookDir` at all.
+- `:788-803`, the `onlyBookDir` fast path (write at `:801`) — standalone books.
+
+- [ ] **Step 1: Write the failing tests** — one per branch: concurrent
+  propagation and a direct cast write to a book in the match set; both survive.
+
+- [ ] **Step 2: Run to verify both fail.**
+
+- [ ] **Step 3: Lock per book inside each branch**, with the `readJson` moved
+  inside. Do **not** wrap the whole walk — that would hold a lock on every book
+  in the workspace across a full directory scan (spec §3.2).
+
+Rule 1 check: `forEachMatchingCastCharacter` is now a locked leaf, so no caller
+may wrap it in a cast lock for the same book. Task 10 depends on this.
+
+- [ ] **Step 4: Run, mutation-verify both branches separately, commit.**
+
+```bash
+git add server/src/routes/voices.ts server/src/routes/voices.test.ts
+git commit -m "fix(server): lock each book of the voices fan-out as it is written"
+```
+
+---
+
+### Task 10: Class 4 — the `qwen-voice.ts` re-entrancy restructure
+
+**Files:**
+- Modify: `server/src/routes/qwen-voice.ts`
+  (`ensureCharacterVoiceUuid`, `persistEmotionVariant`)
+- Modify: `server/src/routes/qwen-voice.test.ts`
+
+The highest-risk task. Both functions have two branches; only the **book-scoped**
+one takes a cast lock. The **series** branch delegates to
+`forEachMatchingCastCharacter`, which after Task 9 locks per book itself —
+wrapping it here would violate rule 1 and self-deadlock the moment the walk
+reaches this book.
+
+- [ ] **Step 1: Write the failing tests** — concurrent book-scoped calls; assert
+  no double-mint and no lost sibling write.
+
+- [ ] **Step 2: Run to verify they fail.**
+
+- [ ] **Step 3: Split each function**
+
+For **both**: the book-scoped branch takes `withCastLock(bookDir, …)` and
+**re-reads inside it**, then re-evaluates every decision and re-derives every
+value that feeds the write — re-check `voiceUuid`, re-derive `qwenStorageKey`.
+The outer read becomes an early-out optimisation and is never authoritative.
+`persistEmotionVariant` in particular computes `baseVoiceId` from the outer read
+and bakes it into the payload as the default slot name; that derivation must move
+inside.
+
+The series branch is left unlocked and delegating.
+
+**Do not remove `withDesignLock` from `ensureCharacterVoiceUuid`.** It is still
+what prevents the same-book double-mint on the series branch, where the decision
+precedes the branch and no cast lock can reach it. (Across two books of one
+series it does not help — pre-existing, tracked on #2006. Do not try to fix that
+here.)
+
+- [ ] **Step 4: Run the full server suite**
+
+Run: `cd server && npm run test:server && npm run test:server-slow`
+Expected: PASS. This task can deadlock rather than fail an assertion — if a spec
+hangs, suspect a cast lock enclosing `forEachMatchingCastCharacter`.
+
+- [ ] **Step 5: Mutation-verify, commit.**
+
+```bash
+git add server/src/routes/qwen-voice.ts server/src/routes/qwen-voice.test.ts
+git commit -m "fix(server): lock the book-scoped voice-uuid and emotion-variant writes"
+```
+
+---
+
+### Task 11: Class 6 — the two delete sites
+
+**Files:**
+- Modify: `server/src/routes/analysis.ts` (the "Start fresh" `rm`)
+- Modify: `server/src/routes/book-state.ts` (the reparse `rm`, inside a `Promise.all`)
+- Modify: their `*.test.ts`
+
+These destroy cast.json and match neither the write pattern nor the guard's.
+They matter **more** after this change: a locked writer whose read predates the
+delete recreates the file afterwards, resurrecting the stale roster the delete
+exists to remove — and the lock lengthens the gap between a queued writer's read
+and its write.
+
+**This is the only `analysis.ts` change in this plan.** Its five *write* sites are
+out of scope (#2015). Touch the `rm` and nothing else.
+
+- [ ] **Step 1: Write the failing test** — a delete concurrent with a cast write;
+  assert the file stays deleted.
+- [ ] **Step 2: Run to verify it fails.**
+- [ ] **Step 3: Wrap each `rm` in `withCastLock(bookDir, …)`.** In
+  `book-state.ts` the `rm` is one arm of a `Promise.all`; wrap that arm.
+- [ ] **Step 4: Run, mutation-verify, commit.**
+
+```bash
+git add server/src/routes/analysis.ts server/src/routes/book-state.ts
+git commit -m "fix(server): take the cast lock when deleting cast.json"
+```
+
+---
+
+### Task 12: The guard test
+
+**Files:**
+- Create: `server/src/workspace/cast-lock.guard.test.ts`
+
+- [ ] **Step 1: Write it**
+
+Walk `server/src/**/*.ts` (excluding `*.test.ts`). For each file containing
+`castJsonPath`, assert every `writeJsonAtomic(castJsonPath(` and
+`rm(castJsonPath(` occurrence sits inside a `withCastLock` / `withCastLocks`
+scope. Maintain an explicit allowlist with a reason per entry:
+
+```ts
+const ALLOWED_UNLOCKED = new Map([
+  ['routes/analysis.ts', 'the 5 merge-base writes are deferred to #2015; the rm IS locked'],
+]);
+```
+
+Document the known blind spots in the file header: it sees one syntactic form, so
+`const p = castJsonPath(dir); await writeJsonAtomic(p, …)` slips through, as
+would a writer routed via `workspace/schema-migrate.ts`'s cast.json seam.
+
+- [ ] **Step 2: Verify it catches a real regression**
+
+Temporarily unwrap one converted site, run the guard, confirm it fails naming that
+file. Restore.
+
+- [ ] **Step 3: Confirm CI wiring — do not add an `extraFiles` entry**
+
+The guard reads `server/src/**`, which `test:server` already globs and
+`verify.yml` already matches, so any diff adding an unlocked site busts both
+caches. An `extraFiles` entry would be a no-op.
+
+Verify: `node scripts/verify-cache.mjs --steps test:server` picks up a change to
+a converted route.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/src/workspace/cast-lock.guard.test.ts
+git commit -m "test(server): fail the build on an unlocked cast.json write"
+```
+
+---
+
+### Task 13: Docs, notes and ticket hygiene
+
+**Files:**
+- Modify: `CLAUDE.md` (*Conventions worth preserving*)
+- Modify: `docs/release-notes-next.md`, `RELEASE_NOTES.md`
+- Modify: `docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md` (status)
+
+- [ ] **Step 1: Add the convention to CLAUDE.md**
+
+One bullet with the four rules from `cast-lock.ts`'s header, including the
+three-class lock order.
+
+- [ ] **Step 2: Release notes, both files**
+
+`docs/release-notes-next.md` — technical, PR-ref'd. `RELEASE_NOTES.md` — one
+user-facing line in brand voice. The user-visible delta is real: concurrent cast
+edits no longer silently discard one another. Do **not** claim cast.json is fully
+protected — `analysis.ts` is not (#2015), and the check-then-act gates are not
+(#2006).
+
+- [ ] **Step 3: On-box acceptance**
+
+No new hardware-only behaviour: every claim here is provable in-process by the
+outcome tests. Say so explicitly in the PR body rather than omitting the step.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md docs/release-notes-next.md RELEASE_NOTES.md docs/superpowers/specs/
+git commit -m "docs(docs): record the cast.json lock convention and release notes"
+```
+
+---
+
+## Before opening the PR
+
+- [ ] `npm run verify:fast:branch`
+- [ ] `cd server && npm run test:server && npm run test:server-slow`
+- [ ] `npm run typecheck` — **run this explicitly.** Vitest and pre-commit are
+      both blind to type errors, so a task that left one will otherwise reach CI.
+- [ ] `npx madge --circular --extensions ts server/src` — still 15 cycles.
+      `cast-lock.ts` is a leaf under `workspace/`; if the count moved, a route
+      module was imported from it.
+- [ ] PR body: `Closes #1981`, `Closes #2000`, `Closes #2001`, `Refs #2006`,
+      `Refs #2015`. Declare Task 8's `library-cast-override` same-book fix and
+      Task 3's #2001 fix under "Also fixed, found in passing".
+- [ ] Mandatory `code-review` pass at `high` effort — multi-scope, 17 modules.

--- a/docs/superpowers/plans/2026-07-31-cast-json-write-lock.md
+++ b/docs/superpowers/plans/2026-07-31-cast-json-write-lock.md
@@ -5,12 +5,15 @@
 **Goal:** Serialise every cast.json read-modify-write behind a per-book lock, so
 two concurrent writers can no longer silently discard each other's mutation.
 
-**Architecture:** A thin named wrapper (`withCastLock` / `withCastLocks`) over the
-existing `withKeyLock` promise-chain mutex, applied at 30 of the 35
-`writeJsonAtomic(castJsonPath(…))` sites plus 2 delete sites. The lock always
-encloses the **read** as well as the write — wrapping only the write buys
-nothing. A third key class (`library-voice:<uuid>`) closes the delete-vs-assign
-race, under a stated global lock order.
+**Architecture:** Three layers. (1) A thin named wrapper (`withCastLock` /
+`withCastLocks`) over the existing `withKeyLock` promise-chain mutex, applied at
+all 35 `writeJsonAtomic(castJsonPath(…))` sites plus 2 delete sites; the lock
+always encloses the **read** as well as the write. (2) A cast.json revision
+counter, for the six places where the decision is read in one lock scope and the
+write lands in another — a lock cannot reach those, so staleness is made
+detectable instead. (3) Two further key classes, `library-voice:<uuid>` and
+`series:<author>/<series>`, for races a per-book key cannot express. Global lock
+order: `design` → `series` → `library-voice` → `cast`.
 
 **Tech Stack:** TypeScript, Node 20, Express, Vitest (node env), real-fs
 integration tests.
@@ -18,16 +21,17 @@ integration tests.
 **Design of record:** [`docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md`](../specs/2026-07-31-cast-json-write-lock-design.md).
 Read it before Task 1. Section references below (§3.1, §5, §10.2 …) point at it.
 
-**Tickets:** `Closes #1981`, `Closes #2000`, `Closes #2001`. `Refs #2006`, `Refs #2015`.
+**Tickets:** `Closes #1981`, `Closes #2000`, `Closes #2001`, `Closes #2006`,
+`Closes #2015`. Nothing is deferred out of this change.
 
 ## Global Constraints
 
 - **Base branch:** cut after `fix/server-1933-assign-readiness` merges, or rebase
   onto it. It rewrites 208 lines of `voice-library.ts` and shifts the assign
   read/write by +138/+178. **Cite symbols, never line numbers, in code comments.**
-- **Global lock order: `design` → `library-voice` → `cast`.** Never acquire an
-  earlier class while holding a later one. Every acquisition site names its
-  position in a comment.
+- **Global lock order: `design` → `series` → `library-voice` → `cast`.** Never
+  acquire an earlier class while holding a later one. Every acquisition site
+  names its position in a comment.
 - **Lock the innermost read-through-write, never the caller.** One level only.
   A locked function must not call another locked function on the same book.
 - **The read goes inside the lock**, and so does every decision derived from it.
@@ -37,7 +41,7 @@ Read it before Task 1. Section references below (§3.1, §5, §10.2 …) point a
   detector**: a partitioned lock does not contend, so it loses a mutation and the
   outcome test goes *red*. Pinning avoids a confusing false failure. Do not add a
   `chains.size` accessor for this — §10.3 explains why it cannot work.
-- **Task 6 must include one cross-module outcome spec** — two *different*
+- **Task 7 must include one cross-module outcome spec** — two *different*
   modules' write sites racing on one book. A spec that races a site against
   itself uses one import and one key, so it can never catch cross-site key
   derivation drift. This is the only shape that can.
@@ -48,9 +52,15 @@ Read it before Task 1. Section references below (§3.1, §5, §10.2 …) point a
 - **Every lock is mutation-verified**: revert the lock at that site, re-run,
   paste the failing output into the task's commit message. A test that was never
   seen red proves nothing.
-- **Do not touch** `analysis.ts`'s 5 write sites (deferred, #2015) or the three
-  clone-consent gates in `voices.ts` / `single-design.ts` / `qwen-voice.ts`
-  (deferred, #2006). Deleting or "improving" them is out of scope.
+- **Every cast.json write goes through `writeCastChecked` (Task 3), never a raw
+  `writeJsonAtomic(castJsonPath(…))`.** The revision counter is only sound if
+  adoption is universal: one writer that does not increment `rev` makes every
+  other writer's check pass against a file that did change, which is worse than
+  no counter — it reads as a guarantee while providing nothing. The Task 13 guard
+  enforces this.
+- **`analysis.ts`'s 5 writes and the three clone-consent gates are IN scope** —
+  Tasks 14 and 15. Earlier drafts deferred them to #2015/#2006; those issues are
+  now closed by this PR. Do not skip them on the strength of a stale comment.
 - Commit convention: `<type>(<scope>): <subject>`. Scope is `server` for all
   code tasks.
 
@@ -60,13 +70,14 @@ Read it before Task 1. Section references below (§3.1, §5, §10.2 …) point a
 
 | File | Responsibility |
 |---|---|
-| `server/src/workspace/cast-lock.ts` | **New.** The three named lock wrappers + the lock-order rule in its header. Sole owner of key derivation. |
+| `server/src/workspace/cast-lock.ts` | **New.** Four named lock wrappers (`withCastLock`, `withCastLocks`, `withLibraryVoiceLock`, `withSeriesLock`) + the lock-order rule in its header. Sole owner of key derivation. |
+| `server/src/workspace/cast-io.ts` | **New.** `readCastForUpdate` / `writeCastChecked` — the revision counter. Sole owner of the `rev` increment. |
 | `server/src/workspace/cast-lock.test.ts` | **New.** Primitive unit tests: sorted acquisition (observed within one call), the AB/BA deadlock test, dedupe, release-on-throw, non-overlapping FIFO waiters, empty-list refusal. |
 | `server/src/workspace/cast-lock.race.test.ts` | **New.** The outcome harness — two overlapping RMWs, both mutations must survive. The reference for every later site test. |
 | `server/src/workspace/file-lock.ts` | Modify — #2001 map-cleanup fix. |
 | `server/src/tts/design-lock.ts` | Modify — same fix, cleanup only. **Do not touch acquire/release/ordering**: `ensureCharacterVoiceUuid`'s series branch still depends on it (§5.1). |
 | `server/src/routes/chapters-restructure.ts` | Modify — same fix; re-derive the safety argument, its control flow differs. |
-| 14 route modules + `voice-library-usage.ts` | Modify — apply the lock per §5. |
+| 17 route modules + `voice-library-usage.ts` | Modify — apply the lock per §5. |
 | `server/src/workspace/cast-lock.guard.test.ts` | **New.** Static guard: no unlocked `writeJsonAtomic(castJsonPath(` / `rm(castJsonPath(`. |
 
 ---
@@ -184,7 +195,7 @@ both reads land before either write, because the write (`mkdir` + `writeFile` +
 
 **The one exception is wall-clock duration, not await depth.** `promote-voice`
 does a sidecar `fetch` before its read, which takes real time and *will*
-separate the two racers. Task 7's test must stub that `fetch` (or point it at a
+separate the two racers. Task 8's test must stub that `fetch` (or point it at a
 local no-op) so the two requests reach their cast reads together. If any other
 route-level red-phase test fails to go red, treat it as a **harness** problem —
 not as evidence the site is safe — and stub whatever slow call sits in its
@@ -199,7 +210,7 @@ git commit -m "test(server): pin the cast.json lost-update race before locking a
 
 ---
 
-### Task 2: `cast-lock.ts` — the three wrappers
+### Task 2: `cast-lock.ts` — the lock wrappers
 
 **Files:**
 - Create: `server/src/workspace/cast-lock.ts`
@@ -435,7 +446,169 @@ git commit -m "feat(server): add the per-book cast.json write lock"
 
 ---
 
-### Task 3: #2001 — the lock helpers' map cleanup has never run
+### Task 3: `cast-io.ts` — the revision counter
+
+Every later task's write goes through this. It must land before any site is
+converted, or those sites get written twice.
+
+**Files:**
+- Create: `server/src/workspace/cast-io.ts`
+- Create: `server/src/workspace/cast-io.test.ts`
+
+**Interfaces:**
+- Consumes: `readJson`, `writeJsonAtomic` from `./state-io.js`; `castJsonPath`.
+- Produces:
+  - `readCastForUpdate(bookDir): Promise<{ cast: CastJson; rev: number }>`
+  - `writeCastChecked(bookDir, next: CastJson, expectedRev: number): Promise<void>`
+  - `class CastRevConflictError extends Error` with `bookDir`, `expected`, `actual`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeJsonAtomic, readJson } from './state-io.js';
+import { castJsonPath } from './paths.js';
+import { readCastForUpdate, writeCastChecked, CastRevConflictError } from './cast-io.js';
+
+let dir: string;
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'cast-io-'));
+  await writeJsonAtomic(castJsonPath(dir), { characters: [{ id: 'alice' }] });
+});
+afterEach(async () => { await rm(dir, { recursive: true, force: true }); });
+
+it('treats a cast.json with no rev as rev 0', async () => {
+  /* Migration is a read-path default: an existing workspace has no rev field
+     and must not need a migration script. */
+  const { rev } = await readCastForUpdate(dir);
+  expect(rev).toBe(0);
+});
+
+it('stamps rev+1 on write', async () => {
+  const { cast, rev } = await readCastForUpdate(dir);
+  await writeCastChecked(dir, cast, rev);
+  expect((await readJson<{ rev?: number }>(castJsonPath(dir)))?.rev).toBe(1);
+});
+
+it('preserves rev across a writer that builds a fresh payload', async () => {
+  /* At least 20 of the 35 writers construct `{ characters: … }` and drop every
+     other top-level field. If the helper did not own the increment, those
+     writers would silently reset the counter and every later rev check would
+     pass against a stale read. */
+  const { rev } = await readCastForUpdate(dir);
+  await writeCastChecked(dir, { characters: [{ id: 'bob' }] }, rev);
+  const after = await readJson<{ rev?: number; characters: unknown[] }>(castJsonPath(dir));
+  expect(after?.rev).toBe(1);
+  expect(after?.characters).toHaveLength(1);
+});
+
+it('throws CastRevConflictError when the revision moved since the read', async () => {
+  const first = await readCastForUpdate(dir);
+  /* Someone else writes in between. */
+  await writeCastChecked(dir, first.cast, first.rev);
+  await expect(writeCastChecked(dir, first.cast, first.rev)).rejects.toBeInstanceOf(
+    CastRevConflictError,
+  );
+});
+
+it('reports both revisions on conflict', async () => {
+  const first = await readCastForUpdate(dir);
+  await writeCastChecked(dir, first.cast, first.rev);
+  await writeCastChecked(dir, first.cast, 1);
+  const err = await writeCastChecked(dir, first.cast, first.rev).catch((e) => e);
+  expect(err).toMatchObject({ expected: 0, actual: 2 });
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd server && npx vitest run src/workspace/cast-io.test.ts`
+Expected: FAIL — `Cannot find module './cast-io.js'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+/* cast.json optimistic concurrency.
+ *
+ * The per-book lock (cast-lock.ts) makes one read-modify-write atomic. It
+ * cannot help when the DECISION is read in one lock scope and the write lands
+ * in another — analysis.ts's merge base, the clone-consent 409 gates,
+ * cast-link-prior's target read. Those need staleness to be DETECTABLE, which
+ * is what `rev` provides.
+ *
+ * SOUNDNESS DEPENDS ON UNIVERSAL ADOPTION. If one writer does not increment
+ * `rev`, every other writer's check passes against a file that did change, and
+ * the counter is worse than none — it reads as a guarantee while providing
+ * nothing. That is why every cast.json write goes through `writeCastChecked`,
+ * and why the guard test (cast-lock.guard.test.ts) fails the build on a raw
+ * writeJsonAtomic(castJsonPath(…)).
+ *
+ * Both helpers assume the caller already holds the cast lock for `bookDir`.
+ * They are the read/write half; cast-lock.ts is the mutual-exclusion half.
+ */
+import { readJson, writeJsonAtomic } from './state-io.js';
+import { castJsonPath } from './paths.js';
+
+export interface CastJson {
+  characters?: unknown[];
+  rev?: number;
+  [k: string]: unknown;
+}
+
+export class CastRevConflictError extends Error {
+  constructor(
+    readonly bookDir: string,
+    readonly expected: number,
+    readonly actual: number,
+  ) {
+    super(
+      `cast.json for ${bookDir} changed under us (expected rev ${expected}, found ${actual}).`,
+    );
+    this.name = 'CastRevConflictError';
+  }
+}
+
+/** Read the cast and the revision it was at. `rev` is absent on every cast.json
+ *  written before this change, so it defaults to 0 — a read-path default, so no
+ *  migration script and no compatibility break. */
+export async function readCastForUpdate(
+  bookDir: string,
+): Promise<{ cast: CastJson; rev: number }> {
+  const cast = (await readJson<CastJson>(castJsonPath(bookDir))) ?? { characters: [] };
+  return { cast, rev: typeof cast.rev === 'number' ? cast.rev : 0 };
+}
+
+/** Write `next`, asserting the on-disk revision is still `expectedRev`.
+ *  Stamps `expectedRev + 1`. The caller MUST hold the cast lock — this re-read
+ *  is a staleness check against writers in OTHER lock scopes, not a substitute
+ *  for mutual exclusion. */
+export async function writeCastChecked(
+  bookDir: string,
+  next: CastJson,
+  expectedRev: number,
+): Promise<void> {
+  const { rev: actual } = await readCastForUpdate(bookDir);
+  if (actual !== expectedRev) throw new CastRevConflictError(bookDir, expectedRev, actual);
+  await writeJsonAtomic(castJsonPath(bookDir), { ...next, rev: expectedRev + 1 });
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd server && npx vitest run src/workspace/cast-io.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/workspace/cast-io.ts server/src/workspace/cast-io.test.ts
+git commit -m "feat(server): add the cast.json revision counter"
+```
+
+### Task 4: #2001 — the lock helpers' map cleanup has never run
 
 **Files:**
 - Modify: `server/src/workspace/file-lock.ts`
@@ -463,7 +636,7 @@ Add the accessor to `file-lock.ts`:
 
 ```ts
 /** Test-only: the number of live chain entries. Used to pin the cleanup in
- *  Task 3 — NOT a partition detector (design §10.3 explains why that idea was
+ *  Task 4 — NOT a partition detector (design §10.3 explains why that idea was
  *  rejected). */
 export function __chainsSizeForTest(): number {
   return chains.size;
@@ -531,7 +704,7 @@ git commit -m "fix(server): make the promise-chain lock helpers actually free th
 
 ---
 
-### Task 4: `POST /:voiceUuid/assign` — the filed defect (#1981)
+### Task 5: `POST /:voiceUuid/assign` — the filed defect (#1981)
 
 **Files:**
 - Modify: `server/src/routes/voice-library.ts` (the `POST /:voiceUuid/assign` handler)
@@ -598,10 +771,10 @@ Three changes to the handler:
    cast read. The library-voice lock opens **before `readEntry`** and closes
    after the cast write.
 
-   This is what makes Task 5 deterministic. `eraseLibraryVoiceArtifacts` deletes
+   This is what makes Task 6 deterministic. `eraseLibraryVoiceArtifacts` deletes
    the entry directory, so with the 404 gate *inside* the lock a delete-first
    ordering makes the assign 404 cleanly; with it outside, the assign proceeds on
-   an entry that is being erased underneath it and Task 5's assertion becomes a
+   an entry that is being erased underneath it and Task 6's assertion becomes a
    coin flip.
 
    Order matters and is not arbitrary: the DELETE path holds the library-voice
@@ -632,7 +805,7 @@ git commit -m "fix(server): serialise the voice-library assign cast.json read-mo
 
 ---
 
-### Task 5: `DELETE /:voiceUuid` — close the erase-vs-assign race
+### Task 6: `DELETE /:voiceUuid` — close the erase-vs-assign race
 
 **Files:**
 - Modify: `server/src/routes/voice-library.ts` (the `DELETE /:voiceUuid` handler)
@@ -699,7 +872,7 @@ git commit -m "fix(server): hold a library-voice lock across voice delete scan, 
 
 ---
 
-### Task 6: Class 1 — the mechanical single-book sites
+### Task 7: Class 1 — the mechanical single-book sites
 
 **Files (15 sites across 11 modules):**
 - `cast-aliases.ts` ×3, `cast-create.ts`, `cast-merge.ts`, `cast-series-patch.ts`,
@@ -709,12 +882,12 @@ git commit -m "fix(server): hold a library-voice lock across voice delete scan, 
   `voice-library.ts` (`DELETE /assign`)
 - Plus each module's colocated `*.test.ts`
 
-`voice-library.ts`'s `POST /assign` (Task 4), `voice-library-usage.ts` (Task 5)
-and `qwen-voice.ts`'s `promote-voice` (Task 7) are **not** in this task.
+`voice-library.ts`'s `POST /assign` (Task 5), `voice-library-usage.ts` (Task 6)
+and `qwen-voice.ts`'s `promote-voice` (Task 8) are **not** in this task.
 
 - [ ] **Step 1: Write one failing test per module, plus the cross-module spec**
 
-Use the Task 4 shape: two concurrent requests to that route, each touching a
+Use the Task 5 shape: two concurrent requests to that route, each touching a
 different character, assert both survive. One module registry per spec file.
 
 **Additionally, one cross-module spec — this is a required deliverable.** Race
@@ -731,12 +904,13 @@ Run: `cd server && npx vitest run src/routes/cast-aliases.test.ts src/routes/cas
 Expected: each new test FAILS.
 
 (`voice-library.test.ts` is in the list for the `DELETE /assign` site only —
-`POST /assign` was Task 4.)
+`POST /assign` was Task 5.)
 
-**Arithmetic check.** 15 sites here + 1 (Task 4 `POST /assign`) + 1 (Task 5
-`voice-library-usage`) + 1 (Task 7 `promote-voice`) + 8 (Task 8) + 2 (Task 9)
-+ 2 (Task 10) = **30 locked**, plus 5 deferred to #2015 = **35**. If your count
-differs, stop — the spec's §5 enumeration is the authority.
+**Arithmetic check.** 15 sites here + 1 (Task 5, `POST /assign`) + 1 (Task 6,
+`voice-library-usage`) + 1 (Task 8, `promote-voice`) + 8 (Task 9) + 2 (Task 10)
++ 2 (Task 11) = **30**, plus `analysis.ts`'s 5 in Task 14 = **35**. Every site is
+covered; nothing is deferred. If your count differs, stop — the spec's §5
+enumeration is the authority.
 
 - [ ] **Step 3: Wrap each read..write span**
 
@@ -831,7 +1005,7 @@ in-progress edits into this commit — a recurring incident in this repo.
 
 ---
 
-### Task 7: `promote-voice` — narrow the lock, do not wrap the span
+### Task 8: `promote-voice` — narrow the lock, do not wrap the span
 
 **Files:**
 - Modify: `server/src/routes/qwen-voice.ts` (`promote-voice`)
@@ -921,7 +1095,7 @@ git commit -m "fix(server): re-read cast.json under a narrow lock in promote-voi
 
 ---
 
-### Task 8: Class 2 — multi-book sites, plus the `library-cast-override` same-book bug
+### Task 9: Class 2 — multi-book sites, plus the `library-cast-override` same-book bug
 
 **Files:**
 - Modify: `cast-link-prior.ts` (2 sites), `cast-not-linked-to.ts` (4 sites),
@@ -983,7 +1157,7 @@ git commit -m "fix(server): lock multi-book cast writes in sorted order and fix 
 
 ---
 
-### Task 9: Class 3 — `voices.ts`'s two fan-out branches
+### Task 10: Class 3 — `voices.ts`'s two fan-out branches
 
 **Files:**
 - Modify: `server/src/routes/voices.ts` (`forEachMatchingCastCharacter`)
@@ -1007,7 +1181,7 @@ Both branches write, and **both need locking**:
   in the workspace across a full directory scan (spec §3.2).
 
 Rule 1 check: `forEachMatchingCastCharacter` is now a locked leaf, so no caller
-may wrap it in a cast lock for the same book. Task 10 depends on this.
+may wrap it in a cast lock for the same book. Task 11 depends on this.
 
 - [ ] **Step 4: Run, mutation-verify both branches separately, commit.**
 
@@ -1018,7 +1192,7 @@ git commit -m "fix(server): lock each book of the voices fan-out as it is writte
 
 ---
 
-### Task 10: Class 4 — the `qwen-voice.ts` re-entrancy restructure
+### Task 11: Class 4 — the `qwen-voice.ts` re-entrancy restructure
 
 **Files:**
 - Modify: `server/src/routes/qwen-voice.ts`
@@ -1027,7 +1201,7 @@ git commit -m "fix(server): lock each book of the voices fan-out as it is writte
 
 The highest-risk task. Both functions have two branches; only the **book-scoped**
 one takes a cast lock. The **series** branch delegates to
-`forEachMatchingCastCharacter`, which after Task 9 locks per book itself —
+`forEachMatchingCastCharacter`, which after Task 10 locks per book itself —
 wrapping it here would violate rule 1 and self-deadlock the moment the walk
 reaches this book.
 
@@ -1069,7 +1243,7 @@ git commit -m "fix(server): lock the book-scoped voice-uuid and emotion-variant 
 
 ---
 
-### Task 11: Class 6 — the two delete sites
+### Task 12: Class 6 — the two delete sites
 
 **Files:**
 - Modify: `server/src/routes/analysis.ts` (the "Start fresh" `rm`)
@@ -1111,7 +1285,7 @@ git commit -m "fix(server): take the cast lock when deleting cast.json"
 
 ---
 
-### Task 12: The guard test
+### Task 13: The guard test
 
 **Files:**
 - Create: `server/src/workspace/cast-lock.guard.test.ts`
@@ -1124,17 +1298,22 @@ Walk `server/src/**/*.ts` (excluding `*.test.ts`). For each file containing
 scope. Maintain an explicit allowlist with a reason per entry:
 
 ```ts
-/* Keyed on file AND expected count, never on file alone. `analysis.ts` holds
-   both the 5 deferred writes and the one rm that Task 11 DOES lock — a
-   file-level exemption would blind the guard to that rm forever, which is the
-   exact hole spec §5 class 6 exists to close. */
-const ALLOWED_UNLOCKED = new Map([
-  ['routes/analysis.ts', { writes: 5, rms: 0, why: 'merge-base writes deferred to #2015 (the rm IS locked)' }],
-]);
+/* Empty by design. Every cast.json write and delete in the tree is locked and
+   revision-checked after Task 14, so there is nothing to exempt.
+
+   An earlier draft carried an allowlist entry for analysis.ts's five deferred
+   writes. Keep this map empty rather than deleting the mechanism: if a future
+   change needs an exemption it must be keyed on file AND expected count, never
+   on file alone — a file-level exemption for analysis.ts would also have
+   blinded the guard to the one rm that IS locked, which is the exact hole spec
+   §5 class 6 exists to close. */
+const ALLOWED_UNLOCKED = new Map<string, { writes: number; rms: number; why: string }>();
 ```
 
-Assert the counts match exactly. A 6th unlocked write in `analysis.ts` must fail
-the guard, not inherit the exemption.
+The guard must also fail on a raw `writeJsonAtomic(castJsonPath(…))` even when
+that call *is* inside a lock scope — after Task 3 the only sanctioned writer is
+`writeCastChecked`, and a locked-but-unchecked write silently breaks the
+counter for everyone else.
 
 Document the known blind spots in the file header: it sees one syntactic form, so
 `const p = castJsonPath(dir); await writeJsonAtomic(p, …)` slips through, as
@@ -1163,7 +1342,250 @@ git commit -m "test(server): fail the build on an unlocked cast.json write"
 
 ---
 
-### Task 13: Docs, notes and ticket hygiene
+### Task 14: `analysis.ts` — a revision-checked merge base (closes #2015)
+
+**Files:**
+- Modify: `server/src/routes/analysis.ts` (the 5 cast writes; **not** the `rm`,
+  which Task 12 already did)
+- Modify: `server/src/routes/analysis.test.ts`
+
+`priorCastForMerge` is read once at the top of a run and is the merge base for
+writes that land minutes later. Holding a lock for the run was rejected (blocks
+every other cast write on that book, unbounded); re-reading blind was rejected
+(iteration N would merge against what N−1 wrote, degrading srv-13's voice/reuse
+carry-forward). The revision counter is the third option: **keep replaying the
+base, but check it, and rebuild only when it actually moved.**
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('does not discard a cast edit made during an analysis run', async () => {
+  /* Start a run, let it reach its first interim write, rename a character
+     through the cast route, then let the run continue. The rename must survive
+     — today the next interim write replays priorCastForMerge over it. */
+  const run = startAnalysis(bookId);
+  await waitForFirstInterimWrite();
+  await request(app).post('/api/cast/aliases').send({ bookId, /* rename alice */ });
+  await run;
+
+  const cast = await readJson<CastJson>(castJsonPath(bookDir));
+  expect(cast?.characters?.find((c) => c.id === 'alice')?.name).toBe('Alice Renamed');
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd server && npx vitest run src/routes/analysis.test.ts -t "cast edit made during"`
+Expected: FAIL — the rename is gone.
+
+- [ ] **Step 3: Capture the rev, check it, rebuild on conflict**
+
+Record the rev alongside `priorCastForMerge` at the top of the run. Each of the
+five writes takes `withCastLock`, calls `writeCastChecked(bookDir, next, rev)`,
+and on `CastRevConflictError`:
+
+1. re-read the cast,
+2. re-run `mergeAnalysisResultWithExistingCast` against **that** as the base,
+3. write with the fresh rev,
+4. adopt the new rev for subsequent writes.
+
+**A conflict must never fail the run.** A user renaming a character mid-analysis
+is normal; the analysis rebuilding its base is the correct response, not an
+error. Log it at info so the rebuild is observable.
+
+`seedReuseGuardsFromPriorCast` and `applyRewriteToPriorCast` also consume the
+base — re-derive both from the fresh cast on the rebuild path, or srv-13's
+carry-forward silently reverts to the stale roster. That is the exact regression
+the "re-read blind" option was rejected for; the difference here is that the
+rebuild happens **only on conflict**, not on every write.
+
+- [ ] **Step 4: Run, mutation-verify, commit**
+
+Revert the conflict branch (let the write throw), confirm the test goes red.
+
+```bash
+git add server/src/routes/analysis.ts server/src/routes/analysis.test.ts
+git commit -m "fix(server): rebuild the analysis merge base when cast.json moved under it"
+```
+
+---
+
+### Task 15: The three clone-consent gates (closes #2006, part 1)
+
+**Files:**
+- Modify: `server/src/routes/voices.ts`, `server/src/routes/single-design.ts`,
+  `server/src/routes/qwen-voice.ts`
+- Modify: their `*.test.ts`
+
+Each reads cast.json, decides a 409, and writes in a different scope. Spec §14.2
+gives one rule in three shapes — this task applies it.
+
+- [ ] **Step 1: Write the failing tests** — one per gate: take the 409 decision,
+  plant a cloned slot before the write lands, assert the write does not silently
+  overwrite it.
+
+- [ ] **Step 2: Run to verify all three fail.**
+
+- [ ] **Step 3: Thread the revision through each**
+
+- **`voices.ts` `PUT /:voiceId/override`** — `hasClonedSlotAmongMatches` records
+  each matching book's rev as it walks. `applyOverrideToCastFiles` then passes
+  that book's rev to `writeCastChecked`. A conflict on book *k* aborts the
+  remainder and returns `409 { code: 'cast-changed', written: [...] }` naming the
+  books already written. **Partial application is reported, not prevented** — full
+  cross-book atomicity needs the workspace-wide lock §3.2 rejected, and that
+  rejection stands (§14.3).
+- **`single-design.ts`** — records the rev at its `characterHasClonedSlot` gate;
+  `runSingleDesign` passes it through to the write. It has already flushed SSE
+  headers, so a conflict cannot 409: log it, skip the write, and surface it in
+  `endJob({ type: 'error', code: 'cast-changed' })`.
+- **`qwen-voice.ts`** — same, through `persistEmotionVariant`. Add an optional
+  `expectedRev` parameter: the JSON route passes it and maps a conflict to a 409;
+  the SSE bulk caller passes it and reports via `endJob`. **Do not** make the
+  helper decide which — it has two callers with two response channels, and that
+  is exactly why §6 rejected a blanket 409.
+
+- [ ] **Step 4: Run, mutation-verify each gate separately, commit**
+
+```bash
+git add server/src/routes/voices.ts server/src/routes/single-design.ts \
+  server/src/routes/qwen-voice.ts server/src/routes/voices.test.ts \
+  server/src/routes/single-design.test.ts server/src/routes/qwen-voice.test.ts
+git commit -m "fix(server): revision-check the clone-consent gates before their writes"
+```
+
+---
+
+### Task 16: The three cross-book consultations (closes #2006, part 2)
+
+**Files:**
+- Modify: `server/src/routes/cast-link-prior.ts`,
+  `server/src/routes/voice-override-linked.ts`,
+  `server/src/routes/cast-series-patch.ts`
+- Modify: their `*.test.ts`
+
+All three derive something from **another book's** cast and write it elsewhere:
+`cast-link-prior` copies the target's `overrideTtsVoices` (including a
+`libraryUuid` it never names) into the source; `voice-override-linked` derives
+`canonicalVoiceId`, `sourceTokens`, `inGroup` and its whole `writes` list from
+the source snapshot; `cast-series-patch` derives `sourceChar` and `targets` the
+same way.
+
+- [ ] **Step 1: Write the failing tests** — mutate the consulted book between the
+  read and the write; assert the operation detects it rather than writing a
+  decision made against data that no longer exists.
+
+- [ ] **Step 2: Run to verify all three fail.**
+
+- [ ] **Step 3: Record and assert the consulted revision**
+
+Each records the rev of every book it *reads to decide*, not only the ones it
+writes, and asserts them at write time via `writeCastChecked`. A conflict is a
+`409 { code: 'cast-changed' }` — all three are HTTP handlers that have not
+responded yet, so the refusal is expressible and the caller retries against
+fresh state.
+
+`cast-link-prior` is the one that also closes a `library-voice` hole: it plants
+references to uuids it cannot know up front, so it cannot take that key. The
+revision check is what makes the plant safe instead.
+
+- [ ] **Step 4: Run, mutation-verify, commit**
+
+```bash
+git add server/src/routes/cast-link-prior.ts server/src/routes/voice-override-linked.ts \
+  server/src/routes/cast-series-patch.ts server/src/routes/cast-link-prior.test.ts \
+  server/src/routes/voice-override-linked.test.ts server/src/routes/cast-series-patch.test.ts
+git commit -m "fix(server): revision-check the cross-book cast consultations"
+```
+
+---
+
+### Task 17: The series lock — the cross-book double-mint (closes #2006, part 3)
+
+**Files:**
+- Modify: `server/src/workspace/cast-lock.ts` (add `withSeriesLock`)
+- Modify: `server/src/workspace/cast-lock.test.ts`
+- Modify: `server/src/routes/qwen-voice.ts` (`ensureCharacterVoiceUuid`)
+- Modify: `server/src/routes/qwen-voice.test.ts`
+
+The one residual the revision counter provably cannot reach. Two bulk designs on
+two books of one series each read their **own** book, each see no `voiceUuid`,
+each mint. The propagation then re-reads every book under its own lock, so every
+write is against a current revision and is therefore "valid" — the staleness is
+in a decision taken **before any file is read**, and no per-file counter can
+encode it.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('mints one voiceUuid when two books of a series design the same identity', async () => {
+  /* Both books carry the same linked identity (voiceId ?? id). Concurrent bulk
+     designs each mint today, and the series ends up split across two uuids. */
+  await Promise.all([
+    ensureCharacterVoiceUuid(bookADir, 'narrator', seriesFilter),
+    ensureCharacterVoiceUuid(bookBDir, 'narrator', seriesFilter),
+  ]);
+  const a = await readJson<CastFile>(castJsonPath(bookADir));
+  const b = await readJson<CastFile>(castJsonPath(bookBDir));
+  const uuidA = a?.characters?.find((c) => c.id === 'narrator')?.voiceUuid;
+  const uuidB = b?.characters?.find((c) => c.id === 'narrator')?.voiceUuid;
+  expect(uuidA).toBeDefined();
+  expect(uuidA).toBe(uuidB);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Expected: FAIL — two different uuids.
+
+- [ ] **Step 3: Add `withSeriesLock` and wrap the series branch**
+
+```ts
+/** Hold the series lock for one author/series pair.
+ *
+ *  Position in the global order: design -> SERIES -> library-voice -> cast.
+ *  Exists for one reason — every design gate keys on bookDir (withDesignLock,
+ *  isDesignBusy, cast-design's inFlightByBook) while a linked-cast propagation
+ *  is series-wide, so two books of one series can each decide "no voiceUuid
+ *  yet" and each mint. That decision precedes any file read, so the cast.json
+ *  revision counter cannot see it. */
+export function withSeriesLock<T>(
+  author: string,
+  series: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return withKeyLock(`series:${author}/${series}`, fn);
+}
+```
+
+Wrap `ensureCharacterVoiceUuid`'s **series branch** — read, decide, mint,
+propagate — in `withSeriesLock(seriesFilter.author, seriesFilter.series, …)`.
+The book-scoped branch (standalones, no `seriesFilter`) is unchanged: its cast
+lock already covers it.
+
+Ordering: the call already sits inside `withDesignLock` (`qwen-voice.ts:193`) and
+the propagation takes cast locks, so this becomes `design → series → cast` —
+consistent with rule 4, not a new constraint on it. Add a primitive test pinning
+that a series lock may be taken while a design lock is held but never the
+reverse.
+
+- [ ] **Step 4: Run the full server suite**
+
+Run: `cd server && npm run test:server && npm run test:server-slow`
+Expected: PASS. Like Task 11, this task can hang rather than fail an assertion —
+if a spec times out, suspect a series lock taken while a cast lock is held.
+
+- [ ] **Step 5: Mutation-verify, commit**
+
+```bash
+git add server/src/workspace/cast-lock.ts server/src/workspace/cast-lock.test.ts \
+  server/src/routes/qwen-voice.ts server/src/routes/qwen-voice.test.ts
+git commit -m "fix(server): mint a series voiceUuid under a series lock"
+```
+
+---
+
+### Task 18: Docs, notes and ticket hygiene
 
 **Files:**
 - Create: `docs/features/<n>-cast-json-write-lock.md` (from `docs/features/TEMPLATE.md`)
@@ -1216,13 +1638,15 @@ State each explicitly rather than omitting it:
   router/redux/layout seam, so Playwright cannot observe it. The two-tab
   walkthrough in the regression plan is the manual equivalent.
 
-- [ ] **Step 6: Confirm the deferred issues carry the residuals**
+- [ ] **Step 6: Close the deferred issues, and check nothing new was filed**
 
-Spec §12 lists eight accepted residuals. Check #2006 and #2015 actually name the
-ones assigned to them — `cast-link-prior`'s unnamed `libraryUuid` references, the
-cross-book double-mint, and the `voice-override-linked` / `cast-series-patch`
-cross-book consultations — and comment them onto the issues if not. A residual
-that exists only in a spec section is a residual being lost.
+#2006 and #2015 are closed by this PR (Tasks 14–17), not carried. Before opening
+it, re-read spec §16: what remains in §12 must be **properties of the design**
+(in-process only, `promote-voice`'s pinned `realVoiceId`, per-book propagation
+atomicity, `cast-design`'s pre-LLM idempotency guards) and not outstanding work.
+If any item there reads as a to-do, it either needs a task in this plan or an
+explicit sentence saying why it is inherent. A residual list nobody intends to
+action is the thing this fold exists to remove.
 
 - [ ] **Step 7: Commit**
 
@@ -1243,7 +1667,7 @@ git commit -m "docs(docs): record the cast.json lock convention and release note
 - [ ] `npx madge --circular --extensions ts server/src` — still 15 cycles.
       `cast-lock.ts` is a leaf under `workspace/`; if the count moved, a route
       module was imported from it.
-- [ ] PR body: `Closes #1981`, `Closes #2000`, `Closes #2001`, `Refs #2006`,
-      `Refs #2015`. Declare Task 8's `library-cast-override` same-book fix and
-      Task 3's #2001 fix under "Also fixed, found in passing".
+- [ ] PR body: `Closes #1981`, `Closes #2000`, `Closes #2001`, `Closes #2006`,
+      `Closes #2015`. Declare Task 9's `library-cast-override` same-book fix and
+      Task 4's #2001 fix under "Also fixed, found in passing".
 - [ ] Mandatory `code-review` pass at `high` effort — multi-scope, 17 modules.

--- a/docs/superpowers/plans/2026-07-31-cast-json-write-lock.md
+++ b/docs/superpowers/plans/2026-07-31-cast-json-write-lock.md
@@ -55,12 +55,13 @@ Read it before Task 1. Section references below (§3.1, §5, §10.2 …) point a
 - **Every lock is mutation-verified**: revert the lock at that site, re-run,
   paste the failing output into the task's commit message. A test that was never
   seen red proves nothing.
-- **Every cast.json write goes through `writeCastChecked` (Task 3), never a raw
-  `writeJsonAtomic(castJsonPath(…))`.** The revision counter is only sound if
-  adoption is universal: one writer that does not increment `rev` makes every
-  other writer's check pass against a file that did change, which is worse than
-  no counter — it reads as a guarantee while providing nothing. The Task 13 guard
-  enforces this.
+- **Tasks 14–16 use `cast-io.ts`'s helpers; the other 30 sites do not.** Those
+  30 read and write inside one cast lock where nothing can interleave, so a
+  staleness check there is inert and costs an extra full read per write. An
+  earlier draft required universal adoption — that was a property of the
+  *revision-counter* design, which is unsound unless every writer increments. The
+  content fingerprint has no such requirement: any write changes the bytes,
+  whoever made it. Do not widen the helpers' use.
 - **`analysis.ts`'s 5 writes and the three clone-consent gates are IN scope** —
   Tasks 14 and 15. Earlier drafts deferred them to #2015/#2006; those issues are
   now closed by this PR. Do not skip them on the strength of a stale comment.
@@ -74,7 +75,7 @@ Read it before Task 1. Section references below (§3.1, §5, §10.2 …) point a
 | File | Responsibility |
 |---|---|
 | `server/src/workspace/cast-lock.ts` | **New.** Four named lock wrappers (`withCastLock`, `withCastLocks`, `withLibraryVoiceLock`, `withSeriesLock`) + the lock-order rule in its header. Sole owner of key derivation. |
-| `server/src/workspace/cast-io.ts` | **New.** `readCastForUpdate` / `writeCastChecked` — the revision counter. Sole owner of the `rev` increment. |
+| `server/src/workspace/cast-io.ts` | **New.** `readCastForUpdate` / `writeCastChecked` / `assertCastUnchanged` — content-fingerprint staleness detection. Used by Tasks 14–16 only. |
 | `server/src/workspace/cast-lock.test.ts` | **New.** Primitive unit tests: sorted acquisition (observed within one call), the AB/BA deadlock test, dedupe, release-on-throw, non-overlapping FIFO waiters, empty-list refusal. |
 | `server/src/workspace/cast-lock.race.test.ts` | **New.** The outcome harness — two overlapping RMWs, both mutations must survive. The reference for every later site test. |
 | `server/src/workspace/file-lock.ts` | Modify — #2001 map-cleanup fix. |
@@ -367,7 +368,7 @@ Expected: FAIL — `Cannot find module './cast-lock.js'`.
  *      never both held; their relative position is declared, not exercised.
  *
  * WHAT THIS DOES NOT COVER: it protects one read-modify-write. A validate-then-
- * write whose halves sit in different lock scopes needs the revision counter in
+ * write whose halves sit in different lock scopes needs the staleness helpers in
  * cast-io.ts, not this file — see that module and design §14.
  *
  * Key derivation lives here and ONLY here. A site that derived the key slightly
@@ -460,10 +461,10 @@ git commit -m "feat(server): add the per-book cast.json write lock"
 
 ---
 
-### Task 3: `cast-io.ts` — the revision counter
+### Task 3: `cast-io.ts` — staleness detection for the cross-scope sites
 
-Every later task's write goes through this. It must land before any site is
-converted, or those sites get written twice.
+Used by Tasks 14–16 only. The other 30 sites keep `readJson`/`writeJsonAtomic`
+under their lock — see "Where it is used" below, and do not widen it.
 
 **Files:**
 - Create: `server/src/workspace/cast-io.ts`
@@ -472,11 +473,10 @@ converted, or those sites get written twice.
 **Interfaces:**
 - Consumes: `readJson`, `writeJsonAtomic` from `./state-io.js`; `castJsonPath`.
 - Produces:
-  - `readCastForUpdate<T extends object>(bookDir): Promise<{ cast: T & Rev; rev: number }>`
-  - `writeCastChecked<T extends object>(bookDir, next: T, expectedRev: number): Promise<void>`
-  - `assertCastRev(bookDir, expectedRev): Promise<void>` — for books you consult
-    but do not write
-  - `class CastRevConflictError extends Error` with `bookDir`, `expected`, `actual`
+  - `readCastForUpdate<T extends object>(bookDir): Promise<{ cast: T; fingerprint: string | null }>`
+  - `writeCastChecked<T extends object>(bookDir, next: T, expected: string | null): Promise<void>`
+  - `assertCastUnchanged(bookDir, expected: string | null): Promise<void>`
+  - `class CastStaleError extends Error` with `bookDir`
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -485,13 +485,13 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { writeJsonAtomic, readJson } from './state-io.js';
+import { writeJsonAtomic } from './state-io.js';
 import { castJsonPath } from './paths.js';
 import {
   readCastForUpdate,
   writeCastChecked,
-  assertCastRev,
-  CastRevConflictError,
+  assertCastUnchanged,
+  CastStaleError,
 } from './cast-io.js';
 
 let dir: string;
@@ -501,53 +501,44 @@ beforeEach(async () => {
 });
 afterEach(async () => { await rm(dir, { recursive: true, force: true }); });
 
-it('treats a cast.json with no rev as rev 0', async () => {
-  /* Migration is a read-path default: an existing workspace has no rev field
-     and must not need a migration script. */
-  const { rev } = await readCastForUpdate(dir);
-  expect(rev).toBe(0);
+it('fingerprints an absent cast as null, distinctly from any content', async () => {
+  await rm(castJsonPath(dir), { force: true });
+  const { fingerprint } = await readCastForUpdate(dir);
+  expect(fingerprint).toBeNull();
 });
 
-it('stamps rev+1 on write', async () => {
-  const { cast, rev } = await readCastForUpdate(dir);
-  await writeCastChecked(dir, cast, rev);
-  expect((await readJson<{ rev?: number }>(castJsonPath(dir)))?.rev).toBe(1);
+it('accepts a write when the file has not changed', async () => {
+  const { cast, fingerprint } = await readCastForUpdate<{ characters: unknown[] }>(dir);
+  await expect(writeCastChecked(dir, cast, fingerprint)).resolves.toBeUndefined();
 });
 
-it('preserves rev across a writer that builds a fresh payload', async () => {
-  /* At least 20 of the 35 writers construct `{ characters: … }` and drop every
-     other top-level field. If the helper did not own the increment, those
-     writers would silently reset the counter and every later rev check would
-     pass against a stale read. */
-  const { rev } = await readCastForUpdate(dir);
-  await writeCastChecked(dir, { characters: [{ id: 'bob' }] }, rev);
-  const after = await readJson<{ rev?: number; characters: unknown[] }>(castJsonPath(dir));
-  expect(after?.rev).toBe(1);
-  expect(after?.characters).toHaveLength(1);
+it('rejects a write when the bytes changed under it', async () => {
+  const { cast, fingerprint } = await readCastForUpdate<{ characters: unknown[] }>(dir);
+  await writeJsonAtomic(castJsonPath(dir), { characters: [{ id: 'bob' }] });
+  await expect(writeCastChecked(dir, cast, fingerprint)).rejects.toBeInstanceOf(CastStaleError);
 });
 
-it('throws CastRevConflictError when the revision moved since the read', async () => {
-  const first = await readCastForUpdate(dir);
-  /* Someone else writes in between. */
-  await writeCastChecked(dir, first.cast, first.rev);
-  await expect(writeCastChecked(dir, first.cast, first.rev)).rejects.toBeInstanceOf(
-    CastRevConflictError,
-  );
+it('detects a delete even when the file is recreated identically (ABA)', async () => {
+  /* The property a revision counter cannot have: 1 -> delete -> recreate as 1
+     reads as "unchanged" to a counter. Here, identical bytes genuinely ARE
+     unchanged, and a delete-then-DIFFERENT-recreate is caught. */
+  const { fingerprint } = await readCastForUpdate(dir);
+  await rm(castJsonPath(dir), { force: true });
+  await writeJsonAtomic(castJsonPath(dir), { characters: [{ id: 'zed' }] });
+  await expect(assertCastUnchanged(dir, fingerprint)).rejects.toBeInstanceOf(CastStaleError);
 });
 
-it('asserts a revision on a consulted book without writing it', async () => {
-  const { rev } = await readCastForUpdate(dir);
-  await expect(assertCastRev(dir, rev)).resolves.toBeUndefined();
-  await writeCastChecked(dir, { characters: [] }, rev);
-  await expect(assertCastRev(dir, rev)).rejects.toBeInstanceOf(CastRevConflictError);
+it('detects a write made by a caller that never used these helpers', async () => {
+  /* The other property a counter cannot have: soundness does not depend on
+     universal adoption. A raw writeJsonAtomic still changes the bytes. */
+  const { fingerprint } = await readCastForUpdate(dir);
+  await writeJsonAtomic(castJsonPath(dir), { characters: [{ id: 'alice' }, { id: 'new' }] });
+  await expect(assertCastUnchanged(dir, fingerprint)).rejects.toBeInstanceOf(CastStaleError);
 });
 
-it('reports both revisions on conflict', async () => {
-  const first = await readCastForUpdate(dir);
-  await writeCastChecked(dir, first.cast, first.rev);
-  await writeCastChecked(dir, first.cast, 1);
-  const err = await writeCastChecked(dir, first.cast, first.rev).catch((e) => e);
-  expect(err).toMatchObject({ expected: 0, actual: 2 });
+it('asserts a consulted book without writing it', async () => {
+  const { fingerprint } = await readCastForUpdate(dir);
+  await expect(assertCastUnchanged(dir, fingerprint)).resolves.toBeUndefined();
 });
 ```
 
@@ -559,95 +550,77 @@ Expected: FAIL — `Cannot find module './cast-io.js'`.
 - [ ] **Step 3: Write the implementation**
 
 ```ts
-/* cast.json optimistic concurrency.
+/* Staleness detection for cast.json.
  *
- * The per-book lock (cast-lock.ts) makes one read-modify-write atomic. It
- * cannot help when the DECISION is read in one lock scope and the write lands
- * in another — analysis.ts's merge base, the clone-consent 409 gates,
- * cast-link-prior's target read. Those need staleness to be DETECTABLE, which
- * is what `rev` provides.
+ * The per-book lock (cast-lock.ts) makes one read-modify-write atomic. It cannot
+ * help when the DECISION is read in one lock scope and the write lands in
+ * another — analysis.ts's merge base, the clone-consent gates, the cross-book
+ * consultations. Those need staleness to be DETECTABLE.
  *
- * SOUNDNESS DEPENDS ON UNIVERSAL ADOPTION. If one writer does not increment
- * `rev`, every other writer's check passes against a file that did change, and
- * the counter is worse than none — it reads as a guarantee while providing
- * nothing. That is why every cast.json write goes through `writeCastChecked`,
- * and why the guard test (cast-lock.guard.test.ts) fails the build on a raw
- * writeJsonAtomic(castJsonPath(…)).
+ * A content fingerprint rather than a `rev` field on cast.json, deliberately
+ * (design §14.1):
+ *   - it is derived from the bytes you already read, so there is no separate
+ *     capture step and no window between snapshot and capture to get wrong;
+ *   - soundness does not depend on every writer participating — any write
+ *     changes the bytes, whoever made it. A counter is "worse than none" if one
+ *     writer skips the increment;
+ *   - delete-then-recreate is handled honestly: identical bytes ARE unchanged.
  *
- * Both helpers assume the caller already holds the cast lock for `bookDir`.
- * They are the read/write half; cast-lock.ts is the mutual-exclusion half.
+ * USED BY THE CROSS-SCOPE SITES ONLY (Tasks 14-16). The ~30 same-scope writers
+ * read and write inside one cast lock, where nothing can interleave and this
+ * comparison is inert — they keep readJson/writeJsonAtomic. Do not widen this.
+ *
+ * All three assume the caller holds the cast lock for `bookDir`.
  */
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
 import { readJson, writeJsonAtomic } from './state-io.js';
 import { castJsonPath } from './paths.js';
 
-/** Anything with an optional revision. Deliberately NOT a concrete CastJson:
- *  `CastFile` is re-declared as a module-private interface in sixteen modules
- *  with five different element types, and TypeScript gives interfaces no
- *  implicit index signature — so a concrete parameter type would fail to accept
- *  any of them and every converted site would be a compile error, surfacing only
- *  at the final `npm run typecheck`. */
-type Rev = { rev?: number };
-
-export class CastRevConflictError extends Error {
-  constructor(
-    readonly bookDir: string,
-    readonly expected: number,
-    readonly actual: number,
-  ) {
-    super(
-      `cast.json for ${bookDir} changed under us (expected rev ${expected}, found ${actual}).`,
-    );
-    this.name = 'CastRevConflictError';
+export class CastStaleError extends Error {
+  constructor(readonly bookDir: string) {
+    super(`cast.json for ${bookDir} changed under us since it was read.`);
+    this.name = 'CastStaleError';
   }
 }
 
-async function currentRev(bookDir: string): Promise<number> {
-  const cast = await readJson<Rev>(castJsonPath(bookDir));
-  return typeof cast?.rev === 'number' ? cast.rev : 0;
+/** sha256 of the raw bytes, or null when the file is absent. `null` is a real
+ *  value, not a failure: "there was nothing here" is distinct from any content,
+ *  which is what makes delete-then-recreate detectable. */
+async function fingerprintOf(bookDir: string): Promise<string | null> {
+  try {
+    const raw = await readFile(castJsonPath(bookDir));
+    return createHash('sha256').update(raw).digest('hex');
+  } catch {
+    return null;
+  }
 }
 
-/** Read the cast and the revision it was at. `rev` is absent on every cast.json
- *  written before this change, so it defaults to 0 — a read-path default, so no
- *  migration script and no compatibility break. `cast` is non-null: an absent
- *  file reads as `{ characters: [] }`. */
 export async function readCastForUpdate<T extends object>(
   bookDir: string,
-): Promise<{ cast: T & Rev; rev: number }> {
-  const cast = (await readJson<T & Rev>(castJsonPath(bookDir))) ?? ({ characters: [] } as T & Rev);
-  return { cast, rev: typeof cast.rev === 'number' ? cast.rev : 0 };
+): Promise<{ cast: T; fingerprint: string | null }> {
+  /* Fingerprint FIRST, then parse, so the hash describes bytes we have actually
+     taken. Reading them in the other order would reintroduce the very window
+     this design exists to remove. */
+  const fingerprint = await fingerprintOf(bookDir);
+  const cast = (await readJson<T>(castJsonPath(bookDir))) ?? ({ characters: [] } as unknown as T);
+  return { cast, fingerprint };
 }
 
-/** Write `next`, asserting the on-disk revision is still `expectedRev`. Stamps
- *  `expectedRev + 1`.
- *
- *  The caller MUST hold the cast lock. Under that lock the comparison is INERT —
- *  no other locked writer can interleave — and it exists for the cross-scope
- *  callers in design §14 whose decision was read in a different lock scope.
- *  Universal adoption is required for the INCREMENT, not the check: one writer
- *  that skips it makes every other writer's check pass against a file that did
- *  change. */
+export async function assertCastUnchanged(
+  bookDir: string,
+  expected: string | null,
+): Promise<void> {
+  if ((await fingerprintOf(bookDir)) !== expected) throw new CastStaleError(bookDir);
+}
+
 export async function writeCastChecked<T extends object>(
   bookDir: string,
   next: T,
-  expectedRev: number,
+  expected: string | null,
 ): Promise<void> {
-  const actual = await currentRev(bookDir);
-  if (actual !== expectedRev) throw new CastRevConflictError(bookDir, expectedRev, actual);
-  await writeJsonAtomic(castJsonPath(bookDir), { ...next, rev: expectedRev + 1 });
-}
-
-/** Assert a revision on a book you CONSULTED but do not write.
- *
- *  Four sites decide from one book and write another — cast-link-prior reads the
- *  target and writes the source; voice-override-linked and cast-series-patch
- *  derive their whole write-list from a source they never write;
- *  cast-add-from-roster reads the target to decide a source write.
- *  `writeCastChecked` asserts only the book it writes, so without this the
- *  counter cannot reach any of them. Hold the consulted book's lock (via
- *  `withCastLocks`) while asserting. */
-export async function assertCastRev(bookDir: string, expectedRev: number): Promise<void> {
-  const actual = await currentRev(bookDir);
-  if (actual !== expectedRev) throw new CastRevConflictError(bookDir, expectedRev, actual);
+  await assertCastUnchanged(bookDir, expected);
+  await writeJsonAtomic(castJsonPath(bookDir), next);
 }
 ```
 
@@ -660,8 +633,10 @@ Expected: PASS (6 tests).
 
 ```bash
 git add server/src/workspace/cast-io.ts server/src/workspace/cast-io.test.ts
-git commit -m "feat(server): add the cast.json revision counter"
+git commit -m "feat(server): add cast.json staleness detection for cross-scope writers"
 ```
+
+---
 
 ### Task 4: #2001 — the lock helpers' map cleanup has never run
 
@@ -1003,29 +978,25 @@ Exemplar — `cast-aliases.ts`, which every other site in this task mirrors:
 
 ```ts
 return withCastLock(bookDir, async () => {
-  /* readCastForUpdate / writeCastChecked, never readJson / writeJsonAtomic —
-     the counter is only sound if every writer increments it (Task 3), and the
-     Task 13 guard fails the build on a raw write even inside a lock. */
-  const { cast, rev } = await readCastForUpdate<CastFile>(bookDir);
-  if (!cast.characters?.length) {
+  /* Plain readJson/writeJsonAtomic, INSIDE the lock. cast-io.ts's staleness
+     helpers are for the cross-scope sites only (Tasks 14-16) — here the read and
+     the write are in one lock scope, so nothing can interleave and a staleness
+     check would be inert. */
+  const cast = await readJson<CastFile>(castJsonPath(bookDir));
+  if (!cast?.characters?.length) {
     return res.status(409).json({ error: 'Book has no cast on disk yet. …' });
   }
   // … findIndex, 404s, build nextCharacters …
-  await writeCastChecked(bookDir, { ...cast, characters: nextCharacters }, rev);
+  await writeJsonAtomic(castJsonPath(bookDir), { ...cast, characters: nextCharacters });
   return res.status(200).json({ /* … */ });
 });
 ```
 
-**Two shape changes every site in this task inherits:**
-
-- `readCastForUpdate` returns `{ cast, rev }` and `cast` is **non-null** with a
-  `characters: []` default. `if (!cast?.characters?.length)` still reads fine,
-  but `if (cast && …)` guards elsewhere become dead — check each one rather than
-  copying the old shape through.
-- Spread the object you read (`{ ...cast, characters }`), not a bare
-  `{ characters }`. At least 20 of the 35 writers currently build a fresh payload
-  that drops every other top-level field; `writeCastChecked` re-adds `rev`, but
-  anything *else* on the document is still yours to preserve.
+**One shape change worth making while you are here:** spread the object you read
+(`{ ...cast, characters }`) rather than writing a bare `{ characters }`. At least
+20 of the 35 writers currently construct a fresh payload that silently drops
+every other top-level field. Nothing depends on that today, but it is a trap
+lying in wait for the next person who adds one.
 
 Per-site notes:
 
@@ -1149,9 +1120,9 @@ given exactly. Replace the tail of the handler with:
    stall every cast write for this book. Global order: no other lock is held
    here (cast is last — see cast-lock.ts rule 4). */
 await withCastLock(located.bookDir, async () => {
-  const { cast: fresh, rev } = await readCastForUpdate<CastFile>(located.bookDir);
-  const freshChar = fresh.characters?.find((c) => c.id === characterId);
-  if (!freshChar) return; // deleted mid-promotion — artifacts already moved
+  const fresh = await readJson<CastFile>(castJsonPath(located.bookDir));
+  const freshChar = fresh?.characters?.find((c) => c.id === characterId);
+  if (!fresh || !freshChar) return; // deleted mid-promotion — artifacts already moved
   const freshSlot = freshChar.overrideTtsVoices?.qwen;
   /* KEEP this guard — it is the current behaviour (qwen-voice.ts:788) and it
      encloses the write. Without it every promote-voice writes cast.json and
@@ -1162,7 +1133,7 @@ await withCastLock(located.bookDir, async () => {
       .map((v) => v?.name)
       .filter((n): n is string => !!n);
     delete freshSlot.variants;
-    await writeCastChecked(located.bookDir, fresh, rev);
+    await writeJsonAtomic(castJsonPath(located.bookDir), fresh);
   }
 });
 /* Teardown stays outside: filesystem work, and holding the lock across it
@@ -1439,10 +1410,12 @@ explicit allowlist with a reason per entry:
 const ALLOWED_UNLOCKED = new Map<string, { writes: number; rms: number; why: string }>();
 ```
 
-The guard must also fail on a raw `writeJsonAtomic(castJsonPath(…))` even when
-that call *is* inside a lock scope — after Task 3 the only sanctioned writer is
-`writeCastChecked`, and a locked-but-unchecked write silently breaks the
-counter for everyone else.
+The guard checks **lockedness only**. It must NOT also require
+`writeCastChecked`: that rule belonged to the revision-counter design, whose
+soundness depended on universal adoption, and it would fail on `cast-io.ts`
+itself — the sanctioned helper writes `writeJsonAtomic(castJsonPath(...))` inside
+no lock scope, because its callers hold the lock. Exclude `workspace/cast-io.ts`
+from the walk by name, with that reason in a comment.
 
 Document the known blind spots in the file header: it sees one syntactic form, so
 `const p = castJsonPath(dir); await writeJsonAtomic(p, …)` slips through, as
@@ -1495,12 +1468,20 @@ The second one is the important one.
 
 ```ts
 it('does not discard a cast edit made during an analysis run', async () => {
+  /* Assert on ALIASES, not on `name`. mergeAnalysisResultWithExistingCast
+     overlays the base's VOICE-DESIGN fields onto the freshly-analysed roster and
+     UNIONS aliases (see its docstring) — `name` comes from the fresh analysis,
+     which re-derives it from the manuscript. A name assertion cannot go green on
+     a correct implementation, and "fixing" it would mean weakening the test or
+     changing merge semantics. */
   const run = startAnalysis(bookId);
   await waitForFirstInterimWrite();
-  await request(app).post('/api/cast/aliases').send({ bookId, /* rename alice */ });
+  await request(app).post('/api/cast/aliases')
+    .send({ bookId, characterId: 'alice', alias: 'The Coalfall Widow' });
   await run;
   const cast = await readJson<CastJson>(castJsonPath(bookDir));
-  expect(cast?.characters?.find((c) => c.id === 'alice')?.name).toBe('Alice Renamed');
+  expect(cast?.characters?.find((c) => c.id === 'alice')?.aliases)
+    .toContain('The Coalfall Widow');
 });
 
 it('keeps bespoke designed voices across a Start-fresh re-analysis', async () => {
@@ -1525,17 +1506,19 @@ Run: `cd server && npx vitest run src/routes/analysis.test.ts -t "cast edit made
 Run: `cd server && npx vitest run src/routes/analysis.test.ts -t "Start-fresh"`
 
 The second must be verified red against a **deliberately wrong** implementation:
-capture the rev next to the `priorCastForMerge` read, rebuild by re-reading. If
+rebuild by plain re-read (base = whatever is on disk). If
 it passes there, the test is not pinning what it claims and the whole task is
 unguarded.
 
-- [ ] **Step 3: Capture the rev after the `rm`; never rebuild to an empty base**
+- [ ] **Step 3: Fingerprint with the snapshot; never rebuild to an empty base**
 
 Three requirements, from spec §14.4:
 
-1. **Capture the revision *after* the `fresh` block's `rm`.** The
-   `priorCastForMerge` snapshot must outlive the delete — that placement is
-   deliberate and its comment says so — but the revision must not.
+1. **Capture the fingerprint from the same read as `priorCastForMerge`** — same
+   bytes, same instant, nothing between them. This is where the revision-counter
+   design failed: a counter needs a separate capture step, and the yields between
+   the snapshot read and any post-`rm` capture point (`pruneStaleReuseLinks`,
+   `loadAnalysisCache`) were a hole a concurrent writer could land in.
 2. **The rebuild may never replace a non-empty prior with an empty base.** When
    the re-read is empty, the retained `priorCastForMerge` *is* the base. The
    rebuild overlays concurrent edits onto the prior; it never substitutes.
@@ -1551,17 +1534,17 @@ acquisition, so `writeCastChecked` cannot conflict and there is no retry loop:
 
 ```ts
 await withCastLock(bookDir, async () => {
-  const { cast: onDisk, rev } = await readCastForUpdate<CastFile>(bookDir);
+  const { cast: onDisk, fingerprint } = await readCastForUpdate<CastFile>(bookDir);
   const base =
-    rev === capturedRev
+    fingerprint === capturedFingerprint
       ? priorCastForMerge
       : rebuildBase(priorCastForMerge, onDisk.characters ?? []);
   await writeCastChecked(
     bookDir,
     { ...onDisk, characters: mergeAnalysisResultWithExistingCast(base, freshRows) },
-    rev,
+    fingerprint,
   );
-  capturedRev = rev + 1;
+  capturedFingerprint = await fingerprintAfterWrite(bookDir);
 });
 ```
 
@@ -1574,8 +1557,9 @@ is normal. Log the rebuild at info so it is observable.
 
 - [ ] **Step 4: Run, mutation-verify, commit**
 
-Mutation-verify by moving the rev capture back above the `rm` and confirming the
-Start-fresh test goes red. Paste that output into the commit message.
+Mutation-verify by replacing the rebuild path with a plain re-read (base =
+whatever is on disk) and confirming the Start-fresh test goes red. Paste that
+output into the commit message.
 
 ```bash
 git add server/src/routes/analysis.ts server/src/routes/analysis.test.ts
@@ -1607,9 +1591,9 @@ gives one rule in three shapes — this task applies it.
   refusal path, so it does not walk the full set then; only the pass path yields
   a complete rev map.
 
-  At write time, per book: if the rev is unchanged, write. If it moved,
+  At write time, per book: if the fingerprint is unchanged, write. If it moved,
   **re-run the clone-consent predicate on the fresh read** — if the book is still
-  clean, adopt the new rev and continue; only a *newly planted cloned slot* is a
+  clean, adopt the new fingerprint and continue; only a *newly planted cloned slot* is a
   genuine refusal. Aborting on any change would turn a whole-workspace override
   from an operation that always completes into one that fails at the
   concurrent-edit rate, and its failure state — the new voice in some books, the
@@ -1618,12 +1602,12 @@ gives one rule in three shapes — this task applies it.
   On a genuine refusal: `409 { code: 'cast-changed', written: [...] }` naming the
   books already written. **Partial application is reported, not prevented** —
   cross-book atomicity needs the workspace-wide lock §3.2 rejected (§14.3).
-- **`single-design.ts`** — records the rev at its `characterHasClonedSlot` gate;
+- **`single-design.ts`** — records the fingerprint at its `characterHasClonedSlot` gate;
   `runSingleDesign` passes it through to the write. It has already flushed SSE
   headers, so a conflict cannot 409: log it, skip the write, and surface it in
   `endJob({ type: 'error', code: 'cast-changed' })`.
 - **`qwen-voice.ts`** — same, through `persistEmotionVariant`. Add an optional
-  `expectedRev` parameter: the JSON route passes it and maps a conflict to a 409;
+  `expectedFingerprint` parameter: the JSON route passes it and maps a conflict to a 409;
   the SSE bulk caller passes it and reports via `endJob`. **Do not** make the
   helper decide which — it has two callers with two response channels, and that
   is exactly why §6 rejected a blanket 409.
@@ -1633,9 +1617,9 @@ here.** It is the function that actually performs both writes (`:801` fast path,
 `:828` walk), and it has five callers — `applyOverrideToCastFiles`,
 `applyTierToCastFiles` (from `cast-tier.ts`), `persistEmotionVariant` and
 `ensureCharacterVoiceUuid` — three of which have no rev to supply. Add
-`expectedRevs?: Map<string, number>` there, defaulting to "no assertion" when a
-book is absent from the map, so Task 10 lands the signature and this task only
-populates it.
+`expectedFingerprints?: Map<string, string | null>` there, defaulting to "no
+assertion" when a book is absent from the map, so Task 10 lands the signature and
+this task only populates it.
 
 - [ ] **Step 4: Run, mutation-verify each gate separately, commit**
 
@@ -1672,8 +1656,8 @@ same way.
 
 - [ ] **Step 3: Record and assert the consulted revision**
 
-Each records the rev of every book it *reads to decide*, not only the ones it
-writes. The consulted book is asserted with **`assertCastRev`** (Task 3) while
+Each records the fingerprint of every book it *reads to decide*, not only the ones it
+writes. The consulted book is asserted with **`assertCastUnchanged`** (Task 3) while
 its lock is held via `withCastLocks`; the written book is asserted by
 `writeCastChecked` as usual. `writeCastChecked` alone cannot do this — it asserts
 only the book it writes, which is not the book these sites consulted.
@@ -1709,7 +1693,7 @@ git commit -m "fix(server): revision-check the cross-book cast consultations"
 - Modify: `server/src/routes/qwen-voice.ts` (`ensureCharacterVoiceUuid`)
 - Modify: `server/src/routes/qwen-voice.test.ts`
 
-The one residual the revision counter provably cannot reach. Two bulk designs on
+The one residual §14's staleness check provably cannot reach. Two bulk designs on
 two books of one series each read their **own** book, each see no `voiceUuid`,
 each mint. The propagation then re-reads every book under its own lock, so every
 write is against a current revision and is therefore "valid" — the staleness is
@@ -1757,7 +1741,7 @@ barrier rather than weakening the assertion.
  *  isDesignBusy, cast-design's inFlightByBook) while a linked-cast propagation
  *  is series-wide, so two books of one series can each decide "no voiceUuid
  *  yet" and each mint. That decision precedes any file read, so the cast.json
- *  revision counter cannot see it. */
+ *  staleness check cannot see it — there is no file whose content encodes it. */
 export function withSeriesLock<T>(
   author: string,
   series: string,
@@ -1829,8 +1813,8 @@ This is substantial cross-cutting work introducing a codebase-wide invariant, so
 it needs a durable `docs/features/` plan, not just the issue bodies. Scan the
 worktrees for the next free plan number first (concurrent sessions claim them).
 Record: the invariant and its four rules, the four lock classes and their order,
-all 35 locked sites, the revision counter and what it does *not* reach (the ABA
-on delete, the client full-document PUT), and a manual acceptance walkthrough.
+all 35 locked sites, the staleness check and what it does *not* reach (the
+client full-document PUT), and a manual acceptance walkthrough.
 
 **Pick the walkthrough carefully.** "Two browser tabs editing one book's cast,
 both edits surviving" describes `PUT /:bookId/state`, which writes the client's

--- a/docs/superpowers/plans/2026-07-31-cast-json-write-lock.md
+++ b/docs/superpowers/plans/2026-07-31-cast-json-write-lock.md
@@ -420,7 +420,7 @@ export function withLibraryVoiceLock<T>(voiceUuid: string, fn: () => Promise<T>)
 - [ ] **Step 4: Run to verify it passes**
 
 Run: `cd server && npx vitest run src/workspace/cast-lock.test.ts`
-Expected: PASS (6 tests).
+Expected: PASS (7 tests).
 
 - [ ] **Step 5: Flip the race harness to the both-survive assertion**
 
@@ -474,14 +474,16 @@ under their lock — see "Where it is used" below, and do not widen it.
 - Consumes: `readJson`, `writeJsonAtomic` from `./state-io.js`; `castJsonPath`.
 - Produces:
   - `readCastForUpdate<T extends object>(bookDir): Promise<{ cast: T; fingerprint: string | null }>`
-  - `writeCastChecked<T extends object>(bookDir, next: T, expected: string | null): Promise<void>`
+  - `writeCastChecked<T extends object>(bookDir, next: T, expected: string | null): Promise<string | null>`
+    — returns the fingerprint of what it wrote
   - `assertCastUnchanged(bookDir, expected: string | null): Promise<void>`
   - `class CastStaleError extends Error` with `bookDir`
 
 - [ ] **Step 1: Write the failing tests**
 
 ```ts
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fsp from 'node:fs/promises';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -536,6 +538,17 @@ it('detects a write made by a caller that never used these helpers', async () =>
   await expect(assertCastUnchanged(dir, fingerprint)).rejects.toBeInstanceOf(CastStaleError);
 });
 
+it('derives the fingerprint from the same bytes it parses', async () => {
+  /* Guards the single-read property. Two reads with an await between them would
+     let a writer land in the gap, and the fingerprint would describe bytes other
+     than the parsed ones — the window a revision counter had and this design
+     exists to remove. Spy on readFile and assert exactly one call. */
+  const spy = vi.spyOn(fsp, 'readFile');
+  await readCastForUpdate(dir);
+  expect(spy.mock.calls.filter(([p]) => String(p).endsWith('cast.json'))).toHaveLength(1);
+  spy.mockRestore();
+});
+
 it('asserts a consulted book without writing it', async () => {
   const { fingerprint } = await readCastForUpdate(dir);
   await expect(assertCastUnchanged(dir, fingerprint)).resolves.toBeUndefined();
@@ -584,50 +597,59 @@ export class CastStaleError extends Error {
   }
 }
 
-/** sha256 of the raw bytes, or null when the file is absent. `null` is a real
- *  value, not a failure: "there was nothing here" is distinct from any content,
- *  which is what makes delete-then-recreate detectable. */
-async function fingerprintOf(bookDir: string): Promise<string | null> {
+/** Read the file's bytes once. `null` when absent — a real value, not a
+ *  failure: "there was nothing here" is distinct from any content, which is what
+ *  makes delete-then-recreate detectable. */
+async function readBytes(bookDir: string): Promise<Buffer | null> {
   try {
-    const raw = await readFile(castJsonPath(bookDir));
-    return createHash('sha256').update(raw).digest('hex');
+    return await readFile(castJsonPath(bookDir));
   } catch {
     return null;
   }
 }
 
+const sha = (raw: Buffer | null): string | null =>
+  raw === null ? null : createHash('sha256').update(raw).digest('hex');
+
 export async function readCastForUpdate<T extends object>(
   bookDir: string,
 ): Promise<{ cast: T; fingerprint: string | null }> {
-  /* Fingerprint FIRST, then parse, so the hash describes bytes we have actually
-     taken. Reading them in the other order would reintroduce the very window
-     this design exists to remove. */
-  const fingerprint = await fingerprintOf(bookDir);
-  const cast = (await readJson<T>(castJsonPath(bookDir))) ?? ({ characters: [] } as unknown as T);
-  return { cast, fingerprint };
+  /* ONE read. Hash and parse are both derived from the same Buffer.
+     Hashing in one readFile and parsing in another would put an await between
+     them and reintroduce the exact window this design exists to remove — a
+     writer landing in the gap makes the fingerprint describe bytes that are not
+     the ones we parsed, which is worse than no check at all because it reads as
+     a guarantee. */
+  const raw = await readBytes(bookDir);
+  const cast = raw === null ? ({ characters: [] } as unknown as T) : (JSON.parse(raw.toString('utf8')) as T);
+  return { cast, fingerprint: sha(raw) };
 }
 
 export async function assertCastUnchanged(
   bookDir: string,
   expected: string | null,
 ): Promise<void> {
-  if ((await fingerprintOf(bookDir)) !== expected) throw new CastStaleError(bookDir);
+  if (sha(await readBytes(bookDir)) !== expected) throw new CastStaleError(bookDir);
 }
 
+/** Write `next` if the file still matches `expected`. Returns the fingerprint of
+ *  what was written, so a caller doing repeated writes (analysis.ts) can carry it
+ *  forward without a re-read. */
 export async function writeCastChecked<T extends object>(
   bookDir: string,
   next: T,
   expected: string | null,
-): Promise<void> {
+): Promise<string | null> {
   await assertCastUnchanged(bookDir, expected);
   await writeJsonAtomic(castJsonPath(bookDir), next);
+  return sha(await readBytes(bookDir));
 }
 ```
 
 - [ ] **Step 4: Run to verify it passes**
 
 Run: `cd server && npx vitest run src/workspace/cast-io.test.ts`
-Expected: PASS (6 tests).
+Expected: PASS (7 tests).
 
 - [ ] **Step 5: Commit**
 
@@ -1539,12 +1561,11 @@ await withCastLock(bookDir, async () => {
     fingerprint === capturedFingerprint
       ? priorCastForMerge
       : rebuildBase(priorCastForMerge, onDisk.characters ?? []);
-  await writeCastChecked(
+  capturedFingerprint = await writeCastChecked(
     bookDir,
     { ...onDisk, characters: mergeAnalysisResultWithExistingCast(base, freshRows) },
     fingerprint,
   );
-  capturedFingerprint = await fingerprintAfterWrite(bookDir);
 });
 ```
 

--- a/docs/superpowers/plans/2026-07-31-cast-json-write-lock.md
+++ b/docs/superpowers/plans/2026-07-31-cast-json-write-lock.md
@@ -357,17 +357,18 @@ Expected: FAIL — `Cannot find module './cast-lock.js'`.
  *   2. The read goes inside the lock, and so does every decision derived from
  *      it. Wrapping only the write buys nothing at all.
  *   3. Two or more books -> withCastLocks, never nested withCastLocks.
- *   4. Global lock order: design -> library-voice -> cast. Never acquire an
- *      earlier class while holding a later one. The DELETE library-voice path
- *      holds `library-voice:<uuid>` across clearLibraryVoiceReferences, which
- *      takes a cast lock per book — so POST /assign must take library-voice
- *      BEFORE its cast lock, not after. The other order is an AB/BA cycle on a
- *      mutex with no timeout and no diagnostic: both requests hang forever.
+ *   4. Global lock order: design -> series -> library-voice -> cast. Never
+ *      acquire an earlier class while holding a later one. The DELETE
+ *      library-voice path holds `library-voice:<uuid>` across
+ *      clearLibraryVoiceReferences, which takes a cast lock per book — so POST
+ *      /assign must take library-voice BEFORE its cast lock, not after. The
+ *      other order is an AB/BA cycle on a mutex with no timeout and no
+ *      diagnostic: both requests hang forever. `series` and `library-voice` are
+ *      never both held; their relative position is declared, not exercised.
  *
- * WHAT THIS DOES NOT COVER: it protects one read-modify-write. It does not make
- * a validate-then-write safe when the validation and the write are in different
- * scopes (#2006), and it does not cover analysis.ts, whose merge base is read
- * once at the start of a run and replayed for minutes (#2015).
+ * WHAT THIS DOES NOT COVER: it protects one read-modify-write. A validate-then-
+ * write whose halves sit in different lock scopes needs the revision counter in
+ * cast-io.ts, not this file — see that module and design §14.
  *
  * Key derivation lives here and ONLY here. A site that derived the key slightly
  * differently would get a second mutex that never contends with the first, and
@@ -471,8 +472,10 @@ converted, or those sites get written twice.
 **Interfaces:**
 - Consumes: `readJson`, `writeJsonAtomic` from `./state-io.js`; `castJsonPath`.
 - Produces:
-  - `readCastForUpdate(bookDir): Promise<{ cast: CastJson; rev: number }>`
-  - `writeCastChecked(bookDir, next: CastJson, expectedRev: number): Promise<void>`
+  - `readCastForUpdate<T extends object>(bookDir): Promise<{ cast: T & Rev; rev: number }>`
+  - `writeCastChecked<T extends object>(bookDir, next: T, expectedRev: number): Promise<void>`
+  - `assertCastRev(bookDir, expectedRev): Promise<void>` — for books you consult
+    but do not write
   - `class CastRevConflictError extends Error` with `bookDir`, `expected`, `actual`
 
 - [ ] **Step 1: Write the failing tests**
@@ -484,7 +487,12 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { writeJsonAtomic, readJson } from './state-io.js';
 import { castJsonPath } from './paths.js';
-import { readCastForUpdate, writeCastChecked, CastRevConflictError } from './cast-io.js';
+import {
+  readCastForUpdate,
+  writeCastChecked,
+  assertCastRev,
+  CastRevConflictError,
+} from './cast-io.js';
 
 let dir: string;
 beforeEach(async () => {
@@ -527,6 +535,13 @@ it('throws CastRevConflictError when the revision moved since the read', async (
   );
 });
 
+it('asserts a revision on a consulted book without writing it', async () => {
+  const { rev } = await readCastForUpdate(dir);
+  await expect(assertCastRev(dir, rev)).resolves.toBeUndefined();
+  await writeCastChecked(dir, { characters: [] }, rev);
+  await expect(assertCastRev(dir, rev)).rejects.toBeInstanceOf(CastRevConflictError);
+});
+
 it('reports both revisions on conflict', async () => {
   const first = await readCastForUpdate(dir);
   await writeCastChecked(dir, first.cast, first.rev);
@@ -565,11 +580,13 @@ Expected: FAIL — `Cannot find module './cast-io.js'`.
 import { readJson, writeJsonAtomic } from './state-io.js';
 import { castJsonPath } from './paths.js';
 
-export interface CastJson {
-  characters?: unknown[];
-  rev?: number;
-  [k: string]: unknown;
-}
+/** Anything with an optional revision. Deliberately NOT a concrete CastJson:
+ *  `CastFile` is re-declared as a module-private interface in sixteen modules
+ *  with five different element types, and TypeScript gives interfaces no
+ *  implicit index signature — so a concrete parameter type would fail to accept
+ *  any of them and every converted site would be a compile error, surfacing only
+ *  at the final `npm run typecheck`. */
+type Rev = { rev?: number };
 
 export class CastRevConflictError extends Error {
   constructor(
@@ -584,35 +601,60 @@ export class CastRevConflictError extends Error {
   }
 }
 
+async function currentRev(bookDir: string): Promise<number> {
+  const cast = await readJson<Rev>(castJsonPath(bookDir));
+  return typeof cast?.rev === 'number' ? cast.rev : 0;
+}
+
 /** Read the cast and the revision it was at. `rev` is absent on every cast.json
  *  written before this change, so it defaults to 0 — a read-path default, so no
- *  migration script and no compatibility break. */
-export async function readCastForUpdate(
+ *  migration script and no compatibility break. `cast` is non-null: an absent
+ *  file reads as `{ characters: [] }`. */
+export async function readCastForUpdate<T extends object>(
   bookDir: string,
-): Promise<{ cast: CastJson; rev: number }> {
-  const cast = (await readJson<CastJson>(castJsonPath(bookDir))) ?? { characters: [] };
+): Promise<{ cast: T & Rev; rev: number }> {
+  const cast = (await readJson<T & Rev>(castJsonPath(bookDir))) ?? ({ characters: [] } as T & Rev);
   return { cast, rev: typeof cast.rev === 'number' ? cast.rev : 0 };
 }
 
-/** Write `next`, asserting the on-disk revision is still `expectedRev`.
- *  Stamps `expectedRev + 1`. The caller MUST hold the cast lock — this re-read
- *  is a staleness check against writers in OTHER lock scopes, not a substitute
- *  for mutual exclusion. */
-export async function writeCastChecked(
+/** Write `next`, asserting the on-disk revision is still `expectedRev`. Stamps
+ *  `expectedRev + 1`.
+ *
+ *  The caller MUST hold the cast lock. Under that lock the comparison is INERT —
+ *  no other locked writer can interleave — and it exists for the cross-scope
+ *  callers in design §14 whose decision was read in a different lock scope.
+ *  Universal adoption is required for the INCREMENT, not the check: one writer
+ *  that skips it makes every other writer's check pass against a file that did
+ *  change. */
+export async function writeCastChecked<T extends object>(
   bookDir: string,
-  next: CastJson,
+  next: T,
   expectedRev: number,
 ): Promise<void> {
-  const { rev: actual } = await readCastForUpdate(bookDir);
+  const actual = await currentRev(bookDir);
   if (actual !== expectedRev) throw new CastRevConflictError(bookDir, expectedRev, actual);
   await writeJsonAtomic(castJsonPath(bookDir), { ...next, rev: expectedRev + 1 });
+}
+
+/** Assert a revision on a book you CONSULTED but do not write.
+ *
+ *  Four sites decide from one book and write another — cast-link-prior reads the
+ *  target and writes the source; voice-override-linked and cast-series-patch
+ *  derive their whole write-list from a source they never write;
+ *  cast-add-from-roster reads the target to decide a source write.
+ *  `writeCastChecked` asserts only the book it writes, so without this the
+ *  counter cannot reach any of them. Hold the consulted book's lock (via
+ *  `withCastLocks`) while asserting. */
+export async function assertCastRev(bookDir: string, expectedRev: number): Promise<void> {
+  const actual = await currentRev(bookDir);
+  if (actual !== expectedRev) throw new CastRevConflictError(bookDir, expectedRev, actual);
 }
 ```
 
 - [ ] **Step 4: Run to verify it passes**
 
 Run: `cd server && npx vitest run src/workspace/cast-io.test.ts`
-Expected: PASS (5 tests).
+Expected: PASS (6 tests).
 
 - [ ] **Step 5: Commit**
 
@@ -961,15 +1003,29 @@ Exemplar — `cast-aliases.ts`, which every other site in this task mirrors:
 
 ```ts
 return withCastLock(bookDir, async () => {
-  const cast = await readJson<CastFile>(castJsonPath(bookDir));
-  if (!cast?.characters?.length) {
+  /* readCastForUpdate / writeCastChecked, never readJson / writeJsonAtomic —
+     the counter is only sound if every writer increments it (Task 3), and the
+     Task 13 guard fails the build on a raw write even inside a lock. */
+  const { cast, rev } = await readCastForUpdate<CastFile>(bookDir);
+  if (!cast.characters?.length) {
     return res.status(409).json({ error: 'Book has no cast on disk yet. …' });
   }
   // … findIndex, 404s, build nextCharacters …
-  await writeJsonAtomic(castJsonPath(bookDir), { characters: nextCharacters });
+  await writeCastChecked(bookDir, { ...cast, characters: nextCharacters }, rev);
   return res.status(200).json({ /* … */ });
 });
 ```
+
+**Two shape changes every site in this task inherits:**
+
+- `readCastForUpdate` returns `{ cast, rev }` and `cast` is **non-null** with a
+  `characters: []` default. `if (!cast?.characters?.length)` still reads fine,
+  but `if (cast && …)` guards elsewhere become dead — check each one rather than
+  copying the old shape through.
+- Spread the object you read (`{ ...cast, characters }`), not a bare
+  `{ characters }`. At least 20 of the 35 writers currently build a fresh payload
+  that drops every other top-level field; `writeCastChecked` re-adds `rev`, but
+  anything *else* on the document is still yours to preserve.
 
 Per-site notes:
 
@@ -1093,9 +1149,9 @@ given exactly. Replace the tail of the handler with:
    stall every cast write for this book. Global order: no other lock is held
    here (cast is last — see cast-lock.ts rule 4). */
 await withCastLock(located.bookDir, async () => {
-  const fresh = await readJson<CastFile>(castJsonPath(located.bookDir));
-  const freshChar = fresh?.characters?.find((c) => c.id === characterId);
-  if (!fresh || !freshChar) return; // deleted mid-promotion — artifacts already moved
+  const { cast: fresh, rev } = await readCastForUpdate<CastFile>(located.bookDir);
+  const freshChar = fresh.characters?.find((c) => c.id === characterId);
+  if (!freshChar) return; // deleted mid-promotion — artifacts already moved
   const freshSlot = freshChar.overrideTtsVoices?.qwen;
   /* KEEP this guard — it is the current behaviour (qwen-voice.ts:788) and it
      encloses the write. Without it every promote-voice writes cast.json and
@@ -1106,7 +1162,7 @@ await withCastLock(located.bookDir, async () => {
       .map((v) => v?.name)
       .filter((n): n is string => !!n);
     delete freshSlot.variants;
-    await writeJsonAtomic(castJsonPath(located.bookDir), fresh);
+    await writeCastChecked(located.bookDir, fresh, rev);
   }
 });
 /* Teardown stays outside: filesystem work, and holding the lock across it
@@ -1319,8 +1375,9 @@ and its write". That is wrong and the spec retracts it — `file-lock.ts:12-14`
 awaits `prior` before `fn()`, so under rule 2 a queued writer's *read* happens
 after the holder's write. Do not reintroduce the claim.)
 
-**This is the only `analysis.ts` change in this plan.** Its five *write* sites are
-out of scope (#2015). Touch the `rm` and nothing else.
+**This task touches only the `rm`.** `analysis.ts`'s five *write* sites are
+converted in Task 14, not here — keep the two changes separate so each is
+reviewable on its own.
 
 - [ ] **Step 1: Write the failing test** — a delete concurrent with a cast write;
   assert the file stays deleted.
@@ -1418,62 +1475,107 @@ git commit -m "test(server): fail the build on an unlocked cast.json write"
 
 **Files:**
 - Modify: `server/src/routes/analysis.ts` (the 5 cast writes; **not** the `rm`,
-  which Task 12 already did)
+  which Task 12 did)
 - Modify: `server/src/routes/analysis.test.ts`
 
-`priorCastForMerge` is read once at the top of a run and is the merge base for
-writes that land minutes later. Holding a lock for the run was rejected (blocks
-every other cast write on that book, unbounded); re-reading blind was rejected
-(iteration N would merge against what N−1 wrote, degrading srv-13's voice/reuse
-carry-forward). The revision counter is the third option: **keep replaying the
-base, but check it, and rebuild only when it actually moved.**
+`priorCastForMerge` is read once near the top of a run and is the merge base for
+writes minutes later. Holding a lock for the run was rejected (blocks every other
+cast write on that book, unbounded); re-reading blind was rejected (iteration N
+would merge against what N−1 wrote, degrading srv-13 carry-forward). The counter
+is the third option: **keep replaying the snapshot, but check it, and overlay
+concurrent edits only when it actually moved.**
 
-- [ ] **Step 1: Write the failing test**
+> **Read spec §14.4 before writing any code in this task.** The obvious
+> implementation re-breaks the 2026-07-14 Coalfall voice-strip on *every* "Start
+> fresh" run, and the obvious test does not catch it.
+
+- [ ] **Step 1: Write BOTH failing tests**
+
+The second one is the important one.
 
 ```ts
 it('does not discard a cast edit made during an analysis run', async () => {
-  /* Start a run, let it reach its first interim write, rename a character
-     through the cast route, then let the run continue. The rename must survive
-     — today the next interim write replays priorCastForMerge over it. */
   const run = startAnalysis(bookId);
   await waitForFirstInterimWrite();
   await request(app).post('/api/cast/aliases').send({ bookId, /* rename alice */ });
   await run;
-
   const cast = await readJson<CastJson>(castJsonPath(bookDir));
   expect(cast?.characters?.find((c) => c.id === 'alice')?.name).toBe('Alice Renamed');
 });
+
+it('keeps bespoke designed voices across a Start-fresh re-analysis', async () => {
+  /* THE regression guard for the 2026-07-14 Coalfall voice-strip. Start fresh
+     rm's cast.json, which resets the on-disk rev to 0 — so a rev captured
+     alongside priorCastForMerge (i.e. ABOVE the rm) guarantees a conflict on the
+     first interim write, and a rebuild that re-reads the deleted file gets an
+     empty base. mergeAnalysisResultWithExistingCast short-circuits on an empty
+     base and returns the fresh roster unmerged: every designed voice gone.
+     This test fails on that implementation and passes on the correct one. */
+  await giveCharacterADesignedVoice(bookDir, 'alice');
+  await runAnalysis(bookId, { fresh: true });
+  const cast = await readJson<CastJson>(castJsonPath(bookDir));
+  const alice = cast?.characters?.find((c) => c.id === 'alice');
+  expect(alice?.overrideTtsVoices?.qwen?.name).toBeDefined();
+});
 ```
 
-- [ ] **Step 2: Run to verify it fails**
+- [ ] **Step 2: Run to verify both fail**
 
 Run: `cd server && npx vitest run src/routes/analysis.test.ts -t "cast edit made during"`
-Expected: FAIL — the rename is gone.
+Run: `cd server && npx vitest run src/routes/analysis.test.ts -t "Start-fresh"`
 
-- [ ] **Step 3: Capture the rev, check it, rebuild on conflict**
+The second must be verified red against a **deliberately wrong** implementation:
+capture the rev next to the `priorCastForMerge` read, rebuild by re-reading. If
+it passes there, the test is not pinning what it claims and the whole task is
+unguarded.
 
-Record the rev alongside `priorCastForMerge` at the top of the run. Each of the
-five writes takes `withCastLock`, calls `writeCastChecked(bookDir, next, rev)`,
-and on `CastRevConflictError`:
+- [ ] **Step 3: Capture the rev after the `rm`; never rebuild to an empty base**
 
-1. re-read the cast,
-2. re-run `mergeAnalysisResultWithExistingCast` against **that** as the base,
-3. write with the fresh rev,
-4. adopt the new rev for subsequent writes.
+Three requirements, from spec §14.4:
+
+1. **Capture the revision *after* the `fresh` block's `rm`.** The
+   `priorCastForMerge` snapshot must outlive the delete — that placement is
+   deliberate and its comment says so — but the revision must not.
+2. **The rebuild may never replace a non-empty prior with an empty base.** When
+   the re-read is empty, the retained `priorCastForMerge` *is* the base. The
+   rebuild overlays concurrent edits onto the prior; it never substitutes.
+3. **Re-apply the load-point healers on the rebuild path** —
+   `dropReuseContinuityKeepDesignedVoice`, `pruneStaleReuseLinks`,
+   `dedupePriorCastByName`, `seedReuseGuardsFromPriorCast`,
+   `applyRewriteToPriorCast`. Their comment says they run "at the single load
+   point, so all cast.json write sites see one prior row per name"; a rebuild
+   that skips them reintroduces the duplicate-by-name rows they collapse.
+
+Shape for each of the five writes — read, decide and write in **one** lock
+acquisition, so `writeCastChecked` cannot conflict and there is no retry loop:
+
+```ts
+await withCastLock(bookDir, async () => {
+  const { cast: onDisk, rev } = await readCastForUpdate<CastFile>(bookDir);
+  const base =
+    rev === capturedRev
+      ? priorCastForMerge
+      : rebuildBase(priorCastForMerge, onDisk.characters ?? []);
+  await writeCastChecked(
+    bookDir,
+    { ...onDisk, characters: mergeAnalysisResultWithExistingCast(base, freshRows) },
+    rev,
+  );
+  capturedRev = rev + 1;
+});
+```
+
+`rebuildBase(prior, current)` returns `prior` unchanged when `current` is empty,
+and otherwise overlays `current`'s rows onto `prior` by id — preserving `prior`'s
+voice fields wherever `current` lacks them — then re-runs the healers.
 
 **A conflict must never fail the run.** A user renaming a character mid-analysis
-is normal; the analysis rebuilding its base is the correct response, not an
-error. Log it at info so the rebuild is observable.
-
-`seedReuseGuardsFromPriorCast` and `applyRewriteToPriorCast` also consume the
-base — re-derive both from the fresh cast on the rebuild path, or srv-13's
-carry-forward silently reverts to the stale roster. That is the exact regression
-the "re-read blind" option was rejected for; the difference here is that the
-rebuild happens **only on conflict**, not on every write.
+is normal. Log the rebuild at info so it is observable.
 
 - [ ] **Step 4: Run, mutation-verify, commit**
 
-Revert the conflict branch (let the write throw), confirm the test goes red.
+Mutation-verify by moving the rev capture back above the `rm` and confirming the
+Start-fresh test goes red. Paste that output into the commit message.
 
 ```bash
 git add server/src/routes/analysis.ts server/src/routes/analysis.test.ts
@@ -1501,12 +1603,21 @@ gives one rule in three shapes — this task applies it.
 - [ ] **Step 3: Thread the revision through each**
 
 - **`voices.ts` `PUT /:voiceId/override`** — `hasClonedSlotAmongMatches` records
-  each matching book's rev as it walks. `applyOverrideToCastFiles` then passes
-  that book's rev to `writeCastChecked`. A conflict on book *k* aborts the
-  remainder and returns `409 { code: 'cast-changed', written: [...] }` naming the
-  books already written. **Partial application is reported, not prevented** — full
-  cross-book atomicity needs the workspace-wide lock §3.2 rejected, and that
-  rejection stands (§14.3).
+  each matching book's rev as it walks. Note it **early-returns `true`** on the
+  refusal path, so it does not walk the full set then; only the pass path yields
+  a complete rev map.
+
+  At write time, per book: if the rev is unchanged, write. If it moved,
+  **re-run the clone-consent predicate on the fresh read** — if the book is still
+  clean, adopt the new rev and continue; only a *newly planted cloned slot* is a
+  genuine refusal. Aborting on any change would turn a whole-workspace override
+  from an operation that always completes into one that fails at the
+  concurrent-edit rate, and its failure state — the new voice in some books, the
+  old in others — is the exact split the propagation exists to prevent.
+
+  On a genuine refusal: `409 { code: 'cast-changed', written: [...] }` naming the
+  books already written. **Partial application is reported, not prevented** —
+  cross-book atomicity needs the workspace-wide lock §3.2 rejected (§14.3).
 - **`single-design.ts`** — records the rev at its `characterHasClonedSlot` gate;
   `runSingleDesign` passes it through to the write. It has already flushed SSE
   headers, so a conflict cannot 409: log it, skip the write, and surface it in
@@ -1516,6 +1627,15 @@ gives one rule in three shapes — this task applies it.
   the SSE bulk caller passes it and reports via `endJob`. **Do not** make the
   helper decide which — it has two callers with two response channels, and that
   is exactly why §6 rejected a blanket 409.
+
+**The `forEachMatchingCastCharacter` signature change belongs in Task 10, not
+here.** It is the function that actually performs both writes (`:801` fast path,
+`:828` walk), and it has five callers — `applyOverrideToCastFiles`,
+`applyTierToCastFiles` (from `cast-tier.ts`), `persistEmotionVariant` and
+`ensureCharacterVoiceUuid` — three of which have no rev to supply. Add
+`expectedRevs?: Map<string, number>` there, defaulting to "no assertion" when a
+book is absent from the map, so Task 10 lands the signature and this task only
+populates it.
 
 - [ ] **Step 4: Run, mutation-verify each gate separately, commit**
 
@@ -1533,7 +1653,8 @@ git commit -m "fix(server): revision-check the clone-consent gates before their 
 **Files:**
 - Modify: `server/src/routes/cast-link-prior.ts`,
   `server/src/routes/voice-override-linked.ts`,
-  `server/src/routes/cast-series-patch.ts`
+  `server/src/routes/cast-series-patch.ts`,
+  `server/src/routes/cast-add-from-roster.ts`
 - Modify: their `*.test.ts`
 
 All three derive something from **another book's** cast and write it elsewhere:
@@ -1552,10 +1673,18 @@ same way.
 - [ ] **Step 3: Record and assert the consulted revision**
 
 Each records the rev of every book it *reads to decide*, not only the ones it
-writes, and asserts them at write time via `writeCastChecked`. A conflict is a
-`409 { code: 'cast-changed' }` — all three are HTTP handlers that have not
-responded yet, so the refusal is expressible and the caller retries against
-fresh state.
+writes. The consulted book is asserted with **`assertCastRev`** (Task 3) while
+its lock is held via `withCastLocks`; the written book is asserted by
+`writeCastChecked` as usual. `writeCastChecked` alone cannot do this — it asserts
+only the book it writes, which is not the book these sites consulted.
+
+A conflict is a `409 { code: 'cast-changed' }` — all are HTTP handlers that have
+not responded yet, so the refusal is expressible.
+
+**Include `cast-add-from-roster.ts`.** It reads the target book to decide a
+source write, which is the same shape, and spec §12 claims it is closed by §14 —
+so either it is converted here or that claim is false. It is the fourth file in
+this task.
 
 `cast-link-prior` is the one that also closes a `library-voice` hole: it plants
 references to uuids it cannot know up front, so it cannot take that key. The
@@ -1610,6 +1739,14 @@ it('mints one voiceUuid when two books of a series design the same identity', as
 
 Expected: FAIL — two different uuids.
 
+**This test is only reliably red after Task 10 lands.** Today the two
+propagations race whole-file and one usually wins outright, so both books often
+converge on a single uuid and the test is green for the wrong reason. Per-book
+locking (Task 10) is what makes the split observable. Task 1's determinism
+measurement does not transfer here — that was two reads issued in one tick, and
+this is two nested workspace walks. If it is flaky, drive the two calls through a
+barrier rather than weakening the assertion.
+
 - [ ] **Step 3: Add `withSeriesLock` and wrap the series branch**
 
 ```ts
@@ -1626,14 +1763,29 @@ export function withSeriesLock<T>(
   series: string,
   fn: () => Promise<T>,
 ): Promise<T> {
-  return withKeyLock(`series:${author}/${series}`, fn);
+  /* Encode both components — neither can contain '/' on disk today (both are
+     directory names under BOOKS_ROOT), but §3.1 insists key derivation be
+     unambiguous rather than incidentally safe. */
+  return withKeyLock(`series:${encodeURIComponent(author)}/${encodeURIComponent(series)}`, fn);
 }
 ```
 
-Wrap `ensureCharacterVoiceUuid`'s **series branch** — read, decide, mint,
-propagate — in `withSeriesLock(seriesFilter.author, seriesFilter.series, …)`.
-The book-scoped branch (standalones, no `seriesFilter`) is unchanged: its cast
-lock already covers it.
+**Wrap the whole function body, not "the series branch".** The `voiceUuid` check
+and the mint sit *above* the branch (spec §5.1); the series branch contains only
+the propagation. Wrapping the branch would leave both racers deciding and minting
+outside the lock and serialise two propagations of two *different* uuids — the
+split-uuid outcome unchanged, under a lock that reads as the fix.
+
+```ts
+return withDesignLock(bookDir, () =>
+  seriesFilter
+    ? withSeriesLock(seriesFilter.author, seriesFilter.series, body)
+    : body(),
+);
+```
+
+where `body` is the existing read → decide → mint → propagate. Standalone books
+take the book-scoped path and need no series key.
 
 Ordering: the call already sits inside `withDesignLock` (`qwen-voice.ts:193`) and
 the propagation takes cast locks, so this becomes `design → series → cast` —
@@ -1676,9 +1828,16 @@ is not.
 This is substantial cross-cutting work introducing a codebase-wide invariant, so
 it needs a durable `docs/features/` plan, not just the issue bodies. Scan the
 worktrees for the next free plan number first (concurrent sessions claim them).
-Record: the invariant and its four rules, the 30 locked sites, the deferred sets
-(#2006, #2015) and *why* each is deferred, and a manual acceptance walkthrough —
-two browser tabs editing one book's cast simultaneously, both edits surviving.
+Record: the invariant and its four rules, the four lock classes and their order,
+all 35 locked sites, the revision counter and what it does *not* reach (the ABA
+on delete, the client full-document PUT), and a manual acceptance walkthrough.
+
+**Pick the walkthrough carefully.** "Two browser tabs editing one book's cast,
+both edits surviving" describes `PUT /:bookId/state`, which writes the client's
+whole characters array and is explicitly outside the counter's reach (spec
+§14.3) — that walkthrough would fail. Use instead: a bulk "Design full cast" job
+running while the user renames a character in another tab; the rename survives
+and the designed voices land.
 
 - [ ] **Step 2: Update `docs/features/INDEX.md` (checklist step 4)**
 
@@ -1687,15 +1846,36 @@ New entry under its area.
 - [ ] **Step 3: Add the convention to CLAUDE.md**
 
 One bullet with the four rules from `cast-lock.ts`'s header, including the
-three-class lock order.
+four-class lock order, and one line pointing at `cast-io.ts` for the revision
+counter.
+
+- [ ] **Step 3b: openapi.yaml and the client retry**
+
+Tasks 15/16 add a new refusal to `PUT /api/voices/{voiceId}/override`,
+`cast-link-prior`, `voice-override-linked` and `cast-series-patch`. `openapi.yaml`
+is the documented source of truth for backend shapes, so:
+
+- Add `409 { code: 'cast-changed' }` to each of those four route blocks. While
+  there, document the two 409s `voices.ts` already returns and never declared.
+- Add the SSE terminal payload `endJob({ type: 'error', code: 'cast-changed' })`
+  for `single-design`.
+- **Handle it client-side.** Spec §14.2 says the caller "retries against fresh
+  state" — that is a claim about behaviour nobody has implemented. Either add the
+  refetch-and-retry in `src/lib/api.ts`, or change §14.2 to say the user sees an
+  actionable error and retries manually. Do not leave the doc asserting a retry
+  the product does not perform.
 
 - [ ] **Step 4: Release notes, both files (checklist step 5)**
 
+
 `docs/release-notes-next.md` — technical, PR-ref'd. `RELEASE_NOTES.md` — one
 user-facing line in brand voice. The user-visible delta is real: concurrent cast
-edits no longer silently discard one another. Do **not** claim cast.json is fully
-protected — `analysis.ts` is not (#2015), and the check-then-act gates are not
-(#2006).
+edits no longer silently discard one another.
+
+Do **not** claim cast.json is *fully* protected. It is not: the counter does not
+survive a delete, and it does not reach the client full-document PUT (spec
+§14.3). Both are properties, not debt — but the release note must not overstate
+them either way.
 
 - [ ] **Step 5: Discharge the remaining checklist steps in the PR body**
 
@@ -1703,9 +1883,10 @@ State each explicitly rather than omitting it:
 
 - **Step 3, on-box acceptance — N/A.** No hardware-only behaviour; every claim
   here is provable in-process by the outcome tests. No register row is owed.
-- **openapi.yaml — N/A.** No wire shape changes. The `isAnalysisBusy` admission
-  gate that *would* have added a 409 across ~20 routes was rejected (spec §6).
-- **Frontend — N/A.** No component, slice or API-surface change.
+- **openapi.yaml — REQUIRED, see Step 3b.** Tasks 15 and 16 add
+  `409 { code: 'cast-changed' }` to four documented routes. (This N/A claim was
+  false in an earlier draft, written before those tasks existed.)
+- **Frontend — REQUIRED, see Step 3b.**
 - **e2e — N/A.** The behaviour is server-side concurrency; it crosses no
   router/redux/layout seam, so Playwright cannot observe it. The two-tab
   walkthrough in the regression plan is the manual equivalent.

--- a/docs/superpowers/plans/2026-07-31-cast-json-write-lock.md
+++ b/docs/superpowers/plans/2026-07-31-cast-json-write-lock.md
@@ -61,7 +61,7 @@ Read it before Task 1. Section references below (§3.1, §5, §10.2 …) point a
 | File | Responsibility |
 |---|---|
 | `server/src/workspace/cast-lock.ts` | **New.** The three named lock wrappers + the lock-order rule in its header. Sole owner of key derivation. |
-| `server/src/workspace/cast-lock.test.ts` | **New.** Primitive unit tests: sorted acquisition, dedupe, release-on-throw, waiter ordering. |
+| `server/src/workspace/cast-lock.test.ts` | **New.** Primitive unit tests: sorted acquisition (observed within one call), the AB/BA deadlock test, dedupe, release-on-throw, non-overlapping FIFO waiters, empty-list refusal. |
 | `server/src/workspace/cast-lock.race.test.ts` | **New.** The outcome harness — two overlapping RMWs, both mutations must survive. The reference for every later site test. |
 | `server/src/workspace/file-lock.ts` | Modify — #2001 map-cleanup fix. |
 | `server/src/tts/design-lock.ts` | Modify — same fix, cleanup only. **Do not touch acquire/release/ordering**: `ensureCharacterVoiceUuid`'s series branch still depends on it (§5.1). |
@@ -84,7 +84,11 @@ Lands the spike as a committed test **before any site is converted**, so the
 - Produces: `assignVoice(castPath, characterId, voice)` and
   `readVoices(castPath)` — the RMW shape every later task's test reuses.
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Pin the defect**
+
+This one is a characterization test, not a red-phase test: it PASSES while the
+bug exists. Task 2 adds the both-survive assertion *beside* it and both stay in
+the file permanently — the pair is the red→green evidence.
 
 ```ts
 /* The outcome harness for the cast.json lock sweep. Two overlapping
@@ -97,6 +101,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { readJson, writeJsonAtomic } from './state-io.js';
+import { castJsonPath } from './paths.js';
 
 interface Cast {
   characters: Array<{ id: string; voice?: string }>;
@@ -107,7 +112,10 @@ let castPath: string;
 
 beforeEach(async () => {
   dir = await mkdtemp(join(tmpdir(), 'cast-lock-race-'));
-  castPath = join(dir, 'cast.json');
+  /* Build at castJsonPath(dir), NOT join(dir, 'cast.json') — castJsonPath
+     returns <dir>/.audiobook/cast.json, and later tasks derive the lock key
+     from the same helper. */
+  castPath = castJsonPath(dir);
   await writeJsonAtomic(castPath, {
     characters: [{ id: 'alice' }, { id: 'bob' }],
   } satisfies Cast);
@@ -143,8 +151,11 @@ describe('cast.json concurrent read-modify-write', () => {
       assignVoice(castPath, 'bob', 'b'),
     ]);
     const v = await readVoices(castPath);
-    /* Documents the defect. Task 2 replaces this with the both-survive
-       assertion once the lock exists. */
+    /* Documents the defect: unlocked, one mutation is always lost. Task 2 adds
+       the locked counterpart beside this. If a future change to readJson /
+       writeJsonAtomic ever stops them yielding in the same tick, this test goes
+       red — the correct response is to update THIS test, never to reintroduce
+       an unlocked write path. */
     expect(v.alice === 'a' && v.bob === 'b').toBe(false);
   });
 });
@@ -160,6 +171,24 @@ Expected: PASS. A pass here means a mutation *was* lost, which is the defect.
 Run: `cd server && npx vitest run src/workspace/cast-lock.race.test.ts --repeat=20`
 Expected: 20/20 PASS. The spec's claim is 200/200; if any run fails, stop and
 report — the whole test strategy depends on this interleave being deterministic.
+
+**On route-level tests being deterministic too.** Route handlers do several
+`await`s before their cast read, and two requests can take different branches
+(`/assign`'s `hasRetainedDesignedClip` `stat` fires only for a designed entry),
+so it is fair to ask whether the bare `Promise.all` still interleaves. Measured
+during planning, 50 trials per configuration, at prologue depths 0v0, 2v2, 3v3,
+2v3, 1v4 and 0v3: **the race was observed 50/50 in every case.** Differing
+`await` depth does not desynchronise it — both requests dispatch in one tick and
+both reads land before either write, because the write (`mkdir` + `writeFile` +
+`rename`) is much the slower half.
+
+**The one exception is wall-clock duration, not await depth.** `promote-voice`
+does a sidecar `fetch` before its read, which takes real time and *will*
+separate the two racers. Task 7's test must stub that `fetch` (or point it at a
+local no-op) so the two requests reach their cast reads together. If any other
+route-level red-phase test fails to go red, treat it as a **harness** problem —
+not as evidence the site is safe — and stub whatever slow call sits in its
+prologue before reaching for a different mechanism.
 
 - [ ] **Step 4: Commit**
 
@@ -193,16 +222,46 @@ import { withCastLock, withCastLocks } from './cast-lock.js';
 const settle = () => new Promise((r) => setTimeout(r, 0));
 
 describe('withCastLocks', () => {
-  it('acquires in the same order regardless of argument order', async () => {
-    const order: string[] = [];
-    const track = (tag: string) => async () => {
-      order.push(tag);
+  /* Sorting is the ONLY thing standing between the 8 two-book sites and a
+     permanent, diagnostic-free hang, so it gets two tests that genuinely fail
+     without it. An earlier draft of this plan tested it by awaiting two
+     withCastLocks calls SEQUENTIALLY and asserting they ran in call order —
+     which is true with or without .sort(), with or without any lock at all.
+     That is the placebo shape this whole PR exists to prevent. */
+
+  it('acquires keys in sorted order within a single call', async () => {
+    const acquired: string[] = [];
+    const spy = vi.spyOn(fileLock, 'withKeyLock').mockImplementation(
+      async (key: string, fn: () => Promise<unknown>) => {
+        acquired.push(key);
+        return fn();
+      },
+    );
+    await withCastLocks(['/w/b', '/w/a'], async () => undefined);
+    expect(acquired).toEqual([castJsonPath('/w/a'), castJsonPath('/w/b')]);
+
+    acquired.length = 0;
+    await withCastLocks(['/w/a', '/w/b'], async () => undefined);
+    expect(acquired).toEqual([castJsonPath('/w/a'), castJsonPath('/w/b')]);
+    spy.mockRestore();
+  });
+
+  it('does not deadlock when two callers pass the books in opposite orders', async () => {
+    /* THE test for .sort(). Both hold their first lock across an await before
+       asking for the second — the classic AB/BA setup. Without sorting this
+       hangs forever; withKeyLock has no timeout. */
+    const hold = async () => {
       await settle();
+      return 'ok';
     };
-    await withCastLocks(['/w/b', '/w/a'], track('first'));
-    await withCastLocks(['/w/a', '/w/b'], track('second'));
-    /* Both calls lock /w/a then /w/b — sorted, so AB/BA cannot arise. */
-    expect(order).toEqual(['first', 'second']);
+    const raced = await Promise.race([
+      Promise.all([
+        withCastLocks(['/w/a', '/w/b'], hold),
+        withCastLocks(['/w/b', '/w/a'], hold),
+      ]),
+      new Promise((r) => setTimeout(() => r('DEADLOCK'), 2000)),
+    ]);
+    expect(raced).toEqual(['ok', 'ok']);
   });
 
   it('dedupes a repeated book instead of self-deadlocking', async () => {
@@ -229,17 +288,26 @@ describe('withCastLocks', () => {
     expect(after).toBe('ok');
   });
 
-  it('runs waiters in FIFO order', async () => {
-    const seen: number[] = [];
+  it('runs waiters in FIFO order without overlapping them', async () => {
+    /* `seen.push(n)` as the FIRST statement would run in map order with or
+       without a lock. Record entry AND exit so overlap is observable. */
+    const seen: string[] = [];
     await Promise.all(
       [1, 2, 3].map((n) =>
         withCastLock('/w/fifo', async () => {
-          seen.push(n);
+          seen.push(`enter${n}`);
           await settle();
+          seen.push(`exit${n}`);
         }),
       ),
     );
-    expect(seen).toEqual([1, 2, 3]);
+    expect(seen).toEqual(['enter1', 'exit1', 'enter2', 'exit2', 'enter3', 'exit3']);
+  });
+
+  it('refuses an empty book list rather than running unlocked', async () => {
+    /* reduceRight over [] returns the initial value, so the critical section
+       would run with no lock acquired at all. */
+    await expect(withCastLocks([], async () => 'ran')).rejects.toThrow();
   });
 });
 ```
@@ -302,6 +370,9 @@ export function withCastLock<T>(bookDir: string, fn: () => Promise<T>): Promise<
  *  promise-chain mutex acquired twice on one key never releases. */
 export function withCastLocks<T>(bookDirs: string[], fn: () => Promise<T>): Promise<T> {
   const keys = [...new Set(bookDirs.map(castJsonPath))].sort();
+  /* reduceRight over an empty array returns `fn` unwrapped, which would run the
+     critical section with no lock at all — fail loudly instead. */
+  if (keys.length === 0) throw new Error('withCastLocks: no bookDirs given');
   const chained = keys.reduceRight<() => Promise<T>>(
     (next, key) => () => withKeyLock(key, next),
     fn,
@@ -333,7 +404,7 @@ In `cast-lock.race.test.ts`, add a second `it` beside the existing one:
 import { withCastLock } from './cast-lock.js';
 
 it('keeps both mutations when the writers hold the cast lock', async () => {
-  const bookDir = dir; // castJsonPath(dir) === castPath for this fixture
+  const bookDir = dir; // castPath was built as castJsonPath(dir) in beforeEach
   await Promise.all([
     withCastLock(bookDir, () => assignVoice(castPath, 'alice', 'a')),
     withCastLock(bookDir, () => assignVoice(castPath, 'bob', 'b')),
@@ -343,9 +414,8 @@ it('keeps both mutations when the writers hold the cast lock', async () => {
 });
 ```
 
-Confirm `castJsonPath(dir)` really equals `castPath` for the fixture; if
-`castJsonPath` appends a subdirectory, build the fixture at that path instead.
-**Do not** hand-roll the key in the test — that would defeat the point of Task 2.
+**Do not** hand-roll the lock key in the test — deriving it any way other than
+through `withCastLock` would defeat the point of Task 2.
 
 - [ ] **Step 6: Run both, then mutation-verify**
 
@@ -403,7 +473,9 @@ export function __chainsSizeForTest(): number {
 - [ ] **Step 2: Run to verify it fails**
 
 Run: `cd server && npx vitest run src/workspace/cast-lock.test.ts -t "drops the map entry"`
-Expected: FAIL — received 1, expected 0. The cleanup is dead code today.
+Expected: FAIL — received `before + 1`. (Not "1 vs 0": the four Task 2 tests
+above have already leaked their own entries into the same map.) The cleanup is
+dead code today.
 
 - [ ] **Step 3: Fix all three helpers**
 
@@ -517,7 +589,21 @@ Three changes to the handler:
    Early `return res.status(...)` inside the callback is fine; the lock releases
    when the callback settles.
 
-3. **Wrap that in `withLibraryVoiceLock(voiceUuid, …)`, outside the cast lock.**
+3. **Wrap in `withLibraryVoiceLock(voiceUuid, …)`, outside the cast lock — and
+   it must start much higher than the cast RMW.** Rule 2 applies to *every* lock
+   class, not just the cast lock: the read goes inside, and so does every
+   decision derived from it. The decisions derived from the library entry are
+   `readEntry` and its 404, the revoked-consent 409, and the
+   `hasRetainedDesignedClip` readiness gate — all of which sit well above the
+   cast read. The library-voice lock opens **before `readEntry`** and closes
+   after the cast write.
+
+   This is what makes Task 5 deterministic. `eraseLibraryVoiceArtifacts` deletes
+   the entry directory, so with the 404 gate *inside* the lock a delete-first
+   ordering makes the assign 404 cleanly; with it outside, the assign proceeds on
+   an entry that is being erased underneath it and Task 5's assertion becomes a
+   coin flip.
+
    Order matters and is not arbitrary: the DELETE path holds the library-voice
    key across `clearLibraryVoiceReferences`, which takes cast locks per book. Take
    them the other way round here and the two paths deadlock permanently.
@@ -615,7 +701,7 @@ git commit -m "fix(server): hold a library-voice lock across voice delete scan, 
 
 ### Task 6: Class 1 — the mechanical single-book sites
 
-**Files (16 sites across 10 modules):**
+**Files (15 sites across 11 modules):**
 - `cast-aliases.ts` ×3, `cast-create.ts`, `cast-merge.ts`, `cast-series-patch.ts`,
   `cast-design.ts` ×2, `voice-style.ts` ×2, `voice-override-linked.ts`,
   `book-state.ts` (the cast write in the save handler),
@@ -641,8 +727,16 @@ alongside the primitive harness, not in either route's spec.
 
 - [ ] **Step 2: Run them and confirm each fails**
 
-Run: `cd server && npx vitest run src/routes/cast-aliases.test.ts src/routes/cast-create.test.ts src/routes/cast-merge.test.ts src/routes/cast-series-patch.test.ts src/routes/cast-design.test.ts src/routes/voice-style.test.ts src/routes/voice-override-linked.test.ts src/routes/book-state.test.ts src/routes/qwen-voice.test.ts src/routes/cast-add-from-roster.test.ts`
+Run: `cd server && npx vitest run src/routes/cast-aliases.test.ts src/routes/cast-create.test.ts src/routes/cast-merge.test.ts src/routes/cast-series-patch.test.ts src/routes/cast-design.test.ts src/routes/voice-style.test.ts src/routes/voice-override-linked.test.ts src/routes/book-state.test.ts src/routes/qwen-voice.test.ts src/routes/cast-add-from-roster.test.ts src/routes/voice-library.test.ts`
 Expected: each new test FAILS.
+
+(`voice-library.test.ts` is in the list for the `DELETE /assign` site only —
+`POST /assign` was Task 4.)
+
+**Arithmetic check.** 15 sites here + 1 (Task 4 `POST /assign`) + 1 (Task 5
+`voice-library-usage`) + 1 (Task 7 `promote-voice`) + 8 (Task 8) + 2 (Task 9)
++ 2 (Task 10) = **30 locked**, plus 5 deferred to #2015 = **35**. If your count
+differs, stop — the spec's §5 enumeration is the authority.
 
 - [ ] **Step 3: Wrap each read..write span**
 
@@ -666,9 +760,10 @@ Per-site notes:
   `writeJsonAtomic(manuscriptEditsJsonPath(...))`. Leave that inner write where
   it is; it is a different file and the cast lock does not cover it.
 - **`cast-design.ts`** — both sites already re-read a `fresh` cast immediately
-  before writing. Lock from that `fresh` read through the write, not from the
-  earlier read. Deleting the re-read is fine once the lock is in place, but if
-  you keep it, the lock must still enclose it.
+  before writing. Lock from that `fresh` read through the write. **Do not remove
+  the re-read**: the only other read is the loop-top one at `:263`, which sits
+  above an LLM persona generation at `:273`, so writing from it would put a
+  multi-second `await` inside the lock or the read outside it — both wrong.
 
   Known and accepted: the two idempotency `continue` guards (`:268`, `:269`) are
   evaluated against the *first* read, before the LLM persona generation at
@@ -714,7 +809,7 @@ Expected: PASS.
 
 - [ ] **Step 5: Mutation-verify each site**
 
-For each of the 10 modules: remove that module's `withCastLock`, re-run its spec,
+For each of the 11 modules: remove that module's `withCastLock`, re-run its spec,
 confirm red, restore. Record the list in the commit message. **A site whose test
 stays green with the lock removed is a placebo — stop and investigate rather than
 moving on.**
@@ -722,9 +817,17 @@ moving on.**
 - [ ] **Step 6: Commit**
 
 ```bash
-git add server/src/routes/
+git add server/src/routes/cast-aliases.ts server/src/routes/cast-create.ts \
+  server/src/routes/cast-merge.ts server/src/routes/cast-series-patch.ts \
+  server/src/routes/cast-design.ts server/src/routes/voice-style.ts \
+  server/src/routes/voice-override-linked.ts server/src/routes/book-state.ts \
+  server/src/routes/qwen-voice.ts server/src/routes/cast-add-from-roster.ts \
+  server/src/routes/voice-library.ts server/src/routes/*.test.ts
 git commit -m "fix(server): serialise the single-book cast.json read-modify-writes"
 ```
+
+Enumerate the files. `git add server/src/routes/` sweeps any concurrent session's
+in-progress edits into this commit — a recurring incident in this repo.
 
 ---
 
@@ -744,6 +847,15 @@ would stall every cast write for that book for minutes.
 
 Concurrent `promote-voice` and a `/assign` on a different character of the same
 book; assert both survive.
+
+**Stub the sidecar `fetch` first.** It is the one prologue in the sweep slow
+enough to separate the two racers in wall-clock terms, so without a stub this
+test will not go red and you will be looking at a placebo. Everything else about
+the bare `Promise.all` harness holds here (see Task 1 Step 3).
+
+Also give the character emotion variants in the fixture — the write is guarded
+on `variants` being non-empty, so a variant-less character never writes cast.json
+at all and there is nothing to race.
 
 - [ ] **Step 2: Run to verify it fails**
 
@@ -768,11 +880,17 @@ await withCastLock(located.bookDir, async () => {
   const freshChar = fresh?.characters?.find((c) => c.id === characterId);
   if (!fresh || !freshChar) return; // deleted mid-promotion — artifacts already moved
   const freshSlot = freshChar.overrideTtsVoices?.qwen;
-  staleVariantIds = Object.values(freshSlot?.variants ?? {})
-    .map((v) => v?.name)
-    .filter((n): n is string => !!n);
-  if (freshSlot) delete freshSlot.variants;
-  await writeJsonAtomic(castJsonPath(located.bookDir), fresh);
+  /* KEEP this guard — it is the current behaviour (qwen-voice.ts:788) and it
+     encloses the write. Without it every promote-voice writes cast.json and
+     takes the lock even when the character has no emotion variants, which is
+     the common path. Evaluated against the FRESH slot, per rule 2. */
+  if (freshSlot?.variants && Object.keys(freshSlot.variants).length > 0) {
+    staleVariantIds = Object.values(freshSlot.variants)
+      .map((v) => v?.name)
+      .filter((n): n is string => !!n);
+    delete freshSlot.variants;
+    await writeJsonAtomic(castJsonPath(located.bookDir), fresh);
+  }
 });
 /* Teardown stays outside: filesystem work, and holding the lock across it
    reintroduces exactly the stall this narrowing avoids. */
@@ -820,8 +938,13 @@ it('does not lose the source merge when source and target are the same book', as
   /* Its guard rejects same-book AND same-character only, so same-book with two
      different characters is reachable — and broken with no concurrency at all:
      two independent reads of one file, two arrays derived from separate
-     snapshots, two writes to the same path. nextTargetCharacters does not
-     contain mergedSource, so the second write discards the first. */
+     snapshots, two writes to the same path. nextTargetCharacters is derived
+     from the PRE-merge targetCast read, so the second write puts alice back
+     unmodified and her merge is gone.
+
+     Assert on `aliases`. This route never touches overrideTtsVoices — it merges
+     description, role, gender, ageRange, tone, attributes and aliases — so an
+     overrideTtsVoices assertion would pass before and after and prove nothing. */
   await request(app).post('/api/library-cast-override')
     .send({ sourceBookId: bookId, sourceCharacterId: 'alice',
             targetBookId: bookId, targetCharacterId: 'bob' })
@@ -829,8 +952,10 @@ it('does not lose the source merge when source and target are the same book', as
 
   const cast = await readJson<CastFile>(castJsonPath(bookDir));
   const byId = Object.fromEntries((cast?.characters ?? []).map((c) => [c.id, c]));
-  expect(byId.alice.overrideTtsVoices).toBeDefined(); // the merge that got dropped
-  expect(byId.bob.overrideTtsVoices).toBeDefined();
+  /* alice's merge takes bob's name into her alias pool. Red today: alice is
+     written back from the pre-merge snapshot. */
+  expect(byId.alice.aliases).toContain(bobName);
+  expect(byId.bob.aliases).toContain(aliceName);
 });
 ```
 
@@ -849,7 +974,10 @@ deadlock, but dedupe alone leaves the data loss — it just puts a lock around i
 - [ ] **Step 4: Run, mutation-verify, commit**
 
 ```bash
-git add server/src/routes/cast-link-prior.ts server/src/routes/cast-not-linked-to.ts server/src/routes/library-cast-override.ts server/src/routes/
+git add server/src/routes/cast-link-prior.ts server/src/routes/cast-not-linked-to.ts \
+  server/src/routes/library-cast-override.ts \
+  server/src/routes/cast-link-prior.test.ts server/src/routes/cast-not-linked-to.test.ts \
+  server/src/routes/library-cast-override.test.ts
 git commit -m "fix(server): lock multi-book cast writes in sorted order and fix the same-book merge"
 ```
 
@@ -949,16 +1077,28 @@ git commit -m "fix(server): lock the book-scoped voice-uuid and emotion-variant 
 - Modify: their `*.test.ts`
 
 These destroy cast.json and match neither the write pattern nor the guard's.
-They matter **more** after this change: a locked writer whose read predates the
-delete recreates the file afterwards, resurrecting the stale roster the delete
-exists to remove — and the lock lengthens the gap between a queued writer's read
-and its write.
+They matter because a delete that is not serialised against the writers can
+simply be undone: a writer that acquires *after* the delete recreates cast.json,
+resurrecting the stale roster the delete exists to remove.
+
+(An earlier draft said the lock "lengthens the gap between a queued writer's read
+and its write". That is wrong and the spec retracts it — `file-lock.ts:12-14`
+awaits `prior` before `fn()`, so under rule 2 a queued writer's *read* happens
+after the holder's write. Do not reintroduce the claim.)
 
 **This is the only `analysis.ts` change in this plan.** Its five *write* sites are
 out of scope (#2015). Touch the `rm` and nothing else.
 
 - [ ] **Step 1: Write the failing test** — a delete concurrent with a cast write;
   assert the file stays deleted.
+
+  **Name the writer deliberately.** Use a rule-2-compliant one that re-reads
+  inside its lock and refuses on an absent cast — `cast-aliases.ts` returns 409
+  "Book has no cast on disk yet", so it leaves the file deleted in both
+  orderings once serialised. Do **not** use `book-state.ts`'s cast-slice
+  handler: it writes `body.patch` regardless of on-disk state and legitimately
+  recreates cast.json when it acquires second, so the assertion would be
+  ordering-dependent rather than lock-dependent.
 - [ ] **Step 2: Run to verify it fails.**
 - [ ] **Step 3: Wrap each `rm` in `withCastLock(bookDir, …)`.** In
   `book-state.ts` the `rm` is one arm of a `Promise.all`; wrap that arm.
@@ -984,10 +1124,17 @@ Walk `server/src/**/*.ts` (excluding `*.test.ts`). For each file containing
 scope. Maintain an explicit allowlist with a reason per entry:
 
 ```ts
+/* Keyed on file AND expected count, never on file alone. `analysis.ts` holds
+   both the 5 deferred writes and the one rm that Task 11 DOES lock — a
+   file-level exemption would blind the guard to that rm forever, which is the
+   exact hole spec §5 class 6 exists to close. */
 const ALLOWED_UNLOCKED = new Map([
-  ['routes/analysis.ts', 'the 5 merge-base writes are deferred to #2015; the rm IS locked'],
+  ['routes/analysis.ts', { writes: 5, rms: 0, why: 'merge-base writes deferred to #2015 (the rm IS locked)' }],
 ]);
 ```
+
+Assert the counts match exactly. A 6th unlocked write in `analysis.ts` must fail
+the guard, not inherit the exemption.
 
 Document the known blind spots in the file header: it sees one syntactic form, so
 `const p = castJsonPath(dir); await writeJsonAtomic(p, …)` slips through, as
@@ -1019,16 +1166,36 @@ git commit -m "test(server): fail the build on an unlocked cast.json write"
 ### Task 13: Docs, notes and ticket hygiene
 
 **Files:**
+- Create: `docs/features/<n>-cast-json-write-lock.md` (from `docs/features/TEMPLATE.md`)
+- Modify: `docs/features/INDEX.md`
 - Modify: `CLAUDE.md` (*Conventions worth preserving*)
 - Modify: `docs/release-notes-next.md`, `RELEASE_NOTES.md`
 - Modify: `docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md` (status)
 
-- [ ] **Step 1: Add the convention to CLAUDE.md**
+Walk CLAUDE.md's Before-shipping checklist and discharge every step explicitly.
+Steps 1 and 4 were silently omitted from an earlier draft of this plan; the
+checklist's own escape hatch is conditional — skipping is fine, *saying nothing*
+is not.
+
+- [ ] **Step 1: Create the regression plan (checklist step 1)**
+
+This is substantial cross-cutting work introducing a codebase-wide invariant, so
+it needs a durable `docs/features/` plan, not just the issue bodies. Scan the
+worktrees for the next free plan number first (concurrent sessions claim them).
+Record: the invariant and its four rules, the 30 locked sites, the deferred sets
+(#2006, #2015) and *why* each is deferred, and a manual acceptance walkthrough —
+two browser tabs editing one book's cast simultaneously, both edits surviving.
+
+- [ ] **Step 2: Update `docs/features/INDEX.md` (checklist step 4)**
+
+New entry under its area.
+
+- [ ] **Step 3: Add the convention to CLAUDE.md**
 
 One bullet with the four rules from `cast-lock.ts`'s header, including the
 three-class lock order.
 
-- [ ] **Step 2: Release notes, both files**
+- [ ] **Step 4: Release notes, both files (checklist step 5)**
 
 `docs/release-notes-next.md` — technical, PR-ref'd. `RELEASE_NOTES.md` — one
 user-facing line in brand voice. The user-visible delta is real: concurrent cast
@@ -1036,15 +1203,32 @@ edits no longer silently discard one another. Do **not** claim cast.json is full
 protected — `analysis.ts` is not (#2015), and the check-then-act gates are not
 (#2006).
 
-- [ ] **Step 3: On-box acceptance**
+- [ ] **Step 5: Discharge the remaining checklist steps in the PR body**
 
-No new hardware-only behaviour: every claim here is provable in-process by the
-outcome tests. Say so explicitly in the PR body rather than omitting the step.
+State each explicitly rather than omitting it:
 
-- [ ] **Step 4: Commit**
+- **Step 3, on-box acceptance — N/A.** No hardware-only behaviour; every claim
+  here is provable in-process by the outcome tests. No register row is owed.
+- **openapi.yaml — N/A.** No wire shape changes. The `isAnalysisBusy` admission
+  gate that *would* have added a 409 across ~20 routes was rejected (spec §6).
+- **Frontend — N/A.** No component, slice or API-surface change.
+- **e2e — N/A.** The behaviour is server-side concurrency; it crosses no
+  router/redux/layout seam, so Playwright cannot observe it. The two-tab
+  walkthrough in the regression plan is the manual equivalent.
+
+- [ ] **Step 6: Confirm the deferred issues carry the residuals**
+
+Spec §12 lists eight accepted residuals. Check #2006 and #2015 actually name the
+ones assigned to them — `cast-link-prior`'s unnamed `libraryUuid` references, the
+cross-book double-mint, and the `voice-override-linked` / `cast-series-patch`
+cross-book consultations — and comment them onto the issues if not. A residual
+that exists only in a spec section is a residual being lost.
+
+- [ ] **Step 7: Commit**
 
 ```bash
-git add CLAUDE.md docs/release-notes-next.md RELEASE_NOTES.md docs/superpowers/specs/
+git add CLAUDE.md docs/release-notes-next.md RELEASE_NOTES.md \
+  docs/features/ docs/superpowers/specs/
 git commit -m "docs(docs): record the cast.json lock convention and release notes"
 ```
 

--- a/docs/superpowers/plans/2026-07-31-cast-json-write-lock.md
+++ b/docs/superpowers/plans/2026-07-31-cast-json-write-lock.md
@@ -26,9 +26,12 @@ Read it before Task 1. Section references below (§3.1, §5, §10.2 …) point a
 
 ## Global Constraints
 
-- **Base branch:** cut after `fix/server-1933-assign-readiness` merges, or rebase
-  onto it. It rewrites 208 lines of `voice-library.ts` and shifts the assign
-  read/write by +138/+178. **Cite symbols, never line numbers, in code comments.**
+- **Base branch: cut off current `main`.** #1933 has since merged, so the
+  sequencing constraint earlier drafts carried is discharged. It landed the
+  +138/+178 shift in `voice-library.ts` that spec §9.1 predicted (the assign RMW
+  is now `:1415` → `:1612`) and added a second readiness gate,
+  `clonedAssignBlock`, *below* the cast read. Spec line numbers are as of
+  `88476dca` and several have moved. **Cite symbols, never line numbers.**
 - **Global lock order: `design` → `series` → `library-voice` → `cast`.** Never
   acquire an earlier class while holding a later one. Every acquisition site
   names its position in a comment.
@@ -227,8 +230,14 @@ git commit -m "test(server): pin the cast.json lost-update race before locking a
 - [ ] **Step 1: Write the failing tests**
 
 ```ts
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { withCastLock, withCastLocks } from './cast-lock.js';
+/* Namespace import so vi.spyOn can intercept the call cast-lock.ts makes
+   internally — Vite's SSR transform rewrites it to a property access resolved
+   at call time. Do NOT reach for vi.mock('./file-lock.js') instead; that
+   replaces the module and the spy stops observing real acquisition. */
+import * as fileLock from './file-lock.js';
+import { castJsonPath } from './paths.js';
 
 const settle = () => new Promise((r) => setTimeout(r, 0));
 
@@ -379,7 +388,11 @@ export function withCastLock<T>(bookDir: string, fn: () => Promise<T>): Promise<
  *  Deduping matters because library-cast-override can legitimately receive the
  *  same book twice (its guard rejects same-book AND same-character only), and a
  *  promise-chain mutex acquired twice on one key never releases. */
-export function withCastLocks<T>(bookDirs: string[], fn: () => Promise<T>): Promise<T> {
+/* `async` deliberately: the empty-list guard below must surface as a REJECTED
+   promise, not a synchronous throw. A sync throw fires while evaluating
+   `expect()`'s argument, before `.rejects` can catch it, and the test fails
+   instead of passing. */
+export async function withCastLocks<T>(bookDirs: string[], fn: () => Promise<T>): Promise<T> {
   const keys = [...new Set(bookDirs.map(castJsonPath))].sort();
   /* reduceRight over an empty array returns `fn` unwrapped, which would run the
      critical section with no lock at all — fail loudly instead. */
@@ -405,7 +418,7 @@ export function withLibraryVoiceLock<T>(voiceUuid: string, fn: () => Promise<T>)
 - [ ] **Step 4: Run to verify it passes**
 
 Run: `cd server && npx vitest run src/workspace/cast-lock.test.ts`
-Expected: PASS (4 tests).
+Expected: PASS (6 tests).
 
 - [ ] **Step 5: Flip the race harness to the both-survive assertion**
 
@@ -646,7 +659,7 @@ export function __chainsSizeForTest(): number {
 - [ ] **Step 2: Run to verify it fails**
 
 Run: `cd server && npx vitest run src/workspace/cast-lock.test.ts -t "drops the map entry"`
-Expected: FAIL — received `before + 1`. (Not "1 vs 0": the four Task 2 tests
+Expected: FAIL — received `before + 1`. (Not "1 vs 0": the six Task 2 tests
 above have already leaked their own entries into the same map.) The cleanup is
 dead code today.
 
@@ -842,9 +855,19 @@ Expected: FAIL — reference present and artifacts erased.
 
 - [ ] **Step 3: Wrap scan → clear → erase in the library-voice lock**
 
-Wrap from `scanLibraryVoiceUsage` through `clearLibraryVoiceReferences` and
-`eraseLibraryVoiceArtifacts` in `withLibraryVoiceLock(voiceUuid, …)`. Task 4
-already made `/assign` take the same key, which is what makes this bite.
+Open `withLibraryVoiceLock(voiceUuid, …)` **before `readEntry` and its 404** —
+symmetric with Task 5's assign side — and close it after
+`eraseLibraryVoiceArtifacts`, spanning `scanLibraryVoiceUsage` and
+`clearLibraryVoiceReferences`.
+
+Starting it at `scanLibraryVoiceUsage` instead would leave a decision derived
+from the library entry outside its own lock: rule 2's failure mode, in the very
+PR that establishes rule 2, and not one of the four sanctioned carve-outs. Two
+concurrent DELETEs are harmless in practice (the second erases nothing), but the
+`high`-effort code-review gate will read an unreasoned exception as exactly that,
+and symmetry costs nothing.
+
+Task 5 already made `/assign` take the same key, which is what makes this bite.
 
 In `voice-library-usage.ts`, `clearLibraryVoiceReferences` takes a
 `withCastLock` per book **inside** its loop and **re-reads** the cast in there —
@@ -897,6 +920,26 @@ Every other spec here races a site against itself, which uses one import and one
 key and therefore cannot detect a key mismatch *between* sites. This is the only
 test in the suite that can. Put it in `server/src/workspace/cast-lock.race.test.ts`
 alongside the primitive harness, not in either route's spec.
+
+**Two modules cannot use the self-vs-self shape at all — race them cross-writer:**
+
+- **`cast-design.ts`** — `cast-design.ts:648` gates on
+  `inFlightByBook.get(bookId)`, so a second concurrent POST for the same book
+  *attaches to the running job's SSE stream* rather than starting a second one.
+  There is only ever one design writer per book. Race the job's
+  `fresh`-read-through-write against a different module's writer on that book
+  (`cast-aliases`), or drive the write helper directly rather than through the
+  route.
+- **`book-state.ts`** — its cast slice writes `body.patch` wholesale and is
+  last-writer-wins **by contract**, so "two PUTs, different characters, both
+  survive" stays red after the lock too. (Task 12 already reasons this out for
+  its own test and picks a different writer; the same reasoning applies here.)
+  What the lock actually protects is the **clone-consent guards** inside
+  `preserveDesignedVoices`. The red→green test is: a cast PUT whose patch omits a
+  character's `overrideTtsVoices`, raced against `/assign` planting one.
+  Unlocked, the stale read means `preserveDesignedVoicesOnCastWrite` fails to
+  fill the gap and the designed voice is erased; locked, the read lands after the
+  write and it is restored.
 
 - [ ] **Step 2: Run them and confirm each fails**
 
@@ -1205,8 +1248,24 @@ one takes a cast lock. The **series** branch delegates to
 wrapping it here would violate rule 1 and self-deadlock the moment the walk
 reaches this book.
 
-- [ ] **Step 1: Write the failing tests** — concurrent book-scoped calls; assert
-  no double-mint and no lost sibling write.
+- [ ] **Step 1: Write the failing tests — and NOT as a self-vs-self race**
+
+`ensureCharacterVoiceUuid`'s entire body — read, decide, mint, write — is
+**already inside `withDesignLock(bookDir)`**. Two concurrent calls on one book
+are serialised today, so neither "no double-mint" nor "no lost sibling write"
+can fail, before or after this task. Writing the usual two-concurrent-calls test
+here produces a green test that proves nothing, and Task 1 Step 3's advice
+("a red-phase test that will not go red is a harness problem") would then send
+you hunting a harness bug that does not exist.
+
+Race it against a writer that does **not** hold the design lock:
+
+- **`ensureCharacterVoiceUuid`** vs a `cast-aliases` route call on the same book.
+  Assert the alias mutation survives. Red today: the uuid write replays a
+  snapshot taken before the alias write landed.
+- **`persistEmotionVariant`** has no design lock at all, so the ordinary
+  self-vs-self shape *is* valid there. The two functions are not symmetric and
+  the plan does not treat them as such.
 
 - [ ] **Step 2: Run to verify they fail.**
 
@@ -1295,7 +1354,20 @@ git commit -m "fix(server): take the cast lock when deleting cast.json"
 Walk `server/src/**/*.ts` (excluding `*.test.ts`). For each file containing
 `castJsonPath`, assert every `writeJsonAtomic(castJsonPath(` and
 `rm(castJsonPath(` occurrence sits inside a `withCastLock` / `withCastLocks`
-scope. Maintain an explicit allowlist with a reason per entry:
+scope.
+
+**Use a brace-depth scan, and say so.** For each occurrence, walk backwards to
+the nearest enclosing `withCastLock(` / `withCastLocks(` / `withSeriesLock(`
+call and confirm the occurrence is inside its brace range. A file-level
+heuristic ("does this module mention `withCastLock`?") is not sufficient — it
+cannot resolve *per-occurrence* lockedness, which is exactly what a 6000-line
+module like `analysis.ts` requires, and a guard that cannot do that is
+decorative.
+
+**Acceptance target, stated concretely:** on the finished branch the guard
+reports **zero** unlocked occurrences in every file, including `analysis.ts`
+(whose five writes are revision-checked and locked by Task 14). Maintain an
+explicit allowlist with a reason per entry:
 
 ```ts
 /* Empty by design. Every cast.json write and delete in the tree is locked and

--- a/docs/superpowers/plans/2026-07-31-cast-json-write-lock.md
+++ b/docs/superpowers/plans/2026-07-31-cast-json-write-lock.md
@@ -19,8 +19,9 @@ integration tests.
 Read it before Task 1. Section references below (§3.1, §5, §10.2 …) point at it.
 
 **Tickets:** `Closes #1981`, `Closes #2000`, `Closes #2001`. `Refs #2006`,
-`Refs #2015` — the cross-scope staleness work is deliberately **not** in this PR;
-see "Why the staleness layer is not here" below.
+`Refs #2015` — the cross-scope staleness work is deliberately **not** in this PR.
+Four mechanisms were designed for it and none survived review; the design of
+record §13 has all four and why each failed.
 
 ## Global Constraints
 
@@ -71,7 +72,7 @@ see "Why the staleness layer is not here" below.
 | `server/src/workspace/file-lock.ts` | Modify — #2001 map-cleanup fix. |
 | `server/src/tts/design-lock.ts` | Modify — same fix, cleanup only. **Do not touch acquire/release/ordering**: `ensureCharacterVoiceUuid`'s series branch still depends on it (§5.1). |
 | `server/src/routes/chapters-restructure.ts` | Modify — same fix; re-derive the safety argument, its control flow differs. |
-| 14 route modules + `voice-library-usage.ts` | Modify — apply the lock per §5. |
+| 16 route modules + `voice-library-usage.ts` | Modify — apply the lock per §5. |
 | `server/src/workspace/cast-lock.guard.test.ts` | **New.** Static guard: no unlocked `writeJsonAtomic(castJsonPath(` / `rm(castJsonPath(`. |
 
 ---
@@ -410,7 +411,7 @@ export function withLibraryVoiceLock<T>(voiceUuid: string, fn: () => Promise<T>)
 - [ ] **Step 4: Run to verify it passes**
 
 Run: `cd server && npx vitest run src/workspace/cast-lock.test.ts`
-Expected: PASS (7 tests).
+Expected: PASS (6 tests).
 
 - [ ] **Step 5: Flip the race harness to the both-survive assertion**
 
@@ -1211,15 +1212,13 @@ unlocked occurrences everywhere else. Maintain an explicit allowlist with a
 reason per entry:
 
 ```ts
-/* Empty by design. Every cast.json write and delete in the tree is locked and
-   deferred to #2015, so the entry above is the only exemption.
+/* One entry by design: analysis.ts's five merge-base writes are deferred to
+   #2015 and stay unlocked in this PR.
 
-   An earlier draft carried an allowlist entry for analysis.ts's five deferred
-   writes. Keep this map empty rather than deleting the mechanism: if a future
-   change needs an exemption it must be keyed on file AND expected count, never
-   on file alone — a file-level exemption for analysis.ts would also have
-   blinded the guard to the one rm that IS locked, which is the exact hole spec
-   §5 class 6 exists to close. */
+   Keyed on file AND expected count, never on file alone. A file-level
+   exemption for analysis.ts would also blind the guard to the one rm that IS
+   locked (Task 11) — the exact hole spec §5 class 6 exists to close. A sixth
+   unlocked write in that file must fail the guard, not inherit the exemption. */
 const ALLOWED_UNLOCKED = new Map([
   ['routes/analysis.ts', { writes: 5, rms: 0, why: 'merge-base writes deferred to #2015; the rm IS locked (Task 11)' }],
 ]);
@@ -1353,8 +1352,10 @@ git commit -m "docs(docs): record the cast.json lock convention and release note
 - [ ] `npx madge --circular --extensions ts server/src` — still 15 cycles.
       `cast-lock.ts` is a leaf under `workspace/`; if the count moved, a route
       module was imported from it.
-- [ ] PR body: `Closes #1981`, `Closes #2000`, `Closes #2001`, `Closes #2006`,
-      `Closes #2015`. Declare Task 8's `library-cast-override` same-book fix and
+- [ ] PR body: `Closes #1981`, `Closes #2000`, `Closes #2001`, **`Refs #2006`,
+      `Refs #2015`** — those two stay OPEN. They carry the design history of the
+      four failed staleness mechanisms; auto-closing them discards the brief the
+      next attempt starts from. Declare Task 8's `library-cast-override` same-book fix and
       Task 3's #2001 fix under "Also fixed, found in passing".
 - [ ] Mandatory `code-review` pass at `high` effort — multi-scope, 17 modules.
 

--- a/docs/superpowers/plans/2026-07-31-cast-json-write-lock.md
+++ b/docs/superpowers/plans/2026-07-31-cast-json-write-lock.md
@@ -5,15 +5,12 @@
 **Goal:** Serialise every cast.json read-modify-write behind a per-book lock, so
 two concurrent writers can no longer silently discard each other's mutation.
 
-**Architecture:** Three layers. (1) A thin named wrapper (`withCastLock` /
-`withCastLocks`) over the existing `withKeyLock` promise-chain mutex, applied at
-all 35 `writeJsonAtomic(castJsonPath(…))` sites plus 2 delete sites; the lock
-always encloses the **read** as well as the write. (2) A cast.json revision
-counter, for the six places where the decision is read in one lock scope and the
-write lands in another — a lock cannot reach those, so staleness is made
-detectable instead. (3) Two further key classes, `library-voice:<uuid>` and
-`series:<author>/<series>`, for races a per-book key cannot express. Global lock
-order: `design` → `series` → `library-voice` → `cast`.
+**Architecture:** A thin named wrapper (`withCastLock` / `withCastLocks`) over
+the existing `withKeyLock` promise-chain mutex, applied at 30 of the 35
+`writeJsonAtomic(castJsonPath(…))` sites plus 2 delete sites; the lock always
+encloses the **read** as well as the write, never just the write. A third key
+class, `library-voice:<uuid>`, closes the delete-vs-assign race. Global lock
+order: `design` → `library-voice` → `cast`.
 
 **Tech Stack:** TypeScript, Node 20, Express, Vitest (node env), real-fs
 integration tests.
@@ -21,8 +18,9 @@ integration tests.
 **Design of record:** [`docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md`](../specs/2026-07-31-cast-json-write-lock-design.md).
 Read it before Task 1. Section references below (§3.1, §5, §10.2 …) point at it.
 
-**Tickets:** `Closes #1981`, `Closes #2000`, `Closes #2001`, `Closes #2006`,
-`Closes #2015`. Nothing is deferred out of this change.
+**Tickets:** `Closes #1981`, `Closes #2000`, `Closes #2001`. `Refs #2006`,
+`Refs #2015` — the cross-scope staleness work is deliberately **not** in this PR;
+see "Why the staleness layer is not here" below.
 
 ## Global Constraints
 
@@ -32,9 +30,9 @@ Read it before Task 1. Section references below (§3.1, §5, §10.2 …) point a
   is now `:1415` → `:1612`) and added a second readiness gate,
   `clonedAssignBlock`, *below* the cast read. Spec line numbers are as of
   `88476dca` and several have moved. **Cite symbols, never line numbers.**
-- **Global lock order: `design` → `series` → `library-voice` → `cast`.** Never
-  acquire an earlier class while holding a later one. Every acquisition site
-  names its position in a comment.
+- **Global lock order: `design` → `library-voice` → `cast`.** Never acquire an
+  earlier class while holding a later one. Every acquisition site names its
+  position in a comment.
 - **Lock the innermost read-through-write, never the caller.** One level only.
   A locked function must not call another locked function on the same book.
 - **The read goes inside the lock**, and so does every decision derived from it.
@@ -44,7 +42,7 @@ Read it before Task 1. Section references below (§3.1, §5, §10.2 …) point a
   detector**: a partitioned lock does not contend, so it loses a mutation and the
   outcome test goes *red*. Pinning avoids a confusing false failure. Do not add a
   `chains.size` accessor for this — §10.3 explains why it cannot work.
-- **Task 7 must include one cross-module outcome spec** — two *different*
+- **Task 6 must include one cross-module outcome spec** — two *different*
   modules' write sites racing on one book. A spec that races a site against
   itself uses one import and one key, so it can never catch cross-site key
   derivation drift. This is the only shape that can.
@@ -55,16 +53,9 @@ Read it before Task 1. Section references below (§3.1, §5, §10.2 …) point a
 - **Every lock is mutation-verified**: revert the lock at that site, re-run,
   paste the failing output into the task's commit message. A test that was never
   seen red proves nothing.
-- **Tasks 14–16 use `cast-io.ts`'s helpers; the other 30 sites do not.** Those
-  30 read and write inside one cast lock where nothing can interleave, so a
-  staleness check there is inert and costs an extra full read per write. An
-  earlier draft required universal adoption — that was a property of the
-  *revision-counter* design, which is unsound unless every writer increments. The
-  content fingerprint has no such requirement: any write changes the bytes,
-  whoever made it. Do not widen the helpers' use.
-- **`analysis.ts`'s 5 writes and the three clone-consent gates are IN scope** —
-  Tasks 14 and 15. Earlier drafts deferred them to #2015/#2006; those issues are
-  now closed by this PR. Do not skip them on the strength of a stale comment.
+- **`analysis.ts`'s 5 write sites and the three clone-consent gates are OUT of
+  scope** (#2015, #2006). Do not "improve" them in passing. Task 11 touches
+  `analysis.ts`'s `rm` and nothing else.
 - Commit convention: `<type>(<scope>): <subject>`. Scope is `server` for all
   code tasks.
 
@@ -74,14 +65,13 @@ Read it before Task 1. Section references below (§3.1, §5, §10.2 …) point a
 
 | File | Responsibility |
 |---|---|
-| `server/src/workspace/cast-lock.ts` | **New.** Four named lock wrappers (`withCastLock`, `withCastLocks`, `withLibraryVoiceLock`, `withSeriesLock`) + the lock-order rule in its header. Sole owner of key derivation. |
-| `server/src/workspace/cast-io.ts` | **New.** `readCastForUpdate` / `writeCastChecked` / `assertCastUnchanged` — content-fingerprint staleness detection. Used by Tasks 14–16 only. |
+| `server/src/workspace/cast-lock.ts` | **New.** Three named lock wrappers (`withCastLock`, `withCastLocks`, `withLibraryVoiceLock`) + the lock-order rule in its header. Sole owner of key derivation. |
 | `server/src/workspace/cast-lock.test.ts` | **New.** Primitive unit tests: sorted acquisition (observed within one call), the AB/BA deadlock test, dedupe, release-on-throw, non-overlapping FIFO waiters, empty-list refusal. |
 | `server/src/workspace/cast-lock.race.test.ts` | **New.** The outcome harness — two overlapping RMWs, both mutations must survive. The reference for every later site test. |
 | `server/src/workspace/file-lock.ts` | Modify — #2001 map-cleanup fix. |
 | `server/src/tts/design-lock.ts` | Modify — same fix, cleanup only. **Do not touch acquire/release/ordering**: `ensureCharacterVoiceUuid`'s series branch still depends on it (§5.1). |
 | `server/src/routes/chapters-restructure.ts` | Modify — same fix; re-derive the safety argument, its control flow differs. |
-| 17 route modules + `voice-library-usage.ts` | Modify — apply the lock per §5. |
+| 14 route modules + `voice-library-usage.ts` | Modify — apply the lock per §5. |
 | `server/src/workspace/cast-lock.guard.test.ts` | **New.** Static guard: no unlocked `writeJsonAtomic(castJsonPath(` / `rm(castJsonPath(`. |
 
 ---
@@ -199,7 +189,7 @@ both reads land before either write, because the write (`mkdir` + `writeFile` +
 
 **The one exception is wall-clock duration, not await depth.** `promote-voice`
 does a sidecar `fetch` before its read, which takes real time and *will*
-separate the two racers. Task 8's test must stub that `fetch` (or point it at a
+separate the two racers. Task 7's test must stub that `fetch` (or point it at a
 local no-op) so the two requests reach their cast reads together. If any other
 route-level red-phase test fails to go red, treat it as a **harness** problem —
 not as evidence the site is safe — and stub whatever slow call sits in its
@@ -358,18 +348,18 @@ Expected: FAIL — `Cannot find module './cast-lock.js'`.
  *   2. The read goes inside the lock, and so does every decision derived from
  *      it. Wrapping only the write buys nothing at all.
  *   3. Two or more books -> withCastLocks, never nested withCastLocks.
- *   4. Global lock order: design -> series -> library-voice -> cast. Never
- *      acquire an earlier class while holding a later one. The DELETE
- *      library-voice path holds `library-voice:<uuid>` across
- *      clearLibraryVoiceReferences, which takes a cast lock per book — so POST
- *      /assign must take library-voice BEFORE its cast lock, not after. The
- *      other order is an AB/BA cycle on a mutex with no timeout and no
- *      diagnostic: both requests hang forever. `series` and `library-voice` are
- *      never both held; their relative position is declared, not exercised.
+ *   4. Global lock order: design -> library-voice -> cast. Never acquire an
+ *      earlier class while holding a later one. The DELETE library-voice path
+ *      holds `library-voice:<uuid>` across clearLibraryVoiceReferences, which
+ *      takes a cast lock per book — so POST /assign must take library-voice
+ *      BEFORE its cast lock, not after. The other order is an AB/BA cycle on a
+ *      mutex with no timeout and no diagnostic: both requests hang forever.
  *
- * WHAT THIS DOES NOT COVER: it protects one read-modify-write. A validate-then-
- * write whose halves sit in different lock scopes needs the staleness helpers in
- * cast-io.ts, not this file — see that module and design §14.
+ * WHAT THIS DOES NOT COVER: it protects one read-modify-write. It does NOT make
+ * a validate-then-write safe when the validation and the write sit in different
+ * lock scopes — analysis.ts's merge base (#2015) and the clone-consent gates
+ * (#2006). Four designs for that have been attempted and none survived review;
+ * do not add a fifth here without reading those issues first.
  *
  * Key derivation lives here and ONLY here. A site that derived the key slightly
  * differently would get a second mutex that never contends with the first, and
@@ -461,206 +451,7 @@ git commit -m "feat(server): add the per-book cast.json write lock"
 
 ---
 
-### Task 3: `cast-io.ts` — staleness detection for the cross-scope sites
-
-Used by Tasks 14–16 only. The other 30 sites keep `readJson`/`writeJsonAtomic`
-under their lock — see "Where it is used" below, and do not widen it.
-
-**Files:**
-- Create: `server/src/workspace/cast-io.ts`
-- Create: `server/src/workspace/cast-io.test.ts`
-
-**Interfaces:**
-- Consumes: `readJson`, `writeJsonAtomic` from `./state-io.js`; `castJsonPath`.
-- Produces:
-  - `readCastForUpdate<T extends object>(bookDir): Promise<{ cast: T; fingerprint: string | null }>`
-  - `writeCastChecked<T extends object>(bookDir, next: T, expected: string | null): Promise<string | null>`
-    — returns the fingerprint of what it wrote
-  - `assertCastUnchanged(bookDir, expected: string | null): Promise<void>`
-  - `class CastStaleError extends Error` with `bookDir`
-
-- [ ] **Step 1: Write the failing tests**
-
-```ts
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import * as fsp from 'node:fs/promises';
-import { mkdtemp, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { writeJsonAtomic } from './state-io.js';
-import { castJsonPath } from './paths.js';
-import {
-  readCastForUpdate,
-  writeCastChecked,
-  assertCastUnchanged,
-  CastStaleError,
-} from './cast-io.js';
-
-let dir: string;
-beforeEach(async () => {
-  dir = await mkdtemp(join(tmpdir(), 'cast-io-'));
-  await writeJsonAtomic(castJsonPath(dir), { characters: [{ id: 'alice' }] });
-});
-afterEach(async () => { await rm(dir, { recursive: true, force: true }); });
-
-it('fingerprints an absent cast as null, distinctly from any content', async () => {
-  await rm(castJsonPath(dir), { force: true });
-  const { fingerprint } = await readCastForUpdate(dir);
-  expect(fingerprint).toBeNull();
-});
-
-it('accepts a write when the file has not changed', async () => {
-  const { cast, fingerprint } = await readCastForUpdate<{ characters: unknown[] }>(dir);
-  await expect(writeCastChecked(dir, cast, fingerprint)).resolves.toBeUndefined();
-});
-
-it('rejects a write when the bytes changed under it', async () => {
-  const { cast, fingerprint } = await readCastForUpdate<{ characters: unknown[] }>(dir);
-  await writeJsonAtomic(castJsonPath(dir), { characters: [{ id: 'bob' }] });
-  await expect(writeCastChecked(dir, cast, fingerprint)).rejects.toBeInstanceOf(CastStaleError);
-});
-
-it('detects a delete even when the file is recreated identically (ABA)', async () => {
-  /* The property a revision counter cannot have: 1 -> delete -> recreate as 1
-     reads as "unchanged" to a counter. Here, identical bytes genuinely ARE
-     unchanged, and a delete-then-DIFFERENT-recreate is caught. */
-  const { fingerprint } = await readCastForUpdate(dir);
-  await rm(castJsonPath(dir), { force: true });
-  await writeJsonAtomic(castJsonPath(dir), { characters: [{ id: 'zed' }] });
-  await expect(assertCastUnchanged(dir, fingerprint)).rejects.toBeInstanceOf(CastStaleError);
-});
-
-it('detects a write made by a caller that never used these helpers', async () => {
-  /* The other property a counter cannot have: soundness does not depend on
-     universal adoption. A raw writeJsonAtomic still changes the bytes. */
-  const { fingerprint } = await readCastForUpdate(dir);
-  await writeJsonAtomic(castJsonPath(dir), { characters: [{ id: 'alice' }, { id: 'new' }] });
-  await expect(assertCastUnchanged(dir, fingerprint)).rejects.toBeInstanceOf(CastStaleError);
-});
-
-it('derives the fingerprint from the same bytes it parses', async () => {
-  /* Guards the single-read property. Two reads with an await between them would
-     let a writer land in the gap, and the fingerprint would describe bytes other
-     than the parsed ones — the window a revision counter had and this design
-     exists to remove. Spy on readFile and assert exactly one call. */
-  const spy = vi.spyOn(fsp, 'readFile');
-  await readCastForUpdate(dir);
-  expect(spy.mock.calls.filter(([p]) => String(p).endsWith('cast.json'))).toHaveLength(1);
-  spy.mockRestore();
-});
-
-it('asserts a consulted book without writing it', async () => {
-  const { fingerprint } = await readCastForUpdate(dir);
-  await expect(assertCastUnchanged(dir, fingerprint)).resolves.toBeUndefined();
-});
-```
-
-- [ ] **Step 2: Run to verify they fail**
-
-Run: `cd server && npx vitest run src/workspace/cast-io.test.ts`
-Expected: FAIL — `Cannot find module './cast-io.js'`.
-
-- [ ] **Step 3: Write the implementation**
-
-```ts
-/* Staleness detection for cast.json.
- *
- * The per-book lock (cast-lock.ts) makes one read-modify-write atomic. It cannot
- * help when the DECISION is read in one lock scope and the write lands in
- * another — analysis.ts's merge base, the clone-consent gates, the cross-book
- * consultations. Those need staleness to be DETECTABLE.
- *
- * A content fingerprint rather than a `rev` field on cast.json, deliberately
- * (design §14.1):
- *   - it is derived from the bytes you already read, so there is no separate
- *     capture step and no window between snapshot and capture to get wrong;
- *   - soundness does not depend on every writer participating — any write
- *     changes the bytes, whoever made it. A counter is "worse than none" if one
- *     writer skips the increment;
- *   - delete-then-recreate is handled honestly: identical bytes ARE unchanged.
- *
- * USED BY THE CROSS-SCOPE SITES ONLY (Tasks 14-16). The ~30 same-scope writers
- * read and write inside one cast lock, where nothing can interleave and this
- * comparison is inert — they keep readJson/writeJsonAtomic. Do not widen this.
- *
- * All three assume the caller holds the cast lock for `bookDir`.
- */
-import { createHash } from 'node:crypto';
-import { readFile } from 'node:fs/promises';
-import { readJson, writeJsonAtomic } from './state-io.js';
-import { castJsonPath } from './paths.js';
-
-export class CastStaleError extends Error {
-  constructor(readonly bookDir: string) {
-    super(`cast.json for ${bookDir} changed under us since it was read.`);
-    this.name = 'CastStaleError';
-  }
-}
-
-/** Read the file's bytes once. `null` when absent — a real value, not a
- *  failure: "there was nothing here" is distinct from any content, which is what
- *  makes delete-then-recreate detectable. */
-async function readBytes(bookDir: string): Promise<Buffer | null> {
-  try {
-    return await readFile(castJsonPath(bookDir));
-  } catch {
-    return null;
-  }
-}
-
-const sha = (raw: Buffer | null): string | null =>
-  raw === null ? null : createHash('sha256').update(raw).digest('hex');
-
-export async function readCastForUpdate<T extends object>(
-  bookDir: string,
-): Promise<{ cast: T; fingerprint: string | null }> {
-  /* ONE read. Hash and parse are both derived from the same Buffer.
-     Hashing in one readFile and parsing in another would put an await between
-     them and reintroduce the exact window this design exists to remove — a
-     writer landing in the gap makes the fingerprint describe bytes that are not
-     the ones we parsed, which is worse than no check at all because it reads as
-     a guarantee. */
-  const raw = await readBytes(bookDir);
-  const cast = raw === null ? ({ characters: [] } as unknown as T) : (JSON.parse(raw.toString('utf8')) as T);
-  return { cast, fingerprint: sha(raw) };
-}
-
-export async function assertCastUnchanged(
-  bookDir: string,
-  expected: string | null,
-): Promise<void> {
-  if (sha(await readBytes(bookDir)) !== expected) throw new CastStaleError(bookDir);
-}
-
-/** Write `next` if the file still matches `expected`. Returns the fingerprint of
- *  what was written, so a caller doing repeated writes (analysis.ts) can carry it
- *  forward without a re-read. */
-export async function writeCastChecked<T extends object>(
-  bookDir: string,
-  next: T,
-  expected: string | null,
-): Promise<string | null> {
-  await assertCastUnchanged(bookDir, expected);
-  await writeJsonAtomic(castJsonPath(bookDir), next);
-  return sha(await readBytes(bookDir));
-}
-```
-
-- [ ] **Step 4: Run to verify it passes**
-
-Run: `cd server && npx vitest run src/workspace/cast-io.test.ts`
-Expected: PASS (7 tests).
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add server/src/workspace/cast-io.ts server/src/workspace/cast-io.test.ts
-git commit -m "feat(server): add cast.json staleness detection for cross-scope writers"
-```
-
----
-
-### Task 4: #2001 — the lock helpers' map cleanup has never run
+### Task 3: #2001 — the lock helpers' map cleanup has never run
 
 **Files:**
 - Modify: `server/src/workspace/file-lock.ts`
@@ -688,7 +479,7 @@ Add the accessor to `file-lock.ts`:
 
 ```ts
 /** Test-only: the number of live chain entries. Used to pin the cleanup in
- *  Task 4 — NOT a partition detector (design §10.3 explains why that idea was
+ *  Task 3 — NOT a partition detector (design §10.3 explains why that idea was
  *  rejected). */
 export function __chainsSizeForTest(): number {
   return chains.size;
@@ -756,7 +547,7 @@ git commit -m "fix(server): make the promise-chain lock helpers actually free th
 
 ---
 
-### Task 5: `POST /:voiceUuid/assign` — the filed defect (#1981)
+### Task 4: `POST /:voiceUuid/assign` — the filed defect (#1981)
 
 **Files:**
 - Modify: `server/src/routes/voice-library.ts` (the `POST /:voiceUuid/assign` handler)
@@ -823,10 +614,10 @@ Three changes to the handler:
    cast read. The library-voice lock opens **before `readEntry`** and closes
    after the cast write.
 
-   This is what makes Task 6 deterministic. `eraseLibraryVoiceArtifacts` deletes
+   This is what makes Task 5 deterministic. `eraseLibraryVoiceArtifacts` deletes
    the entry directory, so with the 404 gate *inside* the lock a delete-first
    ordering makes the assign 404 cleanly; with it outside, the assign proceeds on
-   an entry that is being erased underneath it and Task 6's assertion becomes a
+   an entry that is being erased underneath it and Task 5's assertion becomes a
    coin flip.
 
    Order matters and is not arbitrary: the DELETE path holds the library-voice
@@ -857,7 +648,7 @@ git commit -m "fix(server): serialise the voice-library assign cast.json read-mo
 
 ---
 
-### Task 6: `DELETE /:voiceUuid` — close the erase-vs-assign race
+### Task 5: `DELETE /:voiceUuid` — close the erase-vs-assign race
 
 **Files:**
 - Modify: `server/src/routes/voice-library.ts` (the `DELETE /:voiceUuid` handler)
@@ -895,7 +686,7 @@ Expected: FAIL — reference present and artifacts erased.
 - [ ] **Step 3: Wrap scan → clear → erase in the library-voice lock**
 
 Open `withLibraryVoiceLock(voiceUuid, …)` **before `readEntry` and its 404** —
-symmetric with Task 5's assign side — and close it after
+symmetric with Task 4's assign side — and close it after
 `eraseLibraryVoiceArtifacts`, spanning `scanLibraryVoiceUsage` and
 `clearLibraryVoiceReferences`.
 
@@ -906,7 +697,7 @@ concurrent DELETEs are harmless in practice (the second erases nothing), but the
 `high`-effort code-review gate will read an unreasoned exception as exactly that,
 and symmetry costs nothing.
 
-Task 5 already made `/assign` take the same key, which is what makes this bite.
+Task 4 already made `/assign` take the same key, which is what makes this bite.
 
 In `voice-library-usage.ts`, `clearLibraryVoiceReferences` takes a
 `withCastLock` per book **inside** its loop and **re-reads** the cast in there —
@@ -934,7 +725,7 @@ git commit -m "fix(server): hold a library-voice lock across voice delete scan, 
 
 ---
 
-### Task 7: Class 1 — the mechanical single-book sites
+### Task 6: Class 1 — the mechanical single-book sites
 
 **Files (15 sites across 11 modules):**
 - `cast-aliases.ts` ×3, `cast-create.ts`, `cast-merge.ts`, `cast-series-patch.ts`,
@@ -944,12 +735,12 @@ git commit -m "fix(server): hold a library-voice lock across voice delete scan, 
   `voice-library.ts` (`DELETE /assign`)
 - Plus each module's colocated `*.test.ts`
 
-`voice-library.ts`'s `POST /assign` (Task 5), `voice-library-usage.ts` (Task 6)
-and `qwen-voice.ts`'s `promote-voice` (Task 8) are **not** in this task.
+`voice-library.ts`'s `POST /assign` (Task 4), `voice-library-usage.ts` (Task 5)
+and `qwen-voice.ts`'s `promote-voice` (Task 7) are **not** in this task.
 
 - [ ] **Step 1: Write one failing test per module, plus the cross-module spec**
 
-Use the Task 5 shape: two concurrent requests to that route, each touching a
+Use the Task 4 shape: two concurrent requests to that route, each touching a
 different character, assert both survive. One module registry per spec file.
 
 **Additionally, one cross-module spec — this is a required deliverable.** Race
@@ -971,7 +762,7 @@ alongside the primitive harness, not in either route's spec.
   route.
 - **`book-state.ts`** — its cast slice writes `body.patch` wholesale and is
   last-writer-wins **by contract**, so "two PUTs, different characters, both
-  survive" stays red after the lock too. (Task 12 already reasons this out for
+  survive" stays red after the lock too. (Task 11 already reasons this out for
   its own test and picks a different writer; the same reasoning applies here.)
   What the lock actually protects is the **clone-consent guards** inside
   `preserveDesignedVoices`. The red→green test is: a cast PUT whose patch omits a
@@ -986,13 +777,12 @@ Run: `cd server && npx vitest run src/routes/cast-aliases.test.ts src/routes/cas
 Expected: each new test FAILS.
 
 (`voice-library.test.ts` is in the list for the `DELETE /assign` site only —
-`POST /assign` was Task 5.)
+`POST /assign` was Task 4.)
 
-**Arithmetic check.** 15 sites here + 1 (Task 5, `POST /assign`) + 1 (Task 6,
-`voice-library-usage`) + 1 (Task 8, `promote-voice`) + 8 (Task 9) + 2 (Task 10)
-+ 2 (Task 11) = **30**, plus `analysis.ts`'s 5 in Task 14 = **35**. Every site is
-covered; nothing is deferred. If your count differs, stop — the spec's §5
-enumeration is the authority.
+**Arithmetic check.** 15 sites here + 1 (Task 4, `POST /assign`) + 1 (Task 5,
+`voice-library-usage`) + 1 (Task 7, `promote-voice`) + 8 (Task 8) + 2 (Task 9)
++ 2 (Task 10) = **30 locked**, plus `analysis.ts`'s 5 deferred to #2015 = **35**.
+If your count differs, stop — the spec's §5 enumeration is the authority.
 
 - [ ] **Step 3: Wrap each read..write span**
 
@@ -1000,10 +790,8 @@ Exemplar — `cast-aliases.ts`, which every other site in this task mirrors:
 
 ```ts
 return withCastLock(bookDir, async () => {
-  /* Plain readJson/writeJsonAtomic, INSIDE the lock. cast-io.ts's staleness
-     helpers are for the cross-scope sites only (Tasks 14-16) — here the read and
-     the write are in one lock scope, so nothing can interleave and a staleness
-     check would be inert. */
+  /* The read is INSIDE the lock, not just the write. That is the whole point:
+     wrapping only the write buys nothing (design §4 rule 2). */
   const cast = await readJson<CastFile>(castJsonPath(bookDir));
   if (!cast?.characters?.length) {
     return res.status(409).json({ error: 'Book has no cast on disk yet. …' });
@@ -1097,7 +885,7 @@ in-progress edits into this commit — a recurring incident in this repo.
 
 ---
 
-### Task 8: `promote-voice` — narrow the lock, do not wrap the span
+### Task 7: `promote-voice` — narrow the lock, do not wrap the span
 
 **Files:**
 - Modify: `server/src/routes/qwen-voice.ts` (`promote-voice`)
@@ -1187,7 +975,7 @@ git commit -m "fix(server): re-read cast.json under a narrow lock in promote-voi
 
 ---
 
-### Task 9: Class 2 — multi-book sites, plus the `library-cast-override` same-book bug
+### Task 8: Class 2 — multi-book sites, plus the `library-cast-override` same-book bug
 
 **Files:**
 - Modify: `cast-link-prior.ts` (2 sites), `cast-not-linked-to.ts` (4 sites),
@@ -1249,7 +1037,7 @@ git commit -m "fix(server): lock multi-book cast writes in sorted order and fix 
 
 ---
 
-### Task 10: Class 3 — `voices.ts`'s two fan-out branches
+### Task 9: Class 3 — `voices.ts`'s two fan-out branches
 
 **Files:**
 - Modify: `server/src/routes/voices.ts` (`forEachMatchingCastCharacter`)
@@ -1273,7 +1061,7 @@ Both branches write, and **both need locking**:
   in the workspace across a full directory scan (spec §3.2).
 
 Rule 1 check: `forEachMatchingCastCharacter` is now a locked leaf, so no caller
-may wrap it in a cast lock for the same book. Task 11 depends on this.
+may wrap it in a cast lock for the same book. Task 10 depends on this.
 
 - [ ] **Step 4: Run, mutation-verify both branches separately, commit.**
 
@@ -1284,7 +1072,7 @@ git commit -m "fix(server): lock each book of the voices fan-out as it is writte
 
 ---
 
-### Task 11: Class 4 — the `qwen-voice.ts` re-entrancy restructure
+### Task 10: Class 4 — the `qwen-voice.ts` re-entrancy restructure
 
 **Files:**
 - Modify: `server/src/routes/qwen-voice.ts`
@@ -1293,7 +1081,7 @@ git commit -m "fix(server): lock each book of the voices fan-out as it is writte
 
 The highest-risk task. Both functions have two branches; only the **book-scoped**
 one takes a cast lock. The **series** branch delegates to
-`forEachMatchingCastCharacter`, which after Task 10 locks per book itself —
+`forEachMatchingCastCharacter`, which after Task 9 locks per book itself —
 wrapping it here would violate rule 1 and self-deadlock the moment the walk
 reaches this book.
 
@@ -1351,7 +1139,7 @@ git commit -m "fix(server): lock the book-scoped voice-uuid and emotion-variant 
 
 ---
 
-### Task 12: Class 6 — the two delete sites
+### Task 11: Class 6 — the two delete sites
 
 **Files:**
 - Modify: `server/src/routes/analysis.ts` (the "Start fresh" `rm`)
@@ -1369,8 +1157,7 @@ awaits `prior` before `fn()`, so under rule 2 a queued writer's *read* happens
 after the holder's write. Do not reintroduce the claim.)
 
 **This task touches only the `rm`.** `analysis.ts`'s five *write* sites are
-converted in Task 14, not here — keep the two changes separate so each is
-reviewable on its own.
+out of scope for this PR (#2015). Touch the `rm` and nothing else.
 
 - [ ] **Step 1: Write the failing test** — a delete concurrent with a cast write;
   assert the file stays deleted.
@@ -1394,7 +1181,7 @@ git commit -m "fix(server): take the cast lock when deleting cast.json"
 
 ---
 
-### Task 13: The guard test
+### Task 12: The guard test
 
 **Files:**
 - Create: `server/src/workspace/cast-lock.guard.test.ts`
@@ -1407,21 +1194,25 @@ Walk `server/src/**/*.ts` (excluding `*.test.ts`). For each file containing
 scope.
 
 **Use a brace-depth scan, and say so.** For each occurrence, walk backwards to
-the nearest enclosing `withCastLock(` / `withCastLocks(` / `withSeriesLock(`
-call and confirm the occurrence is inside its brace range. A file-level
+the nearest enclosing `withCastLock(` / `withCastLocks(` call and confirm the
+occurrence is inside its brace range. Accept **only** those two —
+`withLibraryVoiceLock` is a different key in the same map, so a cast write
+enclosed by it and no cast lock is not serialised against the other 34 writers,
+and accepting it would make the guard green on exactly the regression it exists
+to catch. A file-level
 heuristic ("does this module mention `withCastLock`?") is not sufficient — it
 cannot resolve *per-occurrence* lockedness, which is exactly what a 6000-line
 module like `analysis.ts` requires, and a guard that cannot do that is
 decorative.
 
 **Acceptance target, stated concretely:** on the finished branch the guard
-reports **zero** unlocked occurrences in every file, including `analysis.ts`
-(whose five writes are revision-checked and locked by Task 14). Maintain an
-explicit allowlist with a reason per entry:
+reports exactly `analysis.ts: 5 unlocked writes, 0 unlocked rms` and zero
+unlocked occurrences everywhere else. Maintain an explicit allowlist with a
+reason per entry:
 
 ```ts
 /* Empty by design. Every cast.json write and delete in the tree is locked and
-   revision-checked after Task 14, so there is nothing to exempt.
+   deferred to #2015, so the entry above is the only exemption.
 
    An earlier draft carried an allowlist entry for analysis.ts's five deferred
    writes. Keep this map empty rather than deleting the mechanism: if a future
@@ -1429,15 +1220,17 @@ explicit allowlist with a reason per entry:
    on file alone — a file-level exemption for analysis.ts would also have
    blinded the guard to the one rm that IS locked, which is the exact hole spec
    §5 class 6 exists to close. */
-const ALLOWED_UNLOCKED = new Map<string, { writes: number; rms: number; why: string }>();
+const ALLOWED_UNLOCKED = new Map([
+  ['routes/analysis.ts', { writes: 5, rms: 0, why: 'merge-base writes deferred to #2015; the rm IS locked (Task 11)' }],
+]);
 ```
 
-The guard checks **lockedness only**. It must NOT also require
-`writeCastChecked`: that rule belonged to the revision-counter design, whose
-soundness depended on universal adoption, and it would fail on `cast-io.ts`
-itself — the sanctioned helper writes `writeJsonAtomic(castJsonPath(...))` inside
-no lock scope, because its callers hold the lock. Exclude `workspace/cast-io.ts`
-from the walk by name, with that reason in a comment.
+The guard checks **lockedness only** — is each occurrence inside a
+`withCastLock` / `withCastLocks` scope. Accept **only** those two.
+`withLibraryVoiceLock` is a different key in the same map, so a cast write
+enclosed by it and no cast lock is not serialised against the other 34 writers;
+accepting it would make the guard green on exactly the regression it exists to
+catch.
 
 Document the known blind spots in the file header: it sees one syntactic form, so
 `const p = castJsonPath(dir); await writeJsonAtomic(p, …)` slips through, as
@@ -1466,355 +1259,7 @@ git commit -m "test(server): fail the build on an unlocked cast.json write"
 
 ---
 
-### Task 14: `analysis.ts` — a revision-checked merge base (closes #2015)
-
-**Files:**
-- Modify: `server/src/routes/analysis.ts` (the 5 cast writes; **not** the `rm`,
-  which Task 12 did)
-- Modify: `server/src/routes/analysis.test.ts`
-
-`priorCastForMerge` is read once near the top of a run and is the merge base for
-writes minutes later. Holding a lock for the run was rejected (blocks every other
-cast write on that book, unbounded); re-reading blind was rejected (iteration N
-would merge against what N−1 wrote, degrading srv-13 carry-forward). The counter
-is the third option: **keep replaying the snapshot, but check it, and overlay
-concurrent edits only when it actually moved.**
-
-> **Read spec §14.4 before writing any code in this task.** The obvious
-> implementation re-breaks the 2026-07-14 Coalfall voice-strip on *every* "Start
-> fresh" run, and the obvious test does not catch it.
-
-- [ ] **Step 1: Write BOTH failing tests**
-
-The second one is the important one.
-
-```ts
-it('does not discard a cast edit made during an analysis run', async () => {
-  /* Assert on ALIASES, not on `name`. mergeAnalysisResultWithExistingCast
-     overlays the base's VOICE-DESIGN fields onto the freshly-analysed roster and
-     UNIONS aliases (see its docstring) — `name` comes from the fresh analysis,
-     which re-derives it from the manuscript. A name assertion cannot go green on
-     a correct implementation, and "fixing" it would mean weakening the test or
-     changing merge semantics. */
-  const run = startAnalysis(bookId);
-  await waitForFirstInterimWrite();
-  await request(app).post('/api/cast/aliases')
-    .send({ bookId, characterId: 'alice', alias: 'The Coalfall Widow' });
-  await run;
-  const cast = await readJson<CastJson>(castJsonPath(bookDir));
-  expect(cast?.characters?.find((c) => c.id === 'alice')?.aliases)
-    .toContain('The Coalfall Widow');
-});
-
-it('keeps bespoke designed voices across a Start-fresh re-analysis', async () => {
-  /* THE regression guard for the 2026-07-14 Coalfall voice-strip. Start fresh
-     rm's cast.json, which resets the on-disk rev to 0 — so a rev captured
-     alongside priorCastForMerge (i.e. ABOVE the rm) guarantees a conflict on the
-     first interim write, and a rebuild that re-reads the deleted file gets an
-     empty base. mergeAnalysisResultWithExistingCast short-circuits on an empty
-     base and returns the fresh roster unmerged: every designed voice gone.
-     This test fails on that implementation and passes on the correct one. */
-  await giveCharacterADesignedVoice(bookDir, 'alice');
-  await runAnalysis(bookId, { fresh: true });
-  const cast = await readJson<CastJson>(castJsonPath(bookDir));
-  const alice = cast?.characters?.find((c) => c.id === 'alice');
-  expect(alice?.overrideTtsVoices?.qwen?.name).toBeDefined();
-});
-```
-
-- [ ] **Step 2: Run to verify both fail**
-
-Run: `cd server && npx vitest run src/routes/analysis.test.ts -t "cast edit made during"`
-Run: `cd server && npx vitest run src/routes/analysis.test.ts -t "Start-fresh"`
-
-The second must be verified red against a **deliberately wrong** implementation:
-rebuild by plain re-read (base = whatever is on disk). If
-it passes there, the test is not pinning what it claims and the whole task is
-unguarded.
-
-- [ ] **Step 3: Fingerprint with the snapshot; never rebuild to an empty base**
-
-Three requirements, from spec §14.4:
-
-1. **Capture the fingerprint from the same read as `priorCastForMerge`** — same
-   bytes, same instant, nothing between them. This is where the revision-counter
-   design failed: a counter needs a separate capture step, and the yields between
-   the snapshot read and any post-`rm` capture point (`pruneStaleReuseLinks`,
-   `loadAnalysisCache`) were a hole a concurrent writer could land in.
-2. **The rebuild may never replace a non-empty prior with an empty base.** When
-   the re-read is empty, the retained `priorCastForMerge` *is* the base. The
-   rebuild overlays concurrent edits onto the prior; it never substitutes.
-3. **Re-apply the load-point healers on the rebuild path** —
-   `dropReuseContinuityKeepDesignedVoice`, `pruneStaleReuseLinks`,
-   `dedupePriorCastByName`, `seedReuseGuardsFromPriorCast`,
-   `applyRewriteToPriorCast`. Their comment says they run "at the single load
-   point, so all cast.json write sites see one prior row per name"; a rebuild
-   that skips them reintroduces the duplicate-by-name rows they collapse.
-
-Shape for each of the five writes — read, decide and write in **one** lock
-acquisition, so `writeCastChecked` cannot conflict and there is no retry loop:
-
-```ts
-await withCastLock(bookDir, async () => {
-  const { cast: onDisk, fingerprint } = await readCastForUpdate<CastFile>(bookDir);
-  const base =
-    fingerprint === capturedFingerprint
-      ? priorCastForMerge
-      : rebuildBase(priorCastForMerge, onDisk.characters ?? []);
-  capturedFingerprint = await writeCastChecked(
-    bookDir,
-    { ...onDisk, characters: mergeAnalysisResultWithExistingCast(base, freshRows) },
-    fingerprint,
-  );
-});
-```
-
-`rebuildBase(prior, current)` returns `prior` unchanged when `current` is empty,
-and otherwise overlays `current`'s rows onto `prior` by id — preserving `prior`'s
-voice fields wherever `current` lacks them — then re-runs the healers.
-
-**A conflict must never fail the run.** A user renaming a character mid-analysis
-is normal. Log the rebuild at info so it is observable.
-
-- [ ] **Step 4: Run, mutation-verify, commit**
-
-Mutation-verify by replacing the rebuild path with a plain re-read (base =
-whatever is on disk) and confirming the Start-fresh test goes red. Paste that
-output into the commit message.
-
-```bash
-git add server/src/routes/analysis.ts server/src/routes/analysis.test.ts
-git commit -m "fix(server): rebuild the analysis merge base when cast.json moved under it"
-```
-
----
-
-### Task 15: The three clone-consent gates (closes #2006, part 1)
-
-**Files:**
-- Modify: `server/src/routes/voices.ts`, `server/src/routes/single-design.ts`,
-  `server/src/routes/qwen-voice.ts`
-- Modify: their `*.test.ts`
-
-Each reads cast.json, decides a 409, and writes in a different scope. Spec §14.2
-gives one rule in three shapes — this task applies it.
-
-- [ ] **Step 1: Write the failing tests** — one per gate: take the 409 decision,
-  plant a cloned slot before the write lands, assert the write does not silently
-  overwrite it.
-
-- [ ] **Step 2: Run to verify all three fail.**
-
-- [ ] **Step 3: Thread the revision through each**
-
-- **`voices.ts` `PUT /:voiceId/override`** — `hasClonedSlotAmongMatches` records
-  each matching book's rev as it walks. Note it **early-returns `true`** on the
-  refusal path, so it does not walk the full set then; only the pass path yields
-  a complete rev map.
-
-  At write time, per book: if the fingerprint is unchanged, write. If it moved,
-  **re-run the clone-consent predicate on the fresh read** — if the book is still
-  clean, adopt the new fingerprint and continue; only a *newly planted cloned slot* is a
-  genuine refusal. Aborting on any change would turn a whole-workspace override
-  from an operation that always completes into one that fails at the
-  concurrent-edit rate, and its failure state — the new voice in some books, the
-  old in others — is the exact split the propagation exists to prevent.
-
-  On a genuine refusal: `409 { code: 'cast-changed', written: [...] }` naming the
-  books already written. **Partial application is reported, not prevented** —
-  cross-book atomicity needs the workspace-wide lock §3.2 rejected (§14.3).
-- **`single-design.ts`** — records the fingerprint at its `characterHasClonedSlot` gate;
-  `runSingleDesign` passes it through to the write. It has already flushed SSE
-  headers, so a conflict cannot 409: log it, skip the write, and surface it in
-  `endJob({ type: 'error', code: 'cast-changed' })`.
-- **`qwen-voice.ts`** — same, through `persistEmotionVariant`. Add an optional
-  `expectedFingerprint` parameter: the JSON route passes it and maps a conflict to a 409;
-  the SSE bulk caller passes it and reports via `endJob`. **Do not** make the
-  helper decide which — it has two callers with two response channels, and that
-  is exactly why §6 rejected a blanket 409.
-
-**The `forEachMatchingCastCharacter` signature change belongs in Task 10, not
-here.** It is the function that actually performs both writes (`:801` fast path,
-`:828` walk), and it has five callers — `applyOverrideToCastFiles`,
-`applyTierToCastFiles` (from `cast-tier.ts`), `persistEmotionVariant` and
-`ensureCharacterVoiceUuid` — three of which have no rev to supply. Add
-`expectedFingerprints?: Map<string, string | null>` there, defaulting to "no
-assertion" when a book is absent from the map, so Task 10 lands the signature and
-this task only populates it.
-
-- [ ] **Step 4: Run, mutation-verify each gate separately, commit**
-
-```bash
-git add server/src/routes/voices.ts server/src/routes/single-design.ts \
-  server/src/routes/qwen-voice.ts server/src/routes/voices.test.ts \
-  server/src/routes/single-design.test.ts server/src/routes/qwen-voice.test.ts
-git commit -m "fix(server): revision-check the clone-consent gates before their writes"
-```
-
----
-
-### Task 16: The three cross-book consultations (closes #2006, part 2)
-
-**Files:**
-- Modify: `server/src/routes/cast-link-prior.ts`,
-  `server/src/routes/voice-override-linked.ts`,
-  `server/src/routes/cast-series-patch.ts`,
-  `server/src/routes/cast-add-from-roster.ts`
-- Modify: their `*.test.ts`
-
-All three derive something from **another book's** cast and write it elsewhere:
-`cast-link-prior` copies the target's `overrideTtsVoices` (including a
-`libraryUuid` it never names) into the source; `voice-override-linked` derives
-`canonicalVoiceId`, `sourceTokens`, `inGroup` and its whole `writes` list from
-the source snapshot; `cast-series-patch` derives `sourceChar` and `targets` the
-same way.
-
-- [ ] **Step 1: Write the failing tests** — mutate the consulted book between the
-  read and the write; assert the operation detects it rather than writing a
-  decision made against data that no longer exists.
-
-- [ ] **Step 2: Run to verify all three fail.**
-
-- [ ] **Step 3: Record and assert the consulted revision**
-
-Each records the fingerprint of every book it *reads to decide*, not only the ones it
-writes. The consulted book is asserted with **`assertCastUnchanged`** (Task 3) while
-its lock is held via `withCastLocks`; the written book is asserted by
-`writeCastChecked` as usual. `writeCastChecked` alone cannot do this — it asserts
-only the book it writes, which is not the book these sites consulted.
-
-A conflict is a `409 { code: 'cast-changed' }` — all are HTTP handlers that have
-not responded yet, so the refusal is expressible.
-
-**Include `cast-add-from-roster.ts`.** It reads the target book to decide a
-source write, which is the same shape, and spec §12 claims it is closed by §14 —
-so either it is converted here or that claim is false. It is the fourth file in
-this task.
-
-`cast-link-prior` is the one that also closes a `library-voice` hole: it plants
-references to uuids it cannot know up front, so it cannot take that key. The
-revision check is what makes the plant safe instead.
-
-- [ ] **Step 4: Run, mutation-verify, commit**
-
-```bash
-git add server/src/routes/cast-link-prior.ts server/src/routes/voice-override-linked.ts \
-  server/src/routes/cast-series-patch.ts server/src/routes/cast-link-prior.test.ts \
-  server/src/routes/voice-override-linked.test.ts server/src/routes/cast-series-patch.test.ts
-git commit -m "fix(server): revision-check the cross-book cast consultations"
-```
-
----
-
-### Task 17: The series lock — the cross-book double-mint (closes #2006, part 3)
-
-**Files:**
-- Modify: `server/src/workspace/cast-lock.ts` (add `withSeriesLock`)
-- Modify: `server/src/workspace/cast-lock.test.ts`
-- Modify: `server/src/routes/qwen-voice.ts` (`ensureCharacterVoiceUuid`)
-- Modify: `server/src/routes/qwen-voice.test.ts`
-
-The one residual §14's staleness check provably cannot reach. Two bulk designs on
-two books of one series each read their **own** book, each see no `voiceUuid`,
-each mint. The propagation then re-reads every book under its own lock, so every
-write is against a current revision and is therefore "valid" — the staleness is
-in a decision taken **before any file is read**, and no per-file counter can
-encode it.
-
-- [ ] **Step 1: Write the failing test**
-
-```ts
-it('mints one voiceUuid when two books of a series design the same identity', async () => {
-  /* Both books carry the same linked identity (voiceId ?? id). Concurrent bulk
-     designs each mint today, and the series ends up split across two uuids. */
-  await Promise.all([
-    ensureCharacterVoiceUuid(bookADir, 'narrator', seriesFilter),
-    ensureCharacterVoiceUuid(bookBDir, 'narrator', seriesFilter),
-  ]);
-  const a = await readJson<CastFile>(castJsonPath(bookADir));
-  const b = await readJson<CastFile>(castJsonPath(bookBDir));
-  const uuidA = a?.characters?.find((c) => c.id === 'narrator')?.voiceUuid;
-  const uuidB = b?.characters?.find((c) => c.id === 'narrator')?.voiceUuid;
-  expect(uuidA).toBeDefined();
-  expect(uuidA).toBe(uuidB);
-});
-```
-
-- [ ] **Step 2: Run to verify it fails**
-
-Expected: FAIL — two different uuids.
-
-**This test is only reliably red after Task 10 lands.** Today the two
-propagations race whole-file and one usually wins outright, so both books often
-converge on a single uuid and the test is green for the wrong reason. Per-book
-locking (Task 10) is what makes the split observable. Task 1's determinism
-measurement does not transfer here — that was two reads issued in one tick, and
-this is two nested workspace walks. If it is flaky, drive the two calls through a
-barrier rather than weakening the assertion.
-
-- [ ] **Step 3: Add `withSeriesLock` and wrap the series branch**
-
-```ts
-/** Hold the series lock for one author/series pair.
- *
- *  Position in the global order: design -> SERIES -> library-voice -> cast.
- *  Exists for one reason — every design gate keys on bookDir (withDesignLock,
- *  isDesignBusy, cast-design's inFlightByBook) while a linked-cast propagation
- *  is series-wide, so two books of one series can each decide "no voiceUuid
- *  yet" and each mint. That decision precedes any file read, so the cast.json
- *  staleness check cannot see it — there is no file whose content encodes it. */
-export function withSeriesLock<T>(
-  author: string,
-  series: string,
-  fn: () => Promise<T>,
-): Promise<T> {
-  /* Encode both components — neither can contain '/' on disk today (both are
-     directory names under BOOKS_ROOT), but §3.1 insists key derivation be
-     unambiguous rather than incidentally safe. */
-  return withKeyLock(`series:${encodeURIComponent(author)}/${encodeURIComponent(series)}`, fn);
-}
-```
-
-**Wrap the whole function body, not "the series branch".** The `voiceUuid` check
-and the mint sit *above* the branch (spec §5.1); the series branch contains only
-the propagation. Wrapping the branch would leave both racers deciding and minting
-outside the lock and serialise two propagations of two *different* uuids — the
-split-uuid outcome unchanged, under a lock that reads as the fix.
-
-```ts
-return withDesignLock(bookDir, () =>
-  seriesFilter
-    ? withSeriesLock(seriesFilter.author, seriesFilter.series, body)
-    : body(),
-);
-```
-
-where `body` is the existing read → decide → mint → propagate. Standalone books
-take the book-scoped path and need no series key.
-
-Ordering: the call already sits inside `withDesignLock` (`qwen-voice.ts:193`) and
-the propagation takes cast locks, so this becomes `design → series → cast` —
-consistent with rule 4, not a new constraint on it. Add a primitive test pinning
-that a series lock may be taken while a design lock is held but never the
-reverse.
-
-- [ ] **Step 4: Run the full server suite**
-
-Run: `cd server && npm run test:server && npm run test:server-slow`
-Expected: PASS. Like Task 11, this task can hang rather than fail an assertion —
-if a spec times out, suspect a series lock taken while a cast lock is held.
-
-- [ ] **Step 5: Mutation-verify, commit**
-
-```bash
-git add server/src/workspace/cast-lock.ts server/src/workspace/cast-lock.test.ts \
-  server/src/routes/qwen-voice.ts server/src/routes/qwen-voice.test.ts
-git commit -m "fix(server): mint a series voiceUuid under a series lock"
-```
-
----
-
-### Task 18: Docs, notes and ticket hygiene
+### Task 13: Docs, notes and ticket hygiene
 
 **Files:**
 - Create: `docs/features/<n>-cast-json-write-lock.md` (from `docs/features/TEMPLATE.md`)
@@ -1834,15 +1279,16 @@ This is substantial cross-cutting work introducing a codebase-wide invariant, so
 it needs a durable `docs/features/` plan, not just the issue bodies. Scan the
 worktrees for the next free plan number first (concurrent sessions claim them).
 Record: the invariant and its four rules, the four lock classes and their order,
-all 35 locked sites, the staleness check and what it does *not* reach (the
-client full-document PUT), and a manual acceptance walkthrough.
+the 30 locked sites, what is deliberately NOT covered (`analysis.ts`'s merge
+base and the clone-consent gates, #2015/#2006, with the four failed designs
+linked), and a manual acceptance walkthrough.
 
 **Pick the walkthrough carefully.** "Two browser tabs editing one book's cast,
 both edits surviving" describes `PUT /:bookId/state`, which writes the client's
-whole characters array and is explicitly outside the counter's reach (spec
-§14.3) — that walkthrough would fail. Use instead: a bulk "Design full cast" job
-running while the user renames a character in another tab; the rename survives
-and the designed voices land.
+whole characters array wholesale and is last-writer-wins by contract — that
+walkthrough would fail, and not because of anything this PR does. Use instead: a
+bulk "Design full cast" job running while the user edits aliases on the same book
+in another tab; both survive.
 
 - [ ] **Step 2: Update `docs/features/INDEX.md` (checklist step 4)**
 
@@ -1851,24 +1297,7 @@ New entry under its area.
 - [ ] **Step 3: Add the convention to CLAUDE.md**
 
 One bullet with the four rules from `cast-lock.ts`'s header, including the
-four-class lock order, and one line pointing at `cast-io.ts` for the revision
-counter.
-
-- [ ] **Step 3b: openapi.yaml and the client retry**
-
-Tasks 15/16 add a new refusal to `PUT /api/voices/{voiceId}/override`,
-`cast-link-prior`, `voice-override-linked` and `cast-series-patch`. `openapi.yaml`
-is the documented source of truth for backend shapes, so:
-
-- Add `409 { code: 'cast-changed' }` to each of those four route blocks. While
-  there, document the two 409s `voices.ts` already returns and never declared.
-- Add the SSE terminal payload `endJob({ type: 'error', code: 'cast-changed' })`
-  for `single-design`.
-- **Handle it client-side.** Spec §14.2 says the caller "retries against fresh
-  state" — that is a claim about behaviour nobody has implemented. Either add the
-  refetch-and-retry in `src/lib/api.ts`, or change §14.2 to say the user sees an
-  actionable error and retries manually. Do not leave the doc asserting a retry
-  the product does not perform.
+three-class lock order.
 
 - [ ] **Step 4: Release notes, both files (checklist step 5)**
 
@@ -1877,10 +1306,10 @@ is the documented source of truth for backend shapes, so:
 user-facing line in brand voice. The user-visible delta is real: concurrent cast
 edits no longer silently discard one another.
 
-Do **not** claim cast.json is *fully* protected. It is not: the counter does not
-survive a delete, and it does not reach the client full-document PUT (spec
-§14.3). Both are properties, not debt — but the release note must not overstate
-them either way.
+Do **not** claim cast.json is *fully* protected. `analysis.ts`'s merge base and
+the clone-consent gates are deliberately out of scope (#2015, #2006), and
+`PUT /:bookId/state` is last-writer-wins by contract. The note should say
+concurrent cast edits no longer discard one another, and stop there.
 
 - [ ] **Step 5: Discharge the remaining checklist steps in the PR body**
 
@@ -1888,23 +1317,22 @@ State each explicitly rather than omitting it:
 
 - **Step 3, on-box acceptance — N/A.** No hardware-only behaviour; every claim
   here is provable in-process by the outcome tests. No register row is owed.
-- **openapi.yaml — REQUIRED, see Step 3b.** Tasks 15 and 16 add
-  `409 { code: 'cast-changed' }` to four documented routes. (This N/A claim was
-  false in an earlier draft, written before those tasks existed.)
-- **Frontend — REQUIRED, see Step 3b.**
+- **openapi.yaml — N/A.** No wire shape changes. (The `409 cast-changed` that a
+  folded staleness layer would have added to four routes went with it to #2006.)
+- **Frontend — N/A.** No component, slice or API-surface change.
 - **e2e — N/A.** The behaviour is server-side concurrency; it crosses no
   router/redux/layout seam, so Playwright cannot observe it. The two-tab
   walkthrough in the regression plan is the manual equivalent.
 
-- [ ] **Step 6: Close the deferred issues, and check nothing new was filed**
+- [ ] **Step 6: Confirm #2006 and #2015 carry their design history**
 
-#2006 and #2015 are closed by this PR (Tasks 14–17), not carried. Before opening
-it, re-read spec §16: what remains in §12 must be **properties of the design**
-(in-process only, `promote-voice`'s pinned `realVoiceId`, per-book propagation
-atomicity, `cast-design`'s pre-LLM idempotency guards) and not outstanding work.
-If any item there reads as a to-do, it either needs a task in this plan or an
-explicit sentence saying why it is inherent. A residual list nobody intends to
-action is the thing this fold exists to remove.
+Both stay open. Each must link the four attempted mechanisms and the reviews
+that killed them, so the next cycle starts from a rich brief. Before opening
+it, re-read spec §12 and §13. Every residual there must be either a property of
+the design (in-process only, `promote-voice`'s pinned `realVoiceId`, per-book
+propagation atomicity, `cast-design`'s pre-LLM idempotency guards) or an item
+carried on #2006/#2015 with its design history attached. Nothing may be a
+to-do that exists only in a spec section.
 
 - [ ] **Step 7: Commit**
 
@@ -1926,6 +1354,8 @@ git commit -m "docs(docs): record the cast.json lock convention and release note
       `cast-lock.ts` is a leaf under `workspace/`; if the count moved, a route
       module was imported from it.
 - [ ] PR body: `Closes #1981`, `Closes #2000`, `Closes #2001`, `Closes #2006`,
-      `Closes #2015`. Declare Task 9's `library-cast-override` same-book fix and
-      Task 4's #2001 fix under "Also fixed, found in passing".
+      `Closes #2015`. Declare Task 8's `library-cast-override` same-book fix and
+      Task 3's #2001 fix under "Also fixed, found in passing".
 - [ ] Mandatory `code-review` pass at `high` effort — multi-scope, 17 modules.
+
+---

--- a/docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md
+++ b/docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md
@@ -1,41 +1,25 @@
 # cast.json write lock — design
 
 **Status:** approved
-**Closes:** #1981 (the filed defect), #2000 (the sweep), #2001 (§11),
-#2006 (§14, §15), #2015 (§14.2) — **nothing is deferred out of this change**
-**Sequencing:** implementation bases on / rebases onto `fix/server-1933-assign-readiness`
+**Closes:** #1981 (the filed defect), #2000 (the sweep), #2001 (§11)
+**Defers:** #2006, #2015 — the cross-scope staleness work, deliberately. Four
+mechanisms were designed for it and none survived review; see §13.
 
-**Scope note (post-review):** §14 and §15 were added after five review rounds,
-on a decision to fold every residual rather than ship a cleanup lane behind this
-PR. They close #2006 and #2015, which earlier drafts deferred. Sections 6, 7 and
-12 are written against the pre-fold scope and are annotated where the fold
-supersedes them — read §14–§16 as the current position.
+**Review:** nine adversarial rounds plus one independent pass by a different
+model. On the lock sweep the trend converged — 3C/8M/3m → 4C/6M/8m → 1C/5M/5m →
+0C/4M/4m on the spec, 2C/8M/6m → 0C/3M/5m on the plan — and the last three rounds
+re-verified its 35-site enumeration and citations clean. On the staleness layer it
+did not converge: four designs, four failures, each passing the round it was
+written in. That asymmetry is why this PR ships one and defers the other.
 
-**Review:** four adversarial passes on the pre-fold scope — 3C/8M/3m, 4C/6M/8m,
-1C/5M/5m, then 0C/4M/4m; a fifth reviewed the plan (2C/8M/6m, all in the plan).
-§14 and §15 postdate all of them and have not yet been through a round. Each round's worst findings landed in whatever the *previous* round had
-just rewritten, which is the main thing to know when reading this document: the
-parts revised most recently are the parts least proven. Round 3 verified ~60
-citations clean; round 4 confirmed the three-class lock order holds across every
-traced path, and that the scope reductions did not hollow the sweep out.
+Two things a reader should carry into the rest of this document:
 
-Two sections were re-decided outright rather than patched. §6 tried "analysis owns
-cast.json" (round 1), then a route-level admission gate (round 2), and now defers
-to #2015 having rejected both — the second survived a full review round before
-failing the next. §7 claimed all four clone-consent gates were folded in (round
-2), then that gate 2 was fixed by a `library-voice` lock (round 3) — which was
-inert, because no *writer* took the key. It now specifies both sides.
-
-The pattern is worth naming: every one of those failures was a design that read
-as coverage while covering nothing. §10's revert-verification and §10.3's
-cross-module outcome spec exist to catch that in the tests; this header exists to
-flag it in the prose.
-
-Round 4 also inverted a claim the first three drafts all carried — that a
-partitioned lock passes tests silently. It does not; partition means no
-contention, which means a lost mutation, which makes the outcome test go **red**
-(§3.1). The countermeasure moved accordingly, from detecting partition to
-covering the one case no self-vs-self race can reach.
+- **The parts revised most recently are the parts least proven.** Every round's
+  worst findings landed in whatever the previous round had just rewritten.
+- **A design that reads as coverage while covering nothing is the recurring
+  failure here**, in the prose and in the tests. §10's revert-verification and
+  §10.3's cross-module outcome spec exist to catch it in the tests; §4's rule-2
+  carve-out criterion exists to catch it in review.
 
 ## 1. What was filed, and what is actually wrong
 
@@ -215,16 +199,11 @@ CLAUDE.md's *Conventions worth preserving*:
    written down, is rule 2's failure mode and not a narrowing.** A reviewer who
    cannot tell which they are looking at should treat it as the failure mode.
 3. **Two or more books → `withCastLocks`, never nested `withCastLock`s.**
-4. **Global lock order: `design` → `series` → `library-voice` → `cast`.** Every
-   acquisition site names where it sits in that order. Never acquire a lock from
-   an earlier class while holding one from a later class.
+4. **Global lock order: `design` → `library-voice` → `cast`.** Every acquisition
+   site names where it sits in that order. Never acquire a lock from an earlier
+   class while holding one from a later class.
 
-Rule 4 covers **four** lock classes. `series:<author>/<series>` is added by §15;
-the existing `design → cast` path (`qwen-voice.ts:193` → `:203`) becomes
-`design → series → cast`, which is consistent with the order rather than a new
-constraint on it.
-
-It covers more than two. The first rewrite stated it over
+Rule 4 covers **three** lock classes, not two. The first rewrite stated it over
 `design` and `cast` only, and §7 then introduced `library-voice:<uuid>` four
 sections later — leaving a rule that would read as satisfied by an ordering it
 had never considered. Concretely, the `DELETE /voice-library/:voiceUuid` path
@@ -497,15 +476,8 @@ interim cast iteration N−1 wrote, so `mergeAnalysisResultWithExistingCast` wou
 no longer merge against the pre-run cast and srv-13's voice/reuse carry-forward
 would silently degrade.
 
-> **Superseded by §14.2.** This section records why the two *lock-based*
-> mitigations were rejected, which is still the reasoning that rules them out.
-> The conclusion — that `analysis.ts` ships unprotected — no longer holds: §14's
-> §14's staleness check closes it without either mitigation, by checking the merge
-> base at each write instead of trying to keep it valid across the run. #2015 is
-> closed by this PR.
-
-**Decision at the time: `analysis.ts` is out of scope. Its five writes stay
-unprotected, recorded as a named residual and filed as #2015.**
+**Decision: `analysis.ts` is out of scope for this PR. Its five writes stay
+unprotected, recorded as a named residual (§12) and carried on #2015.**
 
 Two mitigations were designed and both rejected. They are recorded because each
 looked obviously right at the time, and the second survived a full review round
@@ -614,14 +586,7 @@ This also sequences `voice-library-usage.ts:113` (§5 class 1), since
 `walkConfirmedCasts` is shared between `clearLibraryVoiceReferences` and this
 gate's `scanLibraryVoiceUsage`.
 
-> **Superseded by §14.** Gates 1, 3 and 4 were filed rather than fixed because
-> the open question was what a refusal *means* for a partially-applied cross-book
-> propagation and for a detached job. §14.2 answers exactly that, generically:
-> recompute where you can, 409 where you can, report-and-skip where you can do
-> neither. #2006 is closed by this PR. The analysis below stands — it is why a
-> per-book cast lock alone was never going to be the mechanism.
-
-**Filed at the time as #2006** — one issue, not three. They are the
+**Filed as #2006** — one issue, not three. They are the
 fs-38 Wave 3c clone-consent guards, added because "Phase 0 fixed seven live bugs
 that all had the same shape — a guard-less write erasing a clone marker upstream
 of a resolver" (`voices.ts:888-893`). The real work in each is deciding what a
@@ -835,315 +800,94 @@ the code.
 
 ## 12. Residual risks, accepted
 
-> **Re-scoped by §16.** With §14 and §15 folded in, the items below that were
-> *outstanding work* are closed. What remains is a description of the design's
-> **properties** — things that would need a different approach to change, not a
-> queue. Entries superseded by the fold are marked inline.
+Two different things, kept apart because a reader will otherwise conflate them.
 
-- **No bound on hold time or wait time.** `withKeyLock` (`file-lock.ts:7-19`) has
-  no timeout, no queue cap and no diagnostic for a long-held key. (It *is* FIFO by
-  construction — a promise chain — so waiters are ordered fairly; the first
-  rewrite's "no fairness guarantee" was wrong and contradicted §10.5's own
-  waiter-ordering test.) A slow or wedged holder turns every cast write on that
-  book into an unbounded hang. Today those requests race and one loses a
-  mutation; after this change they wait. That trade is why §6 keeps analysis —
-  the only multi-minute writer — off the mutex entirely, and why §5 narrows
-  `promote-voice`'s lock to exclude its sidecar `fetch`. **With those two
-  exclusions**, expected hold time everywhere is one file read plus one file
-  write. Without them the claim is false, which is how it read before round 3.
+### 12.1 Properties of the design
 
-  A warn-after-N-seconds log was considered and **dropped**. `withKeyLock` has
-  five existing non-cast callers (`book-state.ts:1588`, and
-  `workspace/script-review-ledger.ts:83`/`:105`/`:131`/`:143`), so a timer per acquisition
-  is a behaviour change to all of them, and a non-`unref()`d one would hold the
-  event loop open on what is about to become the hottest lock in the product —
-  in a repo whose flake register already tracks tinypool worker-exit failures.
-  Speculative diagnostics on a shared primitive are not worth that.
-- ~~**`analysis.ts`'s five writes are not protected.**~~ **Closed by §14.2** —
-  the merge base is now revision-checked at each write and rebuilt when it has
-  moved, rather than replayed. #2015 closed.
-- ~~**`cast-link-prior.ts:239-241` plants `libraryUuid` references it never
-  names.**~~ **Closed by §14** — it records the target's revision at read and
-  asserts it at write, so a reference planted from a snapshot that has since
-  moved is detected rather than written blind.
-- ~~**Cross-book concurrent series designs can double-mint a `voiceUuid`.**~~
-  **Closed by §15** — the mint decision moves under a `series:<author>/<series>`
-  key. This is the one item §14 provably could not reach, since
-  the staleness is in a decision taken before any file is read.
-- ~~**Three cross-book check-then-act consultations survive.**~~ **Closed by
-  §14** — each records the revision of every book it consulted and asserts it at
-  write time. Retained here because the three sites are where the counter has to
-  be threaded, and they are easy to miss:
-  - `cast-add-from-roster.ts` reads the target book to decide a source write;
-  - `voice-override-linked.ts` reads the **source** cast and derives
-    `canonicalVoiceId`, `sourceTokens`, the `inGroup` predicate and the entire
-    `writes` list from that snapshot, then writes **other** books via
-    `applyToBook`;
-  - `cast-series-patch.ts` reads the source cast, derives `sourceChar` and the
-    `targets` list, additionally reads other books via
-    `scanSeriesCharactersForBookId`, then writes per book.
+True of the chosen approach. Changing any of them means choosing a different
+approach, not fixing a bug.
 
-  The latter two are the worse pair — they carry *data and grouping* derived from
-  a stale cross-book snapshot into writes in other books, where
-  `cast-add-from-roster` carries only a decision. A per-book lock closes none of
-  the three. Added to **#2006**.
-- **`promote-voice`'s `realVoiceId` is pinned to its pre-lock read** (§5), so a
-  concurrent write that changes `voiceUuid` mid-promotion leaves the artifacts
-  named for the old uuid.
-- **`cast-design.ts`'s two sites keep stale idempotency decisions.** Its
-  `continue` guards are evaluated against the first read, before an LLM persona
-  generation, and the lock covers only the later re-read and write — so two
-  concurrent runs can each generate a persona and the second overwrites the
-  first.
-- **In-process only.** Two server processes against one workspace would defeat
-  this entirely. The product runs one server; verified that `server/src` has no
-  `worker_threads` and no cast.json writer in a child process.
+- **In-process only.** Two server processes against one workspace defeat this
+  entirely. The product runs one server; `server/src` has no `worker_threads` and
+  no cast.json writer in a child process.
   `analyzer/attribution-eval/capture-cli.ts` reads cast.json but writes only to
   the eval corpus dir.
-- **Partial atomicity for series propagation**, per §3.2.
-- **Rule 1 and rule 4 are convention, not enforcement.** A future nested locker,
-  or one that takes cast-then-design, deadlocks at runtime rather than failing a
+- **No bound on hold time or wait time.** `withKeyLock` (`file-lock.ts:7-19`) has
+  no timeout, no queue cap and no diagnostic for a long-held key. (It *is* FIFO —
+  a promise chain — so waiters are ordered fairly.) A wedged holder turns every
+  cast write on that book into an unbounded hang; today those requests race and
+  one loses a mutation. That trade is why §6 keeps `analysis.ts` off the mutex
+  and §5 narrows `promote-voice` to exclude its sidecar `fetch`. With those two
+  exclusions, expected hold time everywhere is one file read plus one file write.
+- **`promote-voice`'s `realVoiceId` is pinned to its pre-lock read** (§5) — the
+  artifacts have already been renamed to it by the time the lock is taken, so
+  re-deriving it would name files that do not exist.
+- **`cast-design.ts`'s idempotency guards are evaluated before an LLM call**, and
+  the lock covers only the later re-read and write, so two concurrent runs can
+  each generate a persona with the second overwriting the first.
+- **A multi-book propagation is per-book atomic, not atomic as a whole** (§3.2).
+- **Rules 1 and 4 are convention, not enforcement.** A future nested locker, or
+  one that takes cast-then-design, deadlocks at runtime rather than failing a
   check.
 - **The guard sees writes, not reads.** A read left outside its lock is silent —
-  the diff looks locked and is not. Only review catches this, which is why rule 2
+  the diff looks locked and is not. Only review catches that, which is why rule 2
   is stated in the code and not only here.
+- **`PUT /:bookId/state`'s cast slice is last-writer-wins by contract.** It
+  writes the client's whole characters array; the lock protects the clone-consent
+  guards inside `preserveDesignedVoices`, not the patch. Two tabs editing one
+  book still resolve last-write-wins, and closing that needs an `If-Match`-style
+  token on the wire.
 
-## 14. Staleness detection — closing check-then-act
+### 12.2 Work carried on #2006 / #2015
 
-§7 and §12 between them named six places where a decision is derived from a
-cast.json snapshot and the write that depends on it lands in a *different* lock
-scope. The per-book lock cannot reach any of them: it makes each read-modify-write
-atomic, and every one of these is a read in one scope and a write in another.
+Real, deferred, and each carrying its design history. A per-RMW lock cannot reach
+any of them — §6 and §7 explain why, and §13 records the four mechanisms that
+were designed for them and failed.
 
-They are not six defects. They are one defect six times:
+- **`analysis.ts`'s five writes replay a merge base read once at the top of a
+  run** (#2015). The largest unprotected writer left standing.
+- **The three clone-consent gates validate and write in different scopes**
+  (#2006) — `voices.ts`'s cross-book veto, and `single-design.ts` /
+  `qwen-voice.ts` writing from contexts that have already flushed SSE headers.
+- **Three cross-book consultations** (#2006) — `cast-add-from-roster` reads the
+  target to decide a source write; `voice-override-linked` and
+  `cast-series-patch` derive their whole write-lists from a source book they
+  never write.
+- **`cast-link-prior.ts:239-241` plants `libraryUuid` references it never names**
+  (#2006), copied from the target book, so §7's `library-voice` key cannot reach
+  it — it cannot know the uuid up front.
+- **Cross-book concurrent series designs can double-mint a `voiceUuid`** (#2006).
+  Pre-existing: every design gate keys on `bookDir` while the propagation is
+  series-wide. This sweep makes the damage finer-grained — a split uuid across
+  the series rather than last-writer-wins — because `forEachMatchingCastCharacter`
+  will lock per book.
 
-| Site | Decision | Write |
-|---|---|---|
-| `analysis.ts` | `priorCastForMerge`, read once near the top of a run | five sites, minutes later |
-| `voices.ts` `PUT /:voiceId/override` | `hasClonedSlotAmongMatches` cross-book veto | `applyOverrideToCastFiles`, per book |
-| `single-design.ts` | `characterHasClonedSlot` 409 | `applyOverrideToCastFiles`, detached after `res.flushHeaders()` |
-| `qwen-voice.ts` | `characterHasClonedSlot` 409 | `persistEmotionVariant` |
-| `cast-link-prior.ts` | target's `overrideTtsVoices` | source book |
-| `voice-override-linked.ts` / `cast-series-patch.ts` | source snapshot → `writes` / `targets` list | other books |
+## 13. Ticketing
 
-**Decision: cast.json carries a revision, and a write that depends on an earlier
-read asserts the revision has not moved.** Optimistic concurrency, not a longer
-lock — a longer lock is what §3.2 and §6 both rejected, for reasons that stand.
+`Closes #1981` (the filed defect), `Closes #2000` (the sweep), `Closes #2001`
+(§11). One PR.
 
-An alternative was evaluated and rejected: drop the counter and apply rule 2
-harder (lock both books and re-validate the predicate inside the write's lock).
-It covers all six and is simpler — but it converts `voices.ts`'s clone-consent
-veto from a global refusal into a per-book one, and it leaves no reusable
-staleness primitive for the next writer. The counter is the deliberate choice.
+`Refs #2006`, `Refs #2015` — the cross-scope staleness work. §6 and §7 explain
+why a per-RMW lock cannot reach those sites. **Four mechanisms were designed for
+them and none survived review**, which is why they are not in this PR:
 
-### 14.1 The shape — a content fingerprint, not a revision field
+1. *"Analysis owns cast.json"* via the `markAnalysisBusy` registry — consulting
+   an unlocked registry is itself check-then-act, the defect being fixed.
+2. *A route-level `isAnalysisBusy` admission gate* — seven of the thirty sites
+   are helpers or detached SSE jobs with no status-code channel, and it was a
+   ~20-route API contract change buying something explicitly not a correctness
+   guarantee.
+3. *A `rev: number` counter on cast.json* — its capture step is separate from the
+   snapshot read, and the rebuild-on-conflict path re-broke the 2026-07-14
+   Coalfall voice-strip on every "Start fresh" run.
+4. *A sha256 content fingerprint* — better primitive (no schema, no adoption
+   requirement, honest about delete-then-recreate), but `analysis.ts`'s snapshot
+   comes from `readPriorCastForMerge`, a two-file fallback that cannot be
+   fingerprinted as "the same bytes"; and `ensureCharacterVoiceUuid` writes
+   cast.json *between* the clone-consent gates' read and their guarded write, so
+   abort-on-conflict regresses every first-ever character design.
 
-**Decision: capture a fingerprint of the consulted cast at read time; assert it
-under the write's lock.** No schema change.
-
-An earlier draft used a `rev: number` field on cast.json with optimistic
-increment. It was rejected after an independent review, and the reasons are
-recorded because the counter is the more obvious design and will be re-proposed:
-
-- **The capture window.** A revision must be *captured* by an operation separate
-  from the snapshot read, so anything that yields between them is a hole. At
-  `analysis.ts` the snapshot is read above the `fresh` block's `rm` (deliberately
-  — it must outlive the delete) while the revision had to be captured *below* it,
-  and `await pruneStaleReuseLinks(...)` plus `await loadAnalysisCache(...)` sit
-  in between. A concurrent writer landing there bumps the revision before
-  capture, the check then passes, and the stale snapshot is replayed — the exact
-  failure the mechanism exists to detect. **A fingerprint is derived from the
-  bytes you already read, so there is no window to get wrong.**
-- **Partial adoption.** The counter is *"worse than none"* if one writer skips
-  the increment: every other writer's check then passes against a file that did
-  change. That fragility is what forced universal adoption across all 35 sites
-  and a brace-depth guard test to police it. A fingerprint needs no adoption at
-  all — any write changes the bytes, whoever made it.
-- **ABA on delete.** `1 -> delete -> recreate as 1` is invisible to a counter (an
-  absent file reads as `0`). With content comparison, identical bytes genuinely
-  *are* unchanged, and a delete-then-different-recreate is detected.
-- **The `fresh` run.** The counter needed a bespoke rule ("capture after the
-  `rm`"). A fingerprint handles it with no special case: the absent file does not
-  match the snapshot, so the rebuild path runs — and §14.4's rule 2 keeps the
-  retained prior as the base.
-
-Three helpers, in `workspace/cast-io.ts`. All assume the caller holds the cast
-lock for the book in question.
-
-```ts
-readCastForUpdate<T extends object>(bookDir): Promise<{ cast: T; fingerprint: string | null }>
-writeCastChecked<T extends object>(bookDir, next: T, expected: string | null): Promise<void>
-assertCastUnchanged(bookDir, expected: string | null): Promise<void>
-```
-
-`fingerprint` is a sha256 of the file's raw bytes, or `null` when the file is
-absent — an honest encoding of "there was nothing here", distinct from any
-content. `writeCastChecked` re-reads, compares, throws `CastStaleError` on
-mismatch, and writes.
-
-**`assertCastUnchanged` is what lets the mechanism reach four of its six
-targets.** Those consult a *different* book than they write — `cast-link-prior`
-reads the target and writes the source; `voice-override-linked` and
-`cast-series-patch` derive their whole write-list from a source they never write;
-`cast-add-from-roster` reads the target to decide a source write.
-`writeCastChecked` asserts only the book it writes. The caller holds the
-consulted book's lock via `withCastLocks` while asserting.
-
-**The helpers are generic (`T extends object`).** `CastFile`/`CastJson` is
-re-declared as a module-private interface in sixteen modules with five different
-element types, and TypeScript gives interfaces no implicit index signature — a
-concrete parameter type would fail to accept any of them, and neither Vitest nor
-pre-commit checks types, so every converted site would be a compile error
-surfacing only at the final `npm run typecheck`.
-
-**Where the check does work, and where it does not.** At the ~30 same-scope sites
-the caller reads and writes inside one `withCastLock` on one key, so nothing can
-interleave and the comparison is **inert**. It is load-bearing only at the
-cross-scope sites in the table above. Those sites — and only those — use these
-helpers; the other 30 keep `readJson`/`writeJsonAtomic` under their lock. This is
-a deliberate reversal of the counter design's universal-adoption rule, which
-existed solely to protect the counter's own fragility and cost an extra full read
-per write at 30 sites that gained nothing from it.
-
-### 14.2 What a conflict means, per caller shape
-
-- **Can recompute → recompute** (`analysis.ts`, §14.4).
-- **Can refuse → 409** `{ code: 'cast-changed' }` for the HTTP gates.
-- **Can neither → report and skip.** The detached SSE jobs log, skip that book,
-  and surface it in the job's completion payload.
-
-**No retry loop.** Every conflict is detected inside the same lock acquisition
-that performs the write, so `writeCastChecked` cannot fail twice.
-
-**At the three clone-consent gates the fingerprint is an optimisation, not the
-mechanism.** On mismatch those gates re-run the clone-consent predicate against
-the fresh read and refuse only if a cloned slot has actually appeared — an
-unrelated edit must not abort a whole-workspace override. So the predicate
-re-check under the write's lock is what decides; the fingerprint only skips it in
-the common case. Said plainly because an earlier draft justified the entire
-mechanism on the claim that a simpler "re-validate under the lock" design would
-weaken these gates, and then specified exactly that re-validation as its own
-conflict path.
-
-### 14.3 What this does not do
-
-- It does not make a multi-book propagation atomic. A conflict on book 7 of 12
-  still leaves 6 written — reported, not prevented (§3.2).
-- **It does not reach `PUT /:bookId/state`'s cast slice.** That route writes the
-  client's entire characters array; the server reads immediately before writing,
-  so the check passes trivially and a stale client snapshot still overwrites a
-  concurrent server-side edit. Closing it needs an `If-Match`-style token on the
-  wire, which is out of scope. The cast lock still protects the clone-consent
-  guards inside `preserveDesignedVoices`.
-
-### 14.4 `analysis.ts` — and the trap two drafts walked into
-
-The first draft said: on conflict, re-read and re-run the merge against **that**
-as the base. **That re-breaks the 2026-07-14 Coalfall voice-strip,
-deterministically, on every "Start fresh" run.** `priorCastForMerge` is read
-*above* the `fresh` block's `rm` — deliberately, and the comment there says so.
-The `rm` removes cast.json; the rebuild re-reads an **absent** file, so its base
-is `[]`; and `mergeAnalysisResultWithExistingCast` short-circuits on an empty
-base (`if (!existing.length) return fresh;`). Every bespoke designed voice
-dropped, cast.json written voiceless — the incident that read placement exists to
-prevent.
-
-The second draft fixed that with "capture the revision after the `rm`", which
-introduced the capture window described in §14.1. The fingerprint removes both
-failure modes rather than trading one for the other.
-
-Three requirements:
-
-1. **The fingerprint is captured from the same read as `priorCastForMerge`** —
-   same bytes, same instant. Nothing may sit between them.
-2. **The rebuild may never replace a non-empty prior with an empty base.** When
-   the re-read is empty — deleted, or a fresh run mid-flight — the retained
-   `priorCastForMerge` *is* the base. The rebuild overlays concurrent edits onto
-   the prior; it never substitutes for it.
-3. **Re-apply the load-point healers on the rebuild path** —
-   `dropReuseContinuityKeepDesignedVoice`, `pruneStaleReuseLinks`,
-   `dedupePriorCastByName`, `seedReuseGuardsFromPriorCast`,
-   `applyRewriteToPriorCast`. Their comment says they run "at the single load
-   point, so all cast.json write sites see one prior row per name"; a rebuild
-   that skips them reintroduces the duplicate-by-name rows they collapse.
-
-Read-check-write happens in one lock acquisition, so there is no retry.
-
-## 15. The series lock — closing the cross-book double-mint
-
-The one residual §14 provably cannot reach.
-
-`ensureCharacterVoiceUuid` mints a `voiceUuid` for a linked cast identity, then
-propagates it across the series. Two bulk designs on **two different books of one
-series** each read their *own* book, each see no `voiceUuid`, each mint, and each
-propagate. Every design gate keys on `bookDir` — `withDesignLock`, `isDesignBusy`,
-`cast-design.ts`'s `inFlightByBook` — while the propagation is series-wide.
-
-§14 does not help: the propagation re-reads every book under its own lock,
-so each write is against a current revision and is therefore "valid". The
-staleness is in the *mint decision*, taken before either book is read. No file's
-revision encodes it.
-
-**Decision: a fourth key class, `series:<author>/<series>`.**
-
-**It wraps the whole function body, not "the series branch".** §5.1 establishes
-that the `voiceUuid` check and the mint sit *above* the branch; the series branch
-contains only the propagation. An earlier draft of this section said "held across
-read → decide → mint → propagate in the series branch", which contradicts §5.1
-and describes lines that do not contain the mint. Wrapping the branch would leave
-both racers deciding and minting outside the lock and serialise two propagations
-of two *different* uuids — the split-uuid outcome unchanged, under a lock that
-reads as the fix. The shape is:
-
-```ts
-withDesignLock(bookDir, () =>
-  seriesFilter
-    ? withSeriesLock(seriesFilter.author, seriesFilter.series, body)
-    : body())
-```
-
-where `body` is the existing read → decide → mint → propagate. Standalone books
-take the book-scoped path and need no series key.
-
-**Global lock order becomes `design` → `series` → `library-voice` → `cast`**
-(§4 rule 4). `design → series → cast` is live via `ensureCharacterVoiceUuid`.
-`series` and `library-voice` are never both held, so their relative position is
-declared rather than exercised — stated here so the ordering is not mistaken for
-a verified constraint.
-
-**Key derivation.** `series:${author}/${series}`. Both components are directory
-names under `BOOKS_ROOT`, so neither can contain `/` on disk today — but §3.1
-insists key derivation be unambiguous, so the helper encodes both components
-rather than concatenating raw.
-
-**Hold time.** This lock is held across the propagation, which for the series
-branch is a full workspace walk. That is the cost §3.2 refused for the *cast*
-class, accepted here because the alternative is the double-mint: the second racer
-must observe the first's mint, and it cannot do that if the lock is released
-before the propagation. §12's "one file read plus one file write" hold-time
-property therefore does **not** extend to the series class, and §12 says so.
-
-## 16. Scope, restated
-
-With §14 and §15 folded in, this PR closes the residual set rather than filing
-it. **#2006 and #2015 are closed here.**
-
-What remains in §12 is not debt. It is a list of **properties of the design** —
-things that would need a different approach to change:
-
-- The lock is in-process. Two server processes against one workspace defeat it.
-- `promote-voice`'s `realVoiceId` is pinned to its pre-lock read *because the
-  artifacts have already been renamed to it*.
-- A multi-book propagation is per-book atomic, not atomic as a whole (§3.2,
-  §14.3) — now detected and reported rather than silent.
-- `cast-design.ts`'s idempotency guards are evaluated before an LLM call.
-- The counter does not survive a delete (ABA), and does not reach the client
-  full-document `PUT /:bookId/state` (§14.3).
-- The series lock is held across a workspace walk (§15).
-
-Each is stated at its site in the code, not only here.
-
-## 17. Ticketing
-
-`Closes #1981`, `Closes #2000`, `Closes #2001`, `Closes #2006`, `Closes #2015`.
-One PR. Nothing is deferred.
+The next attempt should start from those four and from the reviews that killed
+them, both attached to #2006/#2015 — not from a blank page. The honest read is
+that this layer needs its own design cycle against `analysis.ts` and the design
+gates specifically, rather than a section inside a locking PR.

--- a/docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md
+++ b/docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md
@@ -252,20 +252,48 @@ rather than line numbers so both survive the shift.
   runtime rather than failing a check.
 - **Partial atomicity for series propagation**, per §3.2.
 
-## 10. Incidental findings, filed not fixed
+## 10. Folded in: the lock helpers never clean up their key map (#2001)
 
-The `finally` cleanup in all three existing lock helpers never fires:
+The `finally` cleanup in all three existing promise-chain mutexes is dead code.
 `chains.get(key) === gate` compares against `gate`, but what was stored is
-`prior.then(() => gate, …)` — a different promise object. Same bug in
-`file-lock.ts`, `tts/design-lock.ts`, and `chapters-restructure.ts`. Each Map
-therefore grows one entry per distinct key for the process lifetime.
+`prior.then(() => gate, …)` — a different object, so the identity check can never
+hold and `delete` never runs. Each Map grows one entry per distinct key for the
+process lifetime, while the comment above each one asserts the opposite
+(`design-lock.ts`: *"Tidy up when we're the chain tail, so the map doesn't grow
+unbounded"*).
 
-Bounded by book count and so genuinely minor, but it makes the "best-effort
-cleanup, so the map doesn't grow unboundedly" comment false in all three places.
-Filed as **#2001** rather than folded in: it is in code this branch touches, but
-it is a behaviour question (is the cleanup worth keeping at all, given a
-promise-chain mutex needs the tail entry to remain until it settles?) rather than
-an obvious one-answer fix.
+Three copies: `workspace/file-lock.ts`, `tts/design-lock.ts`, and
+`routes/chapters-restructure.ts` — the last additionally allocating a *third*
+promise inside the comparison itself (`bookWriteLock.get(bookId) === prev.then(() => next)`).
 
-The sweep itself is tracked as **#2000**; #1981 remains the filed defect this
-work closes.
+**This is fixed here, not deferred.** The sweep is about to make `withKeyLock`
+the mutex behind every cast.json write in the product; shipping that on top of a
+helper whose cleanup has never worked, and whose comment says it has, is not a
+defensible place to draw a scope line.
+
+The fix is to hold a reference to the promise actually stored and compare against
+that:
+
+```ts
+const mine = prior.then(() => gate, () => gate);
+chains.set(key, mine);
+…
+} finally {
+  release();
+  if (chains.get(key) === mine) chains.delete(key);
+}
+```
+
+Tail-detection is then correct: if a later waiter has replaced the entry, `mine`
+is no longer the tail and the entry is left for that waiter to chain onto; if it
+has not, `mine` has already settled and a fresh caller starting from
+`Promise.resolve()` behaves identically. One answer, no interface change, and it
+takes a test that asserts the map returns to baseline after a lock settles.
+
+Applied identically to all three helpers, with the three comments corrected to
+match. #2001 is closed by this PR.
+
+## 11. Ticketing
+
+`Closes #1981` (the filed defect), `Closes #2000` (the sweep), `Closes #2001`
+(§10). One PR, per the delivery decision.

--- a/docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md
+++ b/docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md
@@ -107,14 +107,19 @@ exports `withKeyLock(key, fn)`, a generic per-key promise-chain mutex — the sa
 idiom as `tts/design-lock.ts`'s `withDesignLock(bookDir, fn)` and
 `chapters-restructure.ts`'s `withBookLock`. Nothing new is invented here.
 
-### 3.1 The two exports
+### 3.1 The exports
 
 New file `server/src/workspace/cast-lock.ts`:
 
 ```ts
 withCastLock<T>(bookDir: string, fn: () => Promise<T>): Promise<T>
 withCastLocks<T>(bookDirs: string[], fn: () => Promise<T>): Promise<T>
+withLibraryVoiceLock<T>(voiceUuid: string, fn: () => Promise<T>): Promise<T>
 ```
+
+The third is §7's key class, named here rather than left as a raw
+`withKeyLock('library-voice:…')` at two call sites — same argument as below: key
+derivation lives in one place or it silently partitions.
 
 `withCastLock` delegates to `withKeyLock(castJsonPath(bookDir), fn)`.
 

--- a/docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md
+++ b/docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md
@@ -6,11 +6,12 @@
 reach), #2015 (`analysis.ts`'s five writes)
 **Sequencing:** implementation bases on / rebases onto `fix/server-1933-assign-readiness`
 
-**Review:** three adversarial passes — 3C/8M/3m, then 4C/6M/8m, then 1C/5M/5m.
-Each round's worst findings landed in whatever the *previous* round had just
-rewritten, which is the main thing to know when reading this document: the parts
-revised most recently are the parts least proven. Round 3 verified ~60 citations
-clean and judged §§1–5 and §§8–11 implementable as they stand.
+**Review:** four adversarial passes — 3C/8M/3m, 4C/6M/8m, 1C/5M/5m, then
+0C/4M/4m. Each round's worst findings landed in whatever the *previous* round had
+just rewritten, which is the main thing to know when reading this document: the
+parts revised most recently are the parts least proven. Round 3 verified ~60
+citations clean; round 4 confirmed the three-class lock order holds across every
+traced path, and that the scope reductions did not hollow the sweep out.
 
 Two sections were re-decided outright rather than patched. §6 tried "analysis owns
 cast.json" (round 1), then a route-level admission gate (round 2), and now defers
@@ -20,9 +21,15 @@ failing the next. §7 claimed all four clone-consent gates were folded in (round
 inert, because no *writer* took the key. It now specifies both sides.
 
 The pattern is worth naming: every one of those failures was a design that read
-as coverage while covering nothing. That is what §10's revert-verification and
-§10.3's import-graph pin exist to catch in the tests, and it is what this header
-exists to flag in the prose.
+as coverage while covering nothing. §10's revert-verification and §10.3's
+cross-module outcome spec exist to catch that in the tests; this header exists to
+flag it in the prose.
+
+Round 4 also inverted a claim the first three drafts all carried — that a
+partitioned lock passes tests silently. It does not; partition means no
+contention, which means a lost mutation, which makes the outcome test go **red**
+(§3.1). The countermeasure moved accordingly, from detecting partition to
+covering the one case no self-vs-self race can reach.
 
 ## 1. What was filed, and what is actually wrong
 
@@ -86,8 +93,15 @@ Two further sites *delete* it. Measured read→write spans:
 `promote-voice` — not `/assign` — holds the longest window in the codebase, and
 it spans a network call to the sidecar. `cast-design.ts`'s re-read-then-write is
 a hand-rolled mitigation of this exact race, corroborating that the defect class
-is real and has been felt before; it is also the shape a lock wants, so those two
-sites convert cleanly.
+is real and has been felt before, and it is the shape a lock wants.
+
+It is not, however, a clean template. Its decisions — the two idempotency
+`continue`s at `:268`/`:269` — are taken from the *first* read, and an LLM persona
+generation runs at `:273` before the `fresh` re-read at `:289`. Locking `:289-293`
+protects other characters' fields but leaves those decisions stale: two concurrent
+runs can each generate a persona and the second overwrites the first. Recorded as
+a residual in §12. The narrowing pattern is right; this instance of it is
+incomplete, and §5 says so where it reuses the shape.
 
 Line numbers here are as of `main` at `88476dca` and will shift — see §9. The
 implementation plan cites symbols, not lines.
@@ -115,8 +129,7 @@ withCastLocks<T>(bookDirs: string[], fn: () => Promise<T>): Promise<T>
 `withCastLock` delegates to `withKeyLock(castJsonPath(bookDir), fn)`.
 
 The wrapper is not ceremony. **Key derivation must live in exactly one place.**
-There are two ways this lock can silently partition into mutexes that never
-contend, and both leave every test green:
+Two things can partition this lock into mutexes that never contend:
 
 - **Derivation drift.** One site keys on `bookDir`, another on
   `castJsonPath(bookDir)`, or on an unnormalised path separator. A single named
@@ -128,9 +141,21 @@ contend, and both leave every test green:
   `routes/backup.test.ts:7`). Any spec where the route under test and a second
   writer resolve through different module registries gets **two `chains` Maps**.
 
-The second mode is the more dangerous, because a partitioned lock behaves like no
-lock *in both directions*: the outcome test passes by partition, and §10.2's
-revert-verification also passes vacuously. §10.3 states the countermeasure.
+**Partition surfaces as a failing test, not a passing one** — the first three
+drafts had this exactly backwards, and it is worth stating plainly because it
+redirects the whole countermeasure. Two `chains` Maps means no contention, which
+means the unlocked behaviour §10.1 measured at 200/200 lost mutations. §10.2's
+outcome test asserts *both* mutations survive, so a partitioned lock makes it go
+**red**. Key-derivation drift has the same signature: different keys, no
+contention, red.
+
+So partition is a false-red/flake risk, not a silent-coverage risk, and the
+import-graph pin in §10.3 is hygiene rather than a detector.
+
+**The genuinely undetectable case is different**, and it is the one to design
+against: a spec that races one site *against itself* resolves both calls through
+one import and one key, so it can never observe a key mismatch **between two
+different sites**. That is what §10.3 now targets.
 
 `withCastLocks` **dedupes, then sorts** the derived keys, then nests:
 
@@ -171,6 +196,18 @@ CLAUDE.md's *Conventions worth preserving*:
 2. **The read goes inside the lock, and so does every decision derived from it.**
    Wrapping only the write buys nothing at all. This is the easy way to produce a
    diff that looks correct and fixes nothing.
+
+   **The carve-out, and its criterion.** Four sites legitimately leave something
+   outside — `promote-voice`'s `realVoiceId`, `cast-design.ts`'s two idempotency
+   guards, `cast-add-from-roster`'s target read, and
+   `ensureCharacterVoiceUuid`'s series branch. A value may stay outside the lock
+   **only when** (a) re-deriving it inside would be wrong rather than merely
+   redundant — because irreversible work outside the lock has already committed to
+   it, as with `realVoiceId`'s renamed artifacts — or (b) it is a cross-book read a
+   per-book lock cannot cover anyway. Every such case is named at its site and
+   carried as a residual in §12. **Anything not on that list, with a reason
+   written down, is rule 2's failure mode and not a narrowing.** A reviewer who
+   cannot tell which they are looking at should treat it as the failure mode.
 3. **Two or more books → `withCastLocks`, never nested `withCastLock`s.**
 4. **Global lock order: `design` → `library-voice` → `cast`.** Every acquisition
    site names where it sits in that order. Never acquire a lock from an earlier
@@ -237,10 +274,39 @@ Three of these are not routine wraps despite sitting in this class:
   network round-trip inside the hottest lock in the product and stall every cast
   write for that book behind it.
 
-  **Instead: narrow the lock to a fresh re-read plus the write, at the end.** The
-  artifact moves and the evict `fetch` stay outside it. This is exactly the shape
-  `cast-design.ts:289`/`:293` already uses, and it keeps §12's "one file read plus
-  one file write" hold-time claim true — which, wrapped naively, it would not be.
+  **Instead: narrow the lock to a fresh re-read plus the write, at the end**, with
+  the artifact moves and the evict `fetch` outside it. That keeps §12's "one file
+  read plus one file write" hold-time claim true — which, wrapped naively, it
+  would not be.
+
+  Narrowing here is not a one-line change, because the `:692` read is load-bearing
+  throughout: `:698` derives `realVoiceId` from `character.voiceUuid`, and that
+  value drives the 400 gate, the `stat` 409, the `rm`s and `rename`s, the
+  `copyFile` and the evict payload; `:787` takes `qwenSlot`, `:789-791` builds
+  `staleVariantIds` from it, and `:792`'s `delete qwenSlot.variants` mutates the
+  `:692` object *in place* — which `:793` then writes. So the lock body is
+  specified exactly, and the implementer invents nothing:
+
+  1. Inside `withCastLock`, **re-read** cast.json and re-find the character. If it
+     is gone, return the same 404 the handler would have.
+  2. **Re-derive `qwenSlot` and `staleVariantIds` from the fresh object**, apply
+     the `delete`, and write that object. The `:692` copy must not be the payload.
+  3. **`realVoiceId` stays pinned to the pre-lock read, deliberately** — the
+     artifacts have already been renamed to it by the time the lock is taken, so
+     re-deriving it afterwards would name files that do not exist. The divergence
+     (a concurrent write changing `voiceUuid` mid-promotion) is a residual,
+     recorded in §12, not something this lock can fix.
+  4. The `staleVariantIds` teardown stays **outside** the lock — it is filesystem
+     work, and holding the lock across it reintroduces the problem being avoided.
+- **`book-state.ts:634`** has **no cast read at the call site** — the write's
+  argument is `await preserveDesignedVoices(bookDir, body.patch)`, and the read
+  lives inside that helper (`book-state.ts:128-130`). Wrapping "the span"
+  mechanically therefore locks the *write only*, which is rule 2's named failure
+  mode. It is also the site where a stale read does the most damage: that read
+  feeds `rejectForeignCloneKeys` (`:135`) and `preserveClonedSlotsOnCastWrite`
+  (`:140`), both **clone-consent guards**. The lock must enclose the
+  `preserveDesignedVoices` call and the write together, or be pushed into the
+  helper.
 - **`cast-add-from-roster.ts:147`** moved here from class 2 after round 2: it
   reads *both* books (`:104`, `:105`) but writes **only the source** (`:147`), and
   `:79` already 400s same-book. A single-book lock on the source is correct;
@@ -248,10 +314,13 @@ Three of these are not routine wraps despite sitting in this class:
   read-only consultation. Note the target read still feeds the decision, so it is
   a check-then-act — accepted per §12, not closed here.
 - **`voice-library-usage.ts:113`** needs its read moved inside the lock, because
-  `walkConfirmedCasts()` (`:43`) *yields* an already-read `cast`. But that walker
-  is **shared** with `scanLibraryVoiceUsage` (`:71-85`) — §7's gate 2 — so
-  changing what it yields reaches into a consent gate. It is a shared-seam
-  restructure, sequenced with §7's library-voice lock rather than done blind.
+  `walkConfirmedCasts()` (`:43`) *yields* an already-read `cast`. An earlier draft
+  called this a shared-seam restructure, on the grounds that the walker is shared
+  with `scanLibraryVoiceUsage` (`:71-85`). It is not: `clearLibraryVoiceReferences`
+  consumes only `bookDir` and `cast.characters`, so it can **ignore the yielded
+  `cast` and re-read `castJsonPath(bookDir)` inside its own per-book lock**,
+  leaving the walker's signature and the read-only scan untouched. A contained
+  conversion, not a design decision.
 
 ### Class 2 — multi-book: `withCastLocks` (8 sites)
 
@@ -303,11 +372,17 @@ See §6.
 cast.json and neither matches `writeJsonAtomic(castJsonPath(`, so the first
 draft's guard test could not see them.
 
-They matter more after this change, not less: a locked writer whose read predates
-the delete recreates cast.json afterwards, resurrecting the stale roster the
-delete exists to remove (`analysis.ts:2836-2841` documents that intent) — and the
-lock *lengthens* the gap between a queued writer's read and its write. Both take
-the cast lock; the guard pattern extends to `rm(castJsonPath(`.
+They matter because a delete that is not serialised against the writers can
+simply be undone: a writer that acquires after the delete recreates cast.json,
+resurrecting the stale roster the delete exists to remove
+(`analysis.ts:2836-2841` documents that intent). Both take the cast lock; the
+guard pattern extends to `rm(castJsonPath(`.
+
+(An earlier draft justified this by claiming the lock "lengthens the gap between
+a queued writer's read and its write". That is wrong under rule 2 —
+`file-lock.ts:12-14` awaits `prior` *before* `fn()`, so a queued writer's read
+happens after the holder's write and the gap is unchanged. The claim held only
+for the sites whose reads are deliberately left outside, i.e. the exceptions.)
 
 ### 5.1 The re-entrancy restructure
 
@@ -359,7 +434,7 @@ at `:193`**, as the function's own docstring claims (`:182-184`).
 **Across books it is not prevented at all, and that is a pre-existing defect this
 spec must not paper over.** `withDesignLock` keys on `bookDir`
 (`design-lock.ts:26-27`), and so do `isDesignBusy`, `isAnalysisBusy` and
-`cast-design.ts:668`'s `inFlightByBook` gate. Two bulk-design jobs on **two
+`cast-design.ts:648`'s `inFlightByBook` gate. Two bulk-design jobs on **two
 different books of one series** therefore hold two different design locks; both
 call `ensureCharacterVoiceUuid(job.bookDir, characterId, seriesFilter)`
 (`cast-design.ts:485`) for the same linked identity, both see no `voiceUuid` at
@@ -632,25 +707,30 @@ as a required step with recorded output.
 
 ### 10.3 The partition assertion — mandatory, and it comes first
 
-Because a partitioned lock passes both the outcome test and the revert
-verification, each outcome spec must establish that the two writers actually
-share one lock instance.
+Two countermeasures were proposed across earlier drafts and both were aimed at
+the wrong failure. Recording the correction, because the reasoning matters more
+than the conclusion:
 
-The first rewrite made a test-only `chains.size` accessor the mandatory
-countermeasure and a pinned import graph the fallback. **That is backwards, and
-the accessor does not work.** It is imported into the *spec file*, so it resolves
-through the spec file's registry — which in the failure mode being detected is
-neither writer's. Worse, in the half-partitioned case the observed size is `1`,
-indistinguishable from a correctly shared lock with one queued waiter, because
-`file-lock.ts:11` overwrites the same key rather than adding an entry per waiter.
-An instance token would only help if each *writer* reported which instance it
-used, and nothing in this design plumbs that.
+- A **test-only `chains.size` accessor** was made mandatory in round 2. It cannot
+  work: imported into the *spec file*, it resolves through the spec file's
+  registry, which in the failure mode being detected is neither writer's. And in
+  the half-partitioned case the observed size is `1` — indistinguishable from a
+  correctly shared lock with one queued waiter, because `file-lock.ts:11`
+  overwrites the key rather than adding an entry per waiter. **Not added.**
+- **Pinning a single import graph** was then made mandatory in round 3, on the
+  premise that partition otherwise passes silently. §3.1 now establishes that
+  partition makes the outcome test go **red**, so this is hygiene against a
+  confusing false failure, not a detector. **Keep it, but as hygiene.**
 
-**Inverted: pinning a single import graph is the mandatory requirement.** Every
-outcome spec drives both writers through one module registry and states in a
-comment that it does; specs in this set do not call `vi.resetModules()` between
-the two writers. No test-only accessor is added — a countermeasure that cannot
-detect the failure it targets is worse than none, because it looks like coverage.
+**The requirement that actually closes the gap:** at least one outcome spec must
+race **two different modules'** write sites against the same book — for example
+`cast-aliases.ts`'s alias split against `voice-style.ts`'s style write. A spec
+that races one site against itself resolves both calls through one import and one
+key, so it can never observe a key mismatch *between* sites, and cross-site
+derivation drift is the one partition mode no self-vs-self test can reach.
+
+Concretely: every outcome spec pins one registry (hygiene), and the cross-module
+spec is a required deliverable, not an optional extra.
 
 This is also why §10.1's spike lands as a committed test rather than a quoted
 number: it is the reference for what a correctly-pinned harness looks like.
@@ -740,8 +820,8 @@ the code.
   write. Without them the claim is false, which is how it read before round 3.
 
   A warn-after-N-seconds log was considered and **dropped**. `withKeyLock` has
-  five existing non-cast callers (`book-state.ts:1588`,
-  `script-review-ledger.ts:83`/`:105`/`:131`/`:143`), so a timer per acquisition
+  five existing non-cast callers (`book-state.ts:1588`, and
+  `workspace/script-review-ledger.ts:83`/`:105`/`:131`/`:143`), so a timer per acquisition
   is a behaviour change to all of them, and a non-`unref()`d one would hold the
   event loop open on what is about to become the hottest lock in the product —
   in a repo whose flake register already tracks tinypool worker-exit failures.
@@ -758,9 +838,29 @@ the code.
   series-wide), and this sweep makes the resulting damage finer-grained — a split
   uuid across the series rather than last-writer-wins. §5.1 has the mechanism;
   added to **#2006**.
-- **`cast-add-from-roster.ts` reads the target book to decide a source write.**
-  That consultation is check-then-act and is not closed by a single-book lock on
-  the source.
+- **Three cross-book check-then-act consultations survive**, not one. Earlier
+  drafts named only the smallest:
+  - `cast-add-from-roster.ts` reads the target book to decide a source write;
+  - `voice-override-linked.ts` reads the **source** cast and derives
+    `canonicalVoiceId`, `sourceTokens`, the `inGroup` predicate and the entire
+    `writes` list from that snapshot, then writes **other** books via
+    `applyToBook`;
+  - `cast-series-patch.ts` reads the source cast, derives `sourceChar` and the
+    `targets` list, additionally reads other books via
+    `scanSeriesCharactersForBookId`, then writes per book.
+
+  The latter two are the worse pair — they carry *data and grouping* derived from
+  a stale cross-book snapshot into writes in other books, where
+  `cast-add-from-roster` carries only a decision. A per-book lock closes none of
+  the three. Added to **#2006**.
+- **`promote-voice`'s `realVoiceId` is pinned to its pre-lock read** (§5), so a
+  concurrent write that changes `voiceUuid` mid-promotion leaves the artifacts
+  named for the old uuid.
+- **`cast-design.ts`'s two sites keep stale idempotency decisions.** Its
+  `continue` guards are evaluated against the first read, before an LLM persona
+  generation, and the lock covers only the later re-read and write — so two
+  concurrent runs can each generate a persona and the second overwrites the
+  first.
 - **In-process only.** Two server processes against one workspace would defeat
   this entirely. The product runs one server; verified that `server/src` has no
   `worker_threads` and no cast.json writer in a child process.

--- a/docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md
+++ b/docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md
@@ -299,7 +299,10 @@ Three of these are not routine wraps despite sitting in this class:
   specified exactly, and the implementer invents nothing:
 
   1. Inside `withCastLock`, **re-read** cast.json and re-find the character. If it
-     is gone, return the same 404 the handler would have.
+     is gone, **no-op — do not 404.** The artifact renames have already committed
+     by this point and the handler reports them as done, so a 404 would misreport
+     completed work. (An earlier draft of this section said 404; the plan's Task 8
+     is correct and this is the retraction.)
   2. **Re-derive `qwenSlot` and `staleVariantIds` from the fresh object**, apply
      the `delete`, and write that object. The `:692` copy must not be the payload.
   3. **`realVoiceId` stays pinned to the pre-lock read, deliberately** — the

--- a/docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md
+++ b/docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md
@@ -500,7 +500,7 @@ would silently degrade.
 > **Superseded by §14.2.** This section records why the two *lock-based*
 > mitigations were rejected, which is still the reasoning that rules them out.
 > The conclusion — that `analysis.ts` ships unprotected — no longer holds: §14's
-> revision counter closes it without either mitigation, by checking the merge
+> §14's staleness check closes it without either mitigation, by checking the merge
 > base at each write instead of trying to keep it valid across the run. #2015 is
 > closed by this PR.
 
@@ -868,7 +868,7 @@ the code.
   moved is detected rather than written blind.
 - ~~**Cross-book concurrent series designs can double-mint a `voiceUuid`.**~~
   **Closed by §15** — the mint decision moves under a `series:<author>/<series>`
-  key. This is the one item the revision counter provably could not reach, since
+  key. This is the one item §14 provably could not reach, since
   the staleness is in a decision taken before any file is read.
 - ~~**Three cross-book check-then-act consultations survive.**~~ **Closed by
   §14** — each records the revision of every book it consulted and asserts it at
@@ -908,7 +908,7 @@ the code.
   the diff looks locked and is not. Only review catches this, which is why rule 2
   is stated in the code and not only here.
 
-## 14. The cast.json revision counter — closing check-then-act
+## 14. Staleness detection — closing check-then-act
 
 §7 and §12 between them named six places where a decision is derived from a
 cast.json snapshot and the write that depends on it lands in a *different* lock
@@ -936,134 +936,142 @@ It covers all six and is simpler — but it converts `voices.ts`'s clone-consent
 veto from a global refusal into a per-book one, and it leaves no reusable
 staleness primitive for the next writer. The counter is the deliberate choice.
 
-### 14.1 The shape
+### 14.1 The shape — a content fingerprint, not a revision field
 
-`cast.json` gains a top-level `rev: number`. Absent means `0` — a read-path
-default, so no migration script and no compatibility break.
+**Decision: capture a fingerprint of the consulted cast at read time; assert it
+under the write's lock.** No schema change.
 
-Three helpers, in `workspace/cast-io.ts`. **All three assume the caller holds the
-cast lock for the book in question.**
+An earlier draft used a `rev: number` field on cast.json with optimistic
+increment. It was rejected after an independent review, and the reasons are
+recorded because the counter is the more obvious design and will be re-proposed:
+
+- **The capture window.** A revision must be *captured* by an operation separate
+  from the snapshot read, so anything that yields between them is a hole. At
+  `analysis.ts` the snapshot is read above the `fresh` block's `rm` (deliberately
+  — it must outlive the delete) while the revision had to be captured *below* it,
+  and `await pruneStaleReuseLinks(...)` plus `await loadAnalysisCache(...)` sit
+  in between. A concurrent writer landing there bumps the revision before
+  capture, the check then passes, and the stale snapshot is replayed — the exact
+  failure the mechanism exists to detect. **A fingerprint is derived from the
+  bytes you already read, so there is no window to get wrong.**
+- **Partial adoption.** The counter is *"worse than none"* if one writer skips
+  the increment: every other writer's check then passes against a file that did
+  change. That fragility is what forced universal adoption across all 35 sites
+  and a brace-depth guard test to police it. A fingerprint needs no adoption at
+  all — any write changes the bytes, whoever made it.
+- **ABA on delete.** `1 -> delete -> recreate as 1` is invisible to a counter (an
+  absent file reads as `0`). With content comparison, identical bytes genuinely
+  *are* unchanged, and a delete-then-different-recreate is detected.
+- **The `fresh` run.** The counter needed a bespoke rule ("capture after the
+  `rm`"). A fingerprint handles it with no special case: the absent file does not
+  match the snapshot, so the rebuild path runs — and §14.4's rule 2 keeps the
+  retained prior as the base.
+
+Three helpers, in `workspace/cast-io.ts`. All assume the caller holds the cast
+lock for the book in question.
 
 ```ts
-readCastForUpdate<T extends object>(bookDir): Promise<{ cast: T & Rev; rev: number }>
-writeCastChecked<T extends object>(bookDir, next: T, expectedRev: number): Promise<void>
-assertCastRev(bookDir, expectedRev): Promise<void>
+readCastForUpdate<T extends object>(bookDir): Promise<{ cast: T; fingerprint: string | null }>
+writeCastChecked<T extends object>(bookDir, next: T, expected: string | null): Promise<void>
+assertCastUnchanged(bookDir, expected: string | null): Promise<void>
 ```
 
-`writeCastChecked` re-reads, compares, throws `CastRevConflictError` if it moved,
-and on success writes `rev: expectedRev + 1`.
+`fingerprint` is a sha256 of the file's raw bytes, or `null` when the file is
+absent — an honest encoding of "there was nothing here", distinct from any
+content. `writeCastChecked` re-reads, compares, throws `CastStaleError` on
+mismatch, and writes.
 
-**`assertCastRev` is the export the first draft of this section was missing, and
-without it §14 could not do what it claimed.** Four of the six sites consult a
-*different* book than they write — `cast-link-prior` reads the target and writes
-the source; `voice-override-linked` and `cast-series-patch` derive their whole
-write-list from a source book they never write; `cast-add-from-roster` reads the
-target to decide a source write. `writeCastChecked` asserts only the book it
-writes, so those four need a way to assert a revision on a book they merely read.
-The caller holds that book's lock via `withCastLocks` while asserting.
+**`assertCastUnchanged` is what lets the mechanism reach four of its six
+targets.** Those consult a *different* book than they write — `cast-link-prior`
+reads the target and writes the source; `voice-override-linked` and
+`cast-series-patch` derive their whole write-list from a source they never write;
+`cast-add-from-roster` reads the target to decide a source write.
+`writeCastChecked` asserts only the book it writes. The caller holds the
+consulted book's lock via `withCastLocks` while asserting.
 
-**The helpers are generic (`T extends object`), not typed to a shared
-`CastJson`.** `CastFile`/`CastJson` is re-declared as a module-private interface
-in sixteen modules with five different element types, and TypeScript gives
-interfaces no implicit index signature — so a concrete `CastJson` parameter with
-`[k: string]: unknown` would fail to accept any of them. Every converted site
-would be a compile error, and neither Vitest nor pre-commit checks types, so it
-would surface only at the final `npm run typecheck`.
+**The helpers are generic (`T extends object`).** `CastFile`/`CastJson` is
+re-declared as a module-private interface in sixteen modules with five different
+element types, and TypeScript gives interfaces no implicit index signature — a
+concrete parameter type would fail to accept any of them, and neither Vitest nor
+pre-commit checks types, so every converted site would be a compile error
+surfacing only at the final `npm run typecheck`.
 
-**The helper owns the increment, and that matters beyond bookkeeping.** At least
-**20 of the 35** current writers construct a fresh payload (`{ characters:
-nextCharacters }`) rather than passing back the object they read — a shape that
-drops every other top-level field, `rev` included.
-
-**What the comparison does and does not do.** At the ~30 same-scope sites the
-caller reads and writes inside one `withCastLock` on one key, and
-`file-lock.ts:12` awaits `prior` before `fn()`, so no other locked writer can
-interleave: `actual` can never differ from `expectedRev` and **the comparison is
-inert there**. It is load-bearing only at the cross-scope sites in the table
-above. Universal adoption is required for the **increment** — one writer that
-skips it makes every other writer's check pass against a file that did change —
-not because the check does work everywhere. Saying so plainly is the point: a
-reviewer reading a converted site should not believe the check is doing something
-it is not.
+**Where the check does work, and where it does not.** At the ~30 same-scope sites
+the caller reads and writes inside one `withCastLock` on one key, so nothing can
+interleave and the comparison is **inert**. It is load-bearing only at the
+cross-scope sites in the table above. Those sites — and only those — use these
+helpers; the other 30 keep `readJson`/`writeJsonAtomic` under their lock. This is
+a deliberate reversal of the counter design's universal-adoption rule, which
+existed solely to protect the counter's own fragility and cost an extra full read
+per write at 30 sites that gained nothing from it.
 
 ### 14.2 What a conflict means, per caller shape
 
-This is the "refusal semantics" question #2006 was filed to answer. One rule,
-three shapes:
-
 - **Can recompute → recompute** (`analysis.ts`, §14.4).
-- **Can refuse → 409** `{ code: 'cast-changed' }` for the HTTP gates. The caller
-  retries against fresh state.
+- **Can refuse → 409** `{ code: 'cast-changed' }` for the HTTP gates.
 - **Can neither → report and skip.** The detached SSE jobs log, skip that book,
-  and surface it in the job's completion payload. §6 established these cannot
-  409; a conflict does not change that, but it makes the skip deliberate and
-  reported rather than a silent overwrite.
+  and surface it in the job's completion payload.
 
-**No retry loop anywhere.** Every conflict is detected inside the same lock
-acquisition that performs the write — read the rev, decide, write with that rev —
-so `writeCastChecked` cannot fail a second time and there is nothing to retry.
-An earlier draft left "a conflict must never fail the run" unbounded, which is
-either a livelock against a steady writer or an unstated terminal failure.
+**No retry loop.** Every conflict is detected inside the same lock acquisition
+that performs the write, so `writeCastChecked` cannot fail twice.
+
+**At the three clone-consent gates the fingerprint is an optimisation, not the
+mechanism.** On mismatch those gates re-run the clone-consent predicate against
+the fresh read and refuse only if a cloned slot has actually appeared — an
+unrelated edit must not abort a whole-workspace override. So the predicate
+re-check under the write's lock is what decides; the fingerprint only skips it in
+the common case. Said plainly because an earlier draft justified the entire
+mechanism on the claim that a simpler "re-validate under the lock" design would
+weaken these gates, and then specified exactly that re-validation as its own
+conflict path.
 
 ### 14.3 What this does not do
 
 - It does not make a multi-book propagation atomic. A conflict on book 7 of 12
-  still leaves 6 written. What changes is that the operation **knows** and says
-  so. Cross-book atomicity needs the workspace-scoped lock §3.2 rejected.
-- **It does not survive a delete (ABA).** `analysis.ts`'s "Start fresh" and
-  `book-state.ts`'s reparse `rm` cast.json, and an absent file reads as `rev: 0`,
-  so `1 → delete → recreate as 1` is indistinguishable from "unchanged". §14.4
-  handles the one caller that spans a delete; for everyone else this is a stated
-  property, not a defect the counter can fix.
+  still leaves 6 written — reported, not prevented (§3.2).
 - **It does not reach `PUT /:bookId/state`'s cast slice.** That route writes the
-  client's entire characters array; the server reads `rev` inside its own lock
-  immediately before writing, so the check passes trivially and a stale client
-  snapshot still overwrites a concurrent server-side edit. Closing that needs an
-  `If-Match`-style rev on the wire, which is out of scope here. The cast lock
-  still protects the clone-consent guards inside `preserveDesignedVoices`, which
-  is what Task 7's test targets.
+  client's entire characters array; the server reads immediately before writing,
+  so the check passes trivially and a stale client snapshot still overwrites a
+  concurrent server-side edit. Closing it needs an `If-Match`-style token on the
+  wire, which is out of scope. The cast lock still protects the clone-consent
+  guards inside `preserveDesignedVoices`.
 
-### 14.4 `analysis.ts` — and the trap the first draft walked into
+### 14.4 `analysis.ts` — and the trap two drafts walked into
 
-The first draft of this section said: on conflict, re-read the cast and re-run
-the merge against **that** as the base. **That would have re-broken the
-2026-07-14 Coalfall voice-strip incident, deterministically, on every "Start
-fresh" run.** The mechanism, because it must not be repeated:
+The first draft said: on conflict, re-read and re-run the merge against **that**
+as the base. **That re-breaks the 2026-07-14 Coalfall voice-strip,
+deterministically, on every "Start fresh" run.** `priorCastForMerge` is read
+*above* the `fresh` block's `rm` — deliberately, and the comment there says so.
+The `rm` removes cast.json; the rebuild re-reads an **absent** file, so its base
+is `[]`; and `mergeAnalysisResultWithExistingCast` short-circuits on an empty
+base (`if (!existing.length) return fresh;`). Every bespoke designed voice
+dropped, cast.json written voiceless — the incident that read placement exists to
+prevent.
 
-`priorCastForMerge` is read *above* the `fresh` block's `rm` — deliberately, and
-the comment there says so: *"Read happens before the fresh block below rm's
-cast.json, so the value survives that deletion."* A rev captured at the same
-point is `N`; the `rm` then resets the on-disk revision to `0`; the run's first
-interim write sees `actual = 0 ≠ N` and takes the rebuild path; the rebuild
-re-reads an **absent** cast, so its base is `[]`; and
-`mergeAnalysisResultWithExistingCast` short-circuits on an empty base
-(`if (!existing.length) return fresh;`). Every bespoke designed voice is dropped
-and cast.json is written voiceless — which is precisely the incident the read
-placement exists to prevent.
+The second draft fixed that with "capture the revision after the `rm`", which
+introduced the capture window described in §14.1. The fingerprint removes both
+failure modes rather than trading one for the other.
 
-Three rules follow, and they are requirements, not guidance:
+Three requirements:
 
-1. **Capture the revision *after* the `fresh` block's `rm`**, not alongside the
-   `priorCastForMerge` read. The snapshot must outlive the delete; the revision
-   must not.
+1. **The fingerprint is captured from the same read as `priorCastForMerge`** —
+   same bytes, same instant. Nothing may sit between them.
 2. **The rebuild may never replace a non-empty prior with an empty base.** When
    the re-read is empty — deleted, or a fresh run mid-flight — the retained
    `priorCastForMerge` *is* the base. The rebuild overlays concurrent edits onto
    the prior; it never substitutes for it.
-3. **Re-apply the load-point healers on the rebuild path.** Not just
-   `seedReuseGuardsFromPriorCast` and `applyRewriteToPriorCast`, but
-   `dropReuseContinuityKeepDesignedVoice`, `pruneStaleReuseLinks` and
-   `dedupePriorCastByName` — whose own comment says they run "at the single load
-   point, so all cast.json write sites see one prior row per name". A rebuild
-   that skips them reintroduces duplicate-by-name rows the load point exists to
-   collapse.
+3. **Re-apply the load-point healers on the rebuild path** —
+   `dropReuseContinuityKeepDesignedVoice`, `pruneStaleReuseLinks`,
+   `dedupePriorCastByName`, `seedReuseGuardsFromPriorCast`,
+   `applyRewriteToPriorCast`. Their comment says they run "at the single load
+   point, so all cast.json write sites see one prior row per name"; a rebuild
+   that skips them reintroduces the duplicate-by-name rows they collapse.
 
-Read-check-write happens in one lock acquisition, so there is no retry and no
-livelock (§14.2).
+Read-check-write happens in one lock acquisition, so there is no retry.
 
 ## 15. The series lock — closing the cross-book double-mint
 
-The one residual the revision counter provably cannot reach.
+The one residual §14 provably cannot reach.
 
 `ensureCharacterVoiceUuid` mints a `voiceUuid` for a linked cast identity, then
 propagates it across the series. Two bulk designs on **two different books of one
@@ -1071,7 +1079,7 @@ series** each read their *own* book, each see no `voiceUuid`, each mint, and eac
 propagate. Every design gate keys on `bookDir` — `withDesignLock`, `isDesignBusy`,
 `cast-design.ts`'s `inFlightByBook` — while the propagation is series-wide.
 
-A counter does not help: the propagation re-reads every book under its own lock,
+§14 does not help: the propagation re-reads every book under its own lock,
 so each write is against a current revision and is therefore "valid". The
 staleness is in the *mint decision*, taken before either book is read. No file's
 revision encodes it.

--- a/docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md
+++ b/docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md
@@ -919,129 +919,223 @@ They are not six defects. They are one defect six times:
 
 | Site | Decision | Write |
 |---|---|---|
-| `analysis.ts` | `priorCastForMerge`, read once at `:2797` | `:3558`, `:3763`, `:4774`, `:5422`, `:5927`, minutes later |
+| `analysis.ts` | `priorCastForMerge`, read once near the top of a run | five sites, minutes later |
 | `voices.ts` `PUT /:voiceId/override` | `hasClonedSlotAmongMatches` cross-book veto | `applyOverrideToCastFiles`, per book |
-| `single-design.ts` | `characterHasClonedSlot` 409 at `:254` | `:178`, detached after `res.flushHeaders()` |
-| `qwen-voice.ts` | `characterHasClonedSlot` 409 at `:552` | `:623` via `persistEmotionVariant` |
-| `cast-link-prior.ts` | target's `overrideTtsVoices`, read at `:105` | source, at `:248` |
-| `voice-override-linked.ts` / `cast-series-patch.ts` | source snapshot → `writes` list / `targets` list | other books |
+| `single-design.ts` | `characterHasClonedSlot` 409 | `applyOverrideToCastFiles`, detached after `res.flushHeaders()` |
+| `qwen-voice.ts` | `characterHasClonedSlot` 409 | `persistEmotionVariant` |
+| `cast-link-prior.ts` | target's `overrideTtsVoices` | source book |
+| `voice-override-linked.ts` / `cast-series-patch.ts` | source snapshot → `writes` / `targets` list | other books |
 
 **Decision: cast.json carries a revision, and a write that depends on an earlier
 read asserts the revision has not moved.** Optimistic concurrency, not a longer
-lock — a longer lock is what §3.2 and §6 both rejected, for good reasons that
-have not changed.
+lock — a longer lock is what §3.2 and §6 both rejected, for reasons that stand.
 
-This is deliberately *one* mechanism rather than six bespoke fixes. Six fixes
-would each be locally obvious and collectively unenforceable: nothing would stop
-a seventh instance, and each would invent its own failure semantics. A revision
-makes staleness **detectable**, which is the property all six actually need.
+An alternative was evaluated and rejected: drop the counter and apply rule 2
+harder (lock both books and re-validate the predicate inside the write's lock).
+It covers all six and is simpler — but it converts `voices.ts`'s clone-consent
+veto from a global refusal into a per-book one, and it leaves no reusable
+staleness primitive for the next writer. The counter is the deliberate choice.
 
 ### 14.1 The shape
 
 `cast.json` gains a top-level `rev: number`. Absent means `0` — a read-path
-default, so no migration script and no compatibility break with an existing
-workspace.
+default, so no migration script and no compatibility break.
 
-Two helpers, in `workspace/cast-io.ts`, both of which assume the caller holds the
-cast lock:
+Three helpers, in `workspace/cast-io.ts`. **All three assume the caller holds the
+cast lock for the book in question.**
 
 ```ts
-readCastForUpdate(bookDir): Promise<{ cast: CastJson; rev: number }>
-writeCastChecked(bookDir, next: CastJson, expectedRev: number): Promise<void>
+readCastForUpdate<T extends object>(bookDir): Promise<{ cast: T & Rev; rev: number }>
+writeCastChecked<T extends object>(bookDir, next: T, expectedRev: number): Promise<void>
+assertCastRev(bookDir, expectedRev): Promise<void>
 ```
 
-`writeCastChecked` re-reads, compares `rev` against `expectedRev`, and throws
-`CastRevConflictError` if it moved. On success it writes `rev: expectedRev + 1`.
+`writeCastChecked` re-reads, compares, throws `CastRevConflictError` if it moved,
+and on success writes `rev: expectedRev + 1`.
+
+**`assertCastRev` is the export the first draft of this section was missing, and
+without it §14 could not do what it claimed.** Four of the six sites consult a
+*different* book than they write — `cast-link-prior` reads the target and writes
+the source; `voice-override-linked` and `cast-series-patch` derive their whole
+write-list from a source book they never write; `cast-add-from-roster` reads the
+target to decide a source write. `writeCastChecked` asserts only the book it
+writes, so those four need a way to assert a revision on a book they merely read.
+The caller holds that book's lock via `withCastLocks` while asserting.
+
+**The helpers are generic (`T extends object`), not typed to a shared
+`CastJson`.** `CastFile`/`CastJson` is re-declared as a module-private interface
+in sixteen modules with five different element types, and TypeScript gives
+interfaces no implicit index signature — so a concrete `CastJson` parameter with
+`[k: string]: unknown` would fail to accept any of them. Every converted site
+would be a compile error, and neither Vitest nor pre-commit checks types, so it
+would surface only at the final `npm run typecheck`.
 
 **The helper owns the increment, and that matters beyond bookkeeping.** At least
 **20 of the 35** current writers construct a fresh payload (`{ characters:
 nextCharacters }`) rather than passing back the object they read — a shape that
-drops every other top-level field. Left alone they would silently erase `rev` on
-every write and the counter would never advance. Routing writes through one
-helper is what stops that, and it is the same argument as §3.1's for key
-derivation.
+drops every other top-level field, `rev` included.
+
+**What the comparison does and does not do.** At the ~30 same-scope sites the
+caller reads and writes inside one `withCastLock` on one key, and
+`file-lock.ts:12` awaits `prior` before `fn()`, so no other locked writer can
+interleave: `actual` can never differ from `expectedRev` and **the comparison is
+inert there**. It is load-bearing only at the cross-scope sites in the table
+above. Universal adoption is required for the **increment** — one writer that
+skips it makes every other writer's check pass against a file that did change —
+not because the check does work everywhere. Saying so plainly is the point: a
+reviewer reading a converted site should not believe the check is doing something
+it is not.
 
 ### 14.2 What a conflict means, per caller shape
 
 This is the "refusal semantics" question #2006 was filed to answer. One rule,
 three shapes:
 
-- **Can recompute → recompute.** `analysis.ts` re-derives its merge against the
-  fresh cast rather than replaying `priorCastForMerge`. Its run must not fail
-  because a user renamed a character mid-analysis. This also answers #2015: the
-  merge base does not need to *survive* the run, it needs to be *checked* at each
-  write and rebuilt when it has moved.
-- **Can refuse → 409.** The HTTP gates (`voices.ts`, `cast-link-prior`,
-  `voice-override-linked`, `cast-series-patch`) return
-  `409 { code: 'cast-changed' }`. The caller retries against fresh state. This is
-  expressible because these handlers have not yet responded.
-- **Can neither → report and skip.** The detached SSE jobs (`single-design.ts`,
-  `qwen-voice.ts`'s bulk path) log the conflict, skip that book, and surface it in
-  the job's completion payload. §6 established these cannot 409; a revision
-  conflict does not change that, but it does make the skip *deliberate and
-  reported* rather than a silent overwrite.
+- **Can recompute → recompute** (`analysis.ts`, §14.4).
+- **Can refuse → 409** `{ code: 'cast-changed' }` for the HTTP gates. The caller
+  retries against fresh state.
+- **Can neither → report and skip.** The detached SSE jobs log, skip that book,
+  and surface it in the job's completion payload. §6 established these cannot
+  409; a conflict does not change that, but it makes the skip deliberate and
+  reported rather than a silent overwrite.
+
+**No retry loop anywhere.** Every conflict is detected inside the same lock
+acquisition that performs the write — read the rev, decide, write with that rev —
+so `writeCastChecked` cannot fail a second time and there is nothing to retry.
+An earlier draft left "a conflict must never fail the run" unbounded, which is
+either a livelock against a steady writer or an unstated terminal failure.
 
 ### 14.3 What this does not do
 
-It does not make a multi-book propagation atomic. A conflict on book 7 of 12
-still leaves 6 books written. What changes is that the operation **knows** and
-says so, instead of overwriting a decision it never saw. Genuine cross-book
-atomicity needs the workspace-scoped lock §3.2 rejected, and that rejection
-stands.
+- It does not make a multi-book propagation atomic. A conflict on book 7 of 12
+  still leaves 6 written. What changes is that the operation **knows** and says
+  so. Cross-book atomicity needs the workspace-scoped lock §3.2 rejected.
+- **It does not survive a delete (ABA).** `analysis.ts`'s "Start fresh" and
+  `book-state.ts`'s reparse `rm` cast.json, and an absent file reads as `rev: 0`,
+  so `1 → delete → recreate as 1` is indistinguishable from "unchanged". §14.4
+  handles the one caller that spans a delete; for everyone else this is a stated
+  property, not a defect the counter can fix.
+- **It does not reach `PUT /:bookId/state`'s cast slice.** That route writes the
+  client's entire characters array; the server reads `rev` inside its own lock
+  immediately before writing, so the check passes trivially and a stale client
+  snapshot still overwrites a concurrent server-side edit. Closing that needs an
+  `If-Match`-style rev on the wire, which is out of scope here. The cast lock
+  still protects the clone-consent guards inside `preserveDesignedVoices`, which
+  is what Task 7's test targets.
+
+### 14.4 `analysis.ts` — and the trap the first draft walked into
+
+The first draft of this section said: on conflict, re-read the cast and re-run
+the merge against **that** as the base. **That would have re-broken the
+2026-07-14 Coalfall voice-strip incident, deterministically, on every "Start
+fresh" run.** The mechanism, because it must not be repeated:
+
+`priorCastForMerge` is read *above* the `fresh` block's `rm` — deliberately, and
+the comment there says so: *"Read happens before the fresh block below rm's
+cast.json, so the value survives that deletion."* A rev captured at the same
+point is `N`; the `rm` then resets the on-disk revision to `0`; the run's first
+interim write sees `actual = 0 ≠ N` and takes the rebuild path; the rebuild
+re-reads an **absent** cast, so its base is `[]`; and
+`mergeAnalysisResultWithExistingCast` short-circuits on an empty base
+(`if (!existing.length) return fresh;`). Every bespoke designed voice is dropped
+and cast.json is written voiceless — which is precisely the incident the read
+placement exists to prevent.
+
+Three rules follow, and they are requirements, not guidance:
+
+1. **Capture the revision *after* the `fresh` block's `rm`**, not alongside the
+   `priorCastForMerge` read. The snapshot must outlive the delete; the revision
+   must not.
+2. **The rebuild may never replace a non-empty prior with an empty base.** When
+   the re-read is empty — deleted, or a fresh run mid-flight — the retained
+   `priorCastForMerge` *is* the base. The rebuild overlays concurrent edits onto
+   the prior; it never substitutes for it.
+3. **Re-apply the load-point healers on the rebuild path.** Not just
+   `seedReuseGuardsFromPriorCast` and `applyRewriteToPriorCast`, but
+   `dropReuseContinuityKeepDesignedVoice`, `pruneStaleReuseLinks` and
+   `dedupePriorCastByName` — whose own comment says they run "at the single load
+   point, so all cast.json write sites see one prior row per name". A rebuild
+   that skips them reintroduces duplicate-by-name rows the load point exists to
+   collapse.
+
+Read-check-write happens in one lock acquisition, so there is no retry and no
+livelock (§14.2).
 
 ## 15. The series lock — closing the cross-book double-mint
 
-The one foldable residual a revision counter provably cannot reach.
+The one residual the revision counter provably cannot reach.
 
 `ensureCharacterVoiceUuid` mints a `voiceUuid` for a linked cast identity, then
 propagates it across the series. Two bulk designs on **two different books of one
 series** each read their *own* book, each see no `voiceUuid`, each mint, and each
-propagate. Every design gate keys on `bookDir` — `withDesignLock`
-(`design-lock.ts:26-27`), `isDesignBusy`, `cast-design.ts:648`'s `inFlightByBook`
-— while the propagation is series-wide.
+propagate. Every design gate keys on `bookDir` — `withDesignLock`, `isDesignBusy`,
+`cast-design.ts`'s `inFlightByBook` — while the propagation is series-wide.
 
-A revision counter does not help, and the reason is worth stating because it is
-counter-intuitive: the propagation **re-reads every book under its own lock**, so
-each write is against a current revision and is therefore "valid". The staleness
-is in the *mint decision*, which happens before either book is read. There is no
-file whose revision encodes it.
+A counter does not help: the propagation re-reads every book under its own lock,
+so each write is against a current revision and is therefore "valid". The
+staleness is in the *mint decision*, taken before either book is read. No file's
+revision encodes it.
 
-**Decision: a fourth key class, `series:<author>/<series>`**, held across
-read → decide → mint → propagate in `ensureCharacterVoiceUuid`'s series branch.
-Standalone books keep the book-scoped branch and need no series key.
+**Decision: a fourth key class, `series:<author>/<series>`.**
+
+**It wraps the whole function body, not "the series branch".** §5.1 establishes
+that the `voiceUuid` check and the mint sit *above* the branch; the series branch
+contains only the propagation. An earlier draft of this section said "held across
+read → decide → mint → propagate in the series branch", which contradicts §5.1
+and describes lines that do not contain the mint. Wrapping the branch would leave
+both racers deciding and minting outside the lock and serialise two propagations
+of two *different* uuids — the split-uuid outcome unchanged, under a lock that
+reads as the fix. The shape is:
+
+```ts
+withDesignLock(bookDir, () =>
+  seriesFilter
+    ? withSeriesLock(seriesFilter.author, seriesFilter.series, body)
+    : body())
+```
+
+where `body` is the existing read → decide → mint → propagate. Standalone books
+take the book-scoped path and need no series key.
 
 **Global lock order becomes `design` → `series` → `library-voice` → `cast`**
-(§4 rule 4). The existing `design → cast` path (`qwen-voice.ts:193` → `:203`)
-becomes `design → series → cast`, which is consistent. No path takes them in any
-other order; that is verified per §4, not assumed.
+(§4 rule 4). `design → series → cast` is live via `ensureCharacterVoiceUuid`.
+`series` and `library-voice` are never both held, so their relative position is
+declared rather than exercised — stated here so the ordering is not mistaken for
+a verified constraint.
+
+**Key derivation.** `series:${author}/${series}`. Both components are directory
+names under `BOOKS_ROOT`, so neither can contain `/` on disk today — but §3.1
+insists key derivation be unambiguous, so the helper encodes both components
+rather than concatenating raw.
+
+**Hold time.** This lock is held across the propagation, which for the series
+branch is a full workspace walk. That is the cost §3.2 refused for the *cast*
+class, accepted here because the alternative is the double-mint: the second racer
+must observe the first's mint, and it cannot do that if the lock is released
+before the propagation. §12's "one file read plus one file write" hold-time
+property therefore does **not** extend to the series class, and §12 says so.
 
 ## 16. Scope, restated
 
 With §14 and §15 folded in, this PR closes the residual set rather than filing
-it. **#2006 and #2015 are closed here, not deferred.**
+it. **#2006 and #2015 are closed here.**
 
-What remains in §12 is no longer debt. It is a list of **properties of the
-design** — things that are true of the chosen approach and would require a
-different approach to change:
+What remains in §12 is not debt. It is a list of **properties of the design** —
+things that would need a different approach to change:
 
 - The lock is in-process. Two server processes against one workspace defeat it.
 - `promote-voice`'s `realVoiceId` is pinned to its pre-lock read *because the
-  artifacts have already been renamed to it* by the time the lock is taken.
-  Re-deriving it would name files that do not exist.
+  artifacts have already been renamed to it*.
 - A multi-book propagation is per-book atomic, not atomic as a whole (§3.2,
   §14.3) — now detected and reported rather than silent.
-- `cast-design.ts`'s idempotency guards are evaluated before an LLM call and the
-  lock covers only the write; a duplicate persona generation is possible.
+- `cast-design.ts`'s idempotency guards are evaluated before an LLM call.
+- The counter does not survive a delete (ABA), and does not reach the client
+  full-document `PUT /:bookId/state` (§14.3).
+- The series lock is held across a workspace walk (§15).
 
-Each is stated at its site in the code, not only here. The distinction matters:
-a reader who finds "residual risks" reads a to-do list, and a to-do list that
-nobody is going to do is worse than an honest description of what the design is.
+Each is stated at its site in the code, not only here.
 
 ## 17. Ticketing
 
-`Closes #1981` (the filed defect), `Closes #2000` (the sweep), `Closes #2001`
-(§11), `Closes #2006` (§14, §15), `Closes #2015` (§14.2). One PR.
-
-Nothing is deferred out of this change. #2006 and #2015 were filed as follow-ups
-during design and are folded back in by §14 and §15 — the residual list in §12 is
-now a description of the design's properties, not a queue of work.
+`Closes #1981`, `Closes #2000`, `Closes #2001`, `Closes #2006`, `Closes #2015`.
+One PR. Nothing is deferred.

--- a/docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md
+++ b/docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md
@@ -1,11 +1,14 @@
 # cast.json write lock — design
 
 **Status:** approved
-**Issues:** #1981 (the filed defect), #2000 (the sweep), #2001 (incidental, §11)
+**Issues:** #1981 (the filed defect), #2000 (the sweep), #2001 (incidental, §11);
+#2006 filed for the three clone-consent gates a per-RMW lock cannot reach (§7)
 **Sequencing:** implementation bases on / rebases onto `fix/server-1933-assign-readiness`
-**Review:** revised after an adversarial pass found 3 Critical / 8 Major / 3 Minor
-against the first draft. All 14 folded; §5, §5.1, §6 and §8 are substantially
-rewritten as a result.
+**Review:** two adversarial passes. Round 1 found 3 Critical / 8 Major / 3 Minor;
+round 2, against the rewrite, found a further 4 Critical / 6 Major / 8 Minor —
+mostly in the sections the first rewrite had just changed. All folded. §6 and §7
+were re-decided outright after round 2 showed both had been designed against a
+wrong map of where the writes are.
 
 ## 1. What was filed, and what is actually wrong
 
@@ -34,7 +37,7 @@ B: read resolves → runs synchronously → writeJsonAtomic starts
 Both writes land. `writeJsonAtomic`'s rename makes each write individually
 non-torn, but the later rename wins outright, and A's mutation is gone.
 
-This is not theoretical. Measured (§7.1): two concurrent read-modify-writes
+This is not theoretical. Measured (§10.1): two concurrent read-modify-writes
 against one cast.json, issued from a bare `Promise.all`, lost a mutation in
 **200 of 200 trials**.
 
@@ -56,12 +59,12 @@ Two further sites *delete* it. Measured read→write spans:
 
 | Site | Span | inside the window |
 |---|---|---|
-| `qwen-voice.ts` `promote-voice` | `:692` → `:793` | `copyFile`, two `rm`s, and a **sidecar `fetch`** at `:768` |
+| `qwen-voice.ts` `promote-voice` | `:692` → `:793` | a `stat`, **four `rm`s**, **three `rename`s**, a `copyFile`, and a **sidecar `fetch`** at `:768` |
 | `cast-merge.ts` | `:77` → `:197` | writes *manuscript-edits.json* at `:171` |
 | `voice-override-linked.ts` | `:235` → `:364` | `await`s |
 | `library-cast-override.ts` | `:88`/`:89` → `:152`/`:153` | `await`s, **two books** |
 | `voice-library.ts` `/assign` | `:1277` → `:1434` | one (`:1386`) — the filed issue |
-| `analysis.ts` | `:2797` → `:3559`/`:3764`/`:4774` | **an entire analysis run** — see §6 |
+| `analysis.ts` | `:2797` → `:3558`/`:3763`/`:4774` | **an entire analysis run** — see §6 |
 | `cast-design.ts` | `:289`→`:293`, `:448`→`:452` | already re-reads `fresh` before writing |
 
 `promote-voice` — not `/assign` — holds the longest window in the codebase, and
@@ -165,9 +168,10 @@ two-lock AB/BA deadlock possible. A **design → cast** path is already live:
 `forEachMatchingCastCharacter`, which under this design takes a cast lock per
 matching book. No **cast → design** path exists today, so the design is not
 deadlocked — but the rule set is what future contributors read, and without rule 4
-it actively teaches them that cross-lock nesting is free. Wrapping
-`single-design.ts:110` or `qwen-voice.ts:532` in a cast lock would deadlock with
-no timeout and no diagnostic.
+it actively teaches them that cross-lock nesting is free. Any future change that
+wraps a `withDesignLock` call in a cast lock — for instance around
+`qwen-voice.ts:193` itself, or around `single-design.ts`'s design invocation —
+creates the opposite order and deadlocks with no timeout and no diagnostic.
 
 **What the lock does not cover.** It protects one read-modify-write. It does not
 make a *validate-then-write* safe when the validation and the write are in
@@ -179,7 +183,7 @@ The first draft's class table summed to 29 and switched counting units mid-table
 This one enumerates every site, counts sites throughout, and must sum to 35. The
 plan carries an arithmetic check on that.
 
-### Class 1 — mechanical: wrap the existing read..write span (17 sites)
+### Class 1 — mechanical: wrap the existing read..write span (18 sites)
 
 | Module | Sites |
 |---|---|
@@ -193,38 +197,57 @@ plan carries an arithmetic check on that.
 | `book-state.ts` | `:634` |
 | `voice-library.ts` | `:1434` (`POST /assign`), `:1536` (`DELETE /assign`) |
 | `qwen-voice.ts` | `:793` (`promote-voice`), `:893` (`DELETE emotion-variant`) |
-| `voice-library-usage.ts` | `:113` |
+| `cast-add-from-roster.ts` | `:147` |
+| `voice-library-usage.ts` | `:113` — **not mechanical, see below** |
 
-`qwen-voice.ts:793` and `:893` were missing from the first draft entirely.
-`:793`'s span covers a sidecar `fetch` and two `rm`s, and it writes the `cast`
-object read at `:692` — the longest and most exposed window in the sweep, not a
-routine wrap. `voice-library-usage.ts:113` is class 1 rather than a fan-out
-because `clearLibraryVoiceReferences` writes one book per iteration; the read
-must move inside the lock, since `walkConfirmedCasts()` (`:43`) *yields* an
-already-read `cast`.
+Three of these are not routine wraps despite sitting in this class:
 
-### Class 2 — multi-book: `withCastLocks` (9 sites)
+- **`qwen-voice.ts:793`** (`promote-voice`) was missing from the first draft
+  entirely. Its span covers a `stat`, four `rm`s, three `rename`s, a `copyFile`
+  and a sidecar `fetch`, and it writes the `cast` object read at `:692` — the
+  longest and most exposed window in the sweep.
+- **`cast-add-from-roster.ts:147`** moved here from class 2 after round 2: it
+  reads *both* books (`:104`, `:105`) but writes **only the source** (`:147`), and
+  `:79` already 400s same-book. A single-book lock on the source is correct;
+  `withCastLocks` across both would widen a lock over a second book for a
+  read-only consultation. Note the target read still feeds the decision, so it is
+  a check-then-act — accepted per §12, not closed here.
+- **`voice-library-usage.ts:113`** needs its read moved inside the lock, because
+  `walkConfirmedCasts()` (`:43`) *yields* an already-read `cast`. But that walker
+  is **shared** with `scanLibraryVoiceUsage` (`:71-85`) — §7's gate 2 — so
+  changing what it yields reaches into a consent gate. It is a shared-seam
+  restructure, sequenced with §7's library-voice lock rather than done blind.
+
+### Class 2 — multi-book: `withCastLocks` (8 sites)
 
 | Module | Sites |
 |---|---|
 | `cast-link-prior.ts` | `:142`, `:248` |
 | `cast-not-linked-to.ts` | `:106`, `:109`, `:202`, `:207` |
 | `library-cast-override.ts` | `:152`, `:153` — plus the §8 fix |
-| `cast-add-from-roster.ts` | `:147` |
 
 ### Class 3 — `voices.ts` fan-out: two branches, two write sites (2 sites)
 
 `forEachMatchingCastCharacter` (`voices.ts:771-834`) has its **own inline walk**;
-it does not use `walkConfirmedCasts` at all, which the first draft got wrong. Two
-distinct branches:
+it does not use `walkConfirmedCasts` at all. Two branches:
 
-- **`:788-803`, the `onlyBookDir` fast path**, writing at `:801`. This is the
-  branch every real call site takes — `cast-design.ts:514` and
-  `single-design.ts:182` both pass `job.bookDir`, and the fs-61 comment at
-  `voices.ts:783` says so explicitly. It carries production traffic and the first
-  draft's class-3 text did not describe it.
-- **`:816-829`, the workspace/series walk**, writing at `:828` — per-book lock
-  inside the loop, read moved in with it.
+- **`:816-829`, the workspace/series walk**, writing at `:828`. **This is the
+  primary production path**, and the first draft claimed the opposite. The fast
+  path is gated on `if (!seriesFilter && onlyBookDir)` (`:788`), and both cited
+  callers pass `seriesFilter` *as well as* `job.bookDir` (`cast-design.ts:510-515`,
+  `single-design.ts:176-183`) — so for any book in a real series the walk runs.
+  Three further callers never pass `onlyBookDir` at all: `applyTierToCastFiles`
+  (`voices.ts:938`, from `cast-tier.ts:38`), `persistEmotionVariant`
+  (`qwen-voice.ts:170`), and `ensureCharacterVoiceUuid` (`qwen-voice.ts:203`).
+  Per-book lock inside the loop, read moved in with it.
+- **`:788-803`, the `onlyBookDir` fast path**, writing at `:801` — taken only when
+  there is no `seriesFilter`, i.e. standalone books.
+
+This correction matters beyond the table: §3.2's granularity trade was originally
+reasoned as though the workspace walk were near-dead. It is not. The trade still
+stands — holding N locks across a full directory walk is still the worse option —
+but it is now a trade against a live path, and §12 records the resulting
+half-old/half-new exposure as a real accepted risk rather than a theoretical one.
 
 ### Class 4 — re-entrancy restructure (2 sites)
 
@@ -236,7 +259,7 @@ distinct branches:
 `:3558`, `:3763`, `:4774`, `:5422`, `:5927`. These do **not** take a cast lock.
 See §6.
 
-**17 + 9 + 2 + 2 + 5 = 35.** ✓
+**18 + 8 + 2 + 2 + 5 = 35.** ✓
 
 ### Class 6 — deletions (2 sites, not counted in the 35)
 
@@ -272,31 +295,60 @@ wrong. It has *no* design lock: `cast-design.ts:521` and `qwen-voice.ts:623` bot
 call it *after* `designQwenVoiceForCharacter` has released the lock
 (`qwen-voice.ts:384-471`). And its outer read is not merely a decision — `:152`
 computes `baseVoiceId = qwenStorageKey(character, characterId)` from the stale
-character, and bakes that value into the write payload at `:162`.
-`qwenStorageKey` reads `voiceUuid`, so a `voiceUuid` that changed between the
-outer read and the lock anchors the variant slot on a base that never existed —
-the #1057 orphaned-base shape, surfacing as a silent Kokoro fallback on
-re-render.
+character, and that value enters the write payload at `:158`/`:161` as the
+default `name` when the qwen slot has none. `qwenStorageKey` reads `voiceUuid`,
+so a `voiceUuid` that changed between the outer read and the lock anchors the
+variant slot on a base that never existed — the #1057 orphaned-base shape,
+surfacing as a silent Kokoro fallback on re-render. (Narrower than the first
+rewrite implied: it bites only when the slot has no existing `name`.)
 
-**The rule for both:** the re-read inside the lock must **re-evaluate every
-decision and re-derive every value** that feeds the write — re-check `voiceUuid`,
-re-derive `qwenStorageKey`. The outer read is an early-out optimisation and is
-never authoritative. The design lock is not part of the guarantee and must not be
-relied on.
+**The rule:** the re-read inside the lock must **re-evaluate every decision and
+re-derive every value** that feeds the write — re-check `voiceUuid`, re-derive
+`qwenStorageKey`. The outer read is an early-out optimisation, never
+authoritative.
 
-Both functions keep the two-branch structure: the book-scoped branch takes the
-cast lock and re-reads inside it; the series branch stays unlocked and delegates
-to `forEachMatchingCastCharacter`, which locks per book itself. That satisfies
-rule 1 and rule 4.
+### The branch this rule cannot cover, stated plainly
+
+Round 2 established that the rule above is satisfiable for the **book-scoped**
+branch of both functions and **not** for `ensureCharacterVoiceUuid`'s **series**
+branch. In that function the `voiceUuid` check (`:197`) and the mint (`:199`) sit
+*above* the branch; the series branch (`:202-205`) then delegates to
+`forEachMatchingCastCharacter`, which re-reads each book but is handed an
+already-decided uuid. There is no cast-lock scope in which the decision could be
+re-evaluated, because the decision precedes the branch.
+
+Two concurrent series-scoped calls therefore both read "no uuid", both mint, and
+both propagate. **That is prevented today, and only, by `withDesignLock(bookDir)`
+at `:193`** — exactly as the function's own docstring claims (`:182-184`).
+
+So the honest position, replacing the first rewrite's "the design lock is not
+part of the guarantee and must not be relied on":
+
+- For the **book-scoped** branch, the cast lock is the guarantee and the design
+  lock is not relied on.
+- For the **series** branch, **the design lock remains load-bearing.** This spec
+  does not change that and does not weaken it. Moving the decision under a cast
+  lock would require `ensureCharacterVoiceUuid` to hold a cast lock across
+  `forEachMatchingCastCharacter`, which violates rule 1 — genuine design work,
+  and out of scope here.
+- §11 edits `design-lock.ts`'s map cleanup **only**. It does not touch
+  acquisition, release, or ordering, so the series branch's existing guarantee is
+  unaffected. The implementation brief calls this out so nobody "simplifies" the
+  design lock away while touching that file.
+
+`persistEmotionVariant` has no design lock to lean on, so its book-scoped branch
+must take the cast lock and re-derive `qwenStorageKey` inside it; its series
+branch inherits `forEachMatchingCastCharacter`'s per-book locking and the same
+residual exposure.
 
 ## 6. `analysis.ts` — ownership, not a mutex
 
 `analysis.ts` is 5 of the 35 sites and the module that writes cast.json most
 often. It is **not a wrappable read-modify-write**: `priorCastForMerge` is read
 once at `:2797`, reconciled at `:2823`, and is then the merge base for writes at
-`:3559`, `:3764` and `:4774` — spread across the whole Phase 0/1 pipeline, with
+`:3558`, `:3763` and `:4774` — spread across the whole Phase 0/1 pipeline, with
 the interim writes *inside* the chapter loop. The subset route has the identical
-shape (read `:5206`, writes `:5423`, `:5927`).
+shape (read `:5206`, writes `:5422`, `:5927`).
 
 Neither available lock strategy works. Holding a cast lock for the run would
 block every other cast write on that book for minutes with no timeout. Re-reading
@@ -305,19 +357,48 @@ interim cast iteration N−1 wrote, so `mergeAnalysisResultWithExistingCast` wou
 no longer merge against the pre-run cast and srv-13's voice/reuse carry-forward
 would silently degrade.
 
-**Decision: analysis owns cast.json for the duration of its run**, expressed
-through the existing `markAnalysisBusy` / `isAnalysisBusy` registry
-(`tts/design-lock.ts:55-65`) rather than the mutex. That registry already exists
-for precisely this reason — it was built so a re-analysis (which rewrites the
-whole cast.json) cannot overlap a bulk design (which writes per-character
-overrides), and it ref-counts so a main plus a subset job can coexist.
+**Decision: a route-level admission gate, and nothing stronger — stated as
+admission control, not as a correctness guarantee.**
 
-Concretely: cast writers consult the registry and refuse with a clear 409 —
-*"analysis is rewriting this book's cast; try again when it finishes"* — rather
-than queueing behind an unbounded lock. That is a better user-visible failure than
-a request that hangs for minutes, and it is the behaviour the registry was
-designed to express. `analysis.ts`'s own five writes stay as they are; ownership,
-not serialisation, is what makes them safe.
+The first rewrite said cast writers would "consult the registry and refuse with a
+clear 409", and that "ownership, not serialisation, is what makes them safe".
+Round 2 showed both halves are wrong, and they are worth recording because the
+failure is instructive:
+
+- **Consulting `isAnalysisBusy` from an unlocked writer is itself check-then-act
+  — the exact defect class this spec exists to close.** `isAnalysisBusy` is a bare
+  `Map` read (`tts/design-lock.ts:63-65`) with no coupling to the cast mutex. A
+  writer that reads `false`, then `await`s its cast read — the very yield §1
+  identifies as the race — then writes, races a run that marks busy
+  (`analysis.ts:2572`, `:5109`) and writes at any of its five sites. The
+  consultation's window is *wider* than the one #1981 filed.
+- **A 409 is not expressible at most sites.** Of the 30 non-analysis sites, at
+  least eight have no status-code channel: `cast-design.ts:293`/`:452` and
+  `single-design.ts:178` run detached after `res.flushHeaders()` and report via
+  SSE `endJob`; `qwen-voice.ts:177`/`:215`, `voices.ts:801`/`:828` and
+  `voice-library-usage.ts:113` are shared helpers with multiple callers, for which
+  "refuse" is undefined — particularly when book 7 of 12 is busy and six are
+  already written.
+
+What actually works is the precedent already in the codebase: `cast-design.ts:655`
+checks busy **at route entry, before flushing SSE headers**, and refuses there.
+That is a route-level admission gate, and it is expressible precisely because
+nothing has been written or sent yet.
+
+So: **HTTP handlers that write cast.json check `isAnalysisBusy` at request entry,
+before any work, and 409 early.** Internal helpers and detached jobs do not check
+— they are downstream of a handler that already did.
+
+**This is admission control, not a lock.** It reduces the collision rate; it does
+not eliminate it, because an analysis run can begin after a handler is admitted.
+The spec says so in `cast-lock.ts`'s header and the code comment says so at each
+gate, in those words. Overstating it is how the next contributor concludes the
+book is covered.
+
+`analysis.ts`'s five writes are therefore **not protected by this PR**. That is
+recorded in §12 as an accepted, named residual rather than dressed up as
+ownership. Making them safe requires either a cast-lock-scoped busy check or a
+restructure of `priorCastForMerge`'s merge base, and both are their own design.
 
 The two deletion sites (§5 class 6) still take the cast lock — a delete is
 instantaneous and does not own the book.
@@ -325,26 +406,56 @@ instantaneous and does not own the book.
 ## 7. Check-then-act: the clone-consent gates, folded in
 
 A per-RMW lock does not close a *validate-then-write* that spans two scopes. Four
-gates read cast.json, decide, and then write elsewhere:
+gates read cast.json, decide, and then write elsewhere. **The first rewrite's
+table had three of these four rows wrong** — it printed the `readJson` line as the
+gate and the gate line as the write, because the citations were regenerated by
+pattern-matching nearby lines rather than re-derived. Corrected, with the function
+each write lives in:
 
-| Gate | Reads / decides | Writes |
-|---|---|---|
-| `voices.ts` `PUT /:voiceId/override` | `:709`/`:720` `hasClonedSlotAmongMatches` → 409 | `:728` `applyOverrideToCastFiles` |
-| `voice-library.ts` `DELETE /:voiceUuid` | `:1683` `scanLibraryVoiceUsage` → 409 usage report | `:1686` `clearLibraryVoiceReferences` |
-| `single-design.ts` | `:235` `characterHasClonedSlot` → 409 | `:254` |
-| `qwen-voice.ts` | `:532` `characterHasClonedSlot` → 409 | `:552` |
+| Gate | Reads | Decides (409) | Writes |
+|---|---|---|---|
+| `voices.ts` `PUT /:voiceId/override` | `:612-642` walk | `:709`/`:720` `hasClonedSlotAmongMatches` | `:728` `applyOverrideToCastFiles`, per book inside `forEachMatchingCastCharacter` |
+| `voice-library.ts` `DELETE /:voiceUuid` | `:1680` `scanLibraryVoiceUsage` | `:1682` (`usage.length > 0 && !confirmed`) | `:1686` `clearLibraryVoiceReferences`, then `eraseLibraryVoiceArtifacts` |
+| `single-design.ts` | `:235` | `:254` `characterHasClonedSlot` | `:178` `applyOverrideToCastFiles`, in `runSingleDesign`, detached after `res.flushHeaders()` (`:266`) |
+| `qwen-voice.ts` | `:532` | `:552` `characterHasClonedSlot` | `:623` `persistEmotionVariant` |
 
-These are the fs-38 Wave 3c GATE 2 clone-consent guards — the ones added because
-"Phase 0 fixed seven live bugs that all had the same shape — a guard-less write
-erasing a clone marker upstream of a resolver" (`voices.ts:888-893`). Shipping a
-lock that *reads as* "cast.json RMW is now safe" while these stay open is how the
-eighth gets missed.
+Against the corrected map, "each gate re-validates inside the lock scope that
+performs its write" is **not achievable for three of the four**:
 
-**Decision: folded into this PR.** Each gate re-validates inside the lock scope
-that performs its write, so the 409 decision and the write it guards are one
-critical section. The `voice-library.ts` delete is the one with real data loss —
-a reference acquired in the gap is left dangling at a `libraryUuid` whose
-artifacts `eraseLibraryVoiceArtifacts` is about to delete.
+- **`voices.ts` is a cross-book veto.** `hasClonedSlotAmongMatches` walks the
+  whole workspace or series and blocks the entire operation if any matching
+  character anywhere carries a cloned slot; the write is per-book. Re-validating
+  inside a per-book lock demotes a workspace veto to a per-book one, and honouring
+  it mid-walk means a 409 on a partially-applied propagation. Fixing it properly
+  means reopening §3.2.
+- **`single-design.ts` and `qwen-voice.ts` write from contexts that cannot
+  refuse** — one detached after header flush, one a helper shared between an SSE
+  bulk job and a JSON route.
+
+**Decision: fix gate 2 here; file the other three.**
+
+**Gate 2 is fixed, and its fix is not a cast lock.** The data loss is real —
+a reference written after the scan passed a book is left dangling at a
+`libraryUuid` whose artifacts `eraseLibraryVoiceArtifacts` is about to erase —
+and it is cross-book by construction, so no per-book cast lock can reach it. The
+fix is a lock on a **different key**: `withKeyLock('library-voice:<uuid>')` held
+across scan → clear → erase, so a concurrent assign of that voice cannot land
+mid-delete. Note also that with `?confirm=1` the user has already consented, so
+there is nothing to re-validate — the lock is protecting the *artifact erasure*,
+not re-deciding the 409.
+
+This also sequences `voice-library-usage.ts:113` (§5 class 1), since
+`walkConfirmedCasts` is shared between `clearLibraryVoiceReferences` and this
+gate's `scanLibraryVoiceUsage`.
+
+**Gates 1, 3 and 4 are filed as #2006** — one issue, not three. They are the
+fs-38 Wave 3c clone-consent guards, added because "Phase 0 fixed seven live bugs
+that all had the same shape — a guard-less write erasing a clone marker upstream
+of a resolver" (`voices.ts:888-893`). The real work in each is deciding what a
+refusal *means* for a partially-applied cross-book propagation and for a detached
+job — a behaviour decision, not a locking one. Shipping a lock that reads as
+"cast.json writes are safe now" while they stay open is how the eighth gets
+missed, which is what #2006 exists to keep visible.
 
 ## 8. `library-cast-override.ts` same-book: folded in
 
@@ -411,7 +522,7 @@ test that is green because the lock partitioned rather than because it held.
 ### 10.1 The interleave mechanism — settled, with evidence
 
 The first draft deferred this to the plan as "an open risk". It is now measured.
-A spike (`server/src/workspace/`, run against real files, single import graph)
+A spike run in this worktree against real files, in a single import graph,
 compared two candidate harnesses:
 
 | Mechanism | Unlocked | Locked |
@@ -426,6 +537,14 @@ needed, and the simpler harness is also the deterministic one.
 **Decision: bare `Promise.all`, used uniformly at every site.** The barrier
 mechanism is not used anywhere — a second mechanism would let a site that fails
 under one be quietly rewritten to the other.
+
+**The spike is task 1 of the implementation plan, not an artifact of this spec.**
+Round 2 correctly objected that these numbers were unreproducible: the spike file
+was written, run, and then moved out of the repo, so the evidentiary spine of §1,
+§3 and §10.2 existed only as a quoted figure. It lands as a real committed test
+(`server/src/workspace/cast-lock.race.test.ts`) **before any site is converted**,
+proving red on the unlocked path first. Its single-import-graph property is not
+incidental — see §10.3.
 
 ### 10.2 The outcome test
 
@@ -444,11 +563,27 @@ as a required step with recorded output.
 ### 10.3 The partition assertion — mandatory, and it comes first
 
 Because a partitioned lock passes both the outcome test and the revert
-verification, **each outcome spec must first assert that the two writers share
-one lock instance.** `cast-lock.ts` exposes a test-only accessor (an instance
-token, or `chains.size`) and the spec asserts contention actually occurred before
-asserting the outcome. Alternatively the spec pins a single import graph and
-states that it does. Without this, §10.2 proves nothing.
+verification, each outcome spec must establish that the two writers actually
+share one lock instance.
+
+The first rewrite made a test-only `chains.size` accessor the mandatory
+countermeasure and a pinned import graph the fallback. **That is backwards, and
+the accessor does not work.** It is imported into the *spec file*, so it resolves
+through the spec file's registry — which in the failure mode being detected is
+neither writer's. Worse, in the half-partitioned case the observed size is `1`,
+indistinguishable from a correctly shared lock with one queued waiter, because
+`file-lock.ts:11` overwrites the same key rather than adding an entry per waiter.
+An instance token would only help if each *writer* reported which instance it
+used, and nothing in this design plumbs that.
+
+**Inverted: pinning a single import graph is the mandatory requirement.** Every
+outcome spec drives both writers through one module registry and states in a
+comment that it does; specs in this set do not call `vi.resetModules()` between
+the two writers. No test-only accessor is added — a countermeasure that cannot
+detect the failure it targets is worse than none, because it looks like coverage.
+
+This is also why §10.1's spike lands as a committed test rather than a quoted
+number: it is the reference for what a correctly-pinned harness looks like.
 
 ### 10.4 Guard test
 
@@ -464,7 +599,7 @@ inside a lock scope* — is preferred if it can be written without false positiv
 
 No `verify-cache.mjs` `extraFiles` entry is needed. The #1847 trap applies to
 files read at runtime from *outside* a step's globs; this guard reads
-`server/src/**`, which `test:server` already globs (`verify-cache.mjs:108`) and
+`server/src/**`, which `test:server` already globs (`verify-cache.mjs:113`) and
 `verify.yml:152` already matches. Any diff adding an unlocked write site
 necessarily busts both. Adding an entry would be a no-op and a cargo-culted
 precedent.
@@ -509,20 +644,42 @@ Tail-detection is then correct, and there is no losing interleave: a waiter's
 read of `prior` and its `chains.set` are in one synchronous block with no `await`
 between (`file-lock.ts:8-11`), as are `release()` and the `delete`. So a waiter
 either registered before the delete (entry ≠ `mine`, no delete) or starts fresh
-from `Promise.resolve()` after `fn()` has already returned. Applied identically
-to all three, with the three comments corrected to match.
+from `Promise.resolve()` after `fn()` has already returned.
+
+The same change applies to all three, but **the safety argument above is derived
+against `file-lock.ts`'s structure and must be re-stated for
+`chapters-restructure.ts`, not assumed.** That copy puts `await prev` *inside*
+its `try` and omits the `.catch()` swallow, so its control flow differs. (In
+practice its chain can never reject — every gate resolves in a `finally` — which
+makes adding the rejection arm semantically inert there; the point is that this
+was checked rather than carried over.) All three comments are corrected to match
+the code.
 
 ## 12. Residual risks, accepted
 
 - **No bound on hold time or wait time.** `withKeyLock` (`file-lock.ts:7-19`) has
-  no timeout, no queue cap, no fairness guarantee and no diagnostic for a
-  long-held key. A slow or wedged holder turns every cast write on that book into
-  an unbounded hang. Today those requests race and one loses a mutation; after
-  this change they wait. That is a real trade, and it is why §6 routes analysis —
-  the only multi-minute holder — to ownership rather than to the mutex. The
-  primitive gains a warn-after-N-seconds log so a wedged key is diagnosable
-  rather than silent. Expected hold time for every other class is one file read
-  plus one file write.
+  no timeout, no queue cap and no diagnostic for a long-held key. (It *is* FIFO by
+  construction — a promise chain — so waiters are ordered fairly; the first
+  rewrite's "no fairness guarantee" was wrong and contradicted §10.5's own
+  waiter-ordering test.) A slow or wedged holder turns every cast write on that
+  book into an unbounded hang. Today those requests race and one loses a
+  mutation; after this change they wait. That trade is why §6 keeps analysis —
+  the only multi-minute writer — off the mutex entirely. Expected hold time for
+  every other class is one file read plus one file write.
+
+  A warn-after-N-seconds log was considered and **dropped**. `withKeyLock` has
+  five existing non-cast callers (`book-state.ts:1588`,
+  `script-review-ledger.ts:83`/`:105`/`:131`/`:143`), so a timer per acquisition
+  is a behaviour change to all of them, and a non-`unref()`d one would hold the
+  event loop open on what is about to become the hottest lock in the product —
+  in a repo whose flake register already tracks tinypool worker-exit failures.
+  Speculative diagnostics on a shared primitive are not worth that.
+- **`analysis.ts`'s five writes are not protected by this PR.** §6's admission
+  gate reduces collisions; it does not serialise them. Named here rather than
+  implied, because §6's first draft claimed otherwise.
+- **`cast-add-from-roster.ts` reads the target book to decide a source write.**
+  That consultation is check-then-act and is not closed by a single-book lock on
+  the source.
 - **In-process only.** Two server processes against one workspace would defeat
   this entirely. The product runs one server; verified that `server/src` has no
   `worker_threads` and no cast.json writer in a child process.
@@ -540,3 +697,10 @@ to all three, with the three comments corrected to match.
 
 `Closes #1981` (the filed defect), `Closes #2000` (the sweep), `Closes #2001`
 (§11). One PR, per the delivery decision.
+
+`Refs #2006` — the three clone-consent gates §7 established a per-RMW lock cannot
+reach. Filed, not folded, because the work in each is deciding what a refusal
+*means* for a partially-applied cross-book propagation and for a detached job.
+That is a behaviour decision needing its own design pass, not a locking one, and
+it is the one place in this spec where deferral is the honest call rather than a
+scope dodge.

--- a/docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md
+++ b/docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md
@@ -1,13 +1,19 @@
 # cast.json write lock — design
 
 **Status:** approved
-**Closes:** #1981 (the filed defect), #2000 (the sweep), #2001 (§11)
-**Defers:** #2006 (three clone-consent gates + two writers a per-RMW lock cannot
-reach), #2015 (`analysis.ts`'s five writes)
+**Closes:** #1981 (the filed defect), #2000 (the sweep), #2001 (§11),
+#2006 (§14, §15), #2015 (§14.2) — **nothing is deferred out of this change**
 **Sequencing:** implementation bases on / rebases onto `fix/server-1933-assign-readiness`
 
-**Review:** four adversarial passes — 3C/8M/3m, 4C/6M/8m, 1C/5M/5m, then
-0C/4M/4m. Each round's worst findings landed in whatever the *previous* round had
+**Scope note (post-review):** §14 and §15 were added after five review rounds,
+on a decision to fold every residual rather than ship a cleanup lane behind this
+PR. They close #2006 and #2015, which earlier drafts deferred. Sections 6, 7 and
+12 are written against the pre-fold scope and are annotated where the fold
+supersedes them — read §14–§16 as the current position.
+
+**Review:** four adversarial passes on the pre-fold scope — 3C/8M/3m, 4C/6M/8m,
+1C/5M/5m, then 0C/4M/4m; a fifth reviewed the plan (2C/8M/6m, all in the plan).
+§14 and §15 postdate all of them and have not yet been through a round. Each round's worst findings landed in whatever the *previous* round had
 just rewritten, which is the main thing to know when reading this document: the
 parts revised most recently are the parts least proven. Round 3 verified ~60
 citations clean; round 4 confirmed the three-class lock order holds across every
@@ -209,11 +215,16 @@ CLAUDE.md's *Conventions worth preserving*:
    written down, is rule 2's failure mode and not a narrowing.** A reviewer who
    cannot tell which they are looking at should treat it as the failure mode.
 3. **Two or more books → `withCastLocks`, never nested `withCastLock`s.**
-4. **Global lock order: `design` → `library-voice` → `cast`.** Every acquisition
-   site names where it sits in that order. Never acquire a lock from an earlier
-   class while holding one from a later class.
+4. **Global lock order: `design` → `series` → `library-voice` → `cast`.** Every
+   acquisition site names where it sits in that order. Never acquire a lock from
+   an earlier class while holding one from a later class.
 
-Rule 4 covers **three** lock classes, not two. The first rewrite stated it over
+Rule 4 covers **four** lock classes. `series:<author>/<series>` is added by §15;
+the existing `design → cast` path (`qwen-voice.ts:193` → `:203`) becomes
+`design → series → cast`, which is consistent with the order rather than a new
+constraint on it.
+
+It covers more than two. The first rewrite stated it over
 `design` and `cast` only, and §7 then introduced `library-voice:<uuid>` four
 sections later — leaving a rule that would read as satisfied by an ordering it
 had never considered. Concretely, the `DELETE /voice-library/:voiceUuid` path
@@ -483,8 +494,15 @@ interim cast iteration N−1 wrote, so `mergeAnalysisResultWithExistingCast` wou
 no longer merge against the pre-run cast and srv-13's voice/reuse carry-forward
 would silently degrade.
 
-**Decision: `analysis.ts` is out of scope for this PR. Its five writes stay
-unprotected, and that is recorded as a named residual (§12) and filed as #2015.**
+> **Superseded by §14.2.** This section records why the two *lock-based*
+> mitigations were rejected, which is still the reasoning that rules them out.
+> The conclusion — that `analysis.ts` ships unprotected — no longer holds: §14's
+> revision counter closes it without either mitigation, by checking the merge
+> base at each write instead of trying to keep it valid across the run. #2015 is
+> closed by this PR.
+
+**Decision at the time: `analysis.ts` is out of scope. Its five writes stay
+unprotected, recorded as a named residual and filed as #2015.**
 
 Two mitigations were designed and both rejected. They are recorded because each
 looked obviously right at the time, and the second survived a full review round
@@ -593,7 +611,14 @@ This also sequences `voice-library-usage.ts:113` (§5 class 1), since
 `walkConfirmedCasts` is shared between `clearLibraryVoiceReferences` and this
 gate's `scanLibraryVoiceUsage`.
 
-**Gates 1, 3 and 4 are filed as #2006** — one issue, not three. They are the
+> **Superseded by §14.** Gates 1, 3 and 4 were filed rather than fixed because
+> the open question was what a refusal *means* for a partially-applied cross-book
+> propagation and for a detached job. §14.2 answers exactly that, generically:
+> recompute where you can, 409 where you can, report-and-skip where you can do
+> neither. #2006 is closed by this PR. The analysis below stands — it is why a
+> per-book cast lock alone was never going to be the mechanism.
+
+**Filed at the time as #2006** — one issue, not three. They are the
 fs-38 Wave 3c clone-consent guards, added because "Phase 0 fixed seven live bugs
 that all had the same shape — a guard-less write erasing a clone marker upstream
 of a resolver" (`voices.ts:888-893`). The real work in each is deciding what a
@@ -807,6 +832,11 @@ the code.
 
 ## 12. Residual risks, accepted
 
+> **Re-scoped by §16.** With §14 and §15 folded in, the items below that were
+> *outstanding work* are closed. What remains is a description of the design's
+> **properties** — things that would need a different approach to change, not a
+> queue. Entries superseded by the fold are marked inline.
+
 - **No bound on hold time or wait time.** `withKeyLock` (`file-lock.ts:7-19`) has
   no timeout, no queue cap and no diagnostic for a long-held key. (It *is* FIFO by
   construction — a promise chain — so waiters are ordered fairly; the first
@@ -826,20 +856,21 @@ the code.
   event loop open on what is about to become the hottest lock in the product —
   in a repo whose flake register already tracks tinypool worker-exit failures.
   Speculative diagnostics on a shared primitive are not worth that.
-- **`analysis.ts`'s five writes are not protected by this PR at all.** Not
-  serialised, not gated — §6 rejected both mitigations it tried. This is the
-  largest unprotected writer left standing, and it is filed as **#2015**. Named
-  bluntly here because two successive drafts of §6 claimed otherwise, each in a
-  way that read as coverage.
-- **`cast-link-prior.ts:239-241` plants `libraryUuid` references it never names**,
-  so §7's `library-voice` key cannot reach it. Fourth entry on **#2006**.
-- **Cross-book concurrent series designs can double-mint a `voiceUuid`.**
-  Pre-existing (every design gate keys on `bookDir` while the propagation is
-  series-wide), and this sweep makes the resulting damage finer-grained — a split
-  uuid across the series rather than last-writer-wins. §5.1 has the mechanism;
-  added to **#2006**.
-- **Three cross-book check-then-act consultations survive**, not one. Earlier
-  drafts named only the smallest:
+- ~~**`analysis.ts`'s five writes are not protected.**~~ **Closed by §14.2** —
+  the merge base is now revision-checked at each write and rebuilt when it has
+  moved, rather than replayed. #2015 closed.
+- ~~**`cast-link-prior.ts:239-241` plants `libraryUuid` references it never
+  names.**~~ **Closed by §14** — it records the target's revision at read and
+  asserts it at write, so a reference planted from a snapshot that has since
+  moved is detected rather than written blind.
+- ~~**Cross-book concurrent series designs can double-mint a `voiceUuid`.**~~
+  **Closed by §15** — the mint decision moves under a `series:<author>/<series>`
+  key. This is the one item the revision counter provably could not reach, since
+  the staleness is in a decision taken before any file is read.
+- ~~**Three cross-book check-then-act consultations survive.**~~ **Closed by
+  §14** — each records the revision of every book it consulted and asserts it at
+  write time. Retained here because the three sites are where the counter has to
+  be threaded, and they are easy to miss:
   - `cast-add-from-roster.ts` reads the target book to decide a source write;
   - `voice-override-linked.ts` reads the **source** cast and derives
     `canonicalVoiceId`, `sourceTokens`, the `inGroup` predicate and the entire
@@ -874,17 +905,140 @@ the code.
   the diff looks locked and is not. Only review catches this, which is why rule 2
   is stated in the code and not only here.
 
-## 13. Ticketing
+## 14. The cast.json revision counter — closing check-then-act
+
+§7 and §12 between them named six places where a decision is derived from a
+cast.json snapshot and the write that depends on it lands in a *different* lock
+scope. The per-book lock cannot reach any of them: it makes each read-modify-write
+atomic, and every one of these is a read in one scope and a write in another.
+
+They are not six defects. They are one defect six times:
+
+| Site | Decision | Write |
+|---|---|---|
+| `analysis.ts` | `priorCastForMerge`, read once at `:2797` | `:3558`, `:3763`, `:4774`, `:5422`, `:5927`, minutes later |
+| `voices.ts` `PUT /:voiceId/override` | `hasClonedSlotAmongMatches` cross-book veto | `applyOverrideToCastFiles`, per book |
+| `single-design.ts` | `characterHasClonedSlot` 409 at `:254` | `:178`, detached after `res.flushHeaders()` |
+| `qwen-voice.ts` | `characterHasClonedSlot` 409 at `:552` | `:623` via `persistEmotionVariant` |
+| `cast-link-prior.ts` | target's `overrideTtsVoices`, read at `:105` | source, at `:248` |
+| `voice-override-linked.ts` / `cast-series-patch.ts` | source snapshot → `writes` list / `targets` list | other books |
+
+**Decision: cast.json carries a revision, and a write that depends on an earlier
+read asserts the revision has not moved.** Optimistic concurrency, not a longer
+lock — a longer lock is what §3.2 and §6 both rejected, for good reasons that
+have not changed.
+
+This is deliberately *one* mechanism rather than six bespoke fixes. Six fixes
+would each be locally obvious and collectively unenforceable: nothing would stop
+a seventh instance, and each would invent its own failure semantics. A revision
+makes staleness **detectable**, which is the property all six actually need.
+
+### 14.1 The shape
+
+`cast.json` gains a top-level `rev: number`. Absent means `0` — a read-path
+default, so no migration script and no compatibility break with an existing
+workspace.
+
+Two helpers, in `workspace/cast-io.ts`, both of which assume the caller holds the
+cast lock:
+
+```ts
+readCastForUpdate(bookDir): Promise<{ cast: CastJson; rev: number }>
+writeCastChecked(bookDir, next: CastJson, expectedRev: number): Promise<void>
+```
+
+`writeCastChecked` re-reads, compares `rev` against `expectedRev`, and throws
+`CastRevConflictError` if it moved. On success it writes `rev: expectedRev + 1`.
+
+**The helper owns the increment, and that matters beyond bookkeeping.** At least
+**20 of the 35** current writers construct a fresh payload (`{ characters:
+nextCharacters }`) rather than passing back the object they read — a shape that
+drops every other top-level field. Left alone they would silently erase `rev` on
+every write and the counter would never advance. Routing writes through one
+helper is what stops that, and it is the same argument as §3.1's for key
+derivation.
+
+### 14.2 What a conflict means, per caller shape
+
+This is the "refusal semantics" question #2006 was filed to answer. One rule,
+three shapes:
+
+- **Can recompute → recompute.** `analysis.ts` re-derives its merge against the
+  fresh cast rather than replaying `priorCastForMerge`. Its run must not fail
+  because a user renamed a character mid-analysis. This also answers #2015: the
+  merge base does not need to *survive* the run, it needs to be *checked* at each
+  write and rebuilt when it has moved.
+- **Can refuse → 409.** The HTTP gates (`voices.ts`, `cast-link-prior`,
+  `voice-override-linked`, `cast-series-patch`) return
+  `409 { code: 'cast-changed' }`. The caller retries against fresh state. This is
+  expressible because these handlers have not yet responded.
+- **Can neither → report and skip.** The detached SSE jobs (`single-design.ts`,
+  `qwen-voice.ts`'s bulk path) log the conflict, skip that book, and surface it in
+  the job's completion payload. §6 established these cannot 409; a revision
+  conflict does not change that, but it does make the skip *deliberate and
+  reported* rather than a silent overwrite.
+
+### 14.3 What this does not do
+
+It does not make a multi-book propagation atomic. A conflict on book 7 of 12
+still leaves 6 books written. What changes is that the operation **knows** and
+says so, instead of overwriting a decision it never saw. Genuine cross-book
+atomicity needs the workspace-scoped lock §3.2 rejected, and that rejection
+stands.
+
+## 15. The series lock — closing the cross-book double-mint
+
+The one foldable residual a revision counter provably cannot reach.
+
+`ensureCharacterVoiceUuid` mints a `voiceUuid` for a linked cast identity, then
+propagates it across the series. Two bulk designs on **two different books of one
+series** each read their *own* book, each see no `voiceUuid`, each mint, and each
+propagate. Every design gate keys on `bookDir` — `withDesignLock`
+(`design-lock.ts:26-27`), `isDesignBusy`, `cast-design.ts:648`'s `inFlightByBook`
+— while the propagation is series-wide.
+
+A revision counter does not help, and the reason is worth stating because it is
+counter-intuitive: the propagation **re-reads every book under its own lock**, so
+each write is against a current revision and is therefore "valid". The staleness
+is in the *mint decision*, which happens before either book is read. There is no
+file whose revision encodes it.
+
+**Decision: a fourth key class, `series:<author>/<series>`**, held across
+read → decide → mint → propagate in `ensureCharacterVoiceUuid`'s series branch.
+Standalone books keep the book-scoped branch and need no series key.
+
+**Global lock order becomes `design` → `series` → `library-voice` → `cast`**
+(§4 rule 4). The existing `design → cast` path (`qwen-voice.ts:193` → `:203`)
+becomes `design → series → cast`, which is consistent. No path takes them in any
+other order; that is verified per §4, not assumed.
+
+## 16. Scope, restated
+
+With §14 and §15 folded in, this PR closes the residual set rather than filing
+it. **#2006 and #2015 are closed here, not deferred.**
+
+What remains in §12 is no longer debt. It is a list of **properties of the
+design** — things that are true of the chosen approach and would require a
+different approach to change:
+
+- The lock is in-process. Two server processes against one workspace defeat it.
+- `promote-voice`'s `realVoiceId` is pinned to its pre-lock read *because the
+  artifacts have already been renamed to it* by the time the lock is taken.
+  Re-deriving it would name files that do not exist.
+- A multi-book propagation is per-book atomic, not atomic as a whole (§3.2,
+  §14.3) — now detected and reported rather than silent.
+- `cast-design.ts`'s idempotency guards are evaluated before an LLM call and the
+  lock covers only the write; a duplicate persona generation is possible.
+
+Each is stated at its site in the code, not only here. The distinction matters:
+a reader who finds "residual risks" reads a to-do list, and a to-do list that
+nobody is going to do is worse than an honest description of what the design is.
+
+## 17. Ticketing
 
 `Closes #1981` (the filed defect), `Closes #2000` (the sweep), `Closes #2001`
-(§11). One PR, per the delivery decision.
+(§11), `Closes #2006` (§14, §15), `Closes #2015` (§14.2). One PR.
 
-`Refs #2015` — `analysis.ts`'s five writes, per §6.
-
-`Refs #2006` — the three clone-consent gates §7 established a per-RMW lock cannot
-reach, plus `cast-link-prior`'s unnamed `libraryUuid` references and the
-cross-book double-mint. Filed, not folded, because the work in each is deciding
-what a refusal *means* for a partially-applied cross-book propagation and for a
-detached job. That is a behaviour decision needing its own design pass, not a
-locking one, and it is the one place in this spec where deferral is the honest
-call rather than a scope dodge.
+Nothing is deferred out of this change. #2006 and #2015 were filed as follow-ups
+during design and are folded back in by §14 and §15 — the residual list in §12 is
+now a description of the design's properties, not a queue of work.

--- a/docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md
+++ b/docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md
@@ -1,8 +1,11 @@
 # cast.json write lock — design
 
 **Status:** approved
-**Issues:** #1981 (the filed defect), #2000 (the sweep), #2001 (incidental, §10)
+**Issues:** #1981 (the filed defect), #2000 (the sweep), #2001 (incidental, §11)
 **Sequencing:** implementation bases on / rebases onto `fix/server-1933-assign-readiness`
+**Review:** revised after an adversarial pass found 3 Critical / 8 Major / 3 Minor
+against the first draft. All 14 folded; §5, §5.1, §6 and §8 are substantially
+rewritten as a result.
 
 ## 1. What was filed, and what is actually wrong
 
@@ -29,10 +32,11 @@ B: read resolves → runs synchronously → writeJsonAtomic starts
 ```
 
 Both writes land. `writeJsonAtomic`'s rename makes each write individually
-non-torn, but the later rename wins outright, and A's mutation is gone. Removing
-the inner `await` narrows the window from *an entire filesystem read* to *one
-run-to-completion plus the write's own I/O* — a large and worthwhile reduction in
-the odds — but it does not close the race.
+non-torn, but the later rename wins outright, and A's mutation is gone.
+
+This is not theoretical. Measured (§7.1): two concurrent read-modify-writes
+against one cast.json, issued from a bare `Promise.all`, lost a mutation in
+**200 of 200 trials**.
 
 Two consequences follow, and they shape everything below:
 
@@ -48,28 +52,30 @@ Two consequences follow, and they shape everything below:
 
 Seventeen modules write `writeJsonAtomic(castJsonPath(…))` across 35 call sites.
 cast.json is the most-written file in the workspace and has no lock of any kind.
-Measured read→write spans:
+Two further sites *delete* it. Measured read→write spans:
 
-| Site | Span | `await`s inside |
+| Site | Span | inside the window |
 |---|---|---|
-| `cast-merge.ts` | `:77` → `:197` | yes — writes *manuscript-edits.json* at `:171` inside the window |
-| `voice-override-linked.ts` | `:235` → `:364` | yes |
-| `library-cast-override.ts` | `:88`/`:89` → `:152`/`:153` | yes, and **two books** |
+| `qwen-voice.ts` `promote-voice` | `:692` → `:793` | `copyFile`, two `rm`s, and a **sidecar `fetch`** at `:768` |
+| `cast-merge.ts` | `:77` → `:197` | writes *manuscript-edits.json* at `:171` |
+| `voice-override-linked.ts` | `:235` → `:364` | `await`s |
+| `library-cast-override.ts` | `:88`/`:89` → `:152`/`:153` | `await`s, **two books** |
 | `voice-library.ts` `/assign` | `:1277` → `:1434` | one (`:1386`) — the filed issue |
-| `voice-style.ts` | `:53`→`:69`, `:98`→`:129` | short |
-| `cast-design.ts` | `:289`→`:293`, `:448`→`:452` | already re-reads `fresh` immediately before writing |
+| `analysis.ts` | `:2797` → `:3559`/`:3764`/`:4774` | **an entire analysis run** — see §6 |
+| `cast-design.ts` | `:289`→`:293`, `:448`→`:452` | already re-reads `fresh` before writing |
 
-`cast-design.ts`'s re-read-then-write is a hand-rolled mitigation of exactly this
-race, which is corroborating evidence that the defect class is real and has been
-felt before. It is also the shape a lock wants, so those two sites convert
-cleanly.
+`promote-voice` — not `/assign` — holds the longest window in the codebase, and
+it spans a network call to the sidecar. `cast-design.ts`'s re-read-then-write is
+a hand-rolled mitigation of this exact race, corroborating that the defect class
+is real and has been felt before; it is also the shape a lock wants, so those two
+sites convert cleanly.
 
-Line numbers in this table are as of `main` at `88476dca` and will shift — see
-§8. The implementation plan cites symbols, not lines.
+Line numbers here are as of `main` at `88476dca` and will shift — see §9. The
+implementation plan cites symbols, not lines.
 
 ## 3. Decision: serialise, don't narrow
 
-The fix is a per-book cast.json write lock, applied to **every** writer. Narrowing
+The fix is a per-book cast.json write lock, applied to every writer. Narrowing
 windows is unfalsifiable defence; a lock either holds the critical section or it
 does not, and a test can tell you which.
 
@@ -90,26 +96,39 @@ withCastLocks<T>(bookDirs: string[], fn: () => Promise<T>): Promise<T>
 `withCastLock` delegates to `withKeyLock(castJsonPath(bookDir), fn)`.
 
 The wrapper is not ceremony. **Key derivation must live in exactly one place.**
-If two sites derive the key differently — `bookDir` at one, `castJsonPath(bookDir)`
-at another, or an unnormalised path separator on Windows — the lock silently
-partitions into two mutexes that never contend. Every test still passes and the
-protection is gone. A single named function removes the opportunity.
+There are two ways this lock can silently partition into mutexes that never
+contend, and both leave every test green:
+
+- **Derivation drift.** One site keys on `bookDir`, another on
+  `castJsonPath(bookDir)`, or on an unnormalised path separator. A single named
+  function removes the opportunity.
+- **Module-registry drift — the one that will actually bite.** `chains` is
+  module-level state (`file-lock.ts:5`), and **29 server test files call
+  `vi.resetModules()`**, the dominant workspace-test idiom (`mkdtemp` +
+  `WORKSPACE_DIR` + `vi.resetModules` so `paths.ts` re-reads the override — see
+  `routes/backup.test.ts:7`). Any spec where the route under test and a second
+  writer resolve through different module registries gets **two `chains` Maps**.
+
+The second mode is the more dangerous, because a partitioned lock behaves like no
+lock *in both directions*: the outcome test passes by partition, and §7's
+revert-verification also passes vacuously. §7.3 states the countermeasure.
 
 `withCastLocks` **dedupes, then sorts** the derived keys, then nests:
 
 - **Sorting** makes AB/BA deadlock impossible by construction, which matters
   because five call sites take two books and their argument order is
   caller-determined.
-- **Deduping** matters because the two-book routes can legitimately receive the
-  same book twice (`source === target`). A promise-chain mutex is not reentrant;
-  acquiring one key twice in a single call wedges that request forever — not
-  slowly, permanently.
+- **Deduping** matters for `library-cast-override.ts`, the one two-book route
+  that can legitimately receive the same book twice — its guard at `:77` rejects
+  same-book *and* same-character only. (The other four reject same-book outright
+  with a 400: `cast-link-prior.ts:84`, `cast-add-from-roster.ts:79`,
+  `cast-not-linked-to.ts:57` and `:154`.) A promise-chain mutex is not reentrant;
+  acquiring one key twice in a single call wedges that request permanently.
+
+  **That same-book path is already broken without any concurrency**, and §8 folds
+  the fix in.
 
 ### 3.2 Granularity for the N-book fan-outs
-
-`voices.ts`'s `forEachMatchingCastCharacter` and `voice-library-usage.ts`'s
-`clearLibraryVoiceReferences` walk the whole workspace (or a series) and write
-each matching book.
 
 **Decision: lock per book, inside the loop.** Each book's RMW is individually
 atomic; the fan-out as a whole is not.
@@ -123,156 +142,358 @@ accepted cost is that a concurrent writer can interleave *between* two books of
 one propagation, so a series update can land half-old/half-new. That is weaker
 than the guarantee the current code claims and stronger than the one it has.
 
-## 4. The rule
+## 4. The rules
 
-Three lines, stated in `cast-lock.ts`'s header comment and as a bullet under
+Four rules, stated in `cast-lock.ts`'s header comment and as a bullet under
 CLAUDE.md's *Conventions worth preserving*:
 
 1. **Lock the innermost read-through-write, never the caller.** One level only.
    A locked function must not call another locked function on the same book.
-2. **The read goes inside the lock.** Wrapping only the write buys nothing at
-   all. This is the easy way to produce a diff that looks correct and fixes
-   nothing.
+2. **The read goes inside the lock, and so does every decision derived from it.**
+   Wrapping only the write buys nothing at all. This is the easy way to produce a
+   diff that looks correct and fixes nothing.
 3. **Two or more books → `withCastLocks`, never nested `withCastLock`s.**
+4. **Global lock order: design → cast.** Never acquire a cast lock and then a
+   design lock.
 
-Rule 1 is what keeps a non-reentrant mutex safe. Note that `withDesignLock` and
-`withKeyLock` are separate maps, so holding a design lock while taking a cast
-lock is *not* a self-deadlock — only the same key twice is. That is why the rule
-is scoped to the cast lock rather than to locks generally.
+Rule 4 replaces a claim in the first draft that was a non-sequitur:
+*"`withDesignLock` and `withKeyLock` are separate maps, so holding a design lock
+while taking a cast lock is not a self-deadlock — only the same key twice is."*
+Separate maps rule out *self*-deadlock; they are exactly what makes ordinary
+two-lock AB/BA deadlock possible. A **design → cast** path is already live:
+`qwen-voice.ts:193` holds `withDesignLock(bookDir)` across `:203`'s
+`forEachMatchingCastCharacter`, which under this design takes a cast lock per
+matching book. No **cast → design** path exists today, so the design is not
+deadlocked — but the rule set is what future contributors read, and without rule 4
+it actively teaches them that cross-lock nesting is free. Wrapping
+`single-design.ts:110` or `qwen-voice.ts:532` in a cast lock would deadlock with
+no timeout and no diagnostic.
 
-## 5. Site conversion
+**What the lock does not cover.** It protects one read-modify-write. It does not
+make a *validate-then-write* safe when the validation and the write are in
+different lock scopes — see §7's clone-consent gates, folded in at §8.
 
-| Class | Sites | Work |
-|---|---|---|
-| **1 — mechanical** | `cast-aliases` ×3, `cast-create`, `cast-merge`, `voice-style` ×2, `cast-series-patch`, `voice-library` ×2, `voice-override-linked`, `book-state` (the cast write in the save handler), `cast-design` ×2 | wrap the existing read..write span |
-| **2 — multi-book** | `cast-link-prior`, `cast-not-linked-to` ×2, `library-cast-override`, `cast-add-from-roster` | `withCastLocks` |
-| **3 — N-book fan-out** | `voices.ts` `forEachMatchingCastCharacter`, `voice-library-usage.ts` `clearLibraryVoiceReferences` | per-book lock inside the loop, **read moved inside it** |
-| **4 — re-entrancy** | `qwen-voice.ts` `ensureCharacterVoiceUuid`, `persistEmotionVariant` | restructure, see §5.1 |
-| **5 — in-job** | `analysis.ts` ×5 | wrap; verify no lock is held across a chapter loop |
+## 5. Site conversion — all 35, enumerated
 
-Class 3 is not a wrap. `walkConfirmedCasts()` currently *yields* an
-already-read `cast` and the loop body writes it, so the read sits outside any
-lock the body could take. The loop body must re-read under the lock and discard
-the yielded copy for write purposes.
+The first draft's class table summed to 29 and switched counting units mid-table.
+This one enumerates every site, counts sites throughout, and must sum to 35. The
+plan carries an arithmetic check on that.
+
+### Class 1 — mechanical: wrap the existing read..write span (17 sites)
+
+| Module | Sites |
+|---|---|
+| `cast-aliases.ts` | `:161`, `:268`, `:354` |
+| `cast-create.ts` | `:91` |
+| `cast-merge.ts` | `:197` |
+| `cast-series-patch.ts` | `:221` |
+| `cast-design.ts` | `:293`, `:452` |
+| `voice-style.ts` | `:69`, `:129` |
+| `voice-override-linked.ts` | `:364` |
+| `book-state.ts` | `:634` |
+| `voice-library.ts` | `:1434` (`POST /assign`), `:1536` (`DELETE /assign`) |
+| `qwen-voice.ts` | `:793` (`promote-voice`), `:893` (`DELETE emotion-variant`) |
+| `voice-library-usage.ts` | `:113` |
+
+`qwen-voice.ts:793` and `:893` were missing from the first draft entirely.
+`:793`'s span covers a sidecar `fetch` and two `rm`s, and it writes the `cast`
+object read at `:692` — the longest and most exposed window in the sweep, not a
+routine wrap. `voice-library-usage.ts:113` is class 1 rather than a fan-out
+because `clearLibraryVoiceReferences` writes one book per iteration; the read
+must move inside the lock, since `walkConfirmedCasts()` (`:43`) *yields* an
+already-read `cast`.
+
+### Class 2 — multi-book: `withCastLocks` (9 sites)
+
+| Module | Sites |
+|---|---|
+| `cast-link-prior.ts` | `:142`, `:248` |
+| `cast-not-linked-to.ts` | `:106`, `:109`, `:202`, `:207` |
+| `library-cast-override.ts` | `:152`, `:153` — plus the §8 fix |
+| `cast-add-from-roster.ts` | `:147` |
+
+### Class 3 — `voices.ts` fan-out: two branches, two write sites (2 sites)
+
+`forEachMatchingCastCharacter` (`voices.ts:771-834`) has its **own inline walk**;
+it does not use `walkConfirmedCasts` at all, which the first draft got wrong. Two
+distinct branches:
+
+- **`:788-803`, the `onlyBookDir` fast path**, writing at `:801`. This is the
+  branch every real call site takes — `cast-design.ts:514` and
+  `single-design.ts:182` both pass `job.bookDir`, and the fs-61 comment at
+  `voices.ts:783` says so explicitly. It carries production traffic and the first
+  draft's class-3 text did not describe it.
+- **`:816-829`, the workspace/series walk**, writing at `:828` — per-book lock
+  inside the loop, read moved in with it.
+
+### Class 4 — re-entrancy restructure (2 sites)
+
+`qwen-voice.ts:177` (`persistEmotionVariant`) and `:215`
+(`ensureCharacterVoiceUuid`). See §5.1 — these are the highest-risk conversions.
+
+### Class 5 — `analysis.ts`: not a lock site at all (5 sites)
+
+`:3558`, `:3763`, `:4774`, `:5422`, `:5927`. These do **not** take a cast lock.
+See §6.
+
+**17 + 9 + 2 + 2 + 5 = 35.** ✓
+
+### Class 6 — deletions (2 sites, not counted in the 35)
+
+`analysis.ts:2845` (`rm(castJsonPath(…), { force: true })` on "Start fresh") and
+`book-state.ts:923` (the reparse handler, inside a `Promise.all`). Both destroy
+cast.json and neither matches `writeJsonAtomic(castJsonPath(`, so the first
+draft's guard test could not see them.
+
+They matter more after this change, not less: a locked writer whose read predates
+the delete recreates cast.json afterwards, resurrecting the stale roster the
+delete exists to remove (`analysis.ts:2836-2841` documents that intent) — and the
+lock *lengthens* the gap between a queued writer's read and its write. Both take
+the cast lock; the guard pattern extends to `rm(castJsonPath(`.
 
 ### 5.1 The re-entrancy restructure
 
-`ensureCharacterVoiceUuid` (`qwen-voice.ts`) reads cast.json, then branches:
+The first draft said the outer read is used "only for the branch decision (does
+the character exist, does it already have a `voiceUuid`), never as the payload
+for a write." **That decision is exactly the thing that must be inside the lock**,
+and the draft placed it outside.
 
-- **series branch** → delegates to `forEachMatchingCastCharacter`, which under
-  this design locks each book it writes — *including this one*;
-- **book-scoped branch** → mutates the cast it read and writes it itself.
+**`ensureCharacterVoiceUuid`** (`qwen-voice.ts:188-218`) is safe *today* only
+because `withDesignLock(bookDir)` at `:193` wraps read → decide → mint → write as
+one critical section. Its own docstring says so (`:182-184`: "Mints under the
+per-book design lock so two concurrent designs of one character can't mint two
+uuids"). Moving the `voiceUuid` check outside the cast lock makes correctness
+depend entirely on an unrelated lock that this same PR is editing (§11). Two
+concurrent calls would both read "no uuid", both mint, and the second write would
+win — reintroducing the exact double-mint the design lock exists to prevent.
 
-Wrapping the whole function in `withCastLock(bookDir)` self-deadlocks the series
-branch the moment the walk reaches `bookDir`. The fix is to split: the
-book-scoped branch takes the lock and **re-reads inside it**; the series branch
-stays unlocked and delegates. The outer read is then used only for the branch
-decision (does the character exist, does it already have a `voiceUuid`), never
-as the payload for a write.
+**`persistEmotionVariant` is not the same shape**, and "identical treatment" was
+wrong. It has *no* design lock: `cast-design.ts:521` and `qwen-voice.ts:623` both
+call it *after* `designQwenVoiceForCharacter` has released the lock
+(`qwen-voice.ts:384-471`). And its outer read is not merely a decision — `:152`
+computes `baseVoiceId = qwenStorageKey(character, characterId)` from the stale
+character, and bakes that value into the write payload at `:162`.
+`qwenStorageKey` reads `voiceUuid`, so a `voiceUuid` that changed between the
+outer read and the lock anchors the variant slot on a base that never existed —
+the #1057 orphaned-base shape, surfacing as a silent Kokoro fallback on
+re-render.
 
-`persistEmotionVariant` has the identical two-branch shape and gets the identical
-treatment.
+**The rule for both:** the re-read inside the lock must **re-evaluate every
+decision and re-derive every value** that feeds the write — re-check `voiceUuid`,
+re-derive `qwenStorageKey`. The outer read is an early-out optimisation and is
+never authoritative. The design lock is not part of the guarantee and must not be
+relied on.
 
-Both are the concrete instance of rule 1, and both are the highest-risk
-conversions in the sweep.
+Both functions keep the two-branch structure: the book-scoped branch takes the
+cast lock and re-reads inside it; the series branch stays unlocked and delegates
+to `forEachMatchingCastCharacter`, which locks per book itself. That satisfies
+rule 1 and rule 4.
 
-## 6. #1981 specifically
+## 6. `analysis.ts` — ownership, not a mutex
+
+`analysis.ts` is 5 of the 35 sites and the module that writes cast.json most
+often. It is **not a wrappable read-modify-write**: `priorCastForMerge` is read
+once at `:2797`, reconciled at `:2823`, and is then the merge base for writes at
+`:3559`, `:3764` and `:4774` — spread across the whole Phase 0/1 pipeline, with
+the interim writes *inside* the chapter loop. The subset route has the identical
+shape (read `:5206`, writes `:5423`, `:5927`).
+
+Neither available lock strategy works. Holding a cast lock for the run would
+block every other cast write on that book for minutes with no timeout. Re-reading
+inside each write's lock would change behaviour: iteration N would re-read the
+interim cast iteration N−1 wrote, so `mergeAnalysisResultWithExistingCast` would
+no longer merge against the pre-run cast and srv-13's voice/reuse carry-forward
+would silently degrade.
+
+**Decision: analysis owns cast.json for the duration of its run**, expressed
+through the existing `markAnalysisBusy` / `isAnalysisBusy` registry
+(`tts/design-lock.ts:55-65`) rather than the mutex. That registry already exists
+for precisely this reason — it was built so a re-analysis (which rewrites the
+whole cast.json) cannot overlap a bulk design (which writes per-character
+overrides), and it ref-counts so a main plus a subset job can coexist.
+
+Concretely: cast writers consult the registry and refuse with a clear 409 —
+*"analysis is rewriting this book's cast; try again when it finishes"* — rather
+than queueing behind an unbounded lock. That is a better user-visible failure than
+a request that hangs for minutes, and it is the behaviour the registry was
+designed to express. `analysis.ts`'s own five writes stay as they are; ownership,
+not serialisation, is what makes them safe.
+
+The two deletion sites (§5 class 6) still take the cast lock — a delete is
+instantaneous and does not own the book.
+
+## 7. Check-then-act: the clone-consent gates, folded in
+
+A per-RMW lock does not close a *validate-then-write* that spans two scopes. Four
+gates read cast.json, decide, and then write elsewhere:
+
+| Gate | Reads / decides | Writes |
+|---|---|---|
+| `voices.ts` `PUT /:voiceId/override` | `:709`/`:720` `hasClonedSlotAmongMatches` → 409 | `:728` `applyOverrideToCastFiles` |
+| `voice-library.ts` `DELETE /:voiceUuid` | `:1683` `scanLibraryVoiceUsage` → 409 usage report | `:1686` `clearLibraryVoiceReferences` |
+| `single-design.ts` | `:235` `characterHasClonedSlot` → 409 | `:254` |
+| `qwen-voice.ts` | `:532` `characterHasClonedSlot` → 409 | `:552` |
+
+These are the fs-38 Wave 3c GATE 2 clone-consent guards — the ones added because
+"Phase 0 fixed seven live bugs that all had the same shape — a guard-less write
+erasing a clone marker upstream of a resolver" (`voices.ts:888-893`). Shipping a
+lock that *reads as* "cast.json RMW is now safe" while these stay open is how the
+eighth gets missed.
+
+**Decision: folded into this PR.** Each gate re-validates inside the lock scope
+that performs its write, so the 409 decision and the write it guards are one
+critical section. The `voice-library.ts` delete is the one with real data loss —
+a reference acquired in the gap is left dangling at a `libraryUuid` whose
+artifacts `eraseLibraryVoiceArtifacts` is about to delete.
+
+## 8. `library-cast-override.ts` same-book: folded in
+
+`library-cast-override.ts`'s guard at `:77` rejects same-book *and* same-character
+only, so `source === target` with different characters is reachable — and that
+path is **already broken with no concurrency at all**. `:88` and `:89` are two
+independent reads of the same file; `:141` and `:144` derive two arrays from those
+separate snapshots; `:152` and `:153` write the same path twice. Since
+`nextTargetCharacters` does not contain `mergedSource`, the second write silently
+discards the source character's merge.
+
+`withCastLocks`'s dedupe removes the deadlock and lets both writes proceed — the
+data loss survives, now under a lock, which makes it look addressed. It is a
+defect in code this branch already touches, with one obvious fix, coverable by a
+test in this PR: it clears CLAUDE.md's fix-now bar. Same-book takes one read and
+one merged write.
+
+## 9. #1981 specifically
 
 The lock supersedes the hoist: under a held lock the `await` at `:1386` is
-harmless, and hoisting it costs a wasted manifest read on every request that
-later `404`s on the character or `409`s on engine routing.
+harmless, and hoisting costs a wasted manifest read on every request that later
+`404`s on the character or `409`s on engine routing.
 
-**The hoist still lands**, on an explicitly weaker rationale: with 35 lock sites
-and future writers who will forget, keeping the window `await`-free is cheap
-insurance against partial adoption. The manifest read moves above the cast read
-(it depends only on `entry.provenance`, `voiceUuid`, and `located.state`, all in
-hand by then); the warning *string* is still built at its current site, because
-it needs `character.name`, and string formatting is synchronous.
+**The hoist still lands, on the partial-adoption argument alone.** The first
+draft justified it as "a large and worthwhile reduction in the odds"; that number
+is unmeasured and mechanically dubious — `writeJsonAtomic`
+(`workspace/state-io.ts:93-120`) yields at least three more times before its
+rename lands (`mkdir`, `writeFile`, `renameWithRetry`), and a competing
+`readJson` is a single queued `readFile` that will almost always resolve inside
+that. The honest claim is that it narrows the window by an unmeasured amount, and
+that with 35 lock sites and future writers who will forget, keeping the window
+`await`-free is cheap insurance against partial adoption. That is the whole
+justification.
+
+Mechanically: the manifest read moves above the cast read (it depends only on
+`entry.provenance`, `voiceUuid`, and `located.state`, all in hand by then); the
+warning *string* is still built at its current site, because it needs
+`character.name`, and string formatting is synchronous.
 
 The invariant comment is rewritten. It must say that **the lock is the
-guarantee** and the `await`-free window is a secondary, best-effort narrowing. It
+guarantee** and the `await`-free window is a secondary, unmeasured narrowing. It
 must stop claiming atomicity, because that claim is what made this defect look
 like a one-line violation of a sound rule rather than a symptom of an unsound one.
 
-## 7. Testing
-
-The two failure modes to design against are a lock wrapped around the write only,
-and a mechanism test that pins "no `await` in the window" while the race stays
-open. Both yield a green suite and zero protection.
-
-**Outcome test, per class.** Two overlapping RMWs against one cast.json, each
-mutating a *different* character; assert **both** mutations survive. This is red
-today at every unlocked site (last-write-wins drops one) and green under the
-lock. It is an outcome assertion — it names the surviving data, not the absence
-of a yield — and it stays red after the hoist alone, which is the honest
-demonstration that the hoist was never the fix.
-
-**Mutation-verified by reverting the producer.** Every outcome test is proven by
-removing the lock at that site and watching it go red — not by reading the test
-and agreeing it looks right. A placebo test authored into a plan gets copied
-faithfully and survives spec review; the plan states the revert as a required
-step with recorded output, not as a suggestion.
-
-**Determinism is the open risk.** After the hoist, `/assign`'s window contains no
-slow `await` to interleave against, so a naive `Promise.all` of two requests may
-not reliably interleave. The plan must name exactly one interleave mechanism and
-use it everywhere, rather than letting each test improvise. Candidates and their
-trade-offs are the plan's first task, not this spec's.
-
-**Guard test.** No `writeJsonAtomic(castJsonPath(…))` may appear outside a lock
-scope, so site 36 cannot regress. It must be wired into `verify-cache.mjs`'s
-`extraFiles` **and** `verify.yml`'s path regex — a guard test that reads a repo
-file and is wired into neither never runs on the diff it exists to catch.
-
-**Primitive unit tests.** Sorted acquisition regardless of argument order;
-dedupe; release on throw; waiter ordering.
-
-## 8. Sequencing against #1933
+### 9.1 Sequencing against #1933
 
 `fix/server-1933-assign-readiness` is open, actively edited in another session,
-and rewrites 208 lines of `server/src/routes/voice-library.ts` — moving the
-readiness gate below the cast read. It does **not** introduce a new `await` into
-the window (verified against that branch: the gate stays synchronous, and the
-manifest read remains the only yield), so it adds no hazard. It does shift every
-line in the route by roughly +138.
+and rewrites 208 lines of `server/src/routes/voice-library.ts`, moving the
+readiness gate below the cast read. Verified against that branch: it introduces
+**no new `await`** into the window — the gate stays synchronous, and the only
+yields remain the cast read, the manifest read, and the write. It shifts the read
+`1277 → 1415` (+138) and the write `1434 → 1612` (+178), i.e. it adds ~40 lines
+*inside* the window. Harmless, but the span grows.
 
-The implementation branch therefore cuts after #1933 merges, or rebases onto it
-if it is still open when the sweep starts. This spec and the plan cite symbols
-rather than line numbers so both survive the shift.
+The implementation branch cuts after #1933 merges, or rebases onto it if still
+open. This spec and the plan cite symbols rather than line numbers so both
+survive the shift.
 
-## 9. Residual risks, accepted
+## 10. Testing
 
-- **In-process only.** Two server processes against one workspace would defeat
-  this entirely. The product runs one server; `capture-cli.ts` reads cast.json
-  but never writes it.
-- **The guard test sees writes, not reads.** A read left outside its lock is
-  silent — the diff looks locked and is not. Only review catches this, which is
-  why rule 2 is stated in the code rather than only here.
-- **Rule 1 is convention, not enforcement.** A future nested locker deadlocks at
-  runtime rather than failing a check.
-- **Partial atomicity for series propagation**, per §3.2.
+Two failure modes to design against: a lock wrapped around the write only, and a
+test that is green because the lock partitioned rather than because it held.
 
-## 10. Folded in: the lock helpers never clean up their key map (#2001)
+### 10.1 The interleave mechanism — settled, with evidence
+
+The first draft deferred this to the plan as "an open risk". It is now measured.
+A spike (`server/src/workspace/`, run against real files, single import graph)
+compared two candidate harnesses:
+
+| Mechanism | Unlocked | Locked |
+|---|---|---|
+| bare `Promise.all` of two RMWs, 200 trials | **200/200 lost a mutation** | **0/200** |
+| `vi.spyOn` barrier holding both readers, 20 trials | 20/20 lost a mutation | — |
+
+A bare `Promise.all` loses a mutation **100% of the time**: both `readFile`s are
+issued in the same tick and both resolve before either write. No barrier is
+needed, and the simpler harness is also the deterministic one.
+
+**Decision: bare `Promise.all`, used uniformly at every site.** The barrier
+mechanism is not used anywhere — a second mechanism would let a site that fails
+under one be quietly rewritten to the other.
+
+### 10.2 The outcome test
+
+Two overlapping RMWs against one cast.json, each mutating a *different*
+character; assert **both** mutations survive. Red today at every unlocked site,
+green under the lock. It is an outcome assertion — it names the surviving data,
+not the absence of a yield — and it stays red after the hoist alone, which is the
+honest demonstration that the hoist was never the fix.
+
+**Mutation-verified by reverting the producer.** Every outcome test is proven by
+removing the lock at that site and watching it go red, with the output recorded —
+not by reading the test and agreeing it looks right. A placebo test authored into
+a plan gets copied faithfully and survives spec review; the plan states the revert
+as a required step with recorded output.
+
+### 10.3 The partition assertion — mandatory, and it comes first
+
+Because a partitioned lock passes both the outcome test and the revert
+verification, **each outcome spec must first assert that the two writers share
+one lock instance.** `cast-lock.ts` exposes a test-only accessor (an instance
+token, or `chains.size`) and the spec asserts contention actually occurred before
+asserting the outcome. Alternatively the spec pins a single import graph and
+states that it does. Without this, §10.2 proves nothing.
+
+### 10.4 Guard test
+
+No `writeJsonAtomic(castJsonPath(…))` **or `rm(castJsonPath(…))`** may appear
+outside a lock scope, so site 36 cannot regress.
+
+Its known blind spots, stated rather than papered over: it sees one syntactic
+form, so `const p = castJsonPath(dir); await writeJsonAtomic(p, …)` passes, as
+would a future writer routed through `workspace/schema-migrate.ts`'s cast.json
+seam (`:44`, with the v1→v2 hook still commented at `:92`). The stronger form —
+*if `castJsonPath` appears in a module, every `writeJsonAtomic`/`rm` in it is
+inside a lock scope* — is preferred if it can be written without false positives.
+
+No `verify-cache.mjs` `extraFiles` entry is needed. The #1847 trap applies to
+files read at runtime from *outside* a step's globs; this guard reads
+`server/src/**`, which `test:server` already globs (`verify-cache.mjs:108`) and
+`verify.yml:152` already matches. Any diff adding an unlocked write site
+necessarily busts both. Adding an entry would be a no-op and a cargo-culted
+precedent.
+
+### 10.5 Primitive unit tests
+
+Sorted acquisition regardless of argument order; dedupe; release on throw;
+waiter ordering; and the §11 map-cleanup assertion.
+
+## 11. Folded in: the lock helpers never clean up their key map (#2001)
 
 The `finally` cleanup in all three existing promise-chain mutexes is dead code.
 `chains.get(key) === gate` compares against `gate`, but what was stored is
 `prior.then(() => gate, …)` — a different object, so the identity check can never
 hold and `delete` never runs. Each Map grows one entry per distinct key for the
-process lifetime, while the comment above each one asserts the opposite
+process lifetime, while the comment above each asserts the opposite
 (`design-lock.ts`: *"Tidy up when we're the chain tail, so the map doesn't grow
 unbounded"*).
 
-Three copies: `workspace/file-lock.ts`, `tts/design-lock.ts`, and
-`routes/chapters-restructure.ts` — the last additionally allocating a *third*
-promise inside the comparison itself (`bookWriteLock.get(bookId) === prev.then(() => next)`).
+Three copies: `workspace/file-lock.ts:17`, `tts/design-lock.ts:45`, and
+`routes/chapters-restructure.ts:78` — the last additionally allocating a *third*
+promise inside the comparison itself. (`generation.ts:470`'s
+`serializeQueueMutation` is a single global chain with no map and is correctly
+not affected.)
 
-**This is fixed here, not deferred.** The sweep is about to make `withKeyLock`
-the mutex behind every cast.json write in the product; shipping that on top of a
-helper whose cleanup has never worked, and whose comment says it has, is not a
-defensible place to draw a scope line.
-
-The fix is to hold a reference to the promise actually stored and compare against
-that:
+**Fixed here, not deferred.** The sweep is about to make `withKeyLock` the mutex
+behind every cast.json write in the product; shipping that on a helper whose
+cleanup has never worked, and whose comment says it has, is not a defensible
+scope line.
 
 ```ts
 const mine = prior.then(() => gate, () => gate);
@@ -284,16 +505,38 @@ chains.set(key, mine);
 }
 ```
 
-Tail-detection is then correct: if a later waiter has replaced the entry, `mine`
-is no longer the tail and the entry is left for that waiter to chain onto; if it
-has not, `mine` has already settled and a fresh caller starting from
-`Promise.resolve()` behaves identically. One answer, no interface change, and it
-takes a test that asserts the map returns to baseline after a lock settles.
+Tail-detection is then correct, and there is no losing interleave: a waiter's
+read of `prior` and its `chains.set` are in one synchronous block with no `await`
+between (`file-lock.ts:8-11`), as are `release()` and the `delete`. So a waiter
+either registered before the delete (entry ≠ `mine`, no delete) or starts fresh
+from `Promise.resolve()` after `fn()` has already returned. Applied identically
+to all three, with the three comments corrected to match.
 
-Applied identically to all three helpers, with the three comments corrected to
-match. #2001 is closed by this PR.
+## 12. Residual risks, accepted
 
-## 11. Ticketing
+- **No bound on hold time or wait time.** `withKeyLock` (`file-lock.ts:7-19`) has
+  no timeout, no queue cap, no fairness guarantee and no diagnostic for a
+  long-held key. A slow or wedged holder turns every cast write on that book into
+  an unbounded hang. Today those requests race and one loses a mutation; after
+  this change they wait. That is a real trade, and it is why §6 routes analysis —
+  the only multi-minute holder — to ownership rather than to the mutex. The
+  primitive gains a warn-after-N-seconds log so a wedged key is diagnosable
+  rather than silent. Expected hold time for every other class is one file read
+  plus one file write.
+- **In-process only.** Two server processes against one workspace would defeat
+  this entirely. The product runs one server; verified that `server/src` has no
+  `worker_threads` and no cast.json writer in a child process.
+  `analyzer/attribution-eval/capture-cli.ts` reads cast.json but writes only to
+  the eval corpus dir.
+- **Partial atomicity for series propagation**, per §3.2.
+- **Rule 1 and rule 4 are convention, not enforcement.** A future nested locker,
+  or one that takes cast-then-design, deadlocks at runtime rather than failing a
+  check.
+- **The guard sees writes, not reads.** A read left outside its lock is silent —
+  the diff looks locked and is not. Only review catches this, which is why rule 2
+  is stated in the code and not only here.
+
+## 13. Ticketing
 
 `Closes #1981` (the filed defect), `Closes #2000` (the sweep), `Closes #2001`
-(§10). One PR, per the delivery decision.
+(§11). One PR, per the delivery decision.

--- a/docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md
+++ b/docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md
@@ -1,14 +1,28 @@
 # cast.json write lock — design
 
 **Status:** approved
-**Issues:** #1981 (the filed defect), #2000 (the sweep), #2001 (incidental, §11);
-#2006 filed for the three clone-consent gates a per-RMW lock cannot reach (§7)
+**Closes:** #1981 (the filed defect), #2000 (the sweep), #2001 (§11)
+**Defers:** #2006 (three clone-consent gates + two writers a per-RMW lock cannot
+reach), #2015 (`analysis.ts`'s five writes)
 **Sequencing:** implementation bases on / rebases onto `fix/server-1933-assign-readiness`
-**Review:** two adversarial passes. Round 1 found 3 Critical / 8 Major / 3 Minor;
-round 2, against the rewrite, found a further 4 Critical / 6 Major / 8 Minor —
-mostly in the sections the first rewrite had just changed. All folded. §6 and §7
-were re-decided outright after round 2 showed both had been designed against a
-wrong map of where the writes are.
+
+**Review:** three adversarial passes — 3C/8M/3m, then 4C/6M/8m, then 1C/5M/5m.
+Each round's worst findings landed in whatever the *previous* round had just
+rewritten, which is the main thing to know when reading this document: the parts
+revised most recently are the parts least proven. Round 3 verified ~60 citations
+clean and judged §§1–5 and §§8–11 implementable as they stand.
+
+Two sections were re-decided outright rather than patched. §6 tried "analysis owns
+cast.json" (round 1), then a route-level admission gate (round 2), and now defers
+to #2015 having rejected both — the second survived a full review round before
+failing the next. §7 claimed all four clone-consent gates were folded in (round
+2), then that gate 2 was fixed by a `library-voice` lock (round 3) — which was
+inert, because no *writer* took the key. It now specifies both sides.
+
+The pattern is worth naming: every one of those failures was a design that read
+as coverage while covering nothing. That is what §10's revert-verification and
+§10.3's import-graph pin exist to catch in the tests, and it is what this header
+exists to flag in the prose.
 
 ## 1. What was filed, and what is actually wrong
 
@@ -37,9 +51,11 @@ B: read resolves → runs synchronously → writeJsonAtomic starts
 Both writes land. `writeJsonAtomic`'s rename makes each write individually
 non-torn, but the later rename wins outright, and A's mutation is gone.
 
-This is not theoretical. Measured (§10.1): two concurrent read-modify-writes
-against one cast.json, issued from a bare `Promise.all`, lost a mutation in
-**200 of 200 trials**.
+This is not theoretical. A spike run in this worktree (§10.1) had two concurrent
+read-modify-writes against one cast.json, issued from a bare `Promise.all`, lose a
+mutation in **200 of 200 trials**. That figure is pinned by task 1 of the plan,
+which lands the spike as a committed test before any site is converted — it is not
+reproducible from this document alone.
 
 Two consequences follow, and they shape everything below:
 
@@ -113,8 +129,8 @@ contend, and both leave every test green:
   writer resolve through different module registries gets **two `chains` Maps**.
 
 The second mode is the more dangerous, because a partitioned lock behaves like no
-lock *in both directions*: the outcome test passes by partition, and §7's
-revert-verification also passes vacuously. §7.3 states the countermeasure.
+lock *in both directions*: the outcome test passes by partition, and §10.2's
+revert-verification also passes vacuously. §10.3 states the countermeasure.
 
 `withCastLocks` **dedupes, then sorts** the derived keys, then nests:
 
@@ -156,10 +172,21 @@ CLAUDE.md's *Conventions worth preserving*:
    Wrapping only the write buys nothing at all. This is the easy way to produce a
    diff that looks correct and fixes nothing.
 3. **Two or more books → `withCastLocks`, never nested `withCastLock`s.**
-4. **Global lock order: design → cast.** Never acquire a cast lock and then a
-   design lock.
+4. **Global lock order: `design` → `library-voice` → `cast`.** Every acquisition
+   site names where it sits in that order. Never acquire a lock from an earlier
+   class while holding one from a later class.
 
-Rule 4 replaces a claim in the first draft that was a non-sequitur:
+Rule 4 covers **three** lock classes, not two. The first rewrite stated it over
+`design` and `cast` only, and §7 then introduced `library-voice:<uuid>` four
+sections later — leaving a rule that would read as satisfied by an ordering it
+had never considered. Concretely, the `DELETE /voice-library/:voiceUuid` path
+holds `library-voice:U` across `clearLibraryVoiceReferences`, which takes a cast
+lock per book (`voice-library-usage.ts:113`); so `library-voice → cast` is
+mandatory, and `POST /assign` must acquire `library-voice:U` **before** its cast
+lock rather than after. Acquiring them the other way round is an AB/BA cycle on a
+mutex with no timeout and no diagnostic — both requests hang permanently.
+
+Rule 4 also replaces a claim in the first draft that was a non-sequitur:
 *"`withDesignLock` and `withKeyLock` are separate maps, so holding a design lock
 while taking a cast lock is not a self-deadlock — only the same key twice is."*
 Separate maps rule out *self*-deadlock; they are exactly what makes ordinary
@@ -203,9 +230,17 @@ plan carries an arithmetic check on that.
 Three of these are not routine wraps despite sitting in this class:
 
 - **`qwen-voice.ts:793`** (`promote-voice`) was missing from the first draft
-  entirely. Its span covers a `stat`, four `rm`s, three `rename`s, a `copyFile`
-  and a sidecar `fetch`, and it writes the `cast` object read at `:692` — the
-  longest and most exposed window in the sweep.
+  entirely, and it is the one site that must **not** be wrapped as-is. Its span
+  covers a `stat`, four `rm`s, three `rename`s, a `copyFile` and a sidecar
+  `fetch` (`:768`) — which has no `AbortSignal` and no timeout, so under undici
+  defaults a hung sidecar holds it for minutes. Wrapping `:692→:793` would put a
+  network round-trip inside the hottest lock in the product and stall every cast
+  write for that book behind it.
+
+  **Instead: narrow the lock to a fresh re-read plus the write, at the end.** The
+  artifact moves and the evict `fetch` stay outside it. This is exactly the shape
+  `cast-design.ts:289`/`:293` already uses, and it keeps §12's "one file read plus
+  one file write" hold-time claim true — which, wrapped naively, it would not be.
 - **`cast-add-from-roster.ts:147`** moved here from class 2 after round 2: it
   reads *both* books (`:104`, `:105`) but writes **only the source** (`:147`), and
   `:79` already 400s same-book. A single-book lock on the source is correct;
@@ -231,8 +266,8 @@ Three of these are not routine wraps despite sitting in this class:
 `forEachMatchingCastCharacter` (`voices.ts:771-834`) has its **own inline walk**;
 it does not use `walkConfirmedCasts` at all. Two branches:
 
-- **`:816-829`, the workspace/series walk**, writing at `:828`. **This is the
-  primary production path**, and the first draft claimed the opposite. The fast
+- **`:816-829`, the workspace/series walk**, writing at `:828`. **This path is
+  live for every series book**, and the first draft claimed the opposite. The fast
   path is gated on `if (!seriesFilter && onlyBookDir)` (`:788`), and both cited
   callers pass `seriesFilter` *as well as* `job.bookDir` (`cast-design.ts:510-515`,
   `single-design.ts:176-183`) — so for any book in a real series the walk runs.
@@ -318,17 +353,33 @@ already-decided uuid. There is no cast-lock scope in which the decision could be
 re-evaluated, because the decision precedes the branch.
 
 Two concurrent series-scoped calls therefore both read "no uuid", both mint, and
-both propagate. **That is prevented today, and only, by `withDesignLock(bookDir)`
-at `:193`** — exactly as the function's own docstring claims (`:182-184`).
+both propagate. **Within one book that is prevented by `withDesignLock(bookDir)`
+at `:193`**, as the function's own docstring claims (`:182-184`).
+
+**Across books it is not prevented at all, and that is a pre-existing defect this
+spec must not paper over.** `withDesignLock` keys on `bookDir`
+(`design-lock.ts:26-27`), and so do `isDesignBusy`, `isAnalysisBusy` and
+`cast-design.ts:668`'s `inFlightByBook` gate. Two bulk-design jobs on **two
+different books of one series** therefore hold two different design locks; both
+call `ensureCharacterVoiceUuid(job.bookDir, characterId, seriesFilter)`
+(`cast-design.ts:485`) for the same linked identity, both see no `voiceUuid` at
+`:197`, both mint at `:199`, and both propagate across the whole series at
+`:203`. The design lock is per-book; the propagation is not.
+
+This sweep makes the *outcome* finer-grained rather than worse: today the two
+propagations race whole-file and one wins; afterwards `forEachMatchingCastCharacter`
+locks per book, so they can interleave per book and leave the series carrying a
+**split** uuid. Recorded as a residual in §12 and added to #2006's scope.
 
 So the honest position, replacing the first rewrite's "the design lock is not
 part of the guarantee and must not be relied on":
 
 - For the **book-scoped** branch, the cast lock is the guarantee and the design
   lock is not relied on.
-- For the **series** branch, **the design lock remains load-bearing.** This spec
-  does not change that and does not weaken it. Moving the decision under a cast
-  lock would require `ensureCharacterVoiceUuid` to hold a cast lock across
+- For the **series** branch, **the design lock remains load-bearing for same-book
+  concurrency, and nothing protects the cross-book case.** This spec does not
+  change either. Moving the decision under a cast lock would require
+  `ensureCharacterVoiceUuid` to hold a cast lock across
   `forEachMatchingCastCharacter`, which violates rule 1 — genuine design work,
   and out of scope here.
 - §11 edits `design-lock.ts`'s map cleanup **only**. It does not touch
@@ -357,48 +408,51 @@ interim cast iteration N−1 wrote, so `mergeAnalysisResultWithExistingCast` wou
 no longer merge against the pre-run cast and srv-13's voice/reuse carry-forward
 would silently degrade.
 
-**Decision: a route-level admission gate, and nothing stronger — stated as
-admission control, not as a correctness guarantee.**
+**Decision: `analysis.ts` is out of scope for this PR. Its five writes stay
+unprotected, and that is recorded as a named residual (§12) and filed as #2015.**
 
-The first rewrite said cast writers would "consult the registry and refuse with a
-clear 409", and that "ownership, not serialisation, is what makes them safe".
-Round 2 showed both halves are wrong, and they are worth recording because the
-failure is instructive:
+Two mitigations were designed and both rejected. They are recorded because each
+looked obviously right at the time, and the second survived a full review round
+before failing the next one.
 
-- **Consulting `isAnalysisBusy` from an unlocked writer is itself check-then-act
-  — the exact defect class this spec exists to close.** `isAnalysisBusy` is a bare
-  `Map` read (`tts/design-lock.ts:63-65`) with no coupling to the cast mutex. A
-  writer that reads `false`, then `await`s its cast read — the very yield §1
-  identifies as the race — then writes, races a run that marks busy
-  (`analysis.ts:2572`, `:5109`) and writes at any of its five sites. The
-  consultation's window is *wider* than the one #1981 filed.
-- **A 409 is not expressible at most sites.** Of the 30 non-analysis sites, at
-  least eight have no status-code channel: `cast-design.ts:293`/`:452` and
-  `single-design.ts:178` run detached after `res.flushHeaders()` and report via
-  SSE `endJob`; `qwen-voice.ts:177`/`:215`, `voices.ts:801`/`:828` and
-  `voice-library-usage.ts:113` are shared helpers with multiple callers, for which
-  "refuse" is undefined — particularly when book 7 of 12 is busy and six are
-  already written.
+**Rejected — "analysis owns cast.json", via the `markAnalysisBusy` registry.**
+Consulting `isAnalysisBusy` from an unlocked writer is *itself* check-then-act —
+the exact defect class this spec exists to close. `isAnalysisBusy` is a bare `Map`
+read (`tts/design-lock.ts:63-65`) with no coupling to the cast mutex. A writer
+that reads `false`, then `await`s its cast read — the very yield §1 identifies as
+the race — then writes, races a run that marked busy (`analysis.ts:2572`,
+`:5109`). The consultation's window is *wider* than the one #1981 filed.
 
-What actually works is the precedent already in the codebase: `cast-design.ts:655`
-checks busy **at route entry, before flushing SSE headers**, and refuses there.
-That is a route-level admission gate, and it is expressible precisely because
-nothing has been written or sent yet.
+**Rejected — a route-level admission gate.** The salvage was to check busy at
+request entry and 409 early, on the precedent of `cast-design.ts:655` (currently
+the only `isAnalysisBusy` call site, and a correct one — it checks before
+flushing SSE headers). Three things killed it:
 
-So: **HTTP handlers that write cast.json check `isAnalysisBusy` at request entry,
-before any work, and 409 early.** Internal helpers and detached jobs do not check
-— they are downstream of a handler that already did.
+- **Most sites cannot express a refusal.** Seven of the 30 non-analysis write
+  sites have no status-code channel — `cast-design.ts:293`/`:452` run detached
+  after `res.flushHeaders()` and report via SSE `endJob`; `qwen-voice.ts:177`/
+  `:215`, `voices.ts:801`/`:828` and `voice-library-usage.ts:113` are shared
+  helpers with multiple callers, for which "refuse" is undefined — particularly
+  when book 7 of 12 is busy and six are already written. (Plus
+  `single-design.ts:178`'s call into `voices.ts`, which is a caller rather than
+  one of the 35 sites.)
+- **The gate set is not enumerable from a site-indexed spec.** §5's tables index
+  write *sites*, so routes that write transitively are invisible in them:
+  `cast-merge-suggestions.ts:92` (via `performCastMerge`) and `cast-tier.ts:38`
+  (via `applyTierToCastFiles` → `forEachMatchingCastCharacter`) both write
+  cast.json and would have been missed. For the two-book routes the spec never
+  said which `bookDir` to check.
+- **It is a ~20-route API contract change** — `openapi.yaml` is the documented
+  source of truth for backend shapes — plus release-notes and frontend handling,
+  bought for something the design itself concedes is *not* a correctness
+  guarantee, since a run can begin after a handler is admitted.
 
-**This is admission control, not a lock.** It reduces the collision rate; it does
-not eliminate it, because an analysis run can begin after a handler is admitted.
-The spec says so in `cast-lock.ts`'s header and the code comment says so at each
-gate, in those words. Overstating it is how the next contributor concludes the
-book is covered.
-
-`analysis.ts`'s five writes are therefore **not protected by this PR**. That is
-recorded in §12 as an accepted, named residual rather than dressed up as
-ownership. Making them safe requires either a cast-lock-scoped busy check or a
-restructure of `priorCastForMerge`'s merge base, and both are their own design.
+Paying a contract change across twenty documented routes for a probabilistic
+improvement is a poor trade, and it is the part of this design that kept
+generating findings. The lock sweep stands on its own without it. `#2015` carries
+the real fix — a merge base that survives the run, via compare-and-set or a
+recomputed delta — with the rejected options recorded so they are not
+re-proposed.
 
 The two deletion sites (§5 class 6) still take the cast lock — a delete is
 instantaneous and does not own the book.
@@ -439,10 +493,26 @@ a reference written after the scan passed a book is left dangling at a
 `libraryUuid` whose artifacts `eraseLibraryVoiceArtifacts` is about to erase —
 and it is cross-book by construction, so no per-book cast lock can reach it. The
 fix is a lock on a **different key**: `withKeyLock('library-voice:<uuid>')` held
-across scan → clear → erase, so a concurrent assign of that voice cannot land
-mid-delete. Note also that with `?confirm=1` the user has already consented, so
-there is nothing to re-validate — the lock is protecting the *artifact erasure*,
-not re-deciding the 409.
+across scan → clear → erase. With `?confirm=1` the user has already consented, so
+there is nothing to re-validate — the lock protects the *artifact erasure*, not
+the 409 decision.
+
+**Both sides must take the key, or the lock does nothing.** The first version of
+this section specified only the DELETE side, which would have serialised DELETE
+against DELETE and left the described race entirely open — a lock that makes the
+defect look addressed. The writers that plant a `libraryUuid`:
+
+- **`POST /:voiceUuid/assign`** — writes `libraryUuid` at `voice-library.ts:1416`
+  and `:1425`, persisted at `:1434`. It **acquires `library-voice:<voiceUuid>`
+  first, then its cast lock**, per rule 4's order. It can, because the uuid is its
+  route parameter. This is the acquisition that makes the gate-2 fix real.
+- **`cast-link-prior.ts:239-241`** spreads `target.overrideTtsVoices` — including
+  `libraryUuid` and `provenance` — into the source character and writes at
+  `:248`, creating a new reference, in a different book, to a uuid the request
+  never names. It **cannot** take the key up front, because it does not know which
+  uuids it is about to plant until it has read the target; taking it afterwards is
+  check-then-act over an unbounded uuid set. **Added to #2006** as a fourth entry,
+  and named here as an accepted hole rather than left implicit.
 
 This also sequences `voice-library-usage.ts:113` (§5 class 1), since
 `walkConfirmedCasts` is shared between `clearLibraryVoiceReferences` and this
@@ -519,7 +589,7 @@ survive the shift.
 Two failure modes to design against: a lock wrapped around the write only, and a
 test that is green because the lock partitioned rather than because it held.
 
-### 10.1 The interleave mechanism — settled, with evidence
+### 10.1 The interleave mechanism — settled in mechanism; the number lands as task 1
 
 The first draft deferred this to the plan as "an open risk". It is now measured.
 A spike run in this worktree against real files, in a single import graph,
@@ -620,7 +690,7 @@ process lifetime, while the comment above each asserts the opposite
 unbounded"*).
 
 Three copies: `workspace/file-lock.ts:17`, `tts/design-lock.ts:45`, and
-`routes/chapters-restructure.ts:78` — the last additionally allocating a *third*
+`routes/chapters-restructure.ts:86` — the last additionally allocating a *third*
 promise inside the comparison itself. (`generation.ts:470`'s
 `serializeQueueMutation` is a single global chain with no map and is correctly
 not affected.)
@@ -664,8 +734,10 @@ the code.
   waiter-ordering test.) A slow or wedged holder turns every cast write on that
   book into an unbounded hang. Today those requests race and one loses a
   mutation; after this change they wait. That trade is why §6 keeps analysis —
-  the only multi-minute writer — off the mutex entirely. Expected hold time for
-  every other class is one file read plus one file write.
+  the only multi-minute writer — off the mutex entirely, and why §5 narrows
+  `promote-voice`'s lock to exclude its sidecar `fetch`. **With those two
+  exclusions**, expected hold time everywhere is one file read plus one file
+  write. Without them the claim is false, which is how it read before round 3.
 
   A warn-after-N-seconds log was considered and **dropped**. `withKeyLock` has
   five existing non-cast callers (`book-state.ts:1588`,
@@ -674,9 +746,18 @@ the code.
   event loop open on what is about to become the hottest lock in the product —
   in a repo whose flake register already tracks tinypool worker-exit failures.
   Speculative diagnostics on a shared primitive are not worth that.
-- **`analysis.ts`'s five writes are not protected by this PR.** §6's admission
-  gate reduces collisions; it does not serialise them. Named here rather than
-  implied, because §6's first draft claimed otherwise.
+- **`analysis.ts`'s five writes are not protected by this PR at all.** Not
+  serialised, not gated — §6 rejected both mitigations it tried. This is the
+  largest unprotected writer left standing, and it is filed as **#2015**. Named
+  bluntly here because two successive drafts of §6 claimed otherwise, each in a
+  way that read as coverage.
+- **`cast-link-prior.ts:239-241` plants `libraryUuid` references it never names**,
+  so §7's `library-voice` key cannot reach it. Fourth entry on **#2006**.
+- **Cross-book concurrent series designs can double-mint a `voiceUuid`.**
+  Pre-existing (every design gate keys on `bookDir` while the propagation is
+  series-wide), and this sweep makes the resulting damage finer-grained — a split
+  uuid across the series rather than last-writer-wins. §5.1 has the mechanism;
+  added to **#2006**.
 - **`cast-add-from-roster.ts` reads the target book to decide a source write.**
   That consultation is check-then-act and is not closed by a single-book lock on
   the source.
@@ -698,9 +779,12 @@ the code.
 `Closes #1981` (the filed defect), `Closes #2000` (the sweep), `Closes #2001`
 (§11). One PR, per the delivery decision.
 
+`Refs #2015` — `analysis.ts`'s five writes, per §6.
+
 `Refs #2006` — the three clone-consent gates §7 established a per-RMW lock cannot
-reach. Filed, not folded, because the work in each is deciding what a refusal
-*means* for a partially-applied cross-book propagation and for a detached job.
-That is a behaviour decision needing its own design pass, not a locking one, and
-it is the one place in this spec where deferral is the honest call rather than a
-scope dodge.
+reach, plus `cast-link-prior`'s unnamed `libraryUuid` references and the
+cross-book double-mint. Filed, not folded, because the work in each is deciding
+what a refusal *means* for a partially-applied cross-book propagation and for a
+detached job. That is a behaviour decision needing its own design pass, not a
+locking one, and it is the one place in this spec where deferral is the honest
+call rather than a scope dodge.

--- a/docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md
+++ b/docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md
@@ -1,0 +1,271 @@
+# cast.json write lock — design
+
+**Status:** approved
+**Issues:** #1981 (the filed defect), #2000 (the sweep), #2001 (incidental, §10)
+**Sequencing:** implementation bases on / rebases onto `fix/server-1933-assign-readiness`
+
+## 1. What was filed, and what is actually wrong
+
+#1981 reports that #1953's designed-arm manifest read `await`s inside
+`/api/voice-library/:voiceUuid/assign`'s cast.json read-modify-write window
+(`readJson` → `nextCharacters` → `writeJsonAtomic`), violating the invariant
+documented at length in that route.
+
+The report is accurate. That `await` is the only yield between the cast read and
+the cast write; every other helper in the window (`getResolvedTtsModelKey`,
+`engineForModelKey`, `resolveCharacterEngine`, `cloneStorageKey`,
+`sidecarLanguageName`, `bookStateLanguage`) is synchronous, verified individually.
+
+**But the invariant itself is unsound, and that is the real defect.** The route's
+comment asserts that a window containing zero `await`s makes the RMW "effectively
+atomic". It does not. The *read* is itself a yield point:
+
+```
+A: await readJson(cast)   ─┐ yields to the event loop
+B: await readJson(cast)   ─┘ yields to the event loop
+A: read resolves → runs synchronously → writeJsonAtomic starts
+B: read resolves → runs synchronously → writeJsonAtomic starts
+                                        ↑ B's snapshot predates A's write
+```
+
+Both writes land. `writeJsonAtomic`'s rename makes each write individually
+non-torn, but the later rename wins outright, and A's mutation is gone. Removing
+the inner `await` narrows the window from *an entire filesystem read* to *one
+run-to-completion plus the write's own I/O* — a large and worthwhile reduction in
+the odds — but it does not close the race.
+
+Two consequences follow, and they shape everything below:
+
+1. **#1981's second acceptance criterion cannot be satisfied by the hoist it
+   asks for.** "A concurrent-writer harness proving the second write is not
+   clobbered" fails both before *and* after the hoist. The only test that goes
+   red→green on a hoist alone is one that interleaves specifically at the
+   manifest-read yield point — a mechanism assertion dressed as an outcome one.
+2. **`/assign` is not the worst offender.** It is the only cast.json writer that
+   documented the invariant at all. Its siblings never attempted it.
+
+## 2. The scale of it
+
+Seventeen modules write `writeJsonAtomic(castJsonPath(…))` across 35 call sites.
+cast.json is the most-written file in the workspace and has no lock of any kind.
+Measured read→write spans:
+
+| Site | Span | `await`s inside |
+|---|---|---|
+| `cast-merge.ts` | `:77` → `:197` | yes — writes *manuscript-edits.json* at `:171` inside the window |
+| `voice-override-linked.ts` | `:235` → `:364` | yes |
+| `library-cast-override.ts` | `:88`/`:89` → `:152`/`:153` | yes, and **two books** |
+| `voice-library.ts` `/assign` | `:1277` → `:1434` | one (`:1386`) — the filed issue |
+| `voice-style.ts` | `:53`→`:69`, `:98`→`:129` | short |
+| `cast-design.ts` | `:289`→`:293`, `:448`→`:452` | already re-reads `fresh` immediately before writing |
+
+`cast-design.ts`'s re-read-then-write is a hand-rolled mitigation of exactly this
+race, which is corroborating evidence that the defect class is real and has been
+felt before. It is also the shape a lock wants, so those two sites convert
+cleanly.
+
+Line numbers in this table are as of `main` at `88476dca` and will shift — see
+§8. The implementation plan cites symbols, not lines.
+
+## 3. Decision: serialise, don't narrow
+
+The fix is a per-book cast.json write lock, applied to **every** writer. Narrowing
+windows is unfalsifiable defence; a lock either holds the critical section or it
+does not, and a test can tell you which.
+
+The codebase already has the primitive. `server/src/workspace/file-lock.ts`
+exports `withKeyLock(key, fn)`, a generic per-key promise-chain mutex — the same
+idiom as `tts/design-lock.ts`'s `withDesignLock(bookDir, fn)` and
+`chapters-restructure.ts`'s `withBookLock`. Nothing new is invented here.
+
+### 3.1 The two exports
+
+New file `server/src/workspace/cast-lock.ts`:
+
+```ts
+withCastLock<T>(bookDir: string, fn: () => Promise<T>): Promise<T>
+withCastLocks<T>(bookDirs: string[], fn: () => Promise<T>): Promise<T>
+```
+
+`withCastLock` delegates to `withKeyLock(castJsonPath(bookDir), fn)`.
+
+The wrapper is not ceremony. **Key derivation must live in exactly one place.**
+If two sites derive the key differently — `bookDir` at one, `castJsonPath(bookDir)`
+at another, or an unnormalised path separator on Windows — the lock silently
+partitions into two mutexes that never contend. Every test still passes and the
+protection is gone. A single named function removes the opportunity.
+
+`withCastLocks` **dedupes, then sorts** the derived keys, then nests:
+
+- **Sorting** makes AB/BA deadlock impossible by construction, which matters
+  because five call sites take two books and their argument order is
+  caller-determined.
+- **Deduping** matters because the two-book routes can legitimately receive the
+  same book twice (`source === target`). A promise-chain mutex is not reentrant;
+  acquiring one key twice in a single call wedges that request forever — not
+  slowly, permanently.
+
+### 3.2 Granularity for the N-book fan-outs
+
+`voices.ts`'s `forEachMatchingCastCharacter` and `voice-library-usage.ts`'s
+`clearLibraryVoiceReferences` walk the whole workspace (or a series) and write
+each matching book.
+
+**Decision: lock per book, inside the loop.** Each book's RMW is individually
+atomic; the fan-out as a whole is not.
+
+The alternative — collect all N `bookDir`s, sort, acquire every lock, run the
+whole propagation, release — would make a series update genuinely all-or-nothing.
+It was rejected because a workspace-scoped `PUT /:voiceId/override` would then
+hold a lock on *every book in the workspace* across a full directory walk plus N
+file writes, queueing every other cast write in the process behind it. The
+accepted cost is that a concurrent writer can interleave *between* two books of
+one propagation, so a series update can land half-old/half-new. That is weaker
+than the guarantee the current code claims and stronger than the one it has.
+
+## 4. The rule
+
+Three lines, stated in `cast-lock.ts`'s header comment and as a bullet under
+CLAUDE.md's *Conventions worth preserving*:
+
+1. **Lock the innermost read-through-write, never the caller.** One level only.
+   A locked function must not call another locked function on the same book.
+2. **The read goes inside the lock.** Wrapping only the write buys nothing at
+   all. This is the easy way to produce a diff that looks correct and fixes
+   nothing.
+3. **Two or more books → `withCastLocks`, never nested `withCastLock`s.**
+
+Rule 1 is what keeps a non-reentrant mutex safe. Note that `withDesignLock` and
+`withKeyLock` are separate maps, so holding a design lock while taking a cast
+lock is *not* a self-deadlock — only the same key twice is. That is why the rule
+is scoped to the cast lock rather than to locks generally.
+
+## 5. Site conversion
+
+| Class | Sites | Work |
+|---|---|---|
+| **1 — mechanical** | `cast-aliases` ×3, `cast-create`, `cast-merge`, `voice-style` ×2, `cast-series-patch`, `voice-library` ×2, `voice-override-linked`, `book-state` (the cast write in the save handler), `cast-design` ×2 | wrap the existing read..write span |
+| **2 — multi-book** | `cast-link-prior`, `cast-not-linked-to` ×2, `library-cast-override`, `cast-add-from-roster` | `withCastLocks` |
+| **3 — N-book fan-out** | `voices.ts` `forEachMatchingCastCharacter`, `voice-library-usage.ts` `clearLibraryVoiceReferences` | per-book lock inside the loop, **read moved inside it** |
+| **4 — re-entrancy** | `qwen-voice.ts` `ensureCharacterVoiceUuid`, `persistEmotionVariant` | restructure, see §5.1 |
+| **5 — in-job** | `analysis.ts` ×5 | wrap; verify no lock is held across a chapter loop |
+
+Class 3 is not a wrap. `walkConfirmedCasts()` currently *yields* an
+already-read `cast` and the loop body writes it, so the read sits outside any
+lock the body could take. The loop body must re-read under the lock and discard
+the yielded copy for write purposes.
+
+### 5.1 The re-entrancy restructure
+
+`ensureCharacterVoiceUuid` (`qwen-voice.ts`) reads cast.json, then branches:
+
+- **series branch** → delegates to `forEachMatchingCastCharacter`, which under
+  this design locks each book it writes — *including this one*;
+- **book-scoped branch** → mutates the cast it read and writes it itself.
+
+Wrapping the whole function in `withCastLock(bookDir)` self-deadlocks the series
+branch the moment the walk reaches `bookDir`. The fix is to split: the
+book-scoped branch takes the lock and **re-reads inside it**; the series branch
+stays unlocked and delegates. The outer read is then used only for the branch
+decision (does the character exist, does it already have a `voiceUuid`), never
+as the payload for a write.
+
+`persistEmotionVariant` has the identical two-branch shape and gets the identical
+treatment.
+
+Both are the concrete instance of rule 1, and both are the highest-risk
+conversions in the sweep.
+
+## 6. #1981 specifically
+
+The lock supersedes the hoist: under a held lock the `await` at `:1386` is
+harmless, and hoisting it costs a wasted manifest read on every request that
+later `404`s on the character or `409`s on engine routing.
+
+**The hoist still lands**, on an explicitly weaker rationale: with 35 lock sites
+and future writers who will forget, keeping the window `await`-free is cheap
+insurance against partial adoption. The manifest read moves above the cast read
+(it depends only on `entry.provenance`, `voiceUuid`, and `located.state`, all in
+hand by then); the warning *string* is still built at its current site, because
+it needs `character.name`, and string formatting is synchronous.
+
+The invariant comment is rewritten. It must say that **the lock is the
+guarantee** and the `await`-free window is a secondary, best-effort narrowing. It
+must stop claiming atomicity, because that claim is what made this defect look
+like a one-line violation of a sound rule rather than a symptom of an unsound one.
+
+## 7. Testing
+
+The two failure modes to design against are a lock wrapped around the write only,
+and a mechanism test that pins "no `await` in the window" while the race stays
+open. Both yield a green suite and zero protection.
+
+**Outcome test, per class.** Two overlapping RMWs against one cast.json, each
+mutating a *different* character; assert **both** mutations survive. This is red
+today at every unlocked site (last-write-wins drops one) and green under the
+lock. It is an outcome assertion — it names the surviving data, not the absence
+of a yield — and it stays red after the hoist alone, which is the honest
+demonstration that the hoist was never the fix.
+
+**Mutation-verified by reverting the producer.** Every outcome test is proven by
+removing the lock at that site and watching it go red — not by reading the test
+and agreeing it looks right. A placebo test authored into a plan gets copied
+faithfully and survives spec review; the plan states the revert as a required
+step with recorded output, not as a suggestion.
+
+**Determinism is the open risk.** After the hoist, `/assign`'s window contains no
+slow `await` to interleave against, so a naive `Promise.all` of two requests may
+not reliably interleave. The plan must name exactly one interleave mechanism and
+use it everywhere, rather than letting each test improvise. Candidates and their
+trade-offs are the plan's first task, not this spec's.
+
+**Guard test.** No `writeJsonAtomic(castJsonPath(…))` may appear outside a lock
+scope, so site 36 cannot regress. It must be wired into `verify-cache.mjs`'s
+`extraFiles` **and** `verify.yml`'s path regex — a guard test that reads a repo
+file and is wired into neither never runs on the diff it exists to catch.
+
+**Primitive unit tests.** Sorted acquisition regardless of argument order;
+dedupe; release on throw; waiter ordering.
+
+## 8. Sequencing against #1933
+
+`fix/server-1933-assign-readiness` is open, actively edited in another session,
+and rewrites 208 lines of `server/src/routes/voice-library.ts` — moving the
+readiness gate below the cast read. It does **not** introduce a new `await` into
+the window (verified against that branch: the gate stays synchronous, and the
+manifest read remains the only yield), so it adds no hazard. It does shift every
+line in the route by roughly +138.
+
+The implementation branch therefore cuts after #1933 merges, or rebases onto it
+if it is still open when the sweep starts. This spec and the plan cite symbols
+rather than line numbers so both survive the shift.
+
+## 9. Residual risks, accepted
+
+- **In-process only.** Two server processes against one workspace would defeat
+  this entirely. The product runs one server; `capture-cli.ts` reads cast.json
+  but never writes it.
+- **The guard test sees writes, not reads.** A read left outside its lock is
+  silent — the diff looks locked and is not. Only review catches this, which is
+  why rule 2 is stated in the code rather than only here.
+- **Rule 1 is convention, not enforcement.** A future nested locker deadlocks at
+  runtime rather than failing a check.
+- **Partial atomicity for series propagation**, per §3.2.
+
+## 10. Incidental findings, filed not fixed
+
+The `finally` cleanup in all three existing lock helpers never fires:
+`chains.get(key) === gate` compares against `gate`, but what was stored is
+`prior.then(() => gate, …)` — a different promise object. Same bug in
+`file-lock.ts`, `tts/design-lock.ts`, and `chapters-restructure.ts`. Each Map
+therefore grows one entry per distinct key for the process lifetime.
+
+Bounded by book count and so genuinely minor, but it makes the "best-effort
+cleanup, so the map doesn't grow unboundedly" comment false in all three places.
+Filed as **#2001** rather than folded in: it is in code this branch touches, but
+it is a behaviour question (is the cleanup worth keeping at all, given a
+promise-chain mutex needs the tail entry to remain until it settles?) rather than
+an obvious one-answer fix.
+
+The sweep itself is tracked as **#2000**; #1981 remains the filed defect this
+work closes.


### PR DESCRIPTION
## Summary

Design of record + implementation plan for the cast.json write-lock sweep. Docs
only — no runtime change lands here.

`#1981` filed one instance: `#1953`'s designed-arm manifest read yields inside
the cast.json read-modify-write in `voice-library.ts`. The sweep found the shape
is not local to that route — **35 sites** read cast.json, mutate it and write it
back with at least one `await` in between, and none of them hold a lock. Two
concurrent writers on one book silently discard one another's mutation:
measured **200/200 lost mutations unlocked, 0/200 locked**.

- `docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md` — 13
  sections. §5 enumerates all 35 sites. §13 records the four staleness
  mechanisms that were designed and rejected.
- `docs/superpowers/plans/2026-07-31-cast-json-write-lock.md` — 13 TDD tasks.

**What the implementation PR will ship:** 30 write sites + 2 delete sites behind
a per-book `withCastLock`, a `library-voice:<uuid>` key class for the
delete-vs-assign race, the `#2001` map-cleanup defect in all three copies of
`withKeyLock`, and a static guard test so a new unlocked write fails CI.

**What it deliberately will not:** `analysis.ts`'s five merge-base writes and the
three clone-consent gates. Both validate in one scope and write in another, which
a per-RMW lock cannot reach. Four mechanisms were designed for that layer and
none survived review — the last one re-broke the 2026-07-14 Coalfall voice-strip
deterministically. They stay on `#2006` / `#2015` with the full design history
attached rather than being shipped half-designed.

## Test plan

Docs only — no code, no test surface. The plan's own tests land with the
implementation PR.

Reviewed across nine adversarial rounds plus one independent pass by a different
model. Trend on the lock sweep: 3C/8M → 4C/6M → 1C/5M → 0C/4M on the spec,
2C/8M → 0C/3M on the plan.

Refs #1981
Refs #2000
Refs #2001
Refs #2006
Refs #2015
