### PR TITLE
test(server): add behavioural cast-lock detectors for three uncovered sites

### DIFF
--- a/docs/features/279-cast-json-write-lock.md
+++ b/docs/features/279-cast-json-write-lock.md
@@ -381,9 +381,14 @@ clearing CLAUDE.md's fix-now bar:
   once serialised.
 
 Every race/outcome test in this sweep is proven able to fail, not merely
-read as correct: mutating `withCastLock`'s primitive body to a
-pass-through (`return fn();`) across multiple separate process runs, per
-CLAUDE.md's "a test that passes in the red phase is a harness problem."
+read as correct: mutating to a pass-through (`return fn();`) the primitive
+body of **whichever entry point the site under test actually calls** —
+`withCastLock` OR `withCastLocks`, confirmed by reading the module —
+across multiple separate process runs, per CLAUDE.md's "a test that passes
+in the red phase is a harness problem." Mutating only one of the two is
+NOT a completeness check: it silently exempts every site built on the
+other, and a spec that stays green under it is evidence of nothing (see
+the `#2123` note above, which is what that mistake cost).
 Two shapes were rejected after being measured, not assumed: a bare
 `Promise.all` for AB/BA ordering (proven a placebo — see above), and a
 multi-trial retry loop for a probabilistic race (repeating inside one

--- a/docs/features/279-cast-json-write-lock.md
+++ b/docs/features/279-cast-json-write-lock.md
@@ -336,6 +336,28 @@ clearing CLAUDE.md's fix-now bar:
   critical section (not just that its write survived) — the survival-only
   assertion depends on the racer's full read+write losing outright against
   an 80ms head start, which a slow-enough unlocked write can still beat.
+  `#2123` also closed the sweep's last gap: two single-book sites,
+  `cast-add-from-roster.ts` and `voice-library-usage.ts`'s
+  `clearLibraryVoiceReferences`, had been measured as detector-less by
+  neutralising `withCastLocks` (plural) and finding their specs green — but
+  both actually call `withCastLock` (singular; `cast-add-from-roster.ts`
+  locks only the source book it writes, and `clearLibraryVoiceReferences`
+  holds at most one book's lock at a time), which that mutation never
+  touches. A sweep-wide mutation of ONE primitive silently exempts every
+  site built on the OTHER; confirm the primitive a site actually calls by
+  reading the module, don't assume it from the site's shape (one-book vs.
+  two-book). Each now carries its own `runLockDetector`-style test, racing a
+  genuine `withCastLock` writer instead: `cast-add-from-roster.test.ts`
+  against the route's in-lock `sourceCast` read (no separate unlocked
+  pre-lock read of that path to confuse the gate with — `findBookByBookId`
+  only reads state.json); `voice-library-usage.test.ts` against
+  `clearLibraryVoiceReferences`'s in-lock read, which is genuinely the
+  SECOND read of that book's cast.json (`walkConfirmedCasts()`'s own
+  unlocked scan reads it first), so that gate intercepts by occurrence
+  count rather than first-match, to avoid gating the wrong one. Three
+  modules now carry behavioural lock-existence detectors from this sweep:
+  `cast-not-linked-to.ts` (POST + DELETE), `cast-add-from-roster.ts`, and
+  `voice-library-usage.ts`.
 - `server/src/routes/analysis.fresh-cast-lock.test.ts` and
   `server/src/routes/book-state.reparse.test.ts` — race the two delete
   sites against `cast-aliases`, which re-reads inside its own lock and

--- a/docs/features/279-cast-json-write-lock.md
+++ b/docs/features/279-cast-json-write-lock.md
@@ -316,15 +316,26 @@ clearing CLAUDE.md's fix-now bar:
   deterministic barrier (a hoisted `vi.mock` holding both requests at a
   common point, released together) instead.
   `cast-not-linked-to.test.ts` shipped with only the AB/BA test until
-  `#2123`: its lock-existence detector races a genuine `withCastLocks`
+  `#2123`: its lock-existence detectors race a genuine `withCastLocks`
   writer (an orthogonal field on the SAME book) against the route's own
   in-lock `readJson`, gated via the same barrier idiom — proven red both
   when `withCastLocks` is neutralised (`return fn();`, bypassing its
   `reduceRight` chain — mutation-verified against that primitive, not
   `withCastLock`, which this two-book site never calls) and when
   `sourceCast`'s read is hoisted back outside the still-present lock (a
-  rule-2 regression, the same shape that hit `library-cast-override.ts`
-  above).
+  rule-2 regression — the same stale-snapshot clobber outcome as the
+  `library-cast-override.ts` defect above, though that one was a same-book
+  aliasing bug with zero concurrency involved). This route has TWO locked
+  handlers, POST (mark) and DELETE (unmark), with a structurally identical
+  read-through-write span; an independent review found the original
+  `#2123` detector covered POST only, so hoisting DELETE's read left the
+  file green 16/16 with the static guard blind to it too (it checks the
+  write site, not the read). A second detector, sharing the same
+  `runLockDetector` construction, now covers DELETE as well. Both
+  detectors also assert a `racerEntered` flag set on entry to the racer's
+  critical section (not just that its write survived) — the survival-only
+  assertion depends on the racer's full read+write losing outright against
+  an 80ms head start, which a slow-enough unlocked write can still beat.
 - `server/src/routes/analysis.fresh-cast-lock.test.ts` and
   `server/src/routes/book-state.reparse.test.ts` — race the two delete
   sites against `cast-aliases`, which re-reads inside its own lock and

--- a/docs/features/279-cast-json-write-lock.md
+++ b/docs/features/279-cast-json-write-lock.md
@@ -336,18 +336,34 @@ clearing CLAUDE.md's fix-now bar:
   critical section (not just that its write survived) — the survival-only
   assertion depends on the racer's full read+write losing outright against
   an 80ms head start, which a slow-enough unlocked write can still beat.
-  `#2123` also closed the sweep's last gap: two single-book sites,
-  `cast-add-from-roster.ts` and `voice-library-usage.ts`'s
-  `clearLibraryVoiceReferences`, had been measured as detector-less by
-  neutralising `withCastLocks` (plural) and finding their specs green — but
-  both actually call `withCastLock` (singular; `cast-add-from-roster.ts`
-  locks only the source book it writes, and `clearLibraryVoiceReferences`
-  holds at most one book's lock at a time), which that mutation never
-  touches. A sweep-wide mutation of ONE primitive silently exempts every
-  site built on the OTHER; confirm the primitive a site actually calls by
-  reading the module, don't assume it from the site's shape (one-book vs.
-  two-book). Each now carries its own `runLockDetector`-style test, racing a
-  genuine `withCastLock` writer instead: `cast-add-from-roster.test.ts`
+  `#2123` also re-measured two single-book sites, `cast-add-from-roster.ts`
+  and `voice-library-usage.ts`'s `clearLibraryVoiceReferences`. Both had
+  been read as detector-less by neutralising `withCastLocks` (plural) and
+  finding their specs green — but both actually call `withCastLock`
+  (singular; `cast-add-from-roster.ts` locks only the source book it
+  writes, and `clearLibraryVoiceReferences` holds at most one book's lock
+  at a time), which that mutation never touches. **A sweep-wide mutation of
+  ONE primitive silently exempts every site built on the OTHER**, and a
+  spec staying green under a mutation is evidence of a gap only once you
+  have confirmed the site actually calls the thing you broke. Confirm the
+  primitive by reading the module; don't infer it from the site's shape.
+  Re-measured against the correct primitive the two sites differ:
+  `voice-library-usage.test.ts` was genuinely detector-less (green under
+  `withCastLock` → `return fn();`), while `cast-add-from-roster.test.ts`
+  was already covered — its pre-existing `#1981` self-race test goes red
+  under both that mutation and a rule-2 read-hoist. Its new detector is
+  kept nonetheless because a self-race cannot catch a **divergent lock
+  key**: keying the site's `withCastLock` off a different derivation of
+  the same book (verified by mutating the call site to
+  `sourceLocated.bookDir.toUpperCase()`) leaves the lock fully intact and
+  the self-race green — both callers queue on the same wrong key — while
+  the external-writer detector is the only test that fails. That is the
+  exact failure `cast-lock.ts`'s header warns of ("a site that derived the
+  key slightly differently would get a second mutex that never contends
+  with the first, and every test would still pass"), and it is
+  structurally invisible to any same-site race. Each site now carries its
+  own `runLockDetector`-style test racing a genuine `withCastLock` writer
+  from outside the site: `cast-add-from-roster.test.ts`
   against the route's in-lock `sourceCast` read (no separate unlocked
   pre-lock read of that path to confuse the gate with — `findBookByBookId`
   only reads state.json); `voice-library-usage.test.ts` against

--- a/docs/features/279-cast-json-write-lock.md
+++ b/docs/features/279-cast-json-write-lock.md
@@ -315,6 +315,16 @@ clearing CLAUDE.md's fix-now bar:
   same-tick microtask with no seam to hold open, so AB/BA tests use a
   deterministic barrier (a hoisted `vi.mock` holding both requests at a
   common point, released together) instead.
+  `cast-not-linked-to.test.ts` shipped with only the AB/BA test until
+  `#2123`: its lock-existence detector races a genuine `withCastLocks`
+  writer (an orthogonal field on the SAME book) against the route's own
+  in-lock `readJson`, gated via the same barrier idiom — proven red both
+  when `withCastLocks` is neutralised (`return fn();`, bypassing its
+  `reduceRight` chain — mutation-verified against that primitive, not
+  `withCastLock`, which this two-book site never calls) and when
+  `sourceCast`'s read is hoisted back outside the still-present lock (a
+  rule-2 regression, the same shape that hit `library-cast-override.ts`
+  above).
 - `server/src/routes/analysis.fresh-cast-lock.test.ts` and
   `server/src/routes/book-state.reparse.test.ts` — race the two delete
   sites against `cast-aliases`, which re-reads inside its own lock and

--- a/server/src/routes/cast-add-from-roster.test.ts
+++ b/server/src/routes/cast-add-from-roster.test.ts
@@ -114,10 +114,13 @@ beforeAll(async () => {
   workspaceRoot = mkdtempSync(join(tmpdir(), 'audiobook-cast-add-from-roster-test-'));
   process.env.WORKSPACE_DIR = workspaceRoot;
 
-  const [{ castAddFromRosterRouter }, { makeBookId }] = await Promise.all([
-    import('./cast-add-from-roster.js'),
-    import('../workspace/paths.js'),
-  ]);
+  /* Sequential awaits, NOT `Promise.all` — this file now carries a hoisted
+     async `vi.mock` factory for state-io.js, and a `Promise.all` of dynamic
+     imports can resolve a branch before that factory has materialised,
+     handing the module under test the REAL binding on some runs. Same idiom
+     as cast-not-linked-to.test.ts. */
+  const { castAddFromRosterRouter } = await import('./cast-add-from-roster.js');
+  const { makeBookId } = await import('../workspace/paths.js');
   priorBookId = makeBookId(AUTHOR, SERIES, PRIOR_BOOK);
   sourceBookId = makeBookId(AUTHOR, SERIES, SOURCE_BOOK);
   otherBookId = makeBookId(AUTHOR, 'Different Series', OTHER_BOOK);

--- a/server/src/routes/cast-add-from-roster.test.ts
+++ b/server/src/routes/cast-add-from-roster.test.ts
@@ -14,12 +14,22 @@
    - Same-book target → 400.
    - Repeat call mints a NEW id each time (no dedupe on the server). */
 
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import express, { type Express } from 'express';
 import request from 'supertest';
+
+/* #2123 — hoisted `vi.mock` (NOT a runtime `vi.spyOn`) so the lock-detector
+   test at the bottom of this file can intercept this route's OWN in-lock
+   `readJson(cast.json)` call. Defaults to a plain passthrough — every other
+   test in this file behaves exactly as if this mock weren't here. Same idiom
+   as `cast-not-linked-to.test.ts`'s own #2123 mock. */
+vi.mock('../workspace/state-io.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../workspace/state-io.js')>();
+  return { ...actual, readJson: vi.fn(actual.readJson) };
+});
 
 const AUTHOR = 'Della Renwick';
 const SERIES = 'The Hollow Tide';
@@ -301,5 +311,161 @@ describe('POST /api/books/:bookId/cast/add-from-roster', () => {
     expect(ids).toContain(resLinnet.body.character.id);
     expect(ids).toContain(resWren.body.character.id);
     expect(sourceOnDisk.characters).toHaveLength(initialSourceCast.length + 2);
+  });
+});
+
+/* #2123 (srv-87) — cast-add-from-roster.ts was one of two cast-lock-sweep
+   sites with no BEHAVIOURAL lock detector (the other being
+   voice-library-usage.ts's `clearLibraryVoiceReferences`). Correction to the
+   sweep's own premise, found while building this test: the #2040-era
+   measurement that flagged this file assumed it called `withCastLocks`
+   (plural) — it doesn't. This route calls `withCastLock` (singular, see its
+   own "#1981" comment above `withCastLock(sourceLocated.bookDir, ...)`: only
+   the source book is written, so `withCastLocks` "would be widening the lock
+   for no reason"). Neutralising `withCastLocks` therefore never touches this
+   route at all — mutating it leaves this file green regardless of whether a
+   detector exists. The racer below uses `withCastLock`, the SAME primitive
+   this route calls, per this file's own #1981 concurrent test just above and
+   per `cast-not-linked-to.test.ts`'s #2123 comment on the same principle.
+
+   The #1981 test just above (a bare `Promise.all` self-race on the SAME
+   source book) happens to also catch both the lock-neutralised and the
+   read-hoisted-outside-a-retained-lock mutations reliably in local testing —
+   but it is a natural, untimed race, not the deterministic scripted
+   construction this branch has standardised on elsewhere (see
+   cast-not-linked-to.test.ts's #2123 block comment on why a natural race is
+   not treated as sufficient coverage here). This detector is added
+   independently of that test, not as a replacement for it.
+
+   Unlike cast-not-linked-to.ts, there is no separate unlocked pre-lock read
+   of the SOURCE book's cast.json to confuse the gate with: `findBookByBookId`
+   (called before the lock) only reads state.json, never cast.json (verified
+   by reading `workspace/scan.ts`'s `findBookBy`). The in-lock
+   `readJson(castJsonPath(sourceLocated.bookDir))` at the top of this route's
+   `withCastLock` callback is the FIRST and ONLY read of that path, so a
+   simple "first occurrence" gate (no per-path occurrence counting, unlike
+   voice-library-usage.test.ts's #2123 detector) is correct here.
+
+   The racer touches `narrator.raceProbe` — a field this route never reads or
+   writes — so its survival is a clean signal independent of the route's own
+   append-a-character bookkeeping. `assertRouteOutcome` checks the new
+   character actually landed on disk, so a failing/no-op target trivially
+   "preserving" the racer's write can't pass by accident. */
+async function runLockDetector(
+  targetCall: () => ReturnType<typeof callAdd>,
+  assertRouteOutcome: () => void,
+): Promise<void> {
+  const stateIo = await import('../workspace/state-io.js');
+  const actual = await vi.importActual<typeof import('../workspace/state-io.js')>(
+    '../workspace/state-io.js',
+  );
+  const { castJsonPath } = await import('../workspace/paths.js');
+  const { withCastLock } = await import('../workspace/cast-lock.js');
+  const sourceBookDir = join(workspaceRoot, 'books', AUTHOR, SERIES, SOURCE_BOOK);
+  const sourceCastPath = castJsonPath(sourceBookDir);
+
+  let released!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    released = resolve;
+  });
+  let intercepted = false;
+  const spy = vi.mocked(stateIo.readJson).mockImplementation(async (path: string) => {
+    if (!intercepted && path === sourceCastPath) {
+      intercepted = true;
+      const value = await actual.readJson(path); // real bytes, now — happens-before the racer's write
+      await gate; // hold the RESOLUTION open until released below
+      return value;
+    }
+    return actual.readJson(path);
+  });
+
+  // Bypasses the spy entirely (uses `actual` directly) so the racer's own
+  // read/write are never accidentally re-intercepted — it's a plain,
+  // faithful `withCastLock` consumer, same as any other real caller.
+  let racerEntered = false;
+  async function raceWrite(): Promise<void> {
+    await withCastLock(sourceBookDir, async () => {
+      racerEntered = true; // set on entry, before the read
+      const cast = await actual.readJson<{
+        characters: Array<Record<string, unknown>>;
+      }>(sourceCastPath);
+      const narrator = cast!.characters.find((c) => c.id === 'narrator')!;
+      (narrator as Record<string, unknown>).raceProbe = 'concurrent-writer-survived';
+      await actual.writeJsonAtomic(sourceCastPath, { characters: cast!.characters });
+    });
+  }
+
+  let targetPromise: ReturnType<typeof callAdd> | undefined;
+  let racePromise: Promise<void> | undefined;
+  try {
+    targetPromise = targetCall();
+    targetPromise.catch(() => {}); // supertest is lazy — force real dispatch now
+
+    // Poll rather than a fixed sleep — same precedent as
+    // cast-not-linked-to.test.ts's own #2123 detector.
+    const deadline = Date.now() + 2000;
+    while (!intercepted && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    expect(intercepted).toBe(true);
+
+    racePromise = raceWrite();
+    racePromise.catch(() => {}); // unhandled-rejection window, mirrors targetPromise above
+
+    // Generous head start: completes fully when unlocked (the bug
+    // window), or queues behind the target's held lock when locked (the
+    // fix) — either way nothing depends on tuning a tight timing window.
+    await new Promise((r) => setTimeout(r, 80));
+
+    // Must hold even when the survival assertions below would still pass
+    // by luck (a slow unlocked racer that loses the race anyway).
+    expect(racerEntered).toBe(false);
+
+    released();
+    const [targetRes] = await Promise.all([targetPromise, racePromise]);
+    expect(targetRes.status).toBe(200);
+  } finally {
+    // Idempotent: also fires here so a throw ANYWHERE above (before the
+    // happy-path call) still releases a held `readJson` rather than
+    // leaving it stuck on `await gate` forever. Resolving an
+    // already-resolved promise a second time is a no-op.
+    released();
+    // Not `mockRestore()` — this is a `vi.fn()` wrapper (from the hoisted
+    // `vi.mock` factory above), not a `vi.spyOn` spy, so restore its
+    // default passthrough behaviour explicitly.
+    spy.mockImplementation(actual.readJson);
+    // On the failure path (an assertion above threw) these are still
+    // in-flight — await them so the test can't return while either is
+    // still running against fixtures `afterAll` is about to delete.
+    await Promise.allSettled([targetPromise, racePromise]);
+  }
+
+  assertRouteOutcome();
+
+  const narratorSource = readCast(workspaceRoot, AUTHOR, SERIES, SOURCE_BOOK).characters.find(
+    (c) => c.id === 'narrator',
+  );
+  expect(narratorSource?.raceProbe).toBe('concurrent-writer-survived');
+}
+
+describe('#2123 — cast.json lock is real, and its read stays inside it', () => {
+  it('a concurrent withCastLock writer on the same book survives add-from-roster', async () => {
+    await runLockDetector(
+      () =>
+        callAdd(sourceBookId, {
+          targetBookId: priorBookId,
+          targetCharacterId: 'councillor-linnet',
+        }),
+      () => {
+        const sourceOnDisk = readCast(workspaceRoot, AUTHOR, SERIES, SOURCE_BOOK);
+        expect(sourceOnDisk.characters).toHaveLength(initialSourceCast.length + 1);
+        const added = sourceOnDisk.characters.at(-1);
+        expect(added).toMatchObject({
+          name: 'Councillor Linnet',
+          voiceId: 'v_linnet',
+          voiceState: 'reused',
+        });
+      },
+    );
   });
 });

--- a/server/src/routes/cast-not-linked-to.test.ts
+++ b/server/src/routes/cast-not-linked-to.test.ts
@@ -479,16 +479,29 @@ describe('DELETE /api/books/:bookId/cast/:characterId/not-linked-to (fs-11)', ()
    with no BEHAVIOURAL lock detector: the #1981 AB/BA test above defends
    ordering (a lock-order inversion), not the lock's existence — neutralise
    `withCastLocks` down to `return fn();`, or keep the wrapper in place but
-   hoist `sourceCast`'s read back outside it (a rule-2 regression, the exact
-   shape that bit library-cast-override.ts on this branch), and that test
-   stays green either way.
+   hoist `sourceCast`'s read back outside it (a rule-2 regression — the same
+   stale-snapshot clobber OUTCOME as the `library-cast-override.ts` defect
+   fixed elsewhere on this branch, though that one was a same-book
+   same-character-vs-different-character aliasing bug with zero concurrency
+   involved; the two share an outcome, not a shape), and that test stayed
+   green either way.
 
-   The racer here is a genuine `withCastLocks([bookDir], ...)` writer — the
-   SAME primitive this route calls, not a different one (`withCastLock`
-   singular has no reduceRight chain to bypass and this route never calls
-   it) — touching a field this route never reads: `narrator.raceProbe`.
-   Orthogonal by construction, so its survival (or loss) is a clean signal
-   independent of the route's own notLinkedTo bookkeeping.
+   Both of this route's locked handlers — POST (mark) and DELETE (unmark) —
+   have a structurally identical read-through-write span, so BOTH get their
+   own detector below, via the shared `runLockDetector` helper. An earlier
+   version of this describe covered POST only; an independent review found
+   that hoisting DELETE's `sourceCast` read outside its own retained
+   `withCastLocks` left the whole file green, 16/16 — the static
+   `cast-lock.guard.test.ts` regression guard can't see it either, since it
+   checks where the WRITE sits, not the read.
+
+   The racer in both detectors is a genuine `withCastLocks([bookDir], ...)`
+   writer — the SAME primitive this route calls, not a different one
+   (`withCastLock` singular has no reduceRight chain to bypass and this
+   route never calls it) — touching a field this route never reads:
+   `narrator.raceProbe`. Orthogonal by construction, so its survival (or
+   loss) is a clean signal independent of the route's own notLinkedTo
+   bookkeeping.
 
    The target's IN-LOCK read of `sourceCast` is gated via the hoisted
    `vi.mock` on state-io.js above — real bytes are read immediately (so the
@@ -497,114 +510,189 @@ describe('DELETE /api/books/:bookId/cast/:characterId/not-linked-to (fs-11)', ()
    is confirmed intercepted matters: gating an earlier, outer read (e.g. one
    of the pre-lock `findBookByBookId` lookups) lets the racer finish before
    the target ever asks for its lock, which passes even with the lock
-   primitive neutralised — a placebo. This construction catches both
-   mutations without needing two separate tests:
+   primitive neutralised — a placebo. This construction catches all three
+   mutations (lock neutralised, POST's read hoisted, DELETE's read hoisted)
+   without needing a dedicated test per mutation:
 
    - Correct code: the target already holds the real per-key mutex on the
      keeper book when its read is intercepted, so the racer's own
-     `withCastLocks` call queues behind it and only runs (re-reading FRESH
-     bytes) after the target's write has landed and released the lock. Both
-     changes survive.
+     `withCastLocks` call queues behind it and doesn't even ENTER its
+     critical section (see `racerEntered` below) — let alone complete its
+     read+write — until the target's write has landed and released the
+     lock. Both changes survive.
    - Lock neutralised: the target's held-open read no longer implies any
      real mutex, so the racer — going through the same neutralised
-     primitive — runs unimpeded during the gate window; the target then
-     writes its STALE pre-racer snapshot back over it, and the racer's field
-     is lost.
-   - Read hoisted outside a retained lock: the target's read fires (and gets
-     intercepted) before it ever calls `withCastLocks`, so no mutex is held
-     yet; the racer acquires the real, unmutated lock uncontested and
-     completes; the target then acquires the lock late and writes back its
-     stale (pre-racer) snapshot, clobbering the racer's field the same way. */
+     primitive — enters and runs unimpeded during the gate window; the
+     target then writes its STALE pre-racer snapshot back over it, and the
+     racer's field is lost.
+   - Read hoisted outside a retained lock (either handler): the target's
+     read fires (and gets intercepted) before it ever calls
+     `withCastLocks`, so no mutex is held yet; the racer acquires the real,
+     unmutated lock uncontested and completes; the target then acquires the
+     lock late and writes back its stale (pre-racer) snapshot, clobbering
+     the racer's field the same way.
+
+   Two hardenings on top of the original single-handler construction, both
+   found by independent review:
+
+   - `racerEntered` — set synchronously on the first line inside the
+     racer's `withCastLocks` callback, and asserted still `false` right
+     before the gate is released. The original construction asserted only
+     that `raceProbe` SURVIVED, which requires the racer's full read+write
+     to lose outright against an 80ms head start — on a contended box, an
+     unlocked racer's `readJson` + `writeJsonAtomic` (mkdir + temp write +
+     rename) can plausibly exceed 80ms, in which case `released()` fires
+     first, the target writes its stale snapshot, and the racer THEN reads
+     those fresh bytes and writes its probe on top — both assertions pass
+     and the mutation goes silently undetected. Entering the critical
+     section is a single synchronous assignment, orders of magnitude faster
+     than completing a read+write, so the same 80ms budget gives this
+     assertion enormous margin. Kept ALONGSIDE the survival assertions, not
+     instead of them — the entry flag asserts a MECHANISM (did the racer
+     queue), `raceProbe` surviving asserts the OUTCOME (did the write
+     land); a mechanism-only assertion can miss a parallel wire that
+     produces the wrong outcome anyway.
+   - `racePromise.catch(() => {})` immediately after `raceWrite()` is
+     called, mirroring `targetPromise`'s own immediate `.catch()` below (and
+     for the same reason): `racePromise` isn't awaited until ~80ms later,
+     and an fs error inside the racer (e.g. an EPERM on rename under
+     Windows AV/indexer contention) would otherwise reject unhandled during
+     that window, failing the run with an unhandled-rejection error instead
+     of the real assertions. */
+async function runLockDetector(
+  targetCall: () => ReturnType<typeof callNotLinked>,
+  assertRouteOutcome: () => void,
+): Promise<void> {
+  const stateIo = await import('../workspace/state-io.js');
+  const actual = await vi.importActual<typeof import('../workspace/state-io.js')>(
+    '../workspace/state-io.js',
+  );
+  const { castJsonPath } = await import('../workspace/paths.js');
+  const { withCastLocks } = await import('../workspace/cast-lock.js');
+  const keeperBookDir = join(workspaceRoot, 'books', AUTHOR, SERIES, KEEPER_BOOK);
+  const keeperCastPath = castJsonPath(keeperBookDir);
+
+  let released!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    released = resolve;
+  });
+  let intercepted = false;
+  const spy = vi.mocked(stateIo.readJson).mockImplementation(async (path: string) => {
+    if (!intercepted && path === keeperCastPath) {
+      intercepted = true;
+      const value = await actual.readJson(path); // real bytes, now — happens-before the racer's write
+      await gate; // hold the RESOLUTION open until released below
+      return value;
+    }
+    return actual.readJson(path);
+  });
+
+  // Bypasses the spy entirely (uses `actual` directly) so the racer's own
+  // read/write are never accidentally re-intercepted — it's a plain,
+  // faithful `withCastLocks` consumer, same as any other real route.
+  let racerEntered = false;
+  async function raceWrite(): Promise<void> {
+    await withCastLocks([keeperBookDir], async () => {
+      racerEntered = true; // #2123 Finding 2 — set on entry, before the read
+      const cast = await actual.readJson<{
+        characters: Array<Record<string, unknown>>;
+      }>(keeperCastPath);
+      const narrator = cast!.characters.find((c) => c.id === 'narrator')!;
+      (narrator as Record<string, unknown>).raceProbe = 'concurrent-writer-survived';
+      await actual.writeJsonAtomic(keeperCastPath, { characters: cast!.characters });
+    });
+  }
+
+  let targetPromise: ReturnType<typeof callNotLinked> | undefined;
+  let racePromise: Promise<void> | undefined;
+  try {
+    targetPromise = targetCall();
+    targetPromise.catch(() => {}); // supertest is lazy — force real dispatch now
+
+    // Poll rather than a fixed sleep — same precedent as voices.test.ts's
+    // and book-state.reparse.test.ts's own #1981 races.
+    const deadline = Date.now() + 2000;
+    while (!intercepted && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    expect(intercepted).toBe(true);
+
+    racePromise = raceWrite();
+    racePromise.catch(() => {}); // #2123 Finding 4 — see block comment above
+
+    // Generous head start: completes fully when unlocked (the bug
+    // window), or queues behind the target's held lock when locked (the
+    // fix) — either way nothing depends on tuning a tight timing window.
+    await new Promise((r) => setTimeout(r, 80));
+
+    // #2123 Finding 2 — see block comment above: this must hold even when
+    // the survival assertions below would still pass by luck.
+    expect(racerEntered).toBe(false);
+
+    released();
+    const [targetRes] = await Promise.all([targetPromise, racePromise]);
+    expect(targetRes.status).toBe(200);
+  } finally {
+    // Idempotent: also fires here so a throw ANYWHERE above (before the
+    // happy-path call) still releases a held `readJson` rather than
+    // leaving it stuck on `await gate` forever. Resolving an
+    // already-resolved promise a second time is a no-op.
+    released();
+    // Not `mockRestore()` — this is a `vi.fn()` wrapper (from the hoisted
+    // `vi.mock` factory above), not a `vi.spyOn` spy, so restore its
+    // default passthrough behaviour explicitly.
+    spy.mockImplementation(actual.readJson);
+    // On the failure path (an assertion above threw) these are still
+    // in-flight — await them so the test can't return while either is
+    // still running against fixtures `afterAll` is about to delete.
+    await Promise.allSettled([targetPromise, racePromise]);
+  }
+
+  assertRouteOutcome();
+
+  const narratorKeeper = readCast(workspaceRoot, AUTHOR, SERIES, KEEPER_BOOK).characters.find(
+    (c) => c.id === 'narrator',
+  );
+  expect(narratorKeeper?.raceProbe).toBe('concurrent-writer-survived');
+}
+
 describe('#2123 — cast.json lock is real, and its read stays inside it', () => {
   it('a concurrent withCastLocks writer on the same book survives a not-linked-to POST', async () => {
-    const stateIo = await import('../workspace/state-io.js');
-    const actual = await vi.importActual<typeof import('../workspace/state-io.js')>(
-      '../workspace/state-io.js',
+    await runLockDetector(
+      () =>
+        callNotLinked(keeperBookId, 'wren', {
+          otherBookId: exileBookId,
+          otherCharacterId: 'wren',
+        }),
+      () => {
+        const wrenKeeper = readCast(workspaceRoot, AUTHOR, SERIES, KEEPER_BOOK).characters.find(
+          (c) => c.id === 'wren',
+        );
+        expect(wrenKeeper?.notLinkedTo).toEqual([{ bookId: exileBookId, characterId: 'wren' }]);
+      },
     );
-    const { castJsonPath } = await import('../workspace/paths.js');
-    const { withCastLocks } = await import('../workspace/cast-lock.js');
-    const keeperBookDir = join(workspaceRoot, 'books', AUTHOR, SERIES, KEEPER_BOOK);
-    const keeperCastPath = castJsonPath(keeperBookDir);
+  });
 
-    let released!: () => void;
-    const gate = new Promise<void>((resolve) => {
-      released = resolve;
+  it('a concurrent withCastLocks writer on the same book survives a not-linked-to DELETE', async () => {
+    // Seed: mark the pair first (same approach as the DELETE describe
+    // above) so there is something for the DELETE to actually remove.
+    await callNotLinked(keeperBookId, 'wren', {
+      otherBookId: exileBookId,
+      otherCharacterId: 'wren',
     });
-    let intercepted = false;
-    const spy = vi.mocked(stateIo.readJson).mockImplementation(async (path: string) => {
-      if (!intercepted && path === keeperCastPath) {
-        intercepted = true;
-        const value = await actual.readJson(path); // real bytes, now — happens-before the racer's write
-        await gate; // hold the RESOLUTION open until released below
-        return value;
-      }
-      return actual.readJson(path);
-    });
 
-    // Bypasses the spy entirely (uses `actual` directly) so the racer's own
-    // read/write are never accidentally re-intercepted — it's a plain,
-    // faithful `withCastLocks` consumer, same as any other real route.
-    async function raceWrite(): Promise<void> {
-      await withCastLocks([keeperBookDir], async () => {
-        const cast = await actual.readJson<{
-          characters: Array<Record<string, unknown>>;
-        }>(keeperCastPath);
-        const narrator = cast!.characters.find((c) => c.id === 'narrator')!;
-        (narrator as Record<string, unknown>).raceProbe = 'concurrent-writer-survived';
-        await actual.writeJsonAtomic(keeperCastPath, { characters: cast!.characters });
-      });
-    }
-
-    let targetPromise: ReturnType<typeof callNotLinked> | undefined;
-    let racePromise: Promise<void> | undefined;
-    try {
-      targetPromise = callNotLinked(keeperBookId, 'wren', {
-        otherBookId: exileBookId,
-        otherCharacterId: 'wren',
-      });
-      targetPromise.catch(() => {}); // supertest is lazy — force real dispatch now
-
-      // Poll rather than a fixed sleep — same precedent as voices.test.ts's
-      // and book-state.reparse.test.ts's own #1981 races.
-      const deadline = Date.now() + 2000;
-      while (!intercepted && Date.now() < deadline) {
-        await new Promise((r) => setTimeout(r, 5));
-      }
-      expect(intercepted).toBe(true);
-
-      racePromise = raceWrite();
-      // Generous head start: completes fully when unlocked (the bug
-      // window), or queues behind the target's held lock when locked (the
-      // fix) — either way nothing depends on tuning a tight timing window.
-      await new Promise((r) => setTimeout(r, 80));
-
-      released();
-      const [targetRes] = await Promise.all([targetPromise, racePromise]);
-      expect(targetRes.status).toBe(200);
-    } finally {
-      // Idempotent: also fires here so a throw ANYWHERE above (before the
-      // happy-path call) still releases a held `readJson` rather than
-      // leaving it stuck on `await gate` forever. Resolving an
-      // already-resolved promise a second time is a no-op.
-      released();
-      // Not `mockRestore()` — this is a `vi.fn()` wrapper (from the hoisted
-      // `vi.mock` factory above), not a `vi.spyOn` spy, so restore its
-      // default passthrough behaviour explicitly.
-      spy.mockImplementation(actual.readJson);
-      // On the failure path (an assertion above threw) these are still
-      // in-flight — await them so the test can't return while either is
-      // still running against fixtures `afterAll` is about to delete.
-      await Promise.allSettled([targetPromise, racePromise]);
-    }
-
-    const wrenKeeper = readCast(workspaceRoot, AUTHOR, SERIES, KEEPER_BOOK).characters.find(
-      (c) => c.id === 'wren',
+    await runLockDetector(
+      () =>
+        callUnmark(keeperBookId, 'wren', {
+          otherBookId: exileBookId,
+          otherCharacterId: 'wren',
+        }),
+      () => {
+        const wrenKeeper = readCast(workspaceRoot, AUTHOR, SERIES, KEEPER_BOOK).characters.find(
+          (c) => c.id === 'wren',
+        );
+        expect(wrenKeeper?.notLinkedTo).toEqual([]);
+      },
     );
-    expect(wrenKeeper?.notLinkedTo).toEqual([{ bookId: exileBookId, characterId: 'wren' }]);
-
-    const narratorKeeper = readCast(workspaceRoot, AUTHOR, SERIES, KEEPER_BOOK).characters.find(
-      (c) => c.id === 'narrator',
-    );
-    expect(narratorKeeper?.raceProbe).toBe('concurrent-writer-survived');
   });
 });

--- a/server/src/routes/cast-not-linked-to.test.ts
+++ b/server/src/routes/cast-not-linked-to.test.ts
@@ -36,6 +36,17 @@ vi.mock('../workspace/scan.js', async (importOriginal) => {
   return { ...actual, findBookByBookId: vi.fn(actual.findBookByBookId) };
 });
 
+/* #2123 — hoisted `vi.mock` (NOT a runtime `vi.spyOn`) so the lock-detector
+   test at the bottom of this file can intercept this route's OWN in-lock
+   `readJson(cast.json)` call. Defaults to a plain passthrough — every other
+   test in this file behaves exactly as if this mock weren't here. Same
+   idiom as the `scan.js` mock above and as voices.test.ts's /
+   book-state.reparse.test.ts's own #1981 race tests. */
+vi.mock('../workspace/state-io.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../workspace/state-io.js')>();
+  return { ...actual, readJson: vi.fn(actual.readJson) };
+});
+
 const AUTHOR = 'Della Renwick';
 const SERIES = 'The Hollow Tide';
 const KEEPER_BOOK = 'The Hollow Tide';
@@ -461,5 +472,139 @@ describe('DELETE /api/books/:bookId/cast/:characterId/not-linked-to (fs-11)', ()
       otherCharacterId: 'lonely',
     });
     expect(standalone.status).toBe(404);
+  });
+});
+
+/* #2123 (srv-87) — cast-not-linked-to.ts was the only cast-lock-sweep site
+   with no BEHAVIOURAL lock detector: the #1981 AB/BA test above defends
+   ordering (a lock-order inversion), not the lock's existence — neutralise
+   `withCastLocks` down to `return fn();`, or keep the wrapper in place but
+   hoist `sourceCast`'s read back outside it (a rule-2 regression, the exact
+   shape that bit library-cast-override.ts on this branch), and that test
+   stays green either way.
+
+   The racer here is a genuine `withCastLocks([bookDir], ...)` writer — the
+   SAME primitive this route calls, not a different one (`withCastLock`
+   singular has no reduceRight chain to bypass and this route never calls
+   it) — touching a field this route never reads: `narrator.raceProbe`.
+   Orthogonal by construction, so its survival (or loss) is a clean signal
+   independent of the route's own notLinkedTo bookkeeping.
+
+   The target's IN-LOCK read of `sourceCast` is gated via the hoisted
+   `vi.mock` on state-io.js above — real bytes are read immediately (so the
+   interception genuinely happens-before the racer's write), only the
+   JS-visible resolution is held open. Firing the racer only once THAT read
+   is confirmed intercepted matters: gating an earlier, outer read (e.g. one
+   of the pre-lock `findBookByBookId` lookups) lets the racer finish before
+   the target ever asks for its lock, which passes even with the lock
+   primitive neutralised — a placebo. This construction catches both
+   mutations without needing two separate tests:
+
+   - Correct code: the target already holds the real per-key mutex on the
+     keeper book when its read is intercepted, so the racer's own
+     `withCastLocks` call queues behind it and only runs (re-reading FRESH
+     bytes) after the target's write has landed and released the lock. Both
+     changes survive.
+   - Lock neutralised: the target's held-open read no longer implies any
+     real mutex, so the racer — going through the same neutralised
+     primitive — runs unimpeded during the gate window; the target then
+     writes its STALE pre-racer snapshot back over it, and the racer's field
+     is lost.
+   - Read hoisted outside a retained lock: the target's read fires (and gets
+     intercepted) before it ever calls `withCastLocks`, so no mutex is held
+     yet; the racer acquires the real, unmutated lock uncontested and
+     completes; the target then acquires the lock late and writes back its
+     stale (pre-racer) snapshot, clobbering the racer's field the same way. */
+describe('#2123 — cast.json lock is real, and its read stays inside it', () => {
+  it('a concurrent withCastLocks writer on the same book survives a not-linked-to POST', async () => {
+    const stateIo = await import('../workspace/state-io.js');
+    const actual = await vi.importActual<typeof import('../workspace/state-io.js')>(
+      '../workspace/state-io.js',
+    );
+    const { castJsonPath } = await import('../workspace/paths.js');
+    const { withCastLocks } = await import('../workspace/cast-lock.js');
+    const keeperBookDir = join(workspaceRoot, 'books', AUTHOR, SERIES, KEEPER_BOOK);
+    const keeperCastPath = castJsonPath(keeperBookDir);
+
+    let released!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      released = resolve;
+    });
+    let intercepted = false;
+    const spy = vi.mocked(stateIo.readJson).mockImplementation(async (path: string) => {
+      if (!intercepted && path === keeperCastPath) {
+        intercepted = true;
+        const value = await actual.readJson(path); // real bytes, now — happens-before the racer's write
+        await gate; // hold the RESOLUTION open until released below
+        return value;
+      }
+      return actual.readJson(path);
+    });
+
+    // Bypasses the spy entirely (uses `actual` directly) so the racer's own
+    // read/write are never accidentally re-intercepted — it's a plain,
+    // faithful `withCastLocks` consumer, same as any other real route.
+    async function raceWrite(): Promise<void> {
+      await withCastLocks([keeperBookDir], async () => {
+        const cast = await actual.readJson<{
+          characters: Array<Record<string, unknown>>;
+        }>(keeperCastPath);
+        const narrator = cast!.characters.find((c) => c.id === 'narrator')!;
+        (narrator as Record<string, unknown>).raceProbe = 'concurrent-writer-survived';
+        await actual.writeJsonAtomic(keeperCastPath, { characters: cast!.characters });
+      });
+    }
+
+    let targetPromise: ReturnType<typeof callNotLinked> | undefined;
+    let racePromise: Promise<void> | undefined;
+    try {
+      targetPromise = callNotLinked(keeperBookId, 'wren', {
+        otherBookId: exileBookId,
+        otherCharacterId: 'wren',
+      });
+      targetPromise.catch(() => {}); // supertest is lazy — force real dispatch now
+
+      // Poll rather than a fixed sleep — same precedent as voices.test.ts's
+      // and book-state.reparse.test.ts's own #1981 races.
+      const deadline = Date.now() + 2000;
+      while (!intercepted && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 5));
+      }
+      expect(intercepted).toBe(true);
+
+      racePromise = raceWrite();
+      // Generous head start: completes fully when unlocked (the bug
+      // window), or queues behind the target's held lock when locked (the
+      // fix) — either way nothing depends on tuning a tight timing window.
+      await new Promise((r) => setTimeout(r, 80));
+
+      released();
+      const [targetRes] = await Promise.all([targetPromise, racePromise]);
+      expect(targetRes.status).toBe(200);
+    } finally {
+      // Idempotent: also fires here so a throw ANYWHERE above (before the
+      // happy-path call) still releases a held `readJson` rather than
+      // leaving it stuck on `await gate` forever. Resolving an
+      // already-resolved promise a second time is a no-op.
+      released();
+      // Not `mockRestore()` — this is a `vi.fn()` wrapper (from the hoisted
+      // `vi.mock` factory above), not a `vi.spyOn` spy, so restore its
+      // default passthrough behaviour explicitly.
+      spy.mockImplementation(actual.readJson);
+      // On the failure path (an assertion above threw) these are still
+      // in-flight — await them so the test can't return while either is
+      // still running against fixtures `afterAll` is about to delete.
+      await Promise.allSettled([targetPromise, racePromise]);
+    }
+
+    const wrenKeeper = readCast(workspaceRoot, AUTHOR, SERIES, KEEPER_BOOK).characters.find(
+      (c) => c.id === 'wren',
+    );
+    expect(wrenKeeper?.notLinkedTo).toEqual([{ bookId: exileBookId, characterId: 'wren' }]);
+
+    const narratorKeeper = readCast(workspaceRoot, AUTHOR, SERIES, KEEPER_BOOK).characters.find(
+      (c) => c.id === 'narrator',
+    );
+    expect(narratorKeeper?.raceProbe).toBe('concurrent-writer-survived');
   });
 });

--- a/server/src/workspace/voice-library-usage.test.ts
+++ b/server/src/workspace/voice-library-usage.test.ts
@@ -8,6 +8,18 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } from 'nod
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+/* #2123 — hoisted `vi.mock` (NOT a runtime `vi.spyOn`) so the lock-detector
+   test at the bottom of this file can intercept this module's OWN in-lock
+   `readJson(cast.json)` call inside `clearLibraryVoiceReferences`. Defaults
+   to a plain passthrough — every other test in this file (including the
+   `vi.resetModules()` + fresh dynamic import each `beforeEach` below) behaves
+   exactly as if this mock weren't here. Same idiom as
+   `cast-not-linked-to.test.ts`'s own #2123 mock. */
+vi.mock('./state-io.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./state-io.js')>();
+  return { ...actual, readJson: vi.fn(actual.readJson) };
+});
+
 let dir: string;
 let usageMod: typeof import('./voice-library-usage.js');
 
@@ -165,5 +177,169 @@ describe('clearLibraryVoiceReferences', () => {
     expect((cast.characters[0].overrideTtsVoices as Record<string, unknown>).qwen).toEqual({
       name: 'unrelated',
     });
+  });
+});
+
+/* #2123 (srv-87) — voice-library-usage.ts was one of two cast-lock-sweep
+   sites with no BEHAVIOURAL lock detector (the other being
+   cast-add-from-roster.ts). Correction to the sweep's own premise, found
+   while building this test: the #2040-era measurement that flagged this
+   file assumed it called `withCastLocks` (plural) — it doesn't.
+   `clearLibraryVoiceReferences` calls `withCastLock` (singular, see its own
+   block comment above: "never `withCastLocks` across every book at once —
+   because ... this loop holds at most ONE cast lock at a time"). Neutralising
+   `withCastLocks` therefore never touches this module at all; the racer below
+   uses `withCastLock`, the SAME primitive the site calls, per this branch's
+   own established convention (cast-not-linked-to.test.ts's #2123 comment).
+
+   `clearLibraryVoiceReferences` reads `castJsonPath(bookDir)` TWICE per
+   qualifying book: once inside `walkConfirmedCasts()`'s own scan (OUTSIDE any
+   lock, deciding which books to visit) and once again, fresh, inside
+   `withCastLock` (the real in-lock read the write is based on). Gating the
+   FIRST occurrence would intercept the walker's unlocked scan read — a
+   placebo, since the racer would then finish before the target ever asks for
+   its lock. The fixture below seeds exactly one qualifying book, so the two
+   reads of that book's cast.json happen in a known, strict order; the gate
+   below tracks occurrences and only intercepts the SECOND.
+
+   The racer touches `narrator.raceProbe` — a field `clearLibraryVoiceReferences`
+   never reads or writes (it only ever rewrites characters whose
+   `overrideTtsVoices` matched the target voiceUuid), so its survival is a
+   clean signal independent of the module's own override-clearing logic. The
+   fixture's `char-marlow` DOES reference the target voiceUuid, so the
+   target's own write is exercised too — `assertRouteOutcome` checks marlow's
+   `qwen` slot actually got cleared, so a no-op target trivially "preserving"
+   the racer's write can't pass by accident.
+
+   Same `racerEntered` mechanism assertion as cast-not-linked-to.test.ts's
+   #2123 detector, for the same reason: the survival assertion alone would
+   also pass if the unlocked racer's read+write happened to lose outright
+   against the 80ms head start on a slow/contended box, which would mask a
+   real regression. */
+describe('#2123 — cast.json lock is real, and its read stays inside it', () => {
+  const AUTHOR = 'Della Renwick';
+  const SERIES = 'The Hollow Tide';
+  const TITLE = 'Lock Detector Book';
+  const VOICE_UUID = 'lib-uuid-lock-detector';
+
+  beforeEach(() => {
+    writeBookOnDisk(dir, AUTHOR, SERIES, TITLE, 'lock-detector-book', [
+      { id: 'narrator', name: 'Narrator', role: 'narrator' },
+      {
+        id: 'char-marlow',
+        name: 'Marlow',
+        overrideTtsVoices: { qwen: { name: 'qwen-lib-1', libraryUuid: VOICE_UUID } },
+      },
+    ]);
+  });
+
+  async function runLockDetector(
+    targetCall: () => Promise<void>,
+    assertRouteOutcome: () => void,
+  ): Promise<void> {
+    const stateIo = await import('./state-io.js');
+    const actual = await vi.importActual<typeof import('./state-io.js')>('./state-io.js');
+    const { castJsonPath } = await import('./paths.js');
+    const { withCastLock } = await import('./cast-lock.js');
+    const bookDir = join(dir, 'books', AUTHOR, SERIES, TITLE);
+    const bookCastPath = castJsonPath(bookDir);
+
+    let released!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      released = resolve;
+    });
+    // Two unlocked reads of this book's cast.json happen per qualifying book
+    // (see block comment above): the walker's scan read (1st), then the
+    // real in-lock read (2nd). Only the 2nd is the one under test.
+    let seen = 0;
+    let intercepted = false;
+    const spy = vi.mocked(stateIo.readJson).mockImplementation(async (path: string) => {
+      if (path === bookCastPath) {
+        seen += 1;
+        if (seen === 2 && !intercepted) {
+          intercepted = true;
+          const value = await actual.readJson(path); // real bytes, now — happens-before the racer's write
+          await gate; // hold the RESOLUTION open until released below
+          return value;
+        }
+      }
+      return actual.readJson(path);
+    });
+
+    // Bypasses the spy entirely (uses `actual` directly) so the racer's own
+    // read/write are never accidentally re-intercepted (and never counted
+    // toward `seen`) — a plain, faithful `withCastLock` consumer.
+    let racerEntered = false;
+    async function raceWrite(): Promise<void> {
+      await withCastLock(bookDir, async () => {
+        racerEntered = true; // set on entry, before the read
+        const cast = await actual.readJson<{
+          characters: Array<Record<string, unknown>>;
+        }>(bookCastPath);
+        const narrator = cast!.characters.find((c) => c.id === 'narrator')!;
+        (narrator as Record<string, unknown>).raceProbe = 'concurrent-writer-survived';
+        await actual.writeJsonAtomic(bookCastPath, { characters: cast!.characters });
+      });
+    }
+
+    let targetPromise: Promise<void> | undefined;
+    let racePromise: Promise<void> | undefined;
+    try {
+      targetPromise = targetCall();
+      targetPromise.catch(() => {});
+
+      // Poll rather than a fixed sleep — same precedent as
+      // cast-not-linked-to.test.ts's own #2123 detector.
+      const deadline = Date.now() + 2000;
+      while (!intercepted && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 5));
+      }
+      expect(intercepted).toBe(true);
+
+      racePromise = raceWrite();
+      racePromise.catch(() => {});
+
+      // Generous head start: completes fully when unlocked (the bug
+      // window), or queues behind the target's held lock when locked (the
+      // fix) — either way nothing depends on tuning a tight timing window.
+      await new Promise((r) => setTimeout(r, 80));
+
+      // Must hold even when the survival assertions below would still pass
+      // by luck (a slow unlocked racer that loses the race anyway).
+      expect(racerEntered).toBe(false);
+
+      released();
+      await Promise.all([targetPromise, racePromise]);
+    } finally {
+      // Idempotent: also fires here so a throw ANYWHERE above still
+      // releases a held `readJson` rather than leaving it stuck forever.
+      released();
+      // Not `mockRestore()` — this is a `vi.fn()` wrapper (from the hoisted
+      // `vi.mock` factory above), not a `vi.spyOn` spy, so restore its
+      // default passthrough behaviour explicitly.
+      spy.mockImplementation(actual.readJson);
+      // On the failure path these are still in-flight — await them so the
+      // test can't return while either is still running against fixtures
+      // `afterEach` is about to delete.
+      await Promise.allSettled([targetPromise, racePromise]);
+    }
+
+    assertRouteOutcome();
+
+    const cast = readCastFromDisk(dir, AUTHOR, SERIES, TITLE);
+    const narrator = cast.characters.find((c) => c.id === 'narrator');
+    expect((narrator as Record<string, unknown>)?.raceProbe).toBe('concurrent-writer-survived');
+  }
+
+  it('a concurrent withCastLock writer on the same book survives clearLibraryVoiceReferences', async () => {
+    await runLockDetector(
+      () => usageMod.clearLibraryVoiceReferences(VOICE_UUID),
+      () => {
+        const cast = readCastFromDisk(dir, AUTHOR, SERIES, TITLE);
+        const marlow = cast.characters.find((c) => c.id === 'char-marlow')!;
+        const overrides = marlow.overrideTtsVoices as Record<string, unknown>;
+        expect(overrides?.qwen).toBeUndefined();
+      },
+    );
   });
 });


### PR DESCRIPTION
## Summary

Adds behavioural cast-lock detectors to three modules that had none, and corrects the coverage claim in the sweep's plan doc. Test-only; no production code changes.

The sweep (#2000) validated its coverage by neutralising `withCastLock` and observing "17 of 18 spec files go red". That audit had a blind spot: **the primitive has two entry points.** `withCastLock` (one book) and `withCastLocks` (several, chained via `reduceRight`). Mutating one cannot redden any site built on the other — and in the audit's output, "this site is uncovered" and "this site doesn't use the thing I broke" look identical.

Re-measured against the primitive each site actually calls:

| Site | Correct primitive | Before this PR |
|---|---|---|
| `cast-not-linked-to.ts` POST | `withCastLocks` | **no detector** |
| `cast-not-linked-to.ts` DELETE | `withCastLocks` | **no detector** |
| `voice-library-usage.ts` | `withCastLock` | **no detector** |
| `cast-add-from-roster.ts` | `withCastLock` | covered |
| `cast-link-prior.ts` | `withCastLocks` | covered |
| `library-cast-override.ts` | `withCastLocks` | covered |

Four detectors added, in three files. Each races a **genuine writer using the same primitive the site calls, from outside the site**, against the site's own **in-lock** `readJson`, held open by a hoisted `vi.mock` gate on `state-io.js`. Each asserts three things: a `racerEntered` flag is still `false` at release (mechanism), the racer's orthogonal probe field survives (outcome), and the site's own write actually landed (so a 404/500 can't pass trivially).

### Why an external racer, where a self-race already exists

`cast-add-from-roster.ts` was already covered — its `#1981` self-race reddens under both a neutralised lock and a rule-2 read-hoist. Its detector is kept anyway, because **a self-race cannot catch a divergent lock key.**

Verified by mutating the call site to key off `sourceLocated.bookDir.toUpperCase()` — the lock is fully intact, just keyed off a different derivation of the same book. The self-race stays **green** (both callers queue on the same wrong key, so they still serialise against each other); the external-writer detector is **the only test that fails**. That is verbatim the failure `cast-lock.ts`'s header warns about — "a site that derived the key slightly differently would get a second mutex that never contends with the first, and every test would still pass" — and it is structurally invisible to any same-site race.

### Corrections to the record

Two claims made during this work were wrong and are corrected here rather than left standing:

- **#2123's cited evidence was invalid.** It reported the gap as "neutralise `withCastLock` → the spec stays green", but `cast-not-linked-to.ts` calls only `withCastLocks`. That mutation could never have reddened the file. The *conclusion* held — re-tested directly, the pre-change file is 15/15 green under a neutralised `withCastLocks` — but the evidence for it proved nothing. Noted on the issue.
- **`cast-add-from-roster.ts` was misreported as detector-less** (including by me, mid-review). It was already covered; only `voice-library-usage.ts` was a genuine gap. The plan note is corrected accordingly rather than claiming a gap that did not exist.

## Test plan

All runs at `--retry=0` (`retry: 1` is live in `server/vitest.config.ts` and has produced a false green on this work, #2028), as genuinely separate process invocations — not `--repeat`.

- **Mutation A — primitive neutralised** (`return fn();`, against the correct primitive per site). Every new detector RED, 5/5 runs each. Coordinator independently reproduced 3/3 on `cast-not-linked-to`.
- **Mutation B — rule-2 regression** (read hoisted outside a *retained* wrapper). Every new detector RED, 5/5 runs each. Applied one site at a time: each mutation reddens only its own site's detector and leaves the others green — so the detectors are site-specific, not incidentally coupled.
- **Mutation B-DELETE is the regression proof for the review finding**: before the second commit this exact mutation left `cast-not-linked-to.test.ts` green 16/16.
- **Key-divergence mutation** (lock intact, key wrong): self-race green, external detector red — see above.
- **Premise re-tests**: pre-change `cast-not-linked-to.test.ts` + neutralised `withCastLocks` → 15/15 green (gap confirmed). Pre-change `cast-add-from-roster.test.ts` + neutralised `withCastLock` → its `#1981` test red (already covered, gap disproved).
- **Mechanism assertion is load-bearing**: under mutation A the failure is at `expect(racerEntered).toBe(false)`, not only at the survival assertion.
- **No collateral**: pre-existing test counts unchanged in every touched file; all mutated production files reverted exactly, `git diff` empty for each, verified.
- Full `test:server` green via pre-commit (475 files, 6493 tests). `verify:fast:branch` green.

## Checklist discharges

- **Release notes — N/A, no shippable delta.** Test-only; no user- or operator-visible behaviour change.
- **On-box acceptance — N/A.** No hardware-only behaviour; every claim is provable in-process. No register row owed.
- **e2e / frontend / openapi — N/A.** Server-side concurrency crosses no router, redux, layout or wire seam.
- **`docs/BACKLOG.md` — no row needed.** #2123 is `type:chore`; `backlog:sync` renders `type:feature` only.
- **Regression plan** — `docs/features/279-cast-json-write-lock.md` coverage section rewritten to match what actually ships.

## Notes for the reviewer

- That each gate catches the **in-lock** read rather than an outer one is proven by the mutation result, not by inspection: an outer gate would let the racer finish before the lock was ever contended, making correct code red too. All four are green on correct code.
- `voice-library-usage.ts` reads the book's cast.json **twice** — once unlocked in `walkConfirmedCasts()`'s scan, once inside the lock. Its gate therefore intercepts by **occurrence count**, not first-match; gating the first would be exactly the placebo shape above.
- Racers call `actual.readJson` / `actual.writeJsonAtomic` so they can never be intercepted by their own gate.
- Every hoisted `vi.mock` defaults to a passthrough, so untouched tests in each file behave as if it were absent.

## Reported, not fixed

`docs/features/279-cast-json-write-lock.md` says "the five two-book routes" at lines 49 and 312 — both predate this branch (present on `main` at `23195f99`). There are four `withCastLocks` call sites across three modules (`cast-link-prior.ts`, `library-cast-override.ts`, `cast-not-linked-to.ts` ×2). Left alone because it is pre-existing and it is not clear what "five" was counting; flagging rather than guessing.

Closes #2123
Refs #2000
