### PR TITLE
docs(docs): record the A33 --apply run against the real workspace

### DIFF
--- a/docs/testing/cast-id-drift-onbox-acceptance.md
+++ b/docs/testing/cast-id-drift-onbox-acceptance.md
@@ -332,7 +332,7 @@ Expected: refuses immediately, naming the reachable port(s), exit code 1, no
 `cast-id-history.json` written anywhere (confirm via a workspace-wide file
 search before and after).
 
-Result: _______________________________________________________________
+Result: **2026-08-05, Claude Code session on the dev box (dudarenok-maker).** **PASS.** `cd server && npm run dev` bound **LAN HTTPS 8443 only** — it never opened 8080 — so this exercised the `LAN_HTTPS_PORT` half of the probe rather than the `PORT` half. `--apply` refused immediately: `Refusing --apply: port(s) 8443 did not return a clear ECONNREFUSED — treating as possibly-live`, exit code **1**. Workspace-wide search for `cast-id-history.json` returned **0** files both before and after. Worth noting for anyone repeating this: had the probe covered only the default 8080, this real server would have been invisible to it.
 
 3. Stop the server before continuing.
 
@@ -350,29 +350,33 @@ last dry run — stop and re-measure before trusting anything below; if the
 cache-evidence line is nonzero, `--apply` refuses outright instead — fix
 `CACHE_DIR` per §8.3 and re-run the dry run first).
 
-Result (console summary matches §8.1): ______________
+Result (console summary matches §8.1): **2026-08-05, Claude Code session on the dev box (dudarenok-maker).** **PASS — exact match.** `mode: APPLY (writing cast-id-history.json)`; books scanned **20**; auto-recordable aliases **3 (27 segment(s))**; reported for human decision **93 id(s) / 161 segment(s)**; re-render candidates **17**; books missing analysis-cache evidence **0**.
+
+> **Read that last figure against the right revision.** This run was made against `main` @ `f3d6ae0f`, i.e. the **pre-#2102** gate, where the cache-evidence count was global and `0` was the go/no-go. #2102 makes the gate honest and scopes the refusal per book, after which the expected output is `books missing analysis-cache evidence: 1` (*Unlocked* parses but names nobody) **plus a new `books with an auto-record withheld: 0`** — and it is that second line, not the first, that gates `--apply`. Do not read this PASS as "the first line must be 0" once #2102 lands.
+
+Invocation: `WORKSPACE_DIR="C:/AudiobookWorkspace" CACHE_DIR="C:/Claude/Projects/Audiobook-Generator/server/handoff/cache" node scripts/repair-cast-id-drift.mjs --apply`. **`WORKSPACE_DIR` must be passed explicitly** — the script does not read `server/.env`, and its `<home>/AudiobookWorkspace` default is empty on this box (see [#2108](https://github.com/dudarenok-maker/Castwright/issues/2108)).
 
 ### 8.6 After `--apply` — confirm what was and wasn't written
 
 5. Read `.audiobook/cast-id-history.json` for *Заказ Коалфолла*.
 
 Result (`supersededBy` contains `mayrin: "mairin"` and
-`coalfall: "coalfall-dragon"`): ______________
+`coalfall: "coalfall-dragon"`): **2026-08-05, Claude Code session on the dev box (dudarenok-maker).** **PASS.** File reads `{"schema": 1, "supersededBy": {"mayrin": "mairin", "coalfall": "coalfall-dragon"}}`.
 
 6. Read `.audiobook/cast-id-history.json` for *Everblaze*.
 
-Result (`supersededBy` contains `"lady-alina": "dame-alina"`): ______________
+Result (`supersededBy` contains `"lady-alina": "dame-alina"`): **2026-08-05, Claude Code session on the dev box (dudarenok-maker).** **PASS.** File reads `{"schema": 1, "supersededBy": {"lady-alina": "dame-alina"}}`.
 
 7. Search the whole workspace for `cast-id-history.json`. Expected: **exactly
    two** files — the two above. No other book gained one.
 
-Result (file count and locations): ______________
+Result (file count and locations): **2026-08-05, Claude Code session on the dev box (dudarenok-maker).** **PASS — exactly two.** `Castwright/Standalones/Заказ Коалфолла/.audiobook/cast-id-history.json` and `Shannon Messenger/Keeper of the Lost Cities/Everblaze/.audiobook/cast-id-history.json`. No other book gained one (workspace-wide `find`, 0 before → 2 after).
 
 8. Diff every book's `cast.json` against its pre-run state (mtime, then
    content). Expected: byte-unchanged everywhere — the pass never touches
    `cast.json`.
 
-Result: ______________
+Result: **2026-08-05, Claude Code session on the dev box (dudarenok-maker).** **PASS.** md5 of all **20** `cast.json` files captured before the run and re-captured after — the two sorted digest lists are identical, so every book's cast is byte-unchanged.
 
 9. Re-run the script in **dry-run** mode (no `--apply`) immediately after.
    Expected: the three now-recorded aliases no longer appear in the
@@ -380,7 +384,7 @@ Result: ______________
    report-only ids are unchanged from §8.1 — proving the write was durable,
    not merely printed once.
 
-Result: ______________
+Result: **2026-08-05, Claude Code session on the dev box (dudarenok-maker).** **PASS on the stated criteria, but it surfaced a defect.** Auto-recordable aliases **3 → 0**; skipped (already recorded) **0 → 3**; report-only **93 ids / 161 segments — unchanged**. The write is durable. **However** the re-render list moved **17 rows / 120 segments → 13 rows / 93 segments**: the 4 rows covered by the 3 new aliases (`mayrin` ch2 8 seg, `coalfall` ch2 13 seg, `lady-alina` ch55 4 seg + ch61 2 seg = 27 segments) dropped off it. That audio is still narrator-substituted on disk, and `buildRerenderRows`' own doc comment plus register row A33 both state the list is unconditional on auto-record status. Filed as [#2107](https://github.com/dudarenok-maker/Castwright/issues/2107).
 
 ### 8.7 Confirm the fix reaches actual audio
 
@@ -391,12 +395,12 @@ Result: ______________
 Expected: `characterSnapshots["mayrin"]` and `characterSnapshots["coalfall"]`
 now exist, naming Мэйрин's and Коалфолл's own live voices — not the narrator.
 
-Result: ______________
+Result: **NOT RUN as of 2026-08-05** — needs the 8 GB card with Qwen resident. Still owed; register row A33 stays open for this and §8.8.
 
 12. **Listen.** Confirm both characters' lines are audibly distinct from the
     narrator, not merely a different id in the JSON.
 
-Result (by ear): ______________
+Result (by ear): **NOT RUN as of 2026-08-05** — depends on step 10/11 above.
 
 ### 8.8 Cast-screen banner cross-check
 
@@ -407,12 +411,13 @@ Expected: the auto-reconciled section names `mayrin`/`coalfall` (Заказ
 still names the untouched ids — spot-check *Exile*'s `unknown-male` as the
 negative control (a reserved-bucket source must still refuse to auto-record).
 
-Result: ______________
+Result: **NOT RUN as of 2026-08-05.** Partial evidence from the CLI only: the post-`--apply` dry run still reports *Exile*'s `unknown-male` as report-only with the reserved-fold-bucket refusal reason intact, so the negative control holds at the script level. The Cast-screen rendering of both sections has not been checked.
 
 ### 8.9 Outcome
 
-- [ ] §§8.4-8.8 run
-- [ ] Defects filed: ____________________________________
+- [x] §§8.4-8.6 run — **2026-08-05**, all PASS
+- [ ] §§8.7-8.8 run — still owed (needs the GPU box + a listen)
+- [x] Defects filed: [#2107](https://github.com/dudarenok-maker/Castwright/issues/2107) (re-render list drops aliased rows after `--apply`), [#2108](https://github.com/dudarenok-maker/Castwright/issues/2108) (a zero-book scan reports the same green summary as a clean one, and `--apply` exits 0)
 
 Record what was observed, by whom, and when — here and in register row A33.
 This is the first time the repair pass has ever written to the real

--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -1379,8 +1379,50 @@ already-analysed book.
 
 Wave 1 (A32) and Wave 2 (B3) are proven or pending against a single already-drifted
 chapter/book each. Wave 3's `scripts/repair-cast-id-drift.mjs` is the pass meant
-to sweep the **whole** 20-book workspace at once, and **has never been run with
-`--apply`** — every number below comes from its dry-run mode, which writes
+to sweep the **whole** 20-book workspace at once.
+
+> **PARTIALLY DISCHARGED — `--apply` was run 2026-08-05** (Claude Code session on
+> the dev box, dudarenok-maker), against `main` @ `f3d6ae0f`. The write path is
+> now proven; **§8.7 (does the fix reach actual audio — re-render *Заказ
+> Коалфолла* ch2 and listen) and §8.8 (Cast-screen banner cross-check) are still
+> owed**, so this row stays open for those two.
+>
+> **What was observed.** The liveness rail refused first, against a *real*
+> `npm run dev` — which bound **LAN HTTPS 8443 only, never 8080**, so it was the
+> `LAN_HTTPS_PORT` half of the probe that caught it (exit 1, nothing written; a
+> probe covering only the default 8080 would have missed this server). With the
+> server stopped, `--apply` recorded exactly the 3 predicted aliases across
+> **2** books — `mayrin → mairin`, `coalfall → coalfall-dragon` (*Заказ
+> Коалфолла*), `lady-alina → dame-alina` (*Everblaze*). No other book gained a
+> `cast-id-history.json` (0 → 2 workspace-wide). All **20** `cast.json` files
+> byte-unchanged (md5 before/after). The immediate dry re-run showed auto-records
+> **3 → 0**, skipped **0 → 3**, report-only **93 / 161 unchanged** — the write is
+> durable.
+>
+> **Two defects filed from the run, neither blocking the write itself:**
+> [#2107](https://github.com/dudarenok-maker/Castwright/issues/2107) — the
+> re-render list dropped **17 rows / 120 segments → 13 / 93** afterwards, losing
+> exactly the 27 segments the new aliases cover, whose audio is still
+> narrator-substituted on disk (the list is documented as unconditional on
+> auto-record status, and `120` is this row's own stated damage figure).
+> [#2108](https://github.com/dudarenok-maker/Castwright/issues/2108) — a wrong
+> `WORKSPACE_DIR` scans **0** books and still prints `books missing
+> analysis-cache evidence: 0` and exits **0** from `--apply`; the script does not
+> read `server/.env`, so the bare command hits an empty `<home>/AudiobookWorkspace`.
+> That one bites this row directly, because the precondition below tells you to
+> trust that line.
+>
+> **Revision-sensitive:** the numbers above are against the **pre-#2102** global
+> cache gate. Once #2102 lands, `books missing analysis-cache evidence` is
+> expected to read **1** (*Unlocked* has a cache that parses and names nobody) and
+> a new `books with an auto-record withheld: 0` becomes the line that actually
+> gates `--apply`. Note for the record that *Unlocked* is not "nothing to
+> repair" — it carries **34 orphaned segments** across ch63/ch67 under
+> `unknown-male`; what makes withholding safe there is that a reserved
+> fold-bucket **source** is never auto-recorded regardless of evidence, which
+> fires before the ambiguity veto matters at all.
+
+Every number below comes from the pass's dry-run mode, which writes
 nothing. No automated test can substitute for the real run: the pure helpers
 (candidate ranking, ambiguity/reserved-source guards, the re-render list shape)
 are unit-tested against synthetic fixtures, and the liveness probe was verified


### PR DESCRIPTION
## Summary

Ran register row **A33** on **2026-08-05** against `main` @ `f3d6ae0f` — the first time `scripts/repair-cast-id-drift.mjs` has ever written to the real `C:\AudiobookWorkspace`. This records the outcome; it ships no code.

**Run sheet §§8.4–8.6 — all PASS.**

| Check | Result |
|---|---|
| Liveness rail vs. a **real** `npm run dev` | Refused, exit 1, nothing written |
| `--apply` aliases recorded | 3, across 2 books — exactly as predicted |
| Other books gaining a history file | 0 (workspace-wide 0 → 2) |
| `cast.json` byte-unchanged | All **20**, md5 before/after |
| Durability (immediate dry re-run) | auto-records 3 → 0, skipped 0 → 3, report-only 93/161 unchanged |

Worth knowing for anyone repeating this: the dev server bound **LAN HTTPS 8443 only and never opened 8080**, so it was the `LAN_HTTPS_PORT` half of the probe that caught it. A probe covering only the default `PORT` would have missed a real, live server.

**§8.7 (re-render *Заказ Коалфолла* ch2 and listen) and §8.8 (Cast-screen cross-check) are NOT run** — they need the 8 GB card with Qwen resident and a human ear. **A33 stays open** for those two rather than closing.

## Defects found by the run

Neither blocks the write itself; both are filed, not fixed here.

- **[#2107](https://github.com/dudarenok-maker/Castwright/issues/2107)** — after `--apply` the re-render list drops **17 rows / 120 segments → 13 / 93**, losing exactly the 27 segments the new aliases cover. That audio is *still* narrator-substituted on disk. Both `buildRerenderRows`' own doc comment and A33 call the list unconditional on auto-record status, and `120` is A33's stated damage figure. Cause is upstream at `collectSegmentOrphans` (`:878-899`): the resolver is built with the freshly-written history, so an aliased id resolves via the `'history'` tier and is `continue`d as "not an orphan" before the row builder sees it. Invisible within a single run — writes happen last — so it only bites on the re-run A33 itself prescribes.
- **[#2108](https://github.com/dudarenok-maker/Castwright/issues/2108)** — a wrong `WORKSPACE_DIR` scans **0** books, still prints `books missing analysis-cache evidence: 0`, and `--apply` exits **0** having written nothing. The script doesn't read `server/.env`, so the bare command lands on an empty `<home>/AudiobookWorkspace`. This bites A33 directly: its precondition tells the operator to trust that exact line. I hit it on my first invocation.

## Coordination with the in-flight repair-guard work

These figures are stamped to the **pre-#2102** global cache gate. Both surfaces now say explicitly that once #2102 lands the first line is *expected* to read `1` (*Unlocked* has a cache that parses and names nobody) and the actual `--apply` gate moves to the new `books with an auto-record withheld: 0` line — so nobody reads this PASS as "the first line must be 0."

One factual correction for the record, which doesn't change #2102's design: *Unlocked* is **not** "zero orphaned ids and nothing to repair" — it carries **34 orphaned segments** across ch63/ch67 under `unknown-male` (ranked candidates Lord Cassius / Sandor / Bo). Scoping the refusal per book is still right, but what makes withholding safe *there* is that a reserved fold-bucket **source** is never auto-recorded regardless of evidence, and that refusal fires ahead of the ambiguity veto. "Emptiness" would generalise the wrong way — a future book with a blind cache *and* a non-reserved orphan is exactly the case the per-book withhold has to carry.

## Test plan

- `npm run check:onbox-register` — passes; A33 is not removed, so the owed total, group counts and row ids are unchanged.
- `npm run test:hooks` — passes (pre-commit, in scope).
- Evidence for every table row above is in the run sheet's filled-in `Result:` lines.

**Live view deliberately not touched.** Checklist step 3 normally requires all three surfaces to move together, and this PR moves only two. Two reasons: the concurrent repair-guard thread owns publishing `onbox-acceptance-register-live-view.html` and is holding it until its numbers settle rather than republishing per round; and the page's derived figures (owed count, group counts, oldest debt) are **unchanged by this PR anyway**, because A33 stays open. Flagging it rather than omitting it silently.

Refs #2040

🤖 Generated with [Claude Code](https://claude.com/claude-code)