### PR TITLE
fix(scripts): re-arm deps-watch transitions on latest changing, not the ahead edge

### DIFF
--- a/.github/workflows/app-deps-watch.yml
+++ b/.github/workflows/app-deps-watch.yml
@@ -3,9 +3,11 @@ name: app-deps-watch
 
 # ops-17 / #790 — monthly pub-dependency watch for the Flutter companion.
 # A1: red when any DIRECT/DEV apps/android dep is behind `latest` (catch-up nudge).
-# A2: a dedicated KGP-migration channel — a ⚠️ banner + a one-off @mention on #790
-# when audio_session / flutter_foreground_task / mobile_scanner first show a newer
-# version (the rare event ops-17 exists to catch), so it is never buried under A1.
+# A2: a dedicated KGP-migration channel — a ⚠️ banner + an @mention on #790 when
+# audio_session / flutter_foreground_task / mobile_scanner show a newly observed
+# `latest` (ops-17b, #2104: not just the first time — every subsequent genuine
+# version bump re-fires too, so a rejected release can't permanently disarm it),
+# so it is never buried under A1.
 # All logic is the unit-tested scripts/deps-watch.mjs; this just runs it.
 on:
   workflow_dispatch:

--- a/docs/superpowers/plans/2026-06-19-ops-17-kgp-guardrail.md
+++ b/docs/superpowers/plans/2026-06-19-ops-17-kgp-guardrail.md
@@ -391,6 +391,10 @@ export function stickyRequest(existing, repo, issue) {
 
 (`STICKY_MARKER` is exported from the Task 1 block; `findSticky` references it as the default arg.)
 
+(`computeTransitions` above is the code as originally shipped. Its semantics were
+superseded by ops-17b (#2104) — see the current doc-comment on `computeTransitions`
+in `scripts/deps-watch.mjs` for what it does now.)
+
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `npm run test:hooks`

--- a/docs/superpowers/specs/2026-06-19-ops-17-kgp-guardrail-design.md
+++ b/docs/superpowers/specs/2026-06-19-ops-17-kgp-guardrail-design.md
@@ -268,8 +268,21 @@ not-currently-broken build.
   - only a **transitive** dep behind → A1 exit 0 (+ listed in summary).
   - a KGP plugin's `latest` now exceeds its pin, prior state at-pin → A2 banner
     + transition flagged + honest "verify KGP" wording (not "migrated").
-  - same plugin still ahead, prior state already-ahead → A2 banner, **no**
-    repeat transition comment (transition fires once).
+  - same plugin still ahead, prior state already-ahead, `latest` UNCHANGED →
+    A2 banner, **no** repeat transition comment (no cron spam).
+  - > **Correction (ops-17b, [#2104](https://github.com/dudarenok-maker/Castwright/issues/2104), 2026-08-05):**
+    > the line above originally read "same plugin still ahead → no repeat
+    > transition comment (transition fires once)" — i.e. an edge detector on
+    > the `ahead` flag. That is wrong: once a plugin is ahead of its pin, every
+    > *subsequent* release re-fires this same "still ahead" branch, so a
+    > flag-edge detector goes silent forever after the first newer release —
+    > exactly the evaluated-and-rejected-release case the recipe below tells an
+    > operator to leave the pin alone for. `computeTransitions` now edge-detects
+    > on the **observed `latest` changing** (strictly increasing vs. the prior
+    > recorded `latest`), not on the `ahead` flag; a prior `ahead: true` record
+    > with no usable `latest` fails loud (fires) instead of silently trusting
+    > it. See `scripts/deps-watch.mjs`'s `computeTransitions` doc-comment for
+    > the exact rule.
   - a KGP plugin **absent** from the payload (current) → treated as at-pin.
   - the `kind` field present (asserts we filter on `kind`, never on a
     non-existent `isDirect`).

--- a/scripts/deps-watch.mjs
+++ b/scripts/deps-watch.mjs
@@ -90,9 +90,29 @@ export function buildState(pluginStatus) {
   return state;
 }
 
-/** Plugins that are ahead now but were not ahead in the prior state. */
+/** Plugins whose OBSERVED LATEST changed since the prior state, not merely
+ *  whose `ahead` flag flipped (ops-17b, #2104) — an edge detector on `ahead`
+ *  alone fires once per plugin ever, then goes permanently silent for every
+ *  subsequent release once a plugin is ahead of its pin (the normal case for
+ *  an evaluated-and-rejected KGP release, where the pin is deliberately left
+ *  alone). Firing rule per prior record for the plugin:
+ *   - absent, or `ahead: false` -> fire iff `ahead` now (unchanged edge case).
+ *   - `ahead: true` with a usable recorded `latest` -> fire iff the new
+ *     `latest` is STRICTLY greater (a downgrade/yank must never fire).
+ *   - `ahead: true` with `latest` missing/null/non-string -> fire. A prior
+ *     record in that shape is corrupt or pre-ops-17b legacy state, not a
+ *     clean "nothing changed" — staying silent there is the exact defect
+ *     this issue is about, one level down. */
 export function computeTransitions(pluginStatus, priorState) {
-  return pluginStatus.filter((s) => s.ahead && !priorState[s.name]?.ahead).map((s) => s.name);
+  return pluginStatus
+    .filter((s) => {
+      if (!s.ahead) return false;
+      const prior = priorState[s.name];
+      if (!prior?.ahead) return true; // absent, or at-pin -> ahead edge
+      if (typeof prior.latest !== 'string' || !prior.latest) return true; // fail loud, don't stay silent
+      return compareSemver(s.latest, prior.latest) > 0;
+    })
+    .map((s) => s.name);
 }
 
 /** The single sticky comment (by marker), or null. Found even if a human
@@ -157,6 +177,8 @@ export function renderTransitionComment(transitions, pluginStatus, mention = '@d
     '',
     ...items,
     '',
-    'Recipe: bump locally → `flutter build apk --release` → if the KGP warning is gone, bump the pin, drop the escape-hatch flags + the `app.yml` Trip-B flag assertion, and close #790.',
+    'Recipe: bump locally → `flutter build apk --release`.',
+    '- If the KGP warning is gone: bump the pin, drop the escape-hatch flags + the `app.yml` Trip-B flag assertion, and close #790.',
+    '- If the warning is still there: leave the pin alone — it is no longer what arms this notification, so the next release still pings you regardless.',
   ].join('\n');
 }

--- a/scripts/deps-watch.mjs
+++ b/scripts/deps-watch.mjs
@@ -11,6 +11,11 @@ export const STICKY_MARKER = '<!-- ops-17-deps-watch -->';
  * Known limitation: collapses prerelease ordering, so `1.0.0` vs `1.0.0-beta`
  * compares EQUAL (stable-over-prerelease is under-reported). Safe for the three
  * KGP plugins (all pinned at stable). Revisit if a plugin pins a `-beta`/`-dev`.
+ * Build metadata is dropped too, so `10.1.0+1` vs `10.1.0` also compares EQUAL.
+ * Unlike the prerelease case this IS reachable here: the workflow runs
+ * `flutter pub outdated --json --show-all` with no `--prereleases`, so
+ * prereleases never reach `latest`, but a `+N`-only republish does — and
+ * won't fire a transition even though the observed `latest` string changed.
  */
 export function compareSemver(a, b) {
   const core = (v) => String(v).split('+')[0].split('-')[0].split('.').map((n) => parseInt(n, 10) || 0);

--- a/scripts/tests/deps-watch.test.mjs
+++ b/scripts/tests/deps-watch.test.mjs
@@ -109,22 +109,42 @@ test('extractState parses the embedded JSON; empty/garbage -> {}', () => {
   assert.deepEqual(extractState('no marker here'), {});
 });
 
-test('computeTransitions: fires only on at-pin -> ahead', () => {
+test('computeTransitions: fires on at-pin -> ahead, and on first run for every currently-ahead plugin', () => {
   const status = [
-    { name: 'audio_session', ahead: true },
-    { name: 'mobile_scanner', ahead: true },
+    { name: 'audio_session', ahead: true, latest: '0.2.4' },
+    { name: 'mobile_scanner', ahead: true, latest: '7.3.0' },
   ];
-  // audio_session was already ahead last run; mobile_scanner just flipped.
-  const prior = { audio_session: { ahead: true }, mobile_scanner: { ahead: false } };
+  // audio_session was already ahead last run at the SAME latest; mobile_scanner just flipped.
+  const prior = { audio_session: { ahead: true, latest: '0.2.4' }, mobile_scanner: { ahead: false } };
   assert.deepEqual(computeTransitions(status, prior), ['mobile_scanner']);
   // empty prior (first run) -> every currently-ahead plugin transitions
   assert.deepEqual(computeTransitions(status, {}), ['audio_session', 'mobile_scanner']);
 });
 
-test('computeTransitions: ahead->ahead does NOT re-fire (transition fires once)', () => {
-  // The core A2 guarantee: a plugin already ahead last run must not re-spam #790.
-  const status = [{ name: 'audio_session', ahead: true }];
-  assert.deepEqual(computeTransitions(status, { audio_session: { ahead: true } }), []);
+test('computeTransitions: ahead->ahead with unchanged latest does NOT re-fire (no cron spam)', () => {
+  // The core no-re-spam guarantee (ops-17b, #2104): reshaped from an edge-detector
+  // on `ahead` to one on `latest` — same prior AND current latest -> [].
+  const status = [{ name: 'audio_session', ahead: true, latest: '0.3.0' }];
+  const prior = { audio_session: { ahead: true, latest: '0.3.0' } };
+  assert.deepEqual(computeTransitions(status, prior), []);
+});
+
+test('computeTransitions: fires on a genuine latest bump even though already ahead (ops-17b repro, #2104)', () => {
+  const status = [{ name: 'flutter_foreground_task', ahead: true, latest: '10.1.0' }];
+  const prior = { flutter_foreground_task: { ahead: true, latest: '10.0.0' } };
+  assert.deepEqual(computeTransitions(status, prior), ['flutter_foreground_task']);
+});
+
+test('computeTransitions: a downgrade (latest moves backwards) does not fire', () => {
+  const status = [{ name: 'mobile_scanner', ahead: true, latest: '10.0.0' }];
+  const prior = { mobile_scanner: { ahead: true, latest: '10.1.0' } };
+  assert.deepEqual(computeTransitions(status, prior), []);
+});
+
+test('computeTransitions: prior ahead:true with no usable latest fails loud (fires)', () => {
+  const status = [{ name: 'mobile_scanner', ahead: true, latest: '7.4.0' }];
+  const prior = { mobile_scanner: { ahead: true } }; // corrupt/legacy state: no `latest` recorded
+  assert.deepEqual(computeTransitions(status, prior), ['mobile_scanner']);
 });
 
 test('computeBehind: empty payload -> [] and exitCodeFor -> 0 (the green baseline)', () => {
@@ -237,4 +257,19 @@ test('renderTransitionComment: null when no transitions; @mention + recipe other
   assert.ok(md.includes('audio_session'));
   assert.ok(md.includes('0.3.0'));
   assert.ok(/flutter build apk --release/.test(md));
+});
+
+test('renderTransitionComment: recipe covers BOTH outcomes, and says the pin no longer arms the notification', () => {
+  // ops-17b (#2104): the old copy only told the operator what to do on success
+  // (bump pin / close #790), which trained them to leave the pin alone on a
+  // rejected release — permanently disarming the watchdog for that plugin.
+  const md = renderTransitionComment(['audio_session'], STATUS_AHEAD);
+  // success path intact: bump pin, drop escape-hatch flags + Trip-B assertion, close #790.
+  assert.ok(/bump the pin/i.test(md));
+  assert.ok(/escape-hatch flags/i.test(md));
+  assert.ok(/app\.yml.* Trip-B/i.test(md) || /Trip-B.*app\.yml/i.test(md));
+  assert.ok(/close #790/i.test(md));
+  // rejected-release path is now covered too, and states the pin isn't what re-arms it.
+  assert.ok(/still (there|applies)|warning is still|not gone/i.test(md));
+  assert.ok(/no longer (what arms|arms)|not what arms/i.test(md));
 });

--- a/scripts/tests/deps-watch.test.mjs
+++ b/scripts/tests/deps-watch.test.mjs
@@ -272,4 +272,10 @@ test('renderTransitionComment: recipe covers BOTH outcomes, and says the pin no 
   // rejected-release path is now covered too, and states the pin isn't what re-arms it.
   assert.ok(/still (there|applies)|warning is still|not gone/i.test(md));
   assert.ok(/no longer (what arms|arms)|not what arms/i.test(md));
+  // The advice must be bound to the rejected-release condition ON THE SAME LINE,
+  // not merely present somewhere in the body — otherwise a rewrite that attaches
+  // "leave the pin alone" to the WRONG bullet (e.g. the success path) would still
+  // pass every assertion above. `.` doesn't match `\n` by default, so this only
+  // matches if both phrases are on one line with nothing else between them.
+  assert.match(md, /warning is still there.*leave the pin alone/i);
 });


### PR DESCRIPTION
## Summary

Closes #2104.

`computeTransitions` (`scripts/deps-watch.mjs`) fired the one-off `@mention` on #790
only when a plugin's `ahead` flag flipped `false → true`. Since `ahead` is
`latest > pin` and stays true until someone bumps the pin, **every release after the
first went unannounced** — the sticky comment's table updated silently and nobody was
told. That is the normal path, not an edge case: the transition comment's own recipe
told the operator to bump the pin only when the migration succeeded, so an
evaluated-and-rejected release (the #2103 case: `flutter_foreground_task` 10.0.0,
`mobile_scanner` 7.4.0) permanently disarmed the watchdog for that plugin.

`computeTransitions` now edge-detects on the **observed `latest`**, not on the flag:

| prior state for the plugin | fires? |
|---|---|
| absent (first run), or `ahead: false` | iff `ahead` now — unchanged |
| `ahead: true` + recorded `latest` | iff the new `latest` is **strictly greater** |
| `ahead: true`, `latest` missing/`null`/non-string | **yes — fails loud** |

Three properties, each a distinct way this could regress:

- **No cron spam.** The workflow is on a schedule; an unchanged `latest` still
  produces no comment. This is what the naive "always fire when ahead" fix destroys.
- **A downgrade never fires** (a yank moving `latest` backwards) — strictly greater,
  not `!==`.
- **Corrupt/legacy state fails loud.** A record claiming `ahead: true` with no usable
  `latest` is *unknown*, not clean; treating it as clean would reproduce this exact
  silence one level down.

`buildState` already persisted `latest`, so this is logic-only — no state-schema change,
and no change to `.github/workflows/app-deps-watch.yml` (the runner already reads prior
state before the sticky is overwritten).

The transition comment's recipe now covers **both** outcomes and states that the pin is
no longer what arms the notification — so the "bump the pin even on a rejected release"
convention introduced in #2103 stops being something an operator has to remember.

## Test plan

`scripts/tests/deps-watch.test.mjs` (`npm run test:hooks`) — 885/885 pass, of which the
deps-watch file is 26.

Four new cases plus two reshaped ones. The existing `ahead->ahead does NOT re-fire` test
was **reshaped, not deleted**: it encoded the anti-spam property using a prior state with
no `latest`, which is now the fail-loud shape, so it was given a `latest` equal to the
current one and still asserts `[]`.

Each new assertion was proven capable of failing, under two separate producer mutations:

- reverting `computeTransitions` to the old `ahead && !prior?.ahead` body ⇒ the
  **latest-bump repro** and the **fail-loud** cases go red;
- replacing the version comparison with an unconditional `return true` (the naive fix)
  ⇒ the **no-cron-spam** and **downgrade** cases go red.

Also ran `npm run verify:fast:branch` (lint green; typecheck/test/test:server/build
correctly out of scope for a `scripts/**` + `docs/**` diff).

## Not owed here, and why

- **Release notes: skipped.** Internal maintainer tooling — no user- or
  operator-visible delta.
- **On-box acceptance: N/A.** No hardware surface.
- **No new plan doc** — small and localized, so the issue body plus the paired tests are
  the spec. The stale "transition fires once" bullet in
  `docs/superpowers/specs/2026-06-19-ops-17-kgp-guardrail-design.md` is corrected in this
  diff with a dated note; the companion plan doc's only remaining reference is inside a
  frozen dated listing narrating the original review, left as historical record.


## Independent review — findings folded in (`40fe1a55`)

The mandatory review pass raised five findings, none blocking. Four are folded in here as
comment/test changes with **no behaviour change**; the fifth is filed.

- **`compareSemver`'s "Known limitation" block now also records build metadata.** `core()`
  does `.split('+')[0]`, so `10.1.0+1` compares EQUAL to `10.1.0` — a metadata-only
  republish won't fire a transition even though the observed `latest` string changed.
  Unlike the prerelease caveat already noted there, this one is *reachable*: the workflow
  passes no `--prereleases`, so prereleases never reach `latest`, but `+N` does. Not made
  metadata-aware, deliberately — `compareSemver` is shared with `computeBehind` and
  `computePluginStatus`, so that has blast radius and two defensible designs.
- **The copy assertion now binds condition to advice on one line.** Measured: a rewrite
  attaching "leave the pin alone" to the *success* bullet passed all six prior assertions.
  Mutation-proven — moving the advice to the wrong bullet turns the new assertion red.
- **`app-deps-watch.yml`'s header no longer claims a "one-off" @mention** on first sighting.
- **The ops-17 plan doc gets one superseded-by pointer** next to its historical
  `computeTransitions` listing. The listing itself is left verbatim — it is a dated record
  of code-as-shipped, not a live statement of behaviour. (The *design spec*, which is a
  live statement, was corrected in `46b4b6a6`.)

Filed rather than folded: **#2113** — `deps-watch-run.mjs` commits the new state (step 5)
*before* it posts the @mention (step 6), so a failed comment POST loses that release's
notification permanently. Same silence class as this issue, one layer down, and
pre-existing — but it has two defensible fixes (swap the steps vs. persist a
pending-notification flag), which makes it design work rather than a fix-now item.

Also verified by the review, on the live data: the sticky on #790 still records
`flutter_foreground_task` 10.0.0 / `mobile_scanner` 7.4.0 as ahead, but #2103 already
bumped those pins — so the first post-merge run computes `ahead: false`, fires nothing,
and rewrites state to at-pin. No stranded or spurious @mention on the cutover.
