### PR TITLE
fix(scripts): post the ops-17 @mention before committing state, and fix the test:hooks cache inputs

### DIFF
--- a/docs/superpowers/specs/2026-06-19-ops-17-kgp-guardrail-design.md
+++ b/docs/superpowers/specs/2026-06-19-ops-17-kgp-guardrail-design.md
@@ -215,6 +215,20 @@ not-currently-broken build.
     - Editing a comment in place sends **no** notification — that's by design:
       the sticky is the durable *current-state* record; the **A2 transition
       comment** and the **A1 red email** are the active pings.
+    - > **Correction (ops-17c, [#2113](https://github.com/dudarenok-maker/Castwright/issues/2113), 2026-08-05):**
+      > this section originally left the write order between the sticky refresh
+      > and the A2 transition comment unspecified. That is a hazard: the sticky
+      > body embeds the new `latest` for every plugin, so if it is written FIRST
+      > and the transition POST that follows throws (rate limit, transient
+      > `gh`/network fault), the next run computes `prior.latest === s.latest` →
+      > no transition, and that release's `@mention` is silently dropped forever
+      > — nothing records it was ever owed. **The invariant: state is committed
+      > only after the notification it implies has been delivered.** The
+      > exported `publish` helper in `scripts/deps-watch.mjs` now posts the A2
+      > transition comment first, then writes the sticky; `deps-watch-run.mjs`
+      > calls it instead of doing the two `gh api` calls inline. A duplicate
+      > `@mention` on a failed sticky write is accepted — cheap and
+      > self-announcing on a monthly cron — where permanent silence is not.
 
 ### 2. Trip B — escape-hatch + pin assertions in `app.yml`
 

--- a/scripts/deps-watch-run.mjs
+++ b/scripts/deps-watch-run.mjs
@@ -1,8 +1,9 @@
 // scripts/deps-watch-run.mjs
 // ops-17 deps-watch IO orchestrator (#790). Pure logic lives in
 // scripts/deps-watch.mjs (unit-tested); this file does only IO:
-// read pubspec + the pub-outdated JSON, fetch/refresh the sticky comment via
-// `gh api`, write the job summary, post the A2 transition comment, set exit code.
+// read pubspec + the pub-outdated JSON, fetch the existing sticky comment via
+// `gh api`, write the job summary, post the A2 transition comment, then
+// refresh the sticky comment, set exit code.
 // Exercised by the workflow_dispatch acceptance run, not by node --test.
 import { readFileSync, appendFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';

--- a/scripts/deps-watch-run.mjs
+++ b/scripts/deps-watch-run.mjs
@@ -15,7 +15,7 @@ import {
   extractState,
   computeTransitions,
   findSticky,
-  stickyRequest,
+  publish,
   renderSticky,
   renderSummary,
   renderTransitionComment,
@@ -61,16 +61,13 @@ try {
   const summary = renderSummary({ pluginStatus, behind, today });
   if (process.env.GITHUB_STEP_SUMMARY) appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`);
 
-  // 5. Sticky comment — edit in place, or create once (decision is pure)
+  // 5. Publish: post the A2 transition comment (a NEW comment => a real
+  //    GitHub notification) FIRST, then the sticky comment — edit in place,
+  //    or create once (decision is pure). State is committed only after the
+  //    notification it implies has been delivered (ops-17c, #2113).
   const stickyBody = renderSticky({ pluginStatus, behind, today });
-  const req = stickyRequest(existing, repo, issue);
-  gh(['api', req.path, '--method', req.method, '-f', `body=${stickyBody}`]);
-
-  // 6. A2 transition notification (a NEW comment => a real GitHub notification)
   const transitionComment = renderTransitionComment(transitions, pluginStatus);
-  if (transitionComment) {
-    gh(['api', `repos/${repo}/issues/${issue}/comments`, '--method', 'POST', '-f', `body=${transitionComment}`]);
-  }
+  publish({ gh, repo, issue, existing, stickyBody, transitionComment });
 
   console.log(`deps-watch: ${behind.length} direct/dev behind; transitions: ${transitions.join(',') || 'none'}`);
   process.exit(exitCodeFor(behind)); // 0 or 1 — the clean path only

--- a/scripts/deps-watch.mjs
+++ b/scripts/deps-watch.mjs
@@ -1,7 +1,7 @@
 // scripts/deps-watch.mjs
-// Pure helpers for the ops-17 deps-watch (#790). NO IO here — see
-// scripts/deps-watch-run.mjs for the orchestrator. Unit-tested under
-// scripts/tests/deps-watch.test.mjs (npm run test:hooks).
+// Pure helpers for the ops-17 deps-watch (#790). NO IO here — `publish` below
+// takes `gh` as an injected dependency and calls it, but never performs IO
+// itself. Unit-tested under scripts/tests/deps-watch.test.mjs (npm run test:hooks).
 
 export const KGP_PLUGINS = ['audio_session', 'flutter_foreground_task', 'mobile_scanner'];
 export const STICKY_MARKER = '<!-- ops-17-deps-watch -->';
@@ -132,6 +132,24 @@ export function stickyRequest(existing, repo, issue) {
   return existing
     ? { method: 'PATCH', path: `repos/${repo}/issues/comments/${existing.id}` }
     : { method: 'POST', path: `repos/${repo}/issues/${issue}/comments` };
+}
+
+/** Posts the A2 transition comment (if any) FIRST, then writes the sticky —
+ *  never the reverse. The sticky body embeds the new `latest` for every
+ *  plugin, so writing it first would let a failed transition POST (rate
+ *  limit, transient `gh`/network fault) commit state for a notification that
+ *  never went out, permanently suppressing it (ops-17c, #2113). State is
+ *  committed only after the notification it implies has been delivered.
+ *  `gh` is injected here, so `publish` calls it but does no IO itself. */
+export function publish({ gh, repo, issue, existing, stickyBody, transitionComment }) {
+  if (transitionComment) {
+    // `-f` (not `-F`) — same rationale as the runner's `gh` helper (gh
+    // community #148257): raw field bytes transmit as-is, so a leading
+    // `@mention` isn't mistaken for a file. Do not "fix" this to `-F`.
+    gh(['api', `repos/${repo}/issues/${issue}/comments`, '--method', 'POST', '-f', `body=${transitionComment}`]);
+  }
+  const req = stickyRequest(existing, repo, issue);
+  gh(['api', req.path, '--method', req.method, '-f', `body=${stickyBody}`]);
 }
 
 /** The human-visible markdown (used for both the job summary and sticky body). */

--- a/scripts/tests/deps-watch.test.mjs
+++ b/scripts/tests/deps-watch.test.mjs
@@ -335,12 +335,18 @@ test('publish: no transition -> exactly one call, and it is the sticky write (no
     gh,
     repo: 'o/r',
     issue: '790',
-    existing: null,
+    // existing is non-null so the sticky write is a PATCH to a comment-id
+    // path — structurally distinct from a transition POST to the issue's
+    // comments collection, not just distinguishable by payload (ops-17c
+    // review, #2115: with existing: null this test's own sticky POST hits
+    // the SAME path a transition POST would, so "it is the sticky write"
+    // was only provable by inspecting the body).
+    existing: { id: 42 },
     stickyBody: 'sticky-body',
     transitionComment: null,
   });
   assert.equal(gh.calls.length, 1);
-  assert.deepEqual(gh.calls[0], ['api', 'repos/o/r/issues/790/comments', '--method', 'POST', '-f', 'body=sticky-body']);
+  assert.deepEqual(gh.calls[0], ['api', 'repos/o/r/issues/comments/42', '--method', 'PATCH', '-f', 'body=sticky-body']);
 });
 
 test('publish: the sticky write throws -> the transition POST already happened (accepted duplicate-risk trade)', () => {

--- a/scripts/tests/deps-watch.test.mjs
+++ b/scripts/tests/deps-watch.test.mjs
@@ -212,6 +212,7 @@ import {
   renderSticky,
   renderSummary,
   renderTransitionComment,
+  publish,
 } from '../deps-watch.mjs';
 
 const STATUS_CLEAN = [
@@ -278,4 +279,82 @@ test('renderTransitionComment: recipe covers BOTH outcomes, and says the pin no 
   // pass every assertion above. `.` doesn't match `\n` by default, so this only
   // matches if both phrases are on one line with nothing else between them.
   assert.match(md, /warning is still there.*leave the pin alone/i);
+});
+
+// A fake `gh` that records each call's argv and can be told to throw on the
+// Nth call (1-indexed) — used to drive `publish` (ops-17c, #2113).
+function fakeGh({ throwOnCall } = {}) {
+  const calls = [];
+  const gh = (args) => {
+    calls.push(args);
+    if (throwOnCall && calls.length === throwOnCall) {
+      throw new Error(`gh call ${calls.length} failed (fake)`);
+    }
+    return '';
+  };
+  gh.calls = calls;
+  return gh;
+}
+
+test('publish: transition present, both calls succeed -> transition POST is call 1, sticky write is call 2', () => {
+  const gh = fakeGh();
+  publish({
+    gh,
+    repo: 'o/r',
+    issue: '790',
+    existing: { id: 42 },
+    stickyBody: 'sticky-body',
+    transitionComment: 'transition-body',
+  });
+  assert.equal(gh.calls.length, 2);
+  assert.deepEqual(gh.calls[0], ['api', 'repos/o/r/issues/790/comments', '--method', 'POST', '-f', 'body=transition-body']);
+  assert.deepEqual(gh.calls[1], ['api', 'repos/o/r/issues/comments/42', '--method', 'PATCH', '-f', 'body=sticky-body']);
+});
+
+test('publish: #2113 regression — the transition POST throws, and the sticky is NEVER called', () => {
+  const gh = fakeGh({ throwOnCall: 1 });
+  assert.throws(() =>
+    publish({
+      gh,
+      repo: 'o/r',
+      issue: '790',
+      existing: { id: 42 },
+      stickyBody: 'sticky-body',
+      transitionComment: 'transition-body',
+    }),
+  );
+  assert.equal(gh.calls.length, 1); // only the failed call — sticky never reached
+  // Must be the TRANSITION post that failed, not merely "some first call" — a
+  // sticky-first ordering would also stop at 1 call, just the wrong one.
+  assert.deepEqual(gh.calls[0], ['api', 'repos/o/r/issues/790/comments', '--method', 'POST', '-f', 'body=transition-body']);
+});
+
+test('publish: no transition -> exactly one call, and it is the sticky write (no spurious POST)', () => {
+  const gh = fakeGh();
+  publish({
+    gh,
+    repo: 'o/r',
+    issue: '790',
+    existing: null,
+    stickyBody: 'sticky-body',
+    transitionComment: null,
+  });
+  assert.equal(gh.calls.length, 1);
+  assert.deepEqual(gh.calls[0], ['api', 'repos/o/r/issues/790/comments', '--method', 'POST', '-f', 'body=sticky-body']);
+});
+
+test('publish: the sticky write throws -> the transition POST already happened (accepted duplicate-risk trade)', () => {
+  const gh = fakeGh({ throwOnCall: 2 });
+  assert.throws(() =>
+    publish({
+      gh,
+      repo: 'o/r',
+      issue: '790',
+      existing: { id: 42 },
+      stickyBody: 'sticky-body',
+      transitionComment: 'transition-body',
+    }),
+  );
+  assert.equal(gh.calls.length, 2);
+  assert.deepEqual(gh.calls[0], ['api', 'repos/o/r/issues/790/comments', '--method', 'POST', '-f', 'body=transition-body']);
 });

--- a/scripts/tests/verify-cache.test.mjs
+++ b/scripts/tests/verify-cache.test.mjs
@@ -7,7 +7,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtempSync, writeFileSync, existsSync, readFileSync, readdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, dirname, resolve } from 'node:path';
+import { join, dirname, resolve, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
 
@@ -430,6 +430,31 @@ test('stepTouchedByDiff: a bump-version.mjs diff matches test:hooks via extraFil
   assert.equal(stepTouchedByDiff(stepByName['test:hooks'], diff), true);
 });
 
+// ops-17c review, #2115 — three dependencies the import-scanning completeness
+// guard structurally cannot see, because none of them is an import edge from
+// a test file: pinokio.js is a require()-only edge (covered by the guard now
+// that the require() pattern exists, but pinned explicitly here too since
+// it's new); pip-constraints.mjs is a transitive dependency (a direct import
+// of install-qwen3.mjs, itself only imported by the two dependent tests, not
+// a direct producer import of any *.test.mjs); eslint.config.mjs is a
+// runtime/subprocess dependency (spawned via `npx eslint`, no module-graph
+// edge at all). All three need an explicit assertion, in the same style as
+// the bump-version.mjs case above.
+test('stepTouchedByDiff: pinokio.js diff matches test:hooks via extraFiles', () => {
+  const diff = ['pinokio.js'];
+  assert.equal(stepTouchedByDiff(stepByName['test:hooks'], diff), true);
+});
+
+test('stepTouchedByDiff: a pip-constraints.mjs diff matches test:hooks via extraFiles (transitive dep of install-qwen3.mjs)', () => {
+  const diff = ['server/tts-sidecar/scripts/pip-constraints.mjs'];
+  assert.equal(stepTouchedByDiff(stepByName['test:hooks'], diff), true);
+});
+
+test('stepTouchedByDiff: an eslint.config.mjs diff matches test:hooks via extraFiles (runtime dep of eslint-guardrail.test.mjs)', () => {
+  const diff = ['eslint.config.mjs'];
+  assert.equal(stepTouchedByDiff(stepByName['test:hooks'], diff), true);
+});
+
 test('stepTouchedByDiff: a frontend config file matches via extraFiles', () => {
   const diff = ['tailwind.config.ts'];
   assert.equal(stepTouchedByDiff(stepByName['test'], diff), true);
@@ -463,14 +488,22 @@ test('stepTouchedByDiff: an empty diff touches nothing', () => {
 const testsDir = resolve(dirname(fileURLToPath(import.meta.url)));
 const repoRoot = resolve(testsDir, '..', '..');
 
-// Pull relative-specifier producer imports out of a test file's source: both
-// the static `from '../x.mjs'` form and the dynamic `import('../x.mjs')`
-// form. Only `./`- or `../`-prefixed specifiers are producer imports.
+// Pull relative-specifier producer imports out of a test file's source: the
+// static ESM `from` form, the dynamic `import()` form, and the CJS
+// `require()` form (pinokio-entry.test.mjs uses createRequire + require()
+// deliberately, to reproduce Pinokio's own CJS kernel loader — that is a
+// genuine direct import edge the guard must see; ops-17c review, #2115).
+// Only a dot- or dot-dot-prefixed relative specifier counts as a producer
+// import — bare specifiers like `node:fs` are not producers under test. (Do
+// not spell out a literal example specifier in this comment: the patterns
+// below would extract it too, and it would then be silently discarded by
+// the on-disk existsSync check in the test below rather than caught.)
 function extractRelativeImportSpecifiers(source) {
   const specifiers = new Set();
   const patterns = [
     /\bfrom\s+['"](\.\.?\/[^'"]+)['"]/g,
     /\bimport\(\s*['"](\.\.?\/[^'"]+)['"]\s*\)/g,
+    /\brequire\(\s*['"](\.\.?\/[^'"]+)['"]\s*\)/g,
   ];
   for (const pattern of patterns) {
     for (const match of source.matchAll(pattern)) {
@@ -479,6 +512,18 @@ function extractRelativeImportSpecifiers(source) {
   }
   return [...specifiers];
 }
+
+// Pins the require() pattern directly. Without this, a regression that drops
+// that pattern is invisible to the completeness guard below whenever the
+// require()d producer (pinokio.js) already happens to be a declared
+// extraFiles entry — the guard would just stop scanning that edge and stay
+// silently green rather than catching the regex regression (ops-17c review,
+// #2115: verified by mutation — removing the require() pattern alone left
+// every test in this file green until this pinning test was added).
+test('extractRelativeImportSpecifiers: extracts a require() edge (pinokio-entry.test.mjs shape)', () => {
+  const source = "const config = require('../../pinokio.js');";
+  assert.deepEqual(extractRelativeImportSpecifiers(source), ['../../pinokio.js']);
+});
 
 test('test:hooks completeness guard: every producer a hooks test imports is a cache input', () => {
   const hooksStep = stepByName['test:hooks'];
@@ -492,7 +537,9 @@ test('test:hooks completeness guard: every producer a hooks test imports is a ca
       const absProducer = resolve(testsDir, specifier);
       if (!existsSync(absProducer)) continue; // not a file on disk — nothing to require as an input
       producersScanned += 1;
-      const repoRelative = _internals.toPosix(absProducer.slice(repoRoot.length + 1));
+      // path.relative (not a fixed-length slice off repoRoot) so a specifier
+      // that happens to resolve outside the repo root doesn't yield garbage.
+      const repoRelative = _internals.toPosix(relative(repoRoot, absProducer));
       if (!stepTouchedByDiff(hooksStep, [repoRelative])) {
         missing.push(`${repoRelative} (imported by scripts/tests/${testFile})`);
       }
@@ -501,10 +548,13 @@ test('test:hooks completeness guard: every producer a hooks test imports is a ca
 
   // Anti-vacuity: if the regex above ever silently matched nothing, this
   // guard would pass forever while proving nothing (ops-18 brief mutation
-  // (c) — the exact "absent reads as clean" failure mode).
+  // (c) — the exact "absent reads as clean" failure mode). A count this low
+  // means either the extraction regex broke, or a legitimate batch of hooks
+  // tests (and their imports) was deleted — both are worth a human look
+  // before lowering this floor.
   assert.ok(
     producersScanned >= 30,
-    `expected to scan at least 30 relative producer imports across scripts/tests/*.test.mjs, found ${producersScanned} — extraction regex may be broken`,
+    `expected to scan at least 30 relative producer imports across scripts/tests/*.test.mjs, found ${producersScanned} — either the extraction regex broke, or hooks tests/imports were legitimately removed`,
   );
 
   assert.deepEqual(

--- a/scripts/tests/verify-cache.test.mjs
+++ b/scripts/tests/verify-cache.test.mjs
@@ -5,9 +5,10 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync, existsSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, existsSync, readFileSync, readdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
 
 import {
@@ -447,6 +448,70 @@ test('stepTouchedByDiff: the server lockfile is in scope for server legs only', 
 
 test('stepTouchedByDiff: an empty diff touches nothing', () => {
   assert.equal(stepTouchedByDiff(stepByName['test'], []), false);
+});
+
+// --- test:hooks completeness guard (ops-18, #2115) -------------------------
+// The globs + extraFiles above are a hand-maintained approximation of "every
+// file a hooks test depends on". This test checks that approximation against
+// reality: statically scan every scripts/tests/*.test.mjs for the producer
+// files it actually imports (relative specifiers only — bare specifiers like
+// `node:fs` or `archiver` aren't producers under test), and assert each one
+// is stepTouchedByDiff-visible to test:hooks. Without this, a producer that a
+// test imports but the cache step doesn't declare sits in the exact #1847
+// trap the extraFiles comments above describe: a producer-only diff prints
+// [cached] and the test that covers it never runs locally.
+const testsDir = resolve(dirname(fileURLToPath(import.meta.url)));
+const repoRoot = resolve(testsDir, '..', '..');
+
+// Pull relative-specifier producer imports out of a test file's source: both
+// the static `from '../x.mjs'` form and the dynamic `import('../x.mjs')`
+// form. Only `./`- or `../`-prefixed specifiers are producer imports.
+function extractRelativeImportSpecifiers(source) {
+  const specifiers = new Set();
+  const patterns = [
+    /\bfrom\s+['"](\.\.?\/[^'"]+)['"]/g,
+    /\bimport\(\s*['"](\.\.?\/[^'"]+)['"]\s*\)/g,
+  ];
+  for (const pattern of patterns) {
+    for (const match of source.matchAll(pattern)) {
+      specifiers.add(match[1]);
+    }
+  }
+  return [...specifiers];
+}
+
+test('test:hooks completeness guard: every producer a hooks test imports is a cache input', () => {
+  const hooksStep = stepByName['test:hooks'];
+  const testFiles = readdirSync(testsDir).filter((f) => f.endsWith('.test.mjs'));
+  const missing = [];
+  let producersScanned = 0;
+
+  for (const testFile of testFiles) {
+    const source = readFileSync(join(testsDir, testFile), 'utf8');
+    for (const specifier of extractRelativeImportSpecifiers(source)) {
+      const absProducer = resolve(testsDir, specifier);
+      if (!existsSync(absProducer)) continue; // not a file on disk — nothing to require as an input
+      producersScanned += 1;
+      const repoRelative = _internals.toPosix(absProducer.slice(repoRoot.length + 1));
+      if (!stepTouchedByDiff(hooksStep, [repoRelative])) {
+        missing.push(`${repoRelative} (imported by scripts/tests/${testFile})`);
+      }
+    }
+  }
+
+  // Anti-vacuity: if the regex above ever silently matched nothing, this
+  // guard would pass forever while proving nothing (ops-18 brief mutation
+  // (c) — the exact "absent reads as clean" failure mode).
+  assert.ok(
+    producersScanned >= 30,
+    `expected to scan at least 30 relative producer imports across scripts/tests/*.test.mjs, found ${producersScanned} — extraction regex may be broken`,
+  );
+
+  assert.deepEqual(
+    missing,
+    [],
+    `producer(s) imported by a hooks test but not an input to test:hooks:\n${missing.join('\n')}`,
+  );
 });
 
 test('computeShared is true for a root manifest/lockfile change', () => {

--- a/scripts/verify-cache.mjs
+++ b/scripts/verify-cache.mjs
@@ -53,7 +53,7 @@ export const STEPS = [
          — no module-graph edge, so without this a fixture-only diff (the
          intended way to add a drift case) would skip the very test it adds.
          Same #1847 trap test:pinokio's comment below documents. */
-      globs: ['scripts/tests/*.test.mjs', 'scripts/tests/fixtures/**'],
+      globs: ['scripts/**/*.{mjs,cjs}', 'scripts/tests/fixtures/**'],
       /* preflight-ffmpeg.cjs is an input because ffmpeg-version.test.mjs
          requires it — a diff that breaks the parser must run its own test.
          RELEASE_NOTES.md / docs/release-notes-next.md / release-notes-gate.mjs
@@ -84,6 +84,16 @@ export const STEPS = [
         'scripts/check-onbox-register.mjs',
         'docs/testing/onbox-acceptance-register.md',
         'docs/testing/onbox-acceptance-register-live-view.html',
+        // launch.mjs lives at the repo root, outside scripts/**, so the
+        // widened glob above doesn't reach it — launch.test.mjs imports it
+        // directly (ops-18, #2115).
+        'launch.mjs',
+        // install-qwen3.mjs lives under server/tts-sidecar/scripts/, outside
+        // scripts/**; the sidecar step's own globs only cover **/*.py +
+        // requirements*.txt, so nothing else picks this up either.
+        // install-qwen3-base17.test.mjs and install-qwen3-flash-attn.test.mjs
+        // both import it (ops-18, #2115).
+        'server/tts-sidecar/scripts/install-qwen3.mjs',
       ],
       includeLockfiles: ['root'],
     },

--- a/scripts/verify-cache.mjs
+++ b/scripts/verify-cache.mjs
@@ -94,6 +94,30 @@ export const STEPS = [
         // install-qwen3-base17.test.mjs and install-qwen3-flash-attn.test.mjs
         // both import it (ops-18, #2115).
         'server/tts-sidecar/scripts/install-qwen3.mjs',
+        // pip-constraints.mjs is a DIRECT import of install-qwen3.mjs itself
+        // (which this PR hand-added above) — install-qwen3.test.mjs's two
+        // dependents (install-qwen3-base17.test.mjs,
+        // install-qwen3-flash-attn.test.mjs) reach it transitively via that
+        // edge. No dedicated test imports it directly, so without this entry
+        // a pip-constraints.mjs-only diff prints [cached] and both tests sit
+        // stale-green (ops-17c review, #2115).
+        'server/tts-sidecar/scripts/pip-constraints.mjs',
+        // pinokio.js sits at the repo root, outside scripts/**, so the
+        // widened glob above doesn't reach it — pinokio-entry.test.mjs loads
+        // it via createRequire + require('../../pinokio.js') (reproducing
+        // Pinokio's own CJS kernel loader), which is a genuine direct import
+        // edge the guard's `require()`-blind regex previously missed
+        // (ops-17c review, #2115).
+        'pinokio.js',
+        // eslint.config.mjs is a RUNTIME/subprocess dependency, not a module
+        // import: eslint-guardrail.test.mjs spawns `npx eslint` against this
+        // real file to prove a planted violation is rejected. No
+        // module-graph edge exists, so without this entry an
+        // eslint.config.mjs-only diff (e.g. deleting the guarded rule)
+        // prints [cached] here — only the separate `lint` step re-runs,
+        // which proves nothing about the guardrail test itself
+        // (ops-17c review, #2115).
+        'eslint.config.mjs',
       ],
       includeLockfiles: ['root'],
     },


### PR DESCRIPTION
## Summary

Two watchdog-plumbing defects in the same `scripts/` surface, both of the same shape:
**something that should have run silently did not.**

**1. ops-17c (#2113) — the deps-watch `@mention` could be dropped permanently.**
`deps-watch-run.mjs` wrote the sticky comment — whose body embeds the new `latest` for
every KGP plugin — *before* posting the A2 transition comment. If the sticky write
succeeded and the transition POST then threw (rate limit, transient `gh`/network fault),
the run exited 2 but state already recorded the new `latest`. The next cron computed
`prior.latest === s.latest` → no transition, and that release's notification was gone for
good, with nothing recording that one had been owed.

`scripts/deps-watch.mjs` now exports `publish()`, which posts the transition comment first
and only then writes the sticky, on the invariant now stated in both the code and the
design doc:

> State is committed only after the notification it implies has been delivered.

The failure economics settle the direction: a duplicate `@mention` on a **monthly** cron is
cheap and self-announcing; permanent silence about the one event this guardrail exists to
catch is the defect. `gh` is injected, so `publish` is unit-testable and still performs no
IO itself.

**2. ops-18 (#2115) — `npm run verify` was skipping the tests that cover your edit.**
The `test:hooks` cache step hashed `scripts/tests/*.test.mjs` plus a hand-maintained list of
**9** producer scripts. The cache does no module-graph resolution, so **50 producers that a
hooks test actually imports were not inputs** — `wt-new.mjs`, `guard-protected-push.mjs`,
`is-docs-only-push.mjs`, `deps-watch.mjs`, and (with some irony) `verify-cache.mjs` itself.
Editing one of those and leaving its test alone printed `test:hooks [cached]`, and the test
covering the change never ran locally. This is the exact `#1847` trap the four existing
`extraFiles` comments diagnose at length — closed, until now, for 9 files out of 59.

Fixed in both directions, because either half alone leaves a hole: the glob widens to
`scripts/**/*.{mjs,cjs}` (erasing today's 50), and a **completeness guard test** statically
scans every hooks test for its producer imports and asserts each is visible to the step — so
the 51st producer nobody remembers to add fails loudly instead of silently.

The rule the guard encodes, after review: **a hooks test's direct dependencies must be
declared inputs; transitive closure is a separate unsolved problem** (#2120). Hand-chasing
transitive deps is how the original 50-producer hole formed.

Also fixed, found in passing: `deps-watch-run.mjs`'s header comment still described the
pre-#2113 publish order. Comment-only.

## Folded in from the independent review

Three live counterexamples to the guard's own claim, each verified with a repro:

- **`require()` edges were invisible.** `pinokio-entry.test.mjs` loads its producer via
  `createRequire` — deliberately, to reproduce Pinokio's CJS kernel loader. A genuine direct
  import edge, inside the guard's declared remit, missed purely on regex shape. Added the
  pattern; declared `pinokio.js`.
- **A direct dep of a file this PR itself hand-added was still missing.**
  `install-qwen3.mjs:41` imports `./pip-constraints.mjs`; editing that left two tests unrun.
- **`eslint.config.mjs`** — `eslint-guardrail.test.mjs` spawns `npx eslint` against the real
  flat config. Deleting a rule left `test:hooks` cached, so only `lint` re-ran, which proves
  nothing about the planted violation still being rejected.

Fixing the first exposed a placebo in the fix itself: with `pinokio.js` already declared in
`extraFiles`, *removing the `require()` pattern turned nothing red* — the guard silently
stops scanning that edge rather than failing. A dedicated test now pins the extraction
function independently of `extraFiles` state.

## Corrections to an earlier version of this description

- I previously claimed #2115's blast radius was **local-only**, on the grounds that cloud
  `verify.yml`'s `^scripts/` match always ran `test:hooks`. **That is false for exactly the
  out-of-tree producers involved.** `launch.mjs`, `server/tts-sidecar/scripts/install-qwen3.mjs`
  and `pinokio.js` match *no* scope that gates `test:hooks`, so a single-file PR touching one
  of them passes the required check without ever running its test. This PR fixes the local
  half for all of them; the cloud half is **#2119**, which needs a test harness for those
  workflow regexes and so did not clear the fix-now bar.
- Test counts corrected below: node reports "suites 10", which is not the file count.

## Test plan

Twelve new assertions across three files, each verified to discriminate — **every mutation
was re-run independently by the coordinating thread, not taken on the implementers' report**
(the #2112 lesson: a reordering or widening fix leaves its guard assertions unproven under a
bare revert, so each mutation targets the plausible *wrong* fix, not just the absent one):

| Mutation | Goes red |
|---|---|
| Restore the original order (sticky first) | ordering, #2113 regression, and duplicate-risk cases (3) |
| Swallow the transition POST error in a `try/catch` | the #2113 regression case |
| Drop the `if (transitionComment)` guard | the no-transition case |
| Narrow the `test:hooks` glob back | the completeness guard, naming ~50 producers |
| Delete `launch.mjs` from `extraFiles` | the completeness guard, naming exactly `launch.mjs` |
| Break the import-extraction regex | the guard's **anti-vacuity** floor (`found 0`) |
| Remove the `require()` pattern | the extraction-function pinning test |
| Drop `eslint.config.mjs` / `pip-constraints.mjs` | their explicit `stepTouchedByDiff` cases |

The anti-vacuity row is the one that matters most: without the `>= 30 producers scanned`
floor, a regex that silently matched nothing would leave the guard passing forever while
proving nothing.

End-to-end, through the production call path rather than the unit seam — the `[cached]`
decision runs through `selectStepFiles` + hashing, *not* the `stepTouchedByDiff` the guard
asserts on, so the unit test alone would not have proven the symptom gone:

```
$ printf '\n// probe\n' >> scripts/deps-watch.mjs   # producer-only edit
$ node scripts/verify-cache.mjs --steps test:hooks --scope-branch
[run] test:hooks            # was [cached] before this PR
[pass] test:hooks (took 23.1s)
```

- `npm run test:hooks` — green, **894 tests across 59 files**.
- `npm run verify:fast:branch` — green (lint 34.1s; `typecheck`/`test`/`test:server`/`build`
  correctly out of scope for a scripts+docs diff).
- Cache-input probe after the change: `deps-watch.mjs`, `wt-new.mjs`, `verify-cache.mjs`,
  `lib/kokoro-fallback.mjs`, `launch.mjs`, `install-qwen3.mjs`, `pinokio.js`,
  `pip-constraints.mjs`, `eslint.config.mjs` all `true`; `src/App.tsx` and
  `server/src/index.ts` stay `false` — the widened glob does not over-reach into other steps'
  territory.

**Live-state check for #2113:** the sticky on #790 still lists two plugins as ahead, but
#2103 already bumped those pins, so the first post-merge run computes `ahead: false` and
fires nothing. No stranded or spurious `@mention` on the cutover.

## Cost this introduces, named rather than left to be discovered

~35 `scripts/*.mjs` files that no hooks test imports (`repair-*`, `migrate-*`, `audit-*`, …)
now bust the `test:hooks` cache. A `chore(scripts)` commit touching only, say,
`scripts/repair-series-reuse.mjs` adds a measured **~24s** `test:hooks` run to pre-commit
where it previously skipped. That is the right trade against a 50-producer stale-green hole,
but it is a real slowdown on the repair-script workflow.

## Not owed, stated rather than silently skipped

- **Release notes** — internal maintainer tooling and local-verify plumbing; no user- or
  operator-visible product delta.
- **On-box acceptance row** — no hardware surface (no GPU, sidecar, analyzer, or real book).
- **Plan doc** — both items are small and localized; per CLAUDE.md the issue body plus the
  paired tests are the spec. The ops-17 *design* doc is updated, since #2113 fixes an
  ordering it did not previously pin.
- **`docs/features/archive/50-verify-cache.md`** — checked, no update needed: it documents
  the harness rather than the step's glob/`extraFiles` list, and its walkthroughs #3/#4
  (expecting `[cached] test:hooks` for `src/`- and `server/src/`-only edits) remain correct
  after the widening.

## Follow-ups filed, not folded

- **#2119** — `verify.yml`'s scope map routes `launch.mjs`, `install-qwen3.mjs` and
  `pinokio.js` to no leg that tests them. Needs a test harness for the workflow regexes.
- **#2120** — the completeness guard is blind to transitive edges
  (`pinokio-scripts/lib/menu.js`) and runtime reads (`check-no-budget-poll.mjs`'s scan of
  `server/src/**/*.test.ts`). Both fixes are behaviour decisions with more than one
  defensible answer.

Closes #2113
Closes #2115
