### PR TITLE
test(server): isolate voices.test.ts cross-series fixture between describes

### DIFF
--- a/docs/features/277-v115-bug-chore-sweep.md
+++ b/docs/features/277-v115-bug-chore-sweep.md
@@ -286,8 +286,17 @@ Two conclusions for Rounds 2 and 3:
   this round; once a half-applied verification mutation was misread as damage,
   and once a mid-cleanup probe file was nearly deleted out from under its owner.
 
-## Round 2 — four lanes, 8 issues (after Round 1 merges)
+## Round 2 — five lanes, 9 issues (after Round 1 merges)
 
+- **#2046** — **SHIPPED.** `voices.test.ts`'s series-scope test was
+  deterministically red under `--retry=0`; three describes performed
+  workspace-wide override writes that legitimately reach the cross-series book
+  but cleaned up only the two same-series ones. Diagnosed as **isolation, not a
+  scope leak** — the received value's qwen slot held an earlier test's name
+  rather than the one the failing test writes, which proves the production
+  `seriesFilter` never touched that book. *Benefit (technical):* removes a red
+  test from behind the retry mask and unblocks #2063 and any future tightening
+  of `retry`. Its own lane — touches one test file, overlapping nothing.
 - **#2011** — an ASR content-QA failure aborts the whole chapter render; the
   structurally identical embed pass 60 lines below is explicitly non-fatal.
   *Benefit (user):* a QA hiccup stops costing an entire chapter.

--- a/server/src/routes/voices.test.ts
+++ b/server/src/routes/voices.test.ts
@@ -76,6 +76,20 @@ function readCastFromDisk(workspace: string, author: string, series: string, tit
   return JSON.parse(readFileSync(path, 'utf8')) as { characters: Array<Record<string, unknown>> };
 }
 
+/* A workspace-wide override write (no `scope` passed) reaches every book
+   sharing the voiceId, including a cross-series one — so a per-describe
+   cleanup that only enumerates the same-series books leaks state into
+   whichever describe runs next. Cleanups that touch a cross-series book
+   share this body; keep it in one place. */
+function clearOverridesOnDisk(workspace: string, author: string, series: string, title: string) {
+  const path = join(workspace, 'books', author, series, title, '.audiobook', 'cast.json');
+  const cast = JSON.parse(readFileSync(path, 'utf8')) as {
+    characters: Array<Record<string, unknown>>;
+  };
+  delete cast.characters[0].overrideTtsVoices;
+  writeFileSync(path, JSON.stringify(cast));
+}
+
 const realFetch = globalThis.fetch;
 
 beforeAll(async () => {
@@ -1305,6 +1319,8 @@ describe('PUT /api/voices/:voiceId/override — refuses to clear a cloned slot (
       delete cast.characters[0].overrideTtsVoices;
       writeFileSync(path, JSON.stringify(cast));
     }
+    // This suite's workspace-wide writes also reach the cross-series book.
+    clearOverridesOnDisk(workspaceRoot, AUTHOR, OTHER_SERIES, OTHER_BOOK);
   });
 
   it('409s a workspace-wide clear when a linked character carries a cloned slot, and writes nothing', async () => {
@@ -1434,6 +1450,8 @@ describe('PUT /api/voices/:voiceId/override — clears a stale libraryUuid/prove
       delete cast.characters[0].overrideTtsVoices;
       writeFileSync(path, JSON.stringify(cast));
     }
+    // This suite's workspace-wide writes also reach the cross-series book.
+    clearOverridesOnDisk(workspaceRoot, AUTHOR, OTHER_SERIES, OTHER_BOOK);
   });
 
   it('[DELTA-I5] an explicit catalogue pick after a designed library assign clears the stale libraryUuid/provenance', async () => {
@@ -1539,6 +1557,8 @@ describe('applyOverrideToCastFiles — direct-call coverage for the qwen half of
       delete cast.characters[0].overrideTtsVoices;
       writeFileSync(path, JSON.stringify(cast));
     }
+    // This suite's workspace-wide writes also reach the cross-series book.
+    clearOverridesOnDisk(workspaceRoot, AUTHOR, OTHER_SERIES, OTHER_BOOK);
   });
 
   it('[I-2] a direct applyOverrideToCastFiles(qwen) call preserves libraryUuid/provenance on a CLONED qwen slot', async () => {
@@ -1563,25 +1583,18 @@ describe('applyOverrideToCastFiles — direct-call coverage for the qwen half of
 });
 
 describe('PUT /api/voices/:voiceId/override — series scope (plan 108)', () => {
-  afterEach(async () => {
+  async function resetAllCasts() {
     /* Clear all three casts between cases so the cross-series assertions
-       start clean. */
+       start clean. Run before AND after each case: an earlier describe in
+       this file could otherwise leak a dirty cross-series fixture into the
+       first test here (afterEach alone only cleans up after this suite's
+       own writes). */
     await request(app).put('/api/voices/v_brann/override').send({ override: null });
-    const otherPath = join(
-      workspaceRoot,
-      'books',
-      AUTHOR,
-      OTHER_SERIES,
-      OTHER_BOOK,
-      '.audiobook',
-      'cast.json',
-    );
-    const cast = JSON.parse(readFileSync(otherPath, 'utf8')) as {
-      characters: Array<Record<string, unknown>>;
-    };
-    delete cast.characters[0].overrideTtsVoices;
-    writeFileSync(otherPath, JSON.stringify(cast));
-  });
+    clearOverridesOnDisk(workspaceRoot, AUTHOR, OTHER_SERIES, OTHER_BOOK);
+  }
+
+  beforeEach(resetAllCasts);
+  afterEach(resetAllCasts);
 
   it("writes ONLY to the anchor book's series, leaving other series untouched", async () => {
     const res = await request(app)

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -79,15 +79,21 @@ const maxWorkers = lowConcurrency ? 1 : 2;
      the shape #2028 describes, and that file is where the hazard was found
      landing #2001. A red-phase test against that state is never silently
      rescued by the suite-wide retry.
-   - Global was surveyed rather than assumed, and rejected on the evidence:
-     surveyed 2026-08-01 via `npx vitest run --retry=0` against this exact
-     suite on unmodified `main` — it reddens `src/routes/voices.test.ts`
+   - Global was surveyed rather than assumed, and rejected on the evidence
+     AS OF 2026-08-01: surveyed via `npx vitest run --retry=0` against this
+     exact suite on unmodified `main` — it reddened `src/routes/voices.test.ts`
      ("writes ONLY to the anchor book's series..."), deterministically, on
-     the FIRST attempt, every time. That test is currently green in every
-     gating run purely because retry:1 papers over it, and that leak is
-     unrelated to this change and out of scope to fix here — filed as
-     #2046. Dropping retry suite-wide would have reddened every lane's CI on
-     that file until #2046 is root-caused.
+     the FIRST attempt, every time. That test was green in every gating run
+     purely because retry:1 papered over it, so dropping retry suite-wide
+     would have reddened every lane's CI on that file.
+     **That specific blocker is now discharged**: #2046 root-caused it as
+     test-fixture pollution (three describes cleaned two of the three books
+     their workspace-wide writes touched — NOT a production scope leak) and
+     fixed it, so that file is green under `--retry=0`. This does not by
+     itself make Global safe: the 2026-08-01 survey named one red file, and
+     nothing has re-surveyed the suite since. Re-run the survey before
+     re-opening the Narrow-vs-Global call — do not read the discharged
+     blocker as a green light.
    retryHazardReporter below is additive on top of Narrow, not a replacement
    for it: Narrow covers file-lock.test.ts specifically; every OTHER file
    still runs under the suite-wide retry:1, and for those, any test that


### PR DESCRIPTION
## Summary

`server/src/routes/voices.test.ts:1586` — "writes ONLY to the anchor book's series, leaving other series untouched" — has been **deterministically red on `main`** and green in every gating run only because `server/vitest.config.ts` sets `retry: 1`. This isolates the fixture so it passes with `--retry=0`.

**Diagnosis: test-fixture pollution, not a scope leak.** The issue named two candidate causes and said the fix depends on which. It is the benign one, and the evidence is decisive rather than circumstantial:

> The failing test writes `{ engine: 'qwen', name: 'qwen-v_brann' }`, and `applyOverrideToCastFiles` sets the slot's `name` on every character it touches. Had the series-scoped write leaked to the cross-series book, that book's qwen slot would read `qwen-v_brann`. It reads `qwen-catalogue-pick` — a value written by an *earlier test*. So the scoped write provably never reached it.

`seriesFilter` (`server/src/routes/voices.ts:624-626`, `:812`) is correct and **no production code changed**. There is no user-facing bug here.

The actual defect: three describes perform workspace-wide override writes, which correctly reach all three books (`:1607` "defaults to a workspace-wide write when no scope is passed" asserts exactly that) — but each `afterEach` clears only the two same-series books:

| describe | write reaching the cross-series book | cleanup cleared |
|---|---|---|
| `:1280` refuses-to-clear-a-cloned-slot | `coqui: 'Asya Anara'` | `[BOOK_ONE, BOOK_TWO]` |
| `:1418` DELTA-I5 stale libraryUuid | `coqui: 'Daisy Studious'` | `[BOOK_ONE, BOOK_TWO]` |
| `:1518` direct `applyOverrideToCastFiles(qwen)` | `qwen: 'qwen-catalogue-pick'` | `[BOOK_ONE, BOOK_TWO]` |

Composed in file order those yield exactly the observed `{coqui: Daisy Studious, qwen: qwen-catalogue-pick}`. The series-scope describe does clear the third book — but only in `afterEach`, which runs *after* its first test.

## What changed

1. **Completed the cleanups at source.** Each of the three `afterEach`s now also clears the cross-series book it wrote to, via one new module-scope helper `clearOverridesOnDisk(workspace, author, series, title)` sitting beside the existing `readCastFromDisk`.
2. **Made the assertion self-defending.** The series-scope describe's reset is hoisted into `resetAllCasts()` and called from `beforeEach` as well as `afterEach`, so the test establishes the precondition it asserts instead of inheriting it.

**Both, deliberately, and each is independently sufficient** — stated plainly rather than implied: with only (1) applied the file is green, and with only (2) applied it is also green. (1) is the root-cause fix — it stops the leak so the next test that reads that book isn't dirty. (2) is the local guard on the test whose correctness depends on the precondition. Keeping only one would leave either a live fixture leak or an assertion that inherits its own precondition.

## Test plan

No new test — the regression test is the existing one, previously masked. What matters is proving it can still fail, so it was mutation-verified against the final consolidated code:

| mutation | result |
|---|---|
| both parts disabled | **RED** — `1 failed | 60 passed`, received `{coqui: Daisy Studious, qwen: qwen-catalogue-pick}` vs expected `undefined` at the assertion — the original failure, reproduced exactly |
| part 1 only (source cleanup) | green — confirms it genuinely removes the pollution rather than decorating |
| part 2 only (`beforeEach`) | green |
| both applied (shipped state) | green |

Verification run:

- `npx vitest run src/routes/voices.test.ts --retry=0` → **61 passed, 0 failed** (was 1 failed / 60 passed)
- `npx vitest run src/routes/voices.test.ts` (default retry) → 61 passed
- `npx vitest run src/routes/ --retry=0` → 112 files / 1840 tests, all green — no other red file in this directory
- full `test:server` via the pre-commit hook → 460 files / 6241 tests green
- `npm run typecheck` → clean

## Notes

- **`retry: 1` is deliberately untouched.** Tightening it is #2028's territory; this PR only removes one of the things standing in its way.
- **Release notes skipped intentionally** — test-only change, no user- or operator-visible delta to describe.
- Plan `docs/features/277-v115-bug-chore-sweep.md` gains the Round 2 row its own Round 1 retrospective called for ("#2046 should go early in Round 2"), and the heading count moves from four lanes / 8 issues to five / 9.

Closes #2046
Refs #2028, #2063

## Also fixed, found in passing

- **`server/vitest.config.ts:82-90`** — the #2028 Global-vs-Narrow note asserted as present fact that `voices.test.ts` is red under `--retry=0` and that Global stays blocked *"until #2046 is root-caused"*. This PR root-causes it, so the comment would have misdirected the next person evaluating #2028 into treating a discharged blocker as live. Rewritten to past tense, recording that the blocker is discharged and why — and explicitly warning that this does **not** make Global safe, since the suite has not been re-surveyed since the 2026-08-01 pass that named one red file. Comment only; `retry: 1` and all behaviour unchanged.

## Filed, not fixed here

The independent review enumerated every hook in this 1700-line file rather than stopping at the one fixed defect, on the principle that finding one instance of a defect shape does not mean the shape is gone. It found more:

- **#2077** — the fs-61 narrator describe is a **second instance of the same shape**, and slightly worse: its workspace-wide write touches four books carrying a bare `narrator` id, its `afterEach` cleans two, and one of the uncleaned two has a deliberately-seeded value that gets permanently overwritten. Harmless today *purely because that describe is last in the file*. Also covers the related weakness that `resetAllCasts`'s clear never checks its status (pre-existing, cannot fire today). Neither clears the fix-now bar — the right fix for the first is a genuine judgement call, and the second is not a regression.
- **#2078** — `export.test.ts` flakes on its first attempt under contended runs, surfaced twice today by the new `[retry-hazard]` reporter. Confirmed transient, **not** this issue's failure mode: green in isolation under `--retry=0`. Filed so the retry-hazard signal stays trustworthy.
