### PR TITLE
docs(docs): correct plan 277's Round 1 issue counts

### DIFF
--- a/docs/features/277-v115-bug-chore-sweep.md
+++ b/docs/features/277-v115-bug-chore-sweep.md
@@ -210,9 +210,14 @@ Files: `server/tts-sidecar/main.py`, `server/tts-sidecar/tests/test_qwen3.py`.
 
 ## Round 1 outcome (2026-08-01)
 
-All four lanes shipped. **13 issues closed across 5 PRs**, and **15 filed** —
-so the queue moved roughly sideways on count. That is the headline finding of
-the round, not a footnote: see "What Round 1 changed about the plan" below.
+All four lanes shipped. **12 pre-existing issues closed across 5 PRs**, and
+**14 filed** — 13 of which are still open (#2065 was filed and fixed inside
+the same round).
+
+**The open queue went 54 → 60**: 17 bugs + 37 chores at the start, 17 bugs +
+43 chores at the end. It did not move sideways; it grew by six. That is the
+headline finding of the round, not a footnote — see "What Round 1 changed
+about the plan" below.
 
 | PR | Closes | Lane |
 |---|---|---|


### PR DESCRIPTION
## Summary

Corrects two things in plan 277's Round 1 record, both verified against `gh` rather than recounted by hand.

**The numbers were wrong.** It said `13 issues closed, 15 filed`. Actual: **12 pre-existing issues closed**, **14 filed** (13 still open — #2065 was filed and fixed inside the same round). The old figure conflated #2065 into the closed count and overcounted filings by one.

**The framing was too kind.** It said the queue `moved roughly sideways on count`. It did not:

| | Bugs | Chores | Total |
|---|---|---|---|
| Round start | 17 | 37 | **54** |
| Round end | 17 | 43 | **60** |

Every bug closed was replaced one-for-one, and chores grew by six. A sweep whose stated goal is clearing the queue should record that it grew — in the headline number, not only in the analysis underneath it.

The breakdown of *why* it grew was already correct and is unchanged: one tracking issue, one self-inflicted and fixed, three always-owed items that existed only as prose inside the issues being closed, four genuine pre-existing defects that were invisible until someone looked, and three design residue from one new mechanism.

## Test plan

Not applicable — docs only. Counts verified by querying issue state directly.

## Release notes

Skipped — process record, no user- or operator-visible delta.

Refs #2042