### PR TITLE
docs(docs): design and implementation plan for the verify scope-map unification

### DIFF
--- a/docs/superpowers/plans/2026-08-05-verify-scope-map-unification.md
+++ b/docs/superpowers/plans/2026-08-05-verify-scope-map-unification.md
@@ -20,7 +20,7 @@ about how scope is *computed* changes) and de-circularises A2. **A2** rewrites
 `verify.yml` to derive per-step scope from `STEPS[]` via a new
 `scripts/ci-scope.mjs`, guarded by four assertions over the parsed workflow.
 **B** hardens `scripts/tests/verify-cache.test.mjs`'s completeness guard with
-comment-stripping, a TS-aware resolver, a transitive walk stopped at
+AST-based extraction, a TS-aware resolver, a transitive walk stopped at
 gitignored paths, and splits `check-no-budget-poll` into its own step.
 
 **Tech Stack:** Node 20 ESM (`.mjs`), `node:test` + `node:assert/strict`,
@@ -65,7 +65,7 @@ verbatim from the spec.
 | `scripts/ci-scope.mjs` | A2 | **new** — derive per-step CI scope from `STEPS[]`; emit `scopes` JSON + `ok` sentinel |
 | `scripts/tests/ci-scope.test.mjs` | A2 | **new** — unit tests for the above (fail-safe, dispatch, shared) |
 | `scripts/tests/workflow-wiring.test.mjs` | A2 | **new** — the four assertions over parsed `verify.yml` |
-| `scripts/lib/module-graph.mjs` | B | **new** — comment-strip, resolve, `check-ignore` classify, transitive walk |
+| `scripts/lib/module-graph.mjs` | B | **new** — AST extract, resolve, `check-ignore` classify, transitive walk |
 | `scripts/tests/module-graph.test.mjs` | B | **new** — synthetic-fixture unit tests incl. M17 |
 | `.github/workflows/verify.yml` | A1, A2 | scope detection + per-step gating |
 | `scripts/verify-cache.mjs` | A1, A2, B | `STEPS[]` — the single source of truth |
@@ -126,6 +126,20 @@ test('stepTouchedByDiff: any workflow diff matches test:hooks', () => {
     true,
   );
 });
+
+// .husky/** is covered TODAY only by verify.yml's `hooks` bash matcher
+// (`^\.husky/`), which A2 deletes. It is an input to NO step — measured:
+// stepTouchedByDiff returns [] for all 13 steps. Without this, A2 ships
+// defect D again for .husky, on the very PR that fixes it for .github, and
+// none of the four wiring assertions can see it (they check key existence
+// and job membership, not whether a derived condition still covers what the
+// legacy one did). release-manifest.test.mjs:95 reads .husky/pre-commit at
+// runtime, so this is a real edge, not a theoretical one.
+test('stepTouchedByDiff: a .husky diff matches test:hooks via globs', () => {
+  for (const hook of ['.husky/pre-commit', '.husky/pre-push', '.husky/commit-msg']) {
+    assert.equal(stepTouchedByDiff(stepByName['test:hooks'], [hook]), true, hook);
+  }
+});
 ```
 
 - [ ] **Step 2: Run it to verify it fails**
@@ -149,6 +163,12 @@ In `scripts/verify-cache.mjs`, the `test:hooks` entry, extend `globs`
            the assertion sits stale-green. Same #1847 trap as fixtures/**
            above (defect D, #2119 review). */
         '.github/workflows/**',
+        /* .husky/** is covered TODAY only by verify.yml's `hooks` bash
+           matcher, which A2 deletes — and it is an input to no step, so
+           without this a .husky-only PR would run zero legs after A2.
+           release-manifest.test.mjs reads .husky/pre-commit at runtime
+           (plan review round 2). */
+        '.husky/**',
       ],
 ```
 
@@ -394,12 +414,29 @@ export function main(argv = process.argv.slice(2), sidecarDir = SIDECAR_DIR) {
     return 0;
   }
 
+  // run-tests.ps1 also probes for pytest itself and SKIPs when a venv exists
+  // but requirements-dev.txt was never installed. Without this, that box goes
+  // from green-skip to RED on `npm run verify` and pre-push — a regression
+  // dressed up as "local behaviour is unchanged".
+  const probe = spawnSync(python, ['-m', 'pytest', '--version'], { encoding: 'utf8' });
+  if ((probe.status ?? 1) !== 0) {
+    const msg = 'sidecar pytest -- venv present but pytest is not installed';
+    if (requireVenv) {
+      process.stderr.write(`ERROR: ${msg}\n`);
+      return 1;
+    }
+    process.stdout.write(`\nSKIP: ${msg}\n`);
+    process.stdout.write('        .venv/bin/python -m pip install -r requirements-dev.txt\n\n');
+    return 0;
+  }
+
   // -m "not golden" mirrors the existing runner: the opt-in golden-audio tier
-  // must never load a model here.
+  // must never load a model here. `--tb=short -q` and the explicit tests/ path
+  // also mirror it, so output is comparable to the PowerShell runner's.
   const passthrough = argv.filter((a) => a !== '--require-venv');
   const result = spawnSync(
     python,
-    ['-m', 'pytest', '-m', 'not golden', ...passthrough],
+    ['-m', 'pytest', '-m', 'not golden', '--tb=short', '-q', 'tests', ...passthrough],
     { cwd: sidecarDir, stdio: 'inherit' },
   );
   if (result.error) {
@@ -510,6 +547,13 @@ Insert after the `server-tests` job in `.github/workflows/verify.yml`:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      # Every other job uses this; without it this job relies on whatever Node
+      # ubuntu-latest happens to ship and pins no version. `npm run
+      # test:sidecar` needs Node but no node_modules, so the composite's
+      # `npm ci` is cheap insurance rather than a requirement.
+      - name: Setup Node + deps
+        uses: ./.github/actions/setup
 
       - name: Setup Python
         if: needs.detect.outputs.sidecar == 'true' || needs.detect.outputs.shared == 'true'
@@ -919,7 +963,11 @@ bash branch must go.
 
 But the `git merge-base` / `git diff` lines below it would then run on a
 dispatch with empty `BASE`/`HEAD` and fail under `set -e`. Guard them.
-Replace the entire `run:` body (`:113` through `:180`) with:
+Replace the `run:` body — **`:114` through `:180`**. Not `:113`: that line is
+`        id: changes`, and deleting it removes the step id that
+`steps.changes.outputs.*` resolves through, so both outputs would silently
+resolve empty. (Task 9's sentinel catches it — fail-closed — but as a
+red run costing a debugging cycle rather than an obvious error.)
 
 ```yaml
         run: |
@@ -1031,12 +1079,18 @@ today. `openapi.yaml` needs no special handling: it is already in `test`'s
 
 Preserve today's behaviour explicitly rather than narrowing by accident:
 
+**`# leg:` must be the LAST comment line before `- name:`.** Task 8's regex
+is `# leg: X\n\s*- name:`, and `\s*` does not span other comment lines — an
+earlier draft of this very snippet put four comment lines in between, so
+`# leg: test` matched nothing and the leg silently vanished from the binding
+map. Put explanatory prose *above* the marker:
+
 ```yaml
-      # leg: test
       # test:e2e is a deliberate extra trigger: this step also runs
       # `npm run test:a11y`, which has no STEP of its own, and an e2e-only
       # diff should still exercise the a11y battery. Dropping it would be a
       # silent narrowing of what runs today.
+      # leg: test
       - name: Frontend tests + a11y
         if: fromJSON(needs.detect.outputs.scopes).step_test || fromJSON(needs.detect.outputs.scopes).step_test_e2e || fromJSON(needs.detect.outputs.scopes).shared
 ```
@@ -1115,16 +1169,20 @@ const referenced = [...source.matchAll(/fromJSON\(needs\.detect\.outputs\.scopes
   .map((m) => m[1]);
 
 test('anti-vacuity: the workflow scan finds references', () => {
-  // UNITS: this counts REFERENCES, not `if:` sites. Measured on the
-  // pre-derivation workflow: 17 `if:` lines but 55 scope references, and A1's
-  // sidecar job adds ~6 more. An earlier draft of this plan set the floor to
-  // 20 while reasoning about "~20 if: sites" — the exact unit conflation the
-  // spec's Measurements section warns about, and the same mistake that left
-  // the old guard's floor at 30 against a real 60. Floor 50 gives ~18%
-  // headroom against ~61.
+  // UNITS: this counts REFERENCES, not `if:` sites — and the two are not
+  // convertible. This floor has now been wrong TWICE for that reason:
+  //   * 20, reasoned from "~20 if: sites" (the regex counts references);
+  //   * 50, reasoned as 55 pre-derivation refs + 6 for A1's sidecar job —
+  //     which assumes conversion preserves refs-per-site. It does not. The
+  //     pre-derivation workflow averages 2.9 refs/site because legacy scope
+  //     names are broader; every derived site is exactly 2 (3 for the two
+  //     union sites). Constructed post-A2: 23 sites, **49 references** —
+  //     BELOW the old floor of 50, i.e. guaranteed spurious red.
+  // Floor 35 gives ~29% headroom under 49. Re-measure against the real
+  // workflow once Task 7 is done rather than trusting this number.
   assert.ok(
-    referenced.length >= 50,
-    `expected >= 50 fromJSON references, found ${referenced.length} — either the regex broke or the workflow lost wiring`,
+    referenced.length >= 35,
+    `expected >= 35 fromJSON references, found ${referenced.length} — either the regex broke or the workflow lost wiring`,
   );
 });
 
@@ -1196,8 +1254,13 @@ test('setup steps depend on the same scope keys as the leg they support', () => 
     /# supports: ([a-z:0-9-]+)\n\s*- name: ([^\n]+)\n\s*if: ([^\n]+)\n/g,
   )];
 
-  assert.ok(setups.length >= 7, `expected >= 7 '# supports:' declarations, found ${setups.length}`);
-  assert.ok(legs.size >= 7, `expected >= 7 '# leg:' declarations, found ${legs.size}`);
+  // 9, not 7: A1 adds two more if:-bearing setup steps (Setup Python,
+  // Bootstrap sidecar venv) on top of the original 3x Install ffmpeg,
+  // 2x Cache Playwright, 2x Install Playwright. The plan's prose said seven
+  // because it was written pre-A1 — a stale constant carried across a phase
+  // boundary. Re-count after Task 7 rather than trusting either number.
+  assert.ok(setups.length >= 9, `expected >= 9 '# supports:' declarations, found ${setups.length}`);
+  assert.ok(legs.size >= 11, `expected >= 11 '# leg:' declarations, found ${legs.size}`);
 
   const mismatched = [];
   for (const [, leg, stepName, condition] of setups) {
@@ -1212,6 +1275,116 @@ test('setup steps depend on the same scope keys as the leg they support', () => 
   assert.deepEqual(mismatched, [], `setup step(s) diverged from their leg:\n${mismatched.join('\n')}`);
 });
 ```
+
+- [ ] **Step 1b: The coverage-parity assertion (the fifth, and the one that matters most)**
+
+The four assertions above check *wiring* — that keys exist, are referenced,
+and live in gated jobs. **None of them checks that a derived condition still
+covers what the legacy condition covered.** That is a different property, and
+it is the one the derivation actually puts at risk: legacy bash matchers are
+broader than the `STEPS[]` inputs replacing them. Measured across a probe
+corpus, **8 of 12 sites narrow**, including `.husky/**` losing coverage
+entirely (fixed in Task 1) and `openapi.yaml` no longer triggering Typecheck.
+
+Some narrowings are correct — Pester should not run on a non-PowerShell diff.
+The defect is having no record of which are intended and no guard against the
+next one. Add to `scripts/tests/workflow-wiring.test.mjs`:
+
+```js
+// Replays the PRE-derivation scope matchers against the POST-derivation
+// conditions over a fixed corpus. Every path that used to run a leg must
+// still run it, unless the narrowing is listed and justified below.
+//
+// This is the only assertion that can see a coverage regression; the other
+// four are blind to it by construction.
+const LEGACY_MATCHERS = {
+  frontend: /^(src\/|index\.html$|vite\.config\.ts$|tailwind\.config\.ts$|tsconfig\.json$|tsconfig\.node\.json$|postcss\.config\.js$|eslint\.config\.(js|mjs)$)/,
+  server: /^(server\/src\/|server\/package(-lock)?\.json$|server\/tsconfig\.json$|server\/vitest\.config(\.slow)?\.ts$|openapi\.yaml$|server\/\.env\.example$|server\/scripts\/sync-env-example\.ts$|scripts\/tests\/fixtures\/)/,
+  sidecar: /^server\/tts-sidecar\//,
+  e2e: /^(e2e\/|playwright\.config\.ts$)/,
+  scripts: /^scripts\//,
+  hooks: /^(\.husky\/|\.github\/workflows\/|scripts\/run-hooks-tests\.mjs$|scripts\/validate-commit-msg\.mjs$|RELEASE_NOTES\.md$|docs\/release-notes-next\.md$|scripts\/release-notes-gate\.mjs$|docs\/testing\/onbox-acceptance-register\.md$|docs\/testing\/onbox-acceptance-register-live-view\.html$)/,
+  pinokio: /^(pinokio\.js$|pinokio-scripts\/|scripts\/run-pinokio-tests\.mjs$)/,
+  openapi: /^openapi\.yaml$/,
+};
+
+// Legacy step name -> the scopes that used to gate it, from git history of
+// verify.yml immediately before A2. Copy these from the pre-A2 file; do not
+// re-derive them from memory.
+const LEGACY_GATES = {
+  'Lint': ['frontend', 'server', 'scripts'],
+  'Typecheck': ['frontend', 'server'],
+  'Config check': ['server'],
+  'Hooks tests': ['hooks', 'scripts'],
+  'PowerShell-helper tests (Pester)': ['scripts'],
+  'Pinokio tests': ['pinokio'],
+  'Frontend tests + a11y': ['frontend', 'e2e', 'openapi'],
+  'Server tests (fast + slow)': ['server', 'sidecar'],
+  'E2E (chromium)': ['frontend', 'e2e'],
+  'E2E visual baselines (chromium)': ['frontend', 'e2e'],
+  'Build': ['frontend', 'server'],
+};
+
+// Narrowings judged CORRECT. Each needs a reason — an unexplained entry here
+// is how a real regression gets waved through.
+const ACCEPTED_NARROWINGS = [
+  // [step name, path, why it is right to stop running]
+  ['PowerShell-helper tests (Pester)', 'scripts/ci-scope.mjs',
+   'Pester covers scripts/lib/*.ps1 only; a .mjs change cannot affect it'],
+  ['Server tests (fast + slow)', 'server/tts-sidecar/main.py',
+   'server TS suite mocks the sidecar; a sidecar-only diff runs pytest instead'],
+];
+
+const PROBE_CORPUS = [
+  'src/app.tsx', 'index.html', 'tailwind.config.ts', 'tsconfig.json',
+  'eslint.config.mjs', 'vite.config.ts', 'openapi.yaml',
+  'server/src/tts/mp3.ts', 'server/package.json', 'server/tts-sidecar/main.py',
+  'e2e/smoke.spec.ts', 'playwright.config.ts',
+  'scripts/ci-scope.mjs', 'scripts/lib/log.ps1', 'scripts/tests/fixtures/x.json',
+  '.husky/pre-commit', '.github/workflows/verify.yml',
+  'pinokio.js', 'pinokio-scripts/lib/menu.js',
+  'launch.mjs', 'server/tts-sidecar/scripts/install-qwen3.mjs',
+  'RELEASE_NOTES.md', 'docs/release-notes-next.md',
+];
+
+test('coverage parity: no derived condition silently narrows a leg', () => {
+  const accepted = new Set(ACCEPTED_NARROWINGS.map(([s, p]) => `${s} ${p}`));
+  const regressions = [];
+
+  for (const [stepName, legacyScopes] of Object.entries(LEGACY_GATES)) {
+    // The derived condition now attached to this step, by `# leg:` marker or
+    // by step name.
+    const m = source.match(
+      new RegExp(`- name: ${stepName.replace(/[.*+?^\${}()|[\\]\\\\]/g, '\\\\$&')}\\n\\s*if: ([^\\n]+)\\n`),
+    );
+    assert.ok(m, `no if: found for step '${stepName}' — did it get renamed?`);
+    const derivedKeys = [...m[1].matchAll(/fromJSON\(needs\.detect\.outputs\.scopes\)\.([A-Za-z0-9_]+)/g)]
+      .map((x) => x[1]);
+
+    for (const path of PROBE_CORPUS) {
+      const ranBefore = legacyScopes.some((s) => LEGACY_MATCHERS[s].test(path));
+      const scopes = computeScopes([path], { eventName: 'pull_request' });
+      const runsNow = derivedKeys.some((k) => scopes[k]);
+      if (ranBefore && !runsNow && !accepted.has(`${stepName} ${path}`)) {
+        regressions.push(`${stepName} no longer runs for ${path}`);
+      }
+    }
+  }
+
+  assert.deepEqual(
+    regressions,
+    [],
+    `derivation silently narrowed coverage:\n${regressions.join('\n')}\n\n` +
+    `Either widen the step's inputs in verify-cache.mjs, or add an entry to ` +
+    `ACCEPTED_NARROWINGS with a reason.`,
+  );
+});
+```
+
+**Working through the failures this produces is Task 7's real work**, not the
+mechanical `if:` rewriting. Each one is a decision: widen the STEP's inputs,
+or accept and document. Do not add blanket `ACCEPTED_NARROWINGS` entries to
+get to green.
 
 - [ ] **Step 2: Run to verify each assertion can fail**
 
@@ -1350,7 +1523,30 @@ Branch: `fix/ops-verify-cache-completeness-guard`, cut after A2 merges.
 
 ---
 
-### Task 10: Comment stripping and the resolver
+### Task 10: AST-based specifier extraction and the resolver
+
+> **Revised after plan review round 2.** An earlier draft hand-rolled a
+> comment-stripping lexer. Two versions of it were written and **both were
+> defective**: the first desynced on regex literals containing quotes; the
+> second closed that but retained a *re-closing* desync — `return /a\/*b/;`
+> is read as division, then `/*` opens a phantom block comment that a later
+> `*/` closes, silently swallowing every import in between while the
+> terminal state finishes at `code`. Demonstrated:
+>
+> ```
+> onDesync reported : null          <- the whole-repo guard sees nothing
+> lexer extracted   : ["./other.mjs"]   <- './real.mjs' vanished
+> ```
+>
+> That fail-open is **not closable by another test case**, because the
+> detector (terminal state) cannot observe it. `acorn` is already resolvable
+> (8.16.0, via eslint) and ignores comments natively, so the entire class
+> disappears. Measured on `scripts/tests/*.test.mjs`: **0 parse failures
+> across 59 files**, and the only difference from the regex approach is that
+> acorn correctly does **not** extract `../../pinokio.js` from inside a
+> string literal — a false positive the regex produced, and the very
+> specifier that resolves outside the repo and triggers `check-ignore`'s
+> exit 128.
 
 **Files:**
 - Create: `scripts/lib/module-graph.mjs`
@@ -1358,8 +1554,8 @@ Branch: `fix/ops-verify-cache-completeness-guard`, cut after A2 merges.
 
 **Interfaces:**
 - Produces:
-  - `stripComments(source)` → string
-  - `extractRelativeSpecifiers(source)` → string[]
+  - `extractRelativeSpecifiers(source)` → string[], or **throws** on unparseable input
+  - `candidatePaths(fromFile, specifier)` → string[] (pure path math)
   - `resolveSpecifier(fromFile, specifier)` → absolute path or `null`
 
 - [ ] **Step 1: Write the failing tests**
@@ -1369,106 +1565,70 @@ Create `scripts/tests/module-graph.test.mjs`:
 ```js
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-// `resolve` and `relative` are needed by the whole-repo desync test below AND
-// by Task 11's out-of-repo case — imported here once for the whole file.
-import { join, resolve, relative, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { stripComments, extractRelativeSpecifiers, resolveSpecifier } from '../lib/module-graph.mjs';
+import { join, resolve } from 'node:path';
+import { extractRelativeSpecifiers, resolveSpecifier } from '../lib/module-graph.mjs';
 
-const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
-
-// Minimal recursive walker: fast-glob is a dependency of the runner, not of
-// this test — node:test files here stay dependency-free.
-function walkDir(dir, exts, acc = []) {
-  if (!existsSync(dir)) return acc;
-  for (const entry of readdirSync(dir)) {
-    if (entry === 'node_modules' || entry === '.git') continue;
-    const p = join(dir, entry);
-    if (statSync(p).isDirectory()) walkDir(p, exts, acc);
-    else if (exts.some((x) => p.endsWith(x))) acc.push(p);
-  }
-  return acc;
-}
-
-test('stripComments removes line comments', () => {
-  assert.equal(stripComments("const a = 1; // require('../x.js')\n").includes('../x.js'), false);
-});
-
-test('stripComments removes block comments', () => {
-  assert.equal(stripComments("/* require('../x.js') */\nconst a = 1;\n").includes('../x.js'), false);
-});
-
-// Guard against over-stripping: a // inside a string literal is not a comment.
-test('stripComments preserves // inside string literals', () => {
-  const out = stripComments(`const url = "https://example.com/x"; // gone\n`);
-  assert.ok(out.includes('https://example.com/x'), 'URL must survive');
-  assert.ok(!out.includes('gone'), 'trailing comment must be removed');
-});
-
-// --- regex literals: the failure mode that makes this a FAIL-OPEN ---------
-// A regex with an odd number of quotes sends a naive scanner into a phantom
-// string state it never leaves, so the REST OF THE FILE goes unscanned and
-// any import in that tail is invisible to the completeness guard. Measured
-// against an earlier draft: 3 real files desynced, including
-// release-notes-gate.mjs, itself a declared test:hooks input.
-test('stripComments survives a regex literal containing quotes', () => {
-  const src = `const r = /media-type="[^"]+"/;\nimport x from './real.mjs';\n`;
-  assert.ok(
-    stripComments(src).includes('./real.mjs'),
-    'an import after a quote-bearing regex must survive',
-  );
-});
-
-test('stripComments survives a regex literal ending in an escaped slash', () => {
-  const src = `if (/^refs\\/heads\\//.test(p)) {}\nconst y = require('./real.js');\n`;
-  assert.ok(stripComments(src).includes('./real.js'));
-});
-
-// The other direction: division must NOT be mistaken for a regex, or
-// everything up to the next / is eaten.
-test('stripComments treats / as division after a value', () => {
-  const src = `const a = (x + 1) / 2; const b = 3 / 4;\nimport z from './real.mjs';\n`;
-  assert.ok(stripComments(src).includes('./real.mjs'));
-});
-
-// The real guard: whole-repo desync detection. The targeted cases above only
-// catch shapes someone thought of; this catches the class. Verified at
-// authoring time — 166 files, 0 desyncs.
-test('stripComments does not desync on any real script in the repo', () => {
-  const roots = [
-    ...walkDir(resolve(repoRoot, 'scripts'), ['.mjs', '.cjs']),
-    ...walkDir(resolve(repoRoot, 'pinokio-scripts'), ['.js']),
-  ];
-  assert.ok(roots.length >= 100, `expected >= 100 scripts to scan, found ${roots.length}`);
-
-  const desynced = [];
-  for (const file of roots) {
-    stripComments(readFileSync(file, 'utf8'), {
-      onDesync: (state) => desynced.push(`${relative(repoRoot, file)} -> ended in '${state}'`),
-    });
-  }
-  assert.deepEqual(desynced, [], `stripComments desynced on:\n${desynced.join('\n')}`);
-});
-
-// This is why stripping is load-bearing rather than cosmetic:
-// verify-cache.mjs:107 has a literal require('../../pinokio.js') in a COMMENT
-// which resolves OUTSIDE the repo root. Under fail-closed resolution that is
-// a false failure.
-test('extractRelativeSpecifiers ignores a specifier inside a comment', () => {
-  const src = "// loads it via createRequire + require('../../pinokio.js')\nimport x from './real.mjs';\n";
-  assert.deepEqual(extractRelativeSpecifiers(src), ['./real.mjs']);
-});
-
-test('extractRelativeSpecifiers finds import, dynamic import and require', () => {
+test('extracts static, dynamic and require specifiers', () => {
   const src = `
 import a from './a.mjs';
 const b = await import('./b.mjs');
 const c = require('./c.js');
-import d from 'node:fs';
+export { d } from './d.mjs';
+export * from './e.mjs';
+import fs from 'node:fs';
+import pkg from 'archiver';
 `;
-  assert.deepEqual(extractRelativeSpecifiers(src).sort(), ['./a.mjs', './b.mjs', './c.js']);
+  assert.deepEqual(
+    extractRelativeSpecifiers(src).sort(),
+    ['./a.mjs', './b.mjs', './c.js', './d.mjs', './e.mjs'],
+  );
+});
+
+// Comments are invisible to a parser — no stripping step, no desync class.
+// verify-cache.mjs:107 has a literal require('../../pinokio.js') in a comment
+// that resolves OUTSIDE the repo; under fail-closed resolution the regex
+// approach turned that into a check-ignore exit-128 crash.
+test('ignores a specifier inside a comment', () => {
+  const src = `// loads it via createRequire + require('../../pinokio.js')\nimport x from './real.mjs';\n`;
+  assert.deepEqual(extractRelativeSpecifiers(src), ['./real.mjs']);
+});
+
+// The regex approach extracted this; acorn does not. It is fixture DATA in a
+// test, not an edge — a false positive that inflated the closure.
+test('ignores a specifier inside a string literal', () => {
+  const src = `const source = "const config = require('../../pinokio.js');";\nimport y from './real.mjs';\n`;
+  assert.deepEqual(extractRelativeSpecifiers(src), ['./real.mjs']);
+});
+
+// The exact shape that defeated the hand-rolled lexer: `return /a\/*b/;` is
+// read as division, `/*` opens a phantom comment, a later `*/` closes it, and
+// every import in between is swallowed with NO desync signal.
+test('a keyword-preceded regex literal does not swallow later imports', () => {
+  const src = [
+    'function f() { return /a\\/*b/; }',
+    "import x from './real.mjs';",
+    '/* ordinary comment */',
+    "import y from './other.mjs';",
+  ].join('\n');
+  assert.deepEqual(extractRelativeSpecifiers(src).sort(), ['./other.mjs', './real.mjs']);
+});
+
+test('handles CJS scripts that are not valid ESM', () => {
+  const src = `const x = require('./a.js');\nmodule.exports = x;\n`;
+  assert.deepEqual(extractRelativeSpecifiers(src), ['./a.js']);
+});
+
+test('handles a hashbang', () => {
+  const src = `#!/usr/bin/env node\nimport a from './a.mjs';\n`;
+  assert.deepEqual(extractRelativeSpecifiers(src), ['./a.mjs']);
+});
+
+// FAIL CLOSED: unparseable input must be reported, never treated as "no
+// edges". Silently returning [] is the "absent reads as clean" shape.
+test('throws on unparseable source rather than returning no edges', () => {
+  assert.throws(() => extractRelativeSpecifiers('function ( { >>> ;'), /parse/i);
 });
 
 function tree(files) {
@@ -1502,12 +1662,29 @@ test('resolveSpecifier returns null when nothing resolves', () => {
   const d = tree({ 'a.mjs': '' });
   assert.equal(resolveSpecifier(join(d, 'a.mjs'), './nope.mjs'), null);
 });
+
+// Anti-vacuity on the extractor itself: every real hooks test must parse.
+// A parse regression would otherwise surface only as a mysteriously shrunken
+// closure. Measured at authoring time: 59 files, 0 failures.
+test('every hooks test file parses', () => {
+  const dir = resolve(import.meta.dirname);
+  const files = readdirSync(dir).filter((f) => f.endsWith('.test.mjs'));
+  assert.ok(files.length >= 40, `expected >= 40 hooks tests, found ${files.length}`);
+  const failures = [];
+  for (const f of files) {
+    try { extractRelativeSpecifiers(readFileSync(join(dir, f), 'utf8')); }
+    catch (err) { failures.push(`${f}: ${err.message}`); }
+  }
+  assert.deepEqual(failures, [], `unparseable hooks test(s):\n${failures.join('\n')}`);
+});
 ```
+
+Add `readdirSync, readFileSync` to the `node:fs` import for the last test.
 
 - [ ] **Step 2: Run to verify failure**
 
 Run: `node --test scripts/tests/module-graph.test.mjs`
-Expected: FAIL — module not found.
+Expected: FAIL — `Cannot find module '../lib/module-graph.mjs'`.
 
 - [ ] **Step 3: Implement**
 
@@ -1516,122 +1693,89 @@ Create `scripts/lib/module-graph.mjs`:
 ```js
 // Static module-graph helpers for the test:hooks completeness guard.
 //
-// Split out of verify-cache.test.mjs so each piece is independently
-// unit-testable: the guard's previous inline regexes could only be exercised
-// through the whole-repo assertion, which meant a synthetic case (an
-// unresolvable specifier, a depth-2 edge) had nowhere to live.
+// Specifiers are extracted by PARSING, not by regex over stripped text. Two
+// hand-rolled comment-stripping lexers were written for this and both had a
+// fail-open: a regex literal could open a phantom comment state that a later
+// `*/` closed, swallowing imports with no detectable signal. A parser has no
+// such failure mode — comments and string literals are simply not expressions.
+//
+// acorn is already a transitive dependency (via eslint) and is used here for
+// its parser only; no plugin, no walker package.
 
 import { existsSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
+import { createRequire } from 'node:module';
 
-// Remove comments before extracting specifiers. Load-bearing: the extraction
-// regexes below match inside comments, and verify-cache.mjs's own comment
-// contains a literal require('../../pinokio.js') that resolves outside the
-// repo. Under fail-closed resolution that would be a false failure — and it
-// is exactly the git check-ignore exit-128 case.
-// Regex literals MUST be consumed atomically. Two ways they break a naive
-// scanner, both live in this repo:
-//   * /media-type="[^"]+"/ has an ODD number of quotes, so the scanner enters
-//     a phantom string state and never leaves — the rest of the file is
-//     silently unscanned (a fail-OPEN: imports in that tail become invisible).
-//     Real: scripts/lib/slim-epub-cover.mjs, wt-merge.mjs, release-notes-gate.mjs
-//     (the last is itself a declared test:hooks input).
-//   * /^refs\/heads\// ends in an escaped slash, so `//` reads as a comment
-//     start and truncates the line. Real: code-stats.mjs, wt-list.mjs.
-// A `/` starts a regex (rather than being division) when the previous
-// significant character is one that cannot end an expression.
-const REGEX_PRECEDERS = new Set(['(', ',', '=', ':', '[', '!', '&', '|', '?', '{', '}', ';', '\n', '+', '-', '*', '%', '<', '>', '~', '^', undefined]);
+const require = createRequire(import.meta.url);
+const acorn = require('acorn');
 
-// `onDesync` is how the whole-repo test detects the failure above. It cannot
-// be detected from the OUTPUT — a desynced scan still emits the text, and
-// re-running it desyncs identically, so the result is stable and looks fine.
-// Only the terminal state reveals it.
-export function stripComments(source, { onDesync } = {}) {
-  let out = '';
-  let i = 0;
-  let prev; // last significant code char
-  let state = 'code'; // code | line | block | single | double | template
-  while (i < source.length) {
-    const c = source[i];
-    const next = source[i + 1];
-    if (state === 'code') {
-      if (c === '/' && next === '/') { state = 'line'; i += 2; continue; }
-      if (c === '/' && next === '*') { state = 'block'; i += 2; continue; }
-      if (c === '/' && REGEX_PRECEDERS.has(prev)) {
-        // Consume the whole literal, honouring escapes and [...] classes,
-        // where an unescaped '/' does NOT terminate.
-        out += c; i += 1;
-        let inClass = false;
-        while (i < source.length) {
-          const r = source[i];
-          if (r === '\\') { out += r + (source[i + 1] ?? ''); i += 2; continue; }
-          if (r === '[') inClass = true;
-          else if (r === ']') inClass = false;
-          else if (r === '/' && !inClass) { out += r; i += 1; break; }
-          else if (r === '\n') break; // unterminated — bail rather than run away
-          out += r; i += 1;
-        }
-        prev = '/';
-        continue;
-      }
-      if (c === "'") state = 'single';
-      else if (c === '"') state = 'double';
-      else if (c === '`') state = 'template';
-      if (!/\s/.test(c)) prev = c;
-      else if (c === '\n') prev = '\n';
-      out += c; i += 1; continue;
-    }
-    if (state === 'line') {
-      if (c === '\n') { state = 'code'; out += c; }
-      i += 1; continue;
-    }
-    if (state === 'block') {
-      if (c === '*' && next === '/') { state = 'code'; i += 2; continue; }
-      if (c === '\n') out += c; // preserve line numbering
-      i += 1; continue;
-    }
-    // inside a string literal
-    if (c === '\\') { out += c + (next ?? ''); i += 2; continue; }
-    if ((state === 'single' && c === "'") || (state === 'double' && c === '"') || (state === 'template' && c === '`')) {
-      state = 'code';
-    }
-    out += c; i += 1;
-  }
-  // A scan that ends anywhere but `code` ran off the rails — most often on a
-  // regex literal with an odd quote count, after which the remainder of the
-  // file was treated as string content and never scanned for imports.
-  if (state !== 'code' && onDesync) onDesync(state);
-  return out;
-}
+const PARSE_OPTIONS = {
+  ecmaVersion: 'latest',
+  allowReturnOutsideFunction: true,
+  allowAwaitOutsideFunction: true,
+  allowHashBang: true,
+};
 
-const PATTERNS = [
-  /\bfrom\s+['"](\.\.?\/[^'"]+)['"]/g,
-  /\bimport\(\s*['"](\.\.?\/[^'"]+)['"]\s*\)/g,
-  /\brequire\(\s*['"](\.\.?\/[^'"]+)['"]\s*\)/g,
-];
+const isRelative = (v) => typeof v === 'string' && /^\.\.?\//.test(v);
 
-// Only dot- or dot-dot-prefixed specifiers are producers under test; bare
-// specifiers (node:fs, archiver) are dependencies, not code under test, and
-// following them would walk into node_modules.
+// Returns the relative specifiers this source depends on.
+//
+// THROWS on unparseable input rather than returning []. An empty result from a
+// broken parse is the "absent reads as clean" shape: the guard would report a
+// file has no dependencies precisely when it cannot tell.
 export function extractRelativeSpecifiers(source) {
-  const stripped = stripComments(source);
-  const found = new Set();
-  for (const pattern of PATTERNS) {
-    for (const match of stripped.matchAll(pattern)) found.add(match[1]);
+  let ast = null;
+  let lastErr = null;
+  // .mjs/.cjs/.js all appear in the closure; try ESM first, then script.
+  for (const sourceType of ['module', 'script']) {
+    try {
+      ast = acorn.parse(source, { ...PARSE_OPTIONS, sourceType });
+      break;
+    } catch (err) {
+      lastErr = err;
+    }
   }
+  if (!ast) {
+    throw new Error(`module-graph: parse failed (${lastErr?.message ?? 'unknown'})`);
+  }
+
+  const found = new Set();
+  (function visit(node) {
+    if (!node || typeof node !== 'object') return;
+    if (Array.isArray(node)) { for (const child of node) visit(child); return; }
+    switch (node.type) {
+      case 'ImportDeclaration':
+      case 'ExportNamedDeclaration':
+      case 'ExportAllDeclaration':
+      case 'ImportExpression':
+        if (isRelative(node.source?.value)) found.add(node.source.value);
+        break;
+      case 'CallExpression':
+        if (node.callee?.name === 'require' && isRelative(node.arguments?.[0]?.value)) {
+          found.add(node.arguments[0].value);
+        }
+        break;
+      default:
+        break;
+    }
+    for (const key of Object.keys(node)) {
+      if (key === 'type' || key === 'start' || key === 'end' || key === 'loc') continue;
+      visit(node[key]);
+    }
+  })(ast);
   return [...found];
 }
 
 const CANDIDATES = ['', '.js', '.mjs', '.cjs', '/index.js', '/index.mjs'];
 
-// Returns the candidate paths a specifier could denote, WITHOUT touching the
-// filesystem. Exported so the stop rule can classify each candidate before
-// any existence probe (see walk()).
+// Candidate paths a specifier could denote, WITHOUT touching the filesystem.
+// Exported so the stop rule can classify each candidate before any existence
+// probe (see walk()).
 export function candidatePaths(fromFile, specifier) {
   const base = resolve(dirname(fromFile), specifier);
   const paths = CANDIDATES.map((ext) => base + ext);
   // TypeScript convention: `./x.js` in source resolves to `./x.ts` on disk.
-  if (specifier.endsWith('.js')) paths.push(base.slice(0, -3) + '.ts');
+  if (specifier.endsWith('.js')) paths.push(`${base.slice(0, -3)}.ts`);
   return paths;
 }
 
@@ -1648,14 +1792,25 @@ export function resolveSpecifier(fromFile, specifier) {
 Run: `node --test scripts/tests/module-graph.test.mjs`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 5: Confirm acorn resolves from this location**
+
+`acorn` is a transitive dependency, not a direct one — it resolves today via
+eslint, but nothing pins that.
+
+Run: `node -e "console.log(require('acorn').version)"`
+Expected: a version string (8.x).
+
+If it ever stops resolving, add `acorn` to `devDependencies` explicitly
+rather than reinstating a hand-rolled lexer. **Do not** re-derive the
+stripping approach; §Task 10's header records why.
+
+- [ ] **Step 6: Commit**
 
 ```bash
 git add scripts/lib/module-graph.mjs scripts/tests/module-graph.test.mjs
-git commit -m "feat(scripts): comment-stripping and TS-aware specifier resolution"
+git commit -m "feat(scripts): AST-based specifier extraction with TS-aware resolution"
 ```
 
----
 
 ### Task 11: The `check-ignore` stop rule
 
@@ -2092,20 +2247,41 @@ Expected: PASS.
 
 Only meaningful here, now that the guard actually consumes `classifyIgnored`.
 
-Temporarily reimplement `classifyIgnored` using `git ls-files` ("untracked")
-instead of `git check-ignore` ("ignored"), then simulate a fresh clone:
+**Write the mutation's code, not its name.** "Use `git ls-files`" read
+literally means *not in the index ⇒ stop*, under which `server/dist/**` is
+untracked whether or not it exists on disk — so renaming the directory
+changes nothing, the mutation stays green, and the implementer reports it as
+a placebo. The predicate that actually reproduces the clone-state divergence
+is *present on disk but untracked*:
+
+```js
+// MUTATION ONLY — the "untracked" predicate this design rejects.
+export function classifyIgnored(absPaths, cwd) {
+  const tracked = new Set(
+    execFileSync('git', ['ls-files'], { cwd, encoding: 'utf8', maxBuffer: 1e8 })
+      .split('\n').filter(Boolean),
+  );
+  return new Map(absPaths.map((p) => [p, !tracked.has(toPosix(relative(cwd, p)))]));
+}
+```
+
+Then simulate a fresh clone:
 
 ```powershell
-Rename-Item server/dist server/dist.bak
+# node_modules/.cache is gitignored; server/dist.bak is NOT, and would
+# litter ~1,812 untracked files into `git status`.
+Rename-Item server/dist ../dist-mutation-stash
 node --test scripts/tests/verify-cache.test.mjs
-Rename-Item server/dist.bak server/dist
+Rename-Item ../dist-mutation-stash server/dist
 ```
 
 (Windows: this moves ~1,812 files and fails if a server process holds any of
-them — stop `npm start` first. On POSIX, `mv server/dist server/dist.bak`.)
+them — stop `npm start` first. On POSIX, `mv server/dist ../dist-mutation-stash`.)
 
 Expected under "untracked": **7 unresolvable specifiers** from
-`scripts/repair-cast-id-drift.mjs:1203-1209`'s `../server/dist/**` imports —
+`scripts/repair-cast-id-drift.mjs`'s `../server/dist/**` dynamic imports
+(currently `:1379-1385`; **grep rather than trusting the line numbers** —
+they moved once already between commits) —
 red on a fresh clone, green on this box. Under `check-ignore`: identical
 either way. Revert the reimplementation.
 
@@ -2372,7 +2548,7 @@ regresses.
 | M4 | wiring floor is not vacuous | Task 8 Step 4 | run it |
 | M5 | a dropped declaration is caught | Task 13 Step 5 | run it |
 | M6 | depth-1 is GREEN against the real repo — so M5 alone cannot prove recursion | Task 12 Step 5 (the inverse: killing recursion reddens the *fixture*) | pinned by test |
-| M7 | comment-stripping is load-bearing | Task 10 Step 1, `extractRelativeSpecifiers ignores a specifier inside a comment` | pinned by test |
+| M7 | comments/strings are not edges, and a keyword-preceded regex literal cannot swallow later imports | Task 10 Step 1 — three tests (comment, string literal, regex-literal) | pinned by test |
 | M8 | the ignored-vs-untracked *predicate* is load-bearing | Task 11 Step 4b | run it |
 | M9 | unresolvable specifiers fail closed | Task 12 Step 1, `walk reports an unresolvable specifier` | pinned by test |
 | M10 | `ci-scope.mjs` fails safe, not silent | Task 5 Steps 5 + 5b | run it |

--- a/docs/superpowers/plans/2026-08-05-verify-scope-map-unification.md
+++ b/docs/superpowers/plans/2026-08-05-verify-scope-map-unification.md
@@ -18,7 +18,7 @@ it sees transitive and runtime dependencies — closing #2119 and #2120.
 **Architecture:** Three sequential PRs. **A1** is purely additive (nothing
 about how scope is *computed* changes) and de-circularises A2. **A2** rewrites
 `verify.yml` to derive per-step scope from `STEPS[]` via a new
-`scripts/ci-scope.mjs`, guarded by four assertions over the parsed workflow.
+`scripts/ci-scope.mjs`, guarded by five assertions over the parsed workflow.
 **B** hardens `scripts/tests/verify-cache.test.mjs`'s completeness guard with
 AST-based extraction, a TS-aware resolver, a transitive walk stopped at
 gitignored paths, and splits `check-no-budget-poll` into its own step.
@@ -64,7 +64,7 @@ verbatim from the spec.
 |---|---|---|
 | `scripts/ci-scope.mjs` | A2 | **new** — derive per-step CI scope from `STEPS[]`; emit `scopes` JSON + `ok` sentinel |
 | `scripts/tests/ci-scope.test.mjs` | A2 | **new** — unit tests for the above (fail-safe, dispatch, shared) |
-| `scripts/tests/workflow-wiring.test.mjs` | A2 | **new** — the four assertions over parsed `verify.yml` |
+| `scripts/tests/workflow-wiring.test.mjs` | A2 | **new** — the five assertions over parsed `verify.yml` (four wiring + coverage parity) |
 | `scripts/lib/module-graph.mjs` | B | **new** — AST extract, resolve, `check-ignore` classify, transitive walk |
 | `scripts/tests/module-graph.test.mjs` | B | **new** — synthetic-fixture unit tests incl. M17 |
 | `.github/workflows/verify.yml` | A1, A2 | scope detection + per-step gating |
@@ -1133,7 +1133,7 @@ git commit -m "feat(ops): gate every verify leg on the derived scope map"
 
 ---
 
-### Task 8: The four wiring assertions
+### Task 8: The five wiring assertions
 
 **Files:**
 - Create: `scripts/tests/workflow-wiring.test.mjs`
@@ -1348,7 +1348,7 @@ const PROBE_CORPUS = [
 ];
 
 test('coverage parity: no derived condition silently narrows a leg', () => {
-  const accepted = new Set(ACCEPTED_NARROWINGS.map(([s, p]) => `${s} ${p}`));
+  const accepted = new Set(ACCEPTED_NARROWINGS.map(([s, p]) => `${s}\u0000${p}`));
   const regressions = [];
 
   for (const [stepName, legacyScopes] of Object.entries(LEGACY_GATES)) {
@@ -1365,7 +1365,7 @@ test('coverage parity: no derived condition silently narrows a leg', () => {
       const ranBefore = legacyScopes.some((s) => LEGACY_MATCHERS[s].test(path));
       const scopes = computeScopes([path], { eventName: 'pull_request' });
       const runsNow = derivedKeys.some((k) => scopes[k]);
-      if (ranBefore && !runsNow && !accepted.has(`${stepName} ${path}`)) {
+      if (ranBefore && !runsNow && !accepted.has(`${stepName}\u0000${path}`)) {
         regressions.push(`${stepName} no longer runs for ${path}`);
       }
     }

--- a/docs/superpowers/plans/2026-08-05-verify-scope-map-unification.md
+++ b/docs/superpowers/plans/2026-08-05-verify-scope-map-unification.md
@@ -361,7 +361,7 @@ Create `scripts/run-sidecar-tests.mjs`:
 import { existsSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { join, dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const SIDECAR_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'server', 'tts-sidecar');
 
@@ -409,7 +409,13 @@ export function main(argv = process.argv.slice(2), sidecarDir = SIDECAR_DIR) {
   return result.status ?? 1;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`.replace(/\\/g, '/')) {
+// Direct-execution guard. MUST use pathToFileURL: the naive
+// `file://${process.argv[1]}` form yields two slashes on Windows
+// (file://C:/...) where import.meta.url has three (file:///C:/...), so it is
+// ALWAYS false there — the script would silently do nothing and exit 0.
+// Every other script in scripts/ uses this form; see bump-version.mjs:654.
+const invokedHref = process.argv[1] ? pathToFileURL(process.argv[1]).href : '';
+if (invokedHref && import.meta.url === invokedHref) {
   process.exit(main());
 }
 ```
@@ -419,6 +425,19 @@ if (import.meta.url === `file://${process.argv[1]}`.replace(/\\/g, '/')) {
 Run: `node --test scripts/tests/run-sidecar-tests.test.mjs`
 Expected: PASS, 4/4.
 
+- [ ] **Step 4b: Prove the entry point actually EXECUTES**
+
+The unit tests import `resolveVenvPython` and would pass even if the script
+never ran anything. Verify the guard directly:
+
+```bash
+node scripts/run-sidecar-tests.mjs
+```
+
+Expected: either the pytest output or the SKIP banner — **never silence**.
+Silence means the direct-execution guard is false and the runner is
+vacuously green, which is precisely the defect this task exists to remove.
+
 - [ ] **Step 5: Rewire the npm script**
 
 In `package.json`, change `test:sidecar` from the `run-powershell.mjs` form
@@ -427,6 +446,31 @@ to:
 ```json
     "test:sidecar": "node scripts/run-sidecar-tests.mjs",
 ```
+
+- [ ] **Step 5b: Keep `test:sidecar`'s own cache inputs honest**
+
+`verify-cache.mjs`'s `test:sidecar` step declares
+`extraFiles: ['server/tts-sidecar/run-tests.ps1']`. After the rewire above,
+the runner that actually executes is `scripts/run-sidecar-tests.mjs` — so
+without this the step sits in the exact #1847 trap this whole plan is about:
+editing the runner would leave `test:sidecar` printing `[cached]`.
+
+```js
+      extraFiles: [
+        'server/tts-sidecar/run-tests.ps1',
+        // The npm script now invokes this instead; run-tests.ps1 is retained
+        // for direct local/PowerShell use, so BOTH are inputs.
+        'scripts/run-sidecar-tests.mjs',
+      ],
+```
+
+Verify:
+
+```bash
+node -e "import('./scripts/verify-cache.mjs').then(({STEPS,stepTouchedByDiff})=>{const s=STEPS.find(x=>x.name==='test:sidecar');console.log(stepTouchedByDiff(s,['scripts/run-sidecar-tests.mjs']));})"
+```
+
+Expected: `true`.
 
 - [ ] **Step 6: Verify local behaviour is unchanged**
 
@@ -686,6 +730,7 @@ Create `scripts/ci-scope.mjs`:
 // string, silently disabling a leg while both wiring directions still pass.
 // One json output makes that map a single static line.
 
+import { pathToFileURL } from 'node:url';
 import { STEPS, stepTouchedByDiff, computeShared } from './verify-cache.mjs';
 
 export function slugFor(stepName) {
@@ -751,15 +796,26 @@ export function main(argv = process.argv.slice(2), env = process.env) {
   return 0;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`.replace(/\\/g, '/')) {
+// See run-sidecar-tests.mjs — the naive `file://${process.argv[1]}` form is
+// ALWAYS false on Windows (two slashes vs three). Here the consequence is
+// worse than silence: the detect job would emit nothing, every `if:` would be
+// false, and only the `ok` sentinel (Task 9) would catch it — as a confusing
+// red rather than a clear one.
+const invokedHref = process.argv[1] ? pathToFileURL(process.argv[1]).href : '';
+if (invokedHref && import.meta.url === invokedHref) {
   process.exit(main());
 }
 ```
 
-- [ ] **Step 4: Run to verify pass**
+- [ ] **Step 4: Run to verify pass, and that it EXECUTES**
 
 Run: `node --test scripts/tests/ci-scope.test.mjs`
 Expected: PASS, all tests.
+
+Run: `node scripts/ci-scope.mjs --files=launch.mjs`
+Expected: two lines — `scopes={...}` and `ok=true`. **Silence means the
+direct-execution guard is broken**; the unit tests cannot catch that because
+they import `computeScopes` directly.
 
 - [ ] **Step 5: Prove the fail-safe (mutation M10)**
 
@@ -851,16 +907,45 @@ git commit -m "feat(ops): derive per-step CI scope from verify-cache STEPS"
       ok: ${{ steps.changes.outputs.ok }}
 ```
 
-- [ ] **Step 2: Replace the detection step body**
+- [ ] **Step 2: Replace the WHOLE detection step body**
 
-Replace the `match()` block (`:142-180`) — keep the `MERGE_BASE`/`FILES`
-lines above it (`:137-141`) untouched:
+Not just the `match()` block. `verify.yml:115-123` has a **separate
+`workflow_dispatch` early-exit** that emits the nine legacy scope names and
+`exit 0`s. Leaving it in place means a manual dispatch emits no `scopes` and
+no `ok` at all — so `fromJSON('')` raises in every `if:` **and** Task 9's
+sentinel fails, turning the documented clean-room full-battery run
+permanently red. `ci-scope.mjs` already handles dispatch (all-true), so the
+bash branch must go.
+
+But the `git merge-base` / `git diff` lines below it would then run on a
+dispatch with empty `BASE`/`HEAD` and fail under `set -e`. Guard them.
+Replace the entire `run:` body (`:113` through `:180`) with:
 
 ```yaml
+        run: |
+          # A manual dispatch has no PR base/head to diff against. Leave FILES
+          # empty and let ci-scope.mjs branch on GITHUB_EVENT_NAME — it emits
+          # all-true for a dispatch, matching the old bash early-exit.
+          FILES=""
+          if [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+            # Merge-base, not BASE itself: a PR branch created from a stale
+            # main would otherwise treat every file main moved past the fork
+            # point as "changed in this PR".
+            MERGE_BASE="$(git merge-base "$BASE" "$HEAD" 2>/dev/null || echo "$BASE")"
+            FILES="$(git diff --name-only "$MERGE_BASE" "$HEAD")"
+          fi
+          echo "Changed files in this PR:"
+          echo "$FILES"
+          echo "---"
           node scripts/ci-scope.mjs --files="$FILES" >> "$GITHUB_OUTPUT"
           echo "--- derived scope ---"
           node scripts/ci-scope.mjs --files="$FILES"
 ```
+
+`GITHUB_EVENT_NAME` is set by the runner automatically, so `ci-scope.mjs`
+reads it without it being passed explicitly.
 
 - [ ] **Step 3: Ensure Node is available in detect**
 
@@ -917,11 +1002,44 @@ apply the same shape to every `if:`:
 
       # Server tests — test:server AND test:server-slow share this one step,
       # so the condition is the union of both steps' keys.
+      # leg: test:server
       - name: Server tests (fast + slow)
         if: fromJSON(needs.detect.outputs.scopes).step_test_server || fromJSON(needs.detect.outputs.scopes).step_test_server_slow || fromJSON(needs.detect.outputs.scopes).shared
 ```
 
+**Every leg step gets a `# leg: <step-name>` marker** immediately above its
+`- name:`. Task 8's setup-binding assertion identifies legs by that marker,
+not by searching for the first `if:` mentioning a key — setup steps precede
+their leg in file order, and slugs nest (`step_test` is a substring of
+`step_test_hooks`), so both heuristics bind the wrong step.
+
 **Do not hoist any of these to job level** (Global Constraints).
+
+- [ ] **Step 1b: Decide the `frontend-tests` condition explicitly**
+
+This one is not mechanical and the spec flags it as an N:M irregularity
+without resolving it. The step runs `vitest --changed` **plus**
+`npm run test:a11y` — so it is not `npm run test`, and `test:a11y` has no
+STEP of its own. Its current condition is
+`frontend || e2e || shared || openapi`.
+
+Measured: `stepTouchedByDiff(STEPS['test'], ['e2e/foo.spec.ts'])` is
+**false**, so a naive `step_test || shared` would stop running the frontend
+unit suite and a11y on an e2e-spec-only PR — a silent narrowing of what runs
+today. `openapi.yaml` needs no special handling: it is already in `test`'s
+`extraFiles`, so `step_test` covers it.
+
+Preserve today's behaviour explicitly rather than narrowing by accident:
+
+```yaml
+      # leg: test
+      # test:e2e is a deliberate extra trigger: this step also runs
+      # `npm run test:a11y`, which has no STEP of its own, and an e2e-only
+      # diff should still exercise the a11y battery. Dropping it would be a
+      # silent narrowing of what runs today.
+      - name: Frontend tests + a11y
+        if: fromJSON(needs.detect.outputs.scopes).step_test || fromJSON(needs.detect.outputs.scopes).step_test_e2e || fromJSON(needs.detect.outputs.scopes).shared
+```
 
 - [ ] **Step 2: Bind each setup step to the leg it supports**
 
@@ -997,10 +1115,16 @@ const referenced = [...source.matchAll(/fromJSON\(needs\.detect\.outputs\.scopes
   .map((m) => m[1]);
 
 test('anti-vacuity: the workflow scan finds references', () => {
-  // Measured at authoring time: ~20 if: sites, most with two disjuncts.
+  // UNITS: this counts REFERENCES, not `if:` sites. Measured on the
+  // pre-derivation workflow: 17 `if:` lines but 55 scope references, and A1's
+  // sidecar job adds ~6 more. An earlier draft of this plan set the floor to
+  // 20 while reasoning about "~20 if: sites" — the exact unit conflation the
+  // spec's Measurements section warns about, and the same mistake that left
+  // the old guard's floor at 30 against a real 60. Floor 50 gives ~18%
+  // headroom against ~61.
   assert.ok(
-    referenced.length >= 20,
-    `expected >= 20 fromJSON references, found ${referenced.length} — either the regex broke or the workflow changed shape`,
+    referenced.length >= 50,
+    `expected >= 50 fromJSON references, found ${referenced.length} — either the regex broke or the workflow lost wiring`,
   );
 });
 
@@ -1043,30 +1167,49 @@ test('^ every job with a derived condition is in the aggregator needs:', () => {
 // Setup steps (ffmpeg, Playwright cache/install) are not legs. Each declares
 // the leg it supports; its condition must be identical to that leg's, or e2e
 // runs without a browser.
-test('setup steps carry the same condition as the leg they support', () => {
-  const stepBlocks = [...source.matchAll(
+// The set of scope keys a condition depends on, order-independent. Compared
+// instead of the raw string because a setup step legitimately carries extra
+// NON-scope conjuncts: verify.yml's two "Install Playwright chromium" steps
+// are `(...scopes...) && steps.playwright-cache.outputs.cache-hit != 'true'`,
+// which can never be string-identical to the leg's condition. An earlier
+// draft compared whole strings and would have instructed the implementer to
+// delete a correct cache guard.
+const scopeKeysOf = (condition) =>
+  [...condition.matchAll(/fromJSON\(needs\.detect\.outputs\.scopes\)\.([A-Za-z0-9_]+)/g)]
+    .map((m) => m[1])
+    .sort()
+    .join('|');
+
+test('setup steps depend on the same scope keys as the leg they support', () => {
+  // Legs are tagged explicitly rather than found by "first step whose if:
+  // mentions this key". That heuristic is wrong twice over: setup steps
+  // PRECEDE their leg in every job (Install ffmpeg :345 before E2E :363), so
+  // first-match returns another setup step; and slugs nest
+  // (step_test is a substring of step_test_hooks / step_test_e2e;
+  // step_test_server of step_test_server_slow), so a substring match binds
+  // the wrong leg entirely.
+  const legs = new Map(
+    [...source.matchAll(/# leg: ([a-z:0-9-]+)\n\s*- name: [^\n]+\n\s*if: ([^\n]+)\n/g)]
+      .map(([, leg, condition]) => [leg, condition.trim()]),
+  );
+  const setups = [...source.matchAll(
     /# supports: ([a-z:0-9-]+)\n\s*- name: ([^\n]+)\n\s*if: ([^\n]+)\n/g,
   )];
-  assert.ok(stepBlocks.length >= 7, `expected >= 7 '# supports:' declarations, found ${stepBlocks.length}`);
 
-  // Build leg name -> its own if: condition.
-  const legConditions = new Map();
-  for (const step of STEPS) {
-    const key = slugFor(step.name);
-    const re = new RegExp(`- name: [^\\n]+\\n\\s*if: ([^\\n]*${key}[^\\n]*)\\n`);
-    const m = source.match(re);
-    if (m) legConditions.set(step.name, m[1].trim());
-  }
+  assert.ok(setups.length >= 7, `expected >= 7 '# supports:' declarations, found ${setups.length}`);
+  assert.ok(legs.size >= 7, `expected >= 7 '# leg:' declarations, found ${legs.size}`);
 
   const mismatched = [];
-  for (const [, leg, stepName, condition] of stepBlocks) {
-    const expected = legConditions.get(leg);
-    if (!expected) { mismatched.push(`${stepName}: unknown leg '${leg}'`); continue; }
-    if (condition.trim() !== expected) {
-      mismatched.push(`${stepName}\n  supports ${leg}\n  has:      ${condition.trim()}\n  expected: ${expected}`);
+  for (const [, leg, stepName, condition] of setups) {
+    const expected = legs.get(leg);
+    if (!expected) { mismatched.push(`${stepName}: no '# leg: ${leg}' declaration found`); continue; }
+    if (scopeKeysOf(condition) !== scopeKeysOf(expected)) {
+      mismatched.push(
+        `${stepName}\n  supports: ${leg}\n  has keys:      ${scopeKeysOf(condition) || '(none)'}\n  leg has keys:  ${scopeKeysOf(expected) || '(none)'}`,
+      );
     }
   }
-  assert.deepEqual(mismatched, [], `setup step condition(s) diverged from their leg:\n${mismatched.join('\n')}`);
+  assert.deepEqual(mismatched, [], `setup step(s) diverged from their leg:\n${mismatched.join('\n')}`);
 });
 ```
 
@@ -1226,10 +1369,28 @@ Create `scripts/tests/module-graph.test.mjs`:
 ```js
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+// `resolve` and `relative` are needed by the whole-repo desync test below AND
+// by Task 11's out-of-repo case — imported here once for the whole file.
+import { join, resolve, relative, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { stripComments, extractRelativeSpecifiers, resolveSpecifier } from '../lib/module-graph.mjs';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+// Minimal recursive walker: fast-glob is a dependency of the runner, not of
+// this test — node:test files here stay dependency-free.
+function walkDir(dir, exts, acc = []) {
+  if (!existsSync(dir)) return acc;
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === '.git') continue;
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) walkDir(p, exts, acc);
+    else if (exts.some((x) => p.endsWith(x))) acc.push(p);
+  }
+  return acc;
+}
 
 test('stripComments removes line comments', () => {
   assert.equal(stripComments("const a = 1; // require('../x.js')\n").includes('../x.js'), false);
@@ -1244,6 +1405,51 @@ test('stripComments preserves // inside string literals', () => {
   const out = stripComments(`const url = "https://example.com/x"; // gone\n`);
   assert.ok(out.includes('https://example.com/x'), 'URL must survive');
   assert.ok(!out.includes('gone'), 'trailing comment must be removed');
+});
+
+// --- regex literals: the failure mode that makes this a FAIL-OPEN ---------
+// A regex with an odd number of quotes sends a naive scanner into a phantom
+// string state it never leaves, so the REST OF THE FILE goes unscanned and
+// any import in that tail is invisible to the completeness guard. Measured
+// against an earlier draft: 3 real files desynced, including
+// release-notes-gate.mjs, itself a declared test:hooks input.
+test('stripComments survives a regex literal containing quotes', () => {
+  const src = `const r = /media-type="[^"]+"/;\nimport x from './real.mjs';\n`;
+  assert.ok(
+    stripComments(src).includes('./real.mjs'),
+    'an import after a quote-bearing regex must survive',
+  );
+});
+
+test('stripComments survives a regex literal ending in an escaped slash', () => {
+  const src = `if (/^refs\\/heads\\//.test(p)) {}\nconst y = require('./real.js');\n`;
+  assert.ok(stripComments(src).includes('./real.js'));
+});
+
+// The other direction: division must NOT be mistaken for a regex, or
+// everything up to the next / is eaten.
+test('stripComments treats / as division after a value', () => {
+  const src = `const a = (x + 1) / 2; const b = 3 / 4;\nimport z from './real.mjs';\n`;
+  assert.ok(stripComments(src).includes('./real.mjs'));
+});
+
+// The real guard: whole-repo desync detection. The targeted cases above only
+// catch shapes someone thought of; this catches the class. Verified at
+// authoring time — 166 files, 0 desyncs.
+test('stripComments does not desync on any real script in the repo', () => {
+  const roots = [
+    ...walkDir(resolve(repoRoot, 'scripts'), ['.mjs', '.cjs']),
+    ...walkDir(resolve(repoRoot, 'pinokio-scripts'), ['.js']),
+  ];
+  assert.ok(roots.length >= 100, `expected >= 100 scripts to scan, found ${roots.length}`);
+
+  const desynced = [];
+  for (const file of roots) {
+    stripComments(readFileSync(file, 'utf8'), {
+      onDesync: (state) => desynced.push(`${relative(repoRoot, file)} -> ended in '${state}'`),
+    });
+  }
+  assert.deepEqual(desynced, [], `stripComments desynced on:\n${desynced.join('\n')}`);
 });
 
 // This is why stripping is load-bearing rather than cosmetic:
@@ -1323,9 +1529,27 @@ import { resolve, dirname } from 'node:path';
 // contains a literal require('../../pinokio.js') that resolves outside the
 // repo. Under fail-closed resolution that would be a false failure — and it
 // is exactly the git check-ignore exit-128 case.
-export function stripComments(source) {
+// Regex literals MUST be consumed atomically. Two ways they break a naive
+// scanner, both live in this repo:
+//   * /media-type="[^"]+"/ has an ODD number of quotes, so the scanner enters
+//     a phantom string state and never leaves — the rest of the file is
+//     silently unscanned (a fail-OPEN: imports in that tail become invisible).
+//     Real: scripts/lib/slim-epub-cover.mjs, wt-merge.mjs, release-notes-gate.mjs
+//     (the last is itself a declared test:hooks input).
+//   * /^refs\/heads\// ends in an escaped slash, so `//` reads as a comment
+//     start and truncates the line. Real: code-stats.mjs, wt-list.mjs.
+// A `/` starts a regex (rather than being division) when the previous
+// significant character is one that cannot end an expression.
+const REGEX_PRECEDERS = new Set(['(', ',', '=', ':', '[', '!', '&', '|', '?', '{', '}', ';', '\n', '+', '-', '*', '%', '<', '>', '~', '^', undefined]);
+
+// `onDesync` is how the whole-repo test detects the failure above. It cannot
+// be detected from the OUTPUT — a desynced scan still emits the text, and
+// re-running it desyncs identically, so the result is stable and looks fine.
+// Only the terminal state reveals it.
+export function stripComments(source, { onDesync } = {}) {
   let out = '';
   let i = 0;
+  let prev; // last significant code char
   let state = 'code'; // code | line | block | single | double | template
   while (i < source.length) {
     const c = source[i];
@@ -1333,9 +1557,28 @@ export function stripComments(source) {
     if (state === 'code') {
       if (c === '/' && next === '/') { state = 'line'; i += 2; continue; }
       if (c === '/' && next === '*') { state = 'block'; i += 2; continue; }
+      if (c === '/' && REGEX_PRECEDERS.has(prev)) {
+        // Consume the whole literal, honouring escapes and [...] classes,
+        // where an unescaped '/' does NOT terminate.
+        out += c; i += 1;
+        let inClass = false;
+        while (i < source.length) {
+          const r = source[i];
+          if (r === '\\') { out += r + (source[i + 1] ?? ''); i += 2; continue; }
+          if (r === '[') inClass = true;
+          else if (r === ']') inClass = false;
+          else if (r === '/' && !inClass) { out += r; i += 1; break; }
+          else if (r === '\n') break; // unterminated — bail rather than run away
+          out += r; i += 1;
+        }
+        prev = '/';
+        continue;
+      }
       if (c === "'") state = 'single';
       else if (c === '"') state = 'double';
       else if (c === '`') state = 'template';
+      if (!/\s/.test(c)) prev = c;
+      else if (c === '\n') prev = '\n';
       out += c; i += 1; continue;
     }
     if (state === 'line') {
@@ -1354,6 +1597,10 @@ export function stripComments(source) {
     }
     out += c; i += 1;
   }
+  // A scan that ends anywhere but `code` ran off the rails — most often on a
+  // regex literal with an odd quote count, after which the remainder of the
+  // file was treated as string content and never scanned for imports.
+  if (state !== 'code' && onDesync) onDesync(state);
   return out;
 }
 
@@ -1483,6 +1730,17 @@ const toPosix = (p) => p.split(sep).join('/');
 
 // Classify a batch of candidate paths as gitignored or not.
 //
+// NOTE: check-ignore is INDEX-AWARE, not pure .gitignore pattern matching.
+// Measured: a file matching an ignore rule but force-added to the index
+// reports exit 1 (NOT ignored); with --no-index it reports 0. This is
+// deliberate and must NOT be "fixed" by adding --no-index: a tracked file is
+// a real producer and belongs in the closure regardless of what .gitignore
+// says about its directory. The server/dist/** conclusion is unaffected —
+// those files are never tracked, so they classify as ignored in both a fresh
+// clone and a built tree, which is the clone-state independence this rule
+// needs. What is NOT true is the simpler story that this is a property of
+// .gitignore alone.
+//
 // BATCHED via --stdin, not one spawn per path: measured 81 individual spawns
 // = 3972 ms vs one batch = 60 ms (66x). test:hooks runs in pre-commit via
 // verify:fast:scoped, a path documented as sub-5s — per-query spawning would
@@ -1515,8 +1773,13 @@ export function classifyIgnored(absPaths, cwd) {
     throw new Error(`check-ignore: failed to spawn git (${proc.error.message}) — refusing to guess`);
   }
   if (proc.status !== 0 && proc.status !== 1) {
+    // Name the paths: check-ignore batches, and on 128 it prints nothing about
+    // the good ones — so without this the error identifies neither the
+    // offending specifier nor the file that imported it. Fail-closed but
+    // undiagnosable is only half a guard.
     throw new Error(
-      `check-ignore: git exited ${proc.status} — refusing to guess.\n${proc.stderr ?? ''}`,
+      `check-ignore: git exited ${proc.status} — refusing to guess.\n` +
+      `${proc.stderr ?? ''}\nPaths in this batch:\n${posix.join('\n')}`,
     );
   }
 
@@ -1533,25 +1796,10 @@ export function classifyIgnored(absPaths, cwd) {
 Run: `node --test scripts/tests/module-graph.test.mjs`
 Expected: PASS.
 
-- [ ] **Step 4b: Run mutation M8 — the predicate itself**
-
-Temporarily reimplement `classifyIgnored` using `git ls-files` ("untracked")
-instead of `git check-ignore` ("ignored"), then simulate a fresh clone by
-renaming `server/dist` aside:
-
-```bash
-mv server/dist server/dist.bak
-node --test scripts/tests/verify-cache.test.mjs   # after Task 13 lands
-mv server/dist.bak server/dist
-```
-
-Expected under the "untracked" predicate: **7 unresolvable specifiers** from
-`scripts/repair-cast-id-drift.mjs`'s `../server/dist/**` imports — i.e. red
-on a fresh clone, green on this box. Under `check-ignore`: identical result
-either way. Revert the reimplementation.
-
-This is the mutation that proves the *predicate choice* is load-bearing, not
-merely the batching or the exit-code handling.
+> **M8 is NOT run here.** At this point the completeness guard still uses the
+> old inline extractor and never calls `classifyIgnored`, so swapping the
+> predicate would change nothing and prove nothing. M8 moves to **Task 13
+> Step 4b**, after the guard actually consumes the walk.
 
 - [ ] **Step 5: Verify the cost claim holds**
 
@@ -1840,6 +2088,31 @@ In `scripts/verify-cache.mjs`, `test:hooks` `extraFiles`:
 Run: `node --test scripts/tests/verify-cache.test.mjs`
 Expected: PASS.
 
+- [ ] **Step 4b: Run mutation M8 — the predicate itself**
+
+Only meaningful here, now that the guard actually consumes `classifyIgnored`.
+
+Temporarily reimplement `classifyIgnored` using `git ls-files` ("untracked")
+instead of `git check-ignore` ("ignored"), then simulate a fresh clone:
+
+```powershell
+Rename-Item server/dist server/dist.bak
+node --test scripts/tests/verify-cache.test.mjs
+Rename-Item server/dist.bak server/dist
+```
+
+(Windows: this moves ~1,812 files and fails if a server process holds any of
+them — stop `npm start` first. On POSIX, `mv server/dist server/dist.bak`.)
+
+Expected under "untracked": **7 unresolvable specifiers** from
+`scripts/repair-cast-id-drift.mjs:1203-1209`'s `../server/dist/**` imports —
+red on a fresh clone, green on this box. Under `check-ignore`: identical
+either way. Revert the reimplementation.
+
+This is the mutation proving the *predicate choice* is load-bearing, as
+distinct from the batching (Task 11 Step 5) and the exit-code contract
+(Task 11 Step 1).
+
 - [ ] **Step 5: Run mutation M5**
 
 Remove `'pinokio-scripts/lib/menu.js'` from `extraFiles`.
@@ -1948,20 +2221,32 @@ if ((result.status ?? 1) !== 0) process.exit(result.status ?? 1);
 process.exit(0);
 ```
 
-- [ ] **Step 6: Run to verify pass**
+- [ ] **Step 6: Wire it into CI — BEFORE running the suite**
 
-Run: `node --test scripts/tests/verify-cache.test.mjs && npm run test:hooks && npm run check:budget-poll`
-Expected: all pass.
-
-- [ ] **Step 7: Wire it into CI**
+Order matters here. `npm run test:hooks` globs `scripts/tests/*.test.mjs`,
+which now includes `workflow-wiring.test.mjs`, whose **←** assertion reports
+any emitted key no workflow condition references. Between Step 3 (adds the
+STEP) and this step, `step_check_budget_poll` is exactly that — so running
+the suite first fails for a reason unrelated to what is being built, and the
+implementer would waste a cycle chasing it.
 
 In `.github/workflows/verify.yml`, in `lint-and-checks`, after "Hooks tests":
 
 ```yaml
+      # leg: check:budget-poll
       - name: Budgeted-poll guardrail
         if: fromJSON(needs.detect.outputs.scopes).step_check_budget_poll || fromJSON(needs.detect.outputs.scopes).shared
         run: npm run check:budget-poll
 ```
+
+`lint-and-checks` is already in the aggregator's `needs:`, so the ↑ assertion
+is satisfied without further change — this is a step in an existing job, not
+a new job.
+
+- [ ] **Step 7: Run to verify pass**
+
+Run: `node --test scripts/tests/verify-cache.test.mjs && npm run test:hooks && npm run check:budget-poll`
+Expected: all pass.
 
 - [ ] **Step 8: Confirm A2's assertions still pass**
 
@@ -2092,7 +2377,7 @@ regresses.
 | M9 | unresolvable specifiers fail closed | Task 12 Step 1, `walk reports an unresolvable specifier` | pinned by test |
 | M10 | `ci-scope.mjs` fails safe, not silent | Task 5 Steps 5 + 5b | run it |
 | M11 | Metric B floor catches a dead regex | Task 13 Step 6 | run it |
-| M12 | the `ok` sentinel rejects an empty value | Task 9 Step 3 | run it |
+| M12 | the `ok` sentinel rejects an empty value | Task 9 Step 3 | **partial — see below** |
 | M13 | the sidecar leg reddens the **pinned context** | Task 4 Step 6 | run it (on the PR) |
 | M14 | a workflow-only edit runs the assertions | Task 1 Steps 1–2 + Task 8 Step 5 | pinned by test |
 | M15 | a job outside `needs:` is caught | Task 8 Step 3 | run it |
@@ -2101,11 +2386,27 @@ regresses.
 | M18 | `check-ignore` exit 128 fails closed | Task 11 Step 1, `throws on a path outside the repository` | pinned by test |
 
 **M6 deserves a note.** It is the one "mutation" that is really a *measured
-claim*: against the real repo a depth-1 walk yields closure 56, clears the
-floor of 50, and reports `missing = []` — **green**. That is why M17's
+claim*: against the real repo a depth-1 walk yields closure **57**, clears
+the floor of 50, and reports `missing = []` — **green**. That is why M17's
 synthetic fixture exists at all. Do not try to make M6 red against the real
 tree; if it ever does go red there, the two declarations from Task 13 have
 been lost and M5 will say so.
+
+**M12 is only partially dischargeable before merge, and the ledger says so
+rather than overclaiming.** Task 9 Step 3 proves the *bash comparison* —
+that an empty `ok` fails the step. It does **not** prove that a silently-empty
+producer is caught end-to-end, because that requires a real workflow run with
+a broken `detect`. Options, in order of preference:
+
+1. On A2's PR, push one scratch commit that drops the `>> "$GITHUB_OUTPUT"`
+   redirect, confirm `npm run verify` goes red with the sentinel's message,
+   then revert it in the same PR.
+2. If that is not acceptable on the required check, mark M12 **unproven at
+   merge** in the PR body and discharge it on the first workflow-only PR
+   after A2 lands.
+
+Do not silently treat Step 3 as full discharge — that is the "test that
+cannot fail" shape this plan exists to prevent.
 
 ## Post-merge
 

--- a/docs/superpowers/plans/2026-08-05-verify-scope-map-unification.md
+++ b/docs/superpowers/plans/2026-08-05-verify-scope-map-unification.md
@@ -1,0 +1,2120 @@
+---
+status: draft
+date: 2026-08-05
+---
+
+# Verify Scope-Map Unification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `scripts/verify-cache.mjs`'s `STEPS[]` the single source of
+truth for "which files does this verify step depend on", derive
+`.github/workflows/verify.yml` from it, and harden the completeness guard so
+it sees transitive and runtime dependencies — closing #2119 and #2120.
+
+**Architecture:** Three sequential PRs. **A1** is purely additive (nothing
+about how scope is *computed* changes) and de-circularises A2. **A2** rewrites
+`verify.yml` to derive per-step scope from `STEPS[]` via a new
+`scripts/ci-scope.mjs`, guarded by four assertions over the parsed workflow.
+**B** hardens `scripts/tests/verify-cache.test.mjs`'s completeness guard with
+comment-stripping, a TS-aware resolver, a transitive walk stopped at
+gitignored paths, and splits `check-no-budget-poll` into its own step.
+
+**Tech Stack:** Node 20 ESM (`.mjs`), `node:test` + `node:assert/strict`,
+GitHub Actions expressions (`fromJSON`), `git check-ignore --stdin`, pytest
+(sidecar), PowerShell (existing sidecar runner).
+
+**Design of record:**
+[`docs/superpowers/specs/2026-08-05-verify-scope-map-unification-design.md`](../specs/2026-08-05-verify-scope-map-unification-design.md)
+
+## Global Constraints
+
+Every task's requirements implicitly include this section. Values are copied
+verbatim from the spec.
+
+- **The aggregator job's `name:` is `npm run verify` and MUST NOT CHANGE.**
+  `main`'s ruleset 17654264 pins `required_status_checks` to the contexts
+  `'npm run verify'` and `'Verify PR body links a GitHub issue'`. Renaming it
+  detaches the gate and every subsequent PR merges with no check at all.
+- **Conditions stay at STEP level, never hoisted to JOB level.** Hoisting
+  makes scoped-down PRs skip jobs, and the aggregator fails on `'skipped'`
+  (`verify.yml:445`) — turning the required check red on every PR.
+- **Every job carrying a derived `if:` MUST appear in the aggregator's
+  `needs:`.** A job outside that list can run, fail, and not block merge.
+- **`shared` stays a disjunct in every derived condition.** Measured: a root
+  `package-lock.json` diff touches **zero** steps via `stepTouchedByDiff`;
+  `computeShared` is a separate global override.
+- **Guards fail CLOSED.** Absent, unparseable, or error-state evidence must
+  report, never be treated as clean. `git check-ignore` exit `128` and
+  git-unavailable both fail closed.
+- **Paths are POSIX-normalised** via `_internals.toPosix` before any
+  `git check-ignore` query or glob comparison.
+- **Every new guard ships with a named mutation that makes it go red.** A
+  guard that cannot be shown failing is not a guard.
+- Commit convention: `<type>(<scope>): <subject>`. Scope for this work is
+  `ops` or `scripts`. Branch shape `<type>/<scope>-<slug>`.
+- Every PR body links its issue (`Closes #NN` / `Refs #NN`).
+
+## File Structure
+
+| File | Phase | Responsibility |
+|---|---|---|
+| `scripts/ci-scope.mjs` | A2 | **new** — derive per-step CI scope from `STEPS[]`; emit `scopes` JSON + `ok` sentinel |
+| `scripts/tests/ci-scope.test.mjs` | A2 | **new** — unit tests for the above (fail-safe, dispatch, shared) |
+| `scripts/tests/workflow-wiring.test.mjs` | A2 | **new** — the four assertions over parsed `verify.yml` |
+| `scripts/lib/module-graph.mjs` | B | **new** — comment-strip, resolve, `check-ignore` classify, transitive walk |
+| `scripts/tests/module-graph.test.mjs` | B | **new** — synthetic-fixture unit tests incl. M17 |
+| `.github/workflows/verify.yml` | A1, A2 | scope detection + per-step gating |
+| `scripts/verify-cache.mjs` | A1, A2, B | `STEPS[]` — the single source of truth |
+| `scripts/tests/verify-cache.test.mjs` | A1, B | completeness guard + step-scope tests |
+| `scripts/run-hooks-tests.mjs` | B | drops the `check-no-budget-poll` spawn |
+| `scripts/run-sidecar-tests.mjs` | A1 | **new** — cross-platform pytest entry point |
+| `server/tts-sidecar/tests/test_xtts_audio_io.py` | A1 | `importorskip("torch")` |
+| `server/tts-sidecar/tests/test_speechbrain_disarm.py` | A1 | `importorskip("speechbrain")` |
+| `package.json` | A1, B | `test:sidecar` rewire; `check:budget-poll` script |
+
+---
+
+# PHASE A1 — additive (Refs #2119)
+
+Branch: `fix/ops-verify-scope-github-and-sidecar`
+
+Nothing here changes how scope is computed. Both parts are pure additions to
+*what runs*, so each is independently revertable.
+
+---
+
+### Task 1: `.github/**` becomes a real input (defect D)
+
+Today, simulating all nine `verify.yml` matchers against the literal path
+`.github/workflows/verify.yml` yields **zero** matches, and `.github` appears
+in no STEP's inputs. A workflow-only PR runs no leg, in cloud or locally.
+
+**Files:**
+- Modify: `scripts/verify-cache.mjs` (`test:hooks` step, `extraFiles`)
+- Modify: `.github/workflows/verify.yml:164` (the `hooks` matcher)
+- Test: `scripts/tests/verify-cache.test.mjs`
+
+**Interfaces:**
+- Consumes: `stepTouchedByDiff(step, diffFiles)`, `stepByName` — existing.
+- Produces: nothing new; widens an existing step's declared inputs.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `scripts/tests/verify-cache.test.mjs`, next to the other
+`stepTouchedByDiff` cases (near `:463`):
+
+```js
+// Defect D (#2119 review): verify.yml matched NO scope, so a workflow-only
+// PR ran zero legs — in cloud AND locally. The wiring assertions added in
+// A2 read verify.yml as evidence, so the step that runs them must be in
+// scope when verify.yml changes, or the guard cannot run on the PR that
+// breaks it.
+test('stepTouchedByDiff: a verify.yml diff matches test:hooks via extraFiles', () => {
+  assert.equal(
+    stepTouchedByDiff(stepByName['test:hooks'], ['.github/workflows/verify.yml']),
+    true,
+  );
+});
+
+test('stepTouchedByDiff: any workflow diff matches test:hooks', () => {
+  assert.equal(
+    stepTouchedByDiff(stepByName['test:hooks'], ['.github/workflows/cross-os.yml']),
+    true,
+  );
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `node --test scripts/tests/verify-cache.test.mjs`
+Expected: FAIL — both new tests, `expected true, got false`.
+
+- [ ] **Step 3: Add the glob to the cache step**
+
+In `scripts/verify-cache.mjs`, the `test:hooks` entry, extend `globs`
+(currently `['scripts/**/*.{mjs,cjs}', 'scripts/tests/fixtures/**']`):
+
+```js
+      globs: [
+        'scripts/**/*.{mjs,cjs}',
+        'scripts/tests/fixtures/**',
+        /* .github/workflows/** is an input because workflow-wiring.test.mjs
+           parses verify.yml at RUNTIME and asserts its `if:` conditions agree
+           with ci-scope.mjs's emitted keys. Without this, a workflow-only diff
+           — precisely the edit that breaks the wiring — prints [cached] and
+           the assertion sits stale-green. Same #1847 trap as fixtures/**
+           above (defect D, #2119 review). */
+        '.github/workflows/**',
+      ],
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `node --test scripts/tests/verify-cache.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 5: Close the same hole in cloud**
+
+In `.github/workflows/verify.yml`, extend the `hooks` matcher at `:164`. Add
+`\.github/workflows/` as an alternative inside the existing group:
+
+```bash
+          match '^(\.husky/|\.github/workflows/|scripts/run-hooks-tests\.mjs$|scripts/validate-commit-msg\.mjs$|RELEASE_NOTES\.md$|docs/release-notes-next\.md$|scripts/release-notes-gate\.mjs$|docs/testing/onbox-acceptance-register\.md$|docs/testing/onbox-acceptance-register-live-view\.html$)' && hooks=true
+```
+
+- [ ] **Step 6: Verify the cloud matcher by simulation**
+
+Run:
+
+```bash
+echo ".github/workflows/verify.yml" | grep -qE '^(\.husky/|\.github/workflows/|scripts/run-hooks-tests\.mjs$)' && echo "hooks=true"
+```
+
+Expected: prints `hooks=true`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/verify-cache.mjs scripts/tests/verify-cache.test.mjs .github/workflows/verify.yml
+git commit -m "fix(ops): make .github/workflows an input to test:hooks (defect D)"
+```
+
+---
+
+### Task 2: Make the sidecar suite collect without torch
+
+Enumerating every module-scope non-stdlib import across all collected
+`test_*.py` files yields exactly two absent from
+`requirements/base.txt + requirements-dev.txt`: `torch` and `speechbrain`.
+Both files already use `pytest.importorskip` elsewhere.
+
+**Files:**
+- Modify: `server/tts-sidecar/tests/test_xtts_audio_io.py:15`
+- Modify: `server/tts-sidecar/tests/test_speechbrain_disarm.py:37`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a suite that collects under a lean venv — Task 4 depends on this.
+
+- [ ] **Step 1: Build the lean venv that CI will use**
+
+This is the evidence gate. Static import inspection is what missed
+`speechbrain`; it does not get a second chance to be the proof.
+
+```bash
+cd server/tts-sidecar
+python -m venv .venv-lean
+./.venv-lean/bin/python -m pip install -q -r requirements/base.txt -r requirements-dev.txt
+```
+
+On Windows use `./.venv-lean/Scripts/python.exe` throughout this task.
+
+- [ ] **Step 2: Run collection to verify it FAILS**
+
+Run: `./.venv-lean/bin/python -m pytest --collect-only -q 2>&1 | tail -20`
+Expected: collection errors naming `test_xtts_audio_io.py` (`No module named
+'torch'`) and `test_speechbrain_disarm.py` (`No module named 'speechbrain'`).
+Exit code 2.
+
+Record the exact error text — it is the "fails before" evidence.
+
+- [ ] **Step 3: Convert both to importorskip**
+
+`server/tts-sidecar/tests/test_xtts_audio_io.py`, replacing line 15's
+`import torch`:
+
+```python
+# torch is an optional heavy dep: it lives in the vendor overlay, not in
+# requirements/base.txt, so the lean CI venv does not have it. Matches this
+# file's own pattern for torchaudio/TTS at the test level (see below).
+torch = pytest.importorskip("torch")
+```
+
+`server/tts-sidecar/tests/test_speechbrain_disarm.py`, replacing line 37's
+`from speechbrain.utils.importutils import LazyModule`:
+
+```python
+# speechbrain lives in requirements/speaker-qa.txt (NOT base.txt) because it
+# pulls torch, so the lean CI venv does not have it. Same treatment as
+# test_speaker_embed.py:21.
+_sb_importutils = pytest.importorskip("speechbrain.utils.importutils")
+LazyModule = _sb_importutils.LazyModule
+```
+
+Ensure `import pytest` precedes both (it does in each file; verify).
+
+- [ ] **Step 4: Run collection to verify it PASSES**
+
+Run: `./.venv-lean/bin/python -m pytest --collect-only -q 2>&1 | tail -5`
+Expected: exit 0, a collected-tests count, **no errors**.
+
+- [ ] **Step 5: Run the suite under the lean venv**
+
+Run: `./.venv-lean/bin/python -m pytest -q 2>&1 | tail -15`
+Expected: exit 0. Tests needing torch/speechbrain report as **skipped**, not
+failed. Record the skip count.
+
+- [ ] **Step 6: Confirm nothing regressed on the full venv**
+
+If a bootstrapped `.venv` exists on this box:
+
+Run: `./.venv/bin/python -m pytest -q server/tts-sidecar/tests/test_xtts_audio_io.py server/tts-sidecar/tests/test_speechbrain_disarm.py`
+Expected: same pass/fail as before the change — `importorskip` is a no-op
+when the module is present.
+
+- [ ] **Step 7: Clean up and commit**
+
+```bash
+rm -rf server/tts-sidecar/.venv-lean
+git add server/tts-sidecar/tests/test_xtts_audio_io.py server/tts-sidecar/tests/test_speechbrain_disarm.py
+git commit -m "test(sidecar): importorskip torch and speechbrain so the suite collects lean"
+```
+
+---
+
+### Task 3: Cross-platform sidecar test entry point
+
+`npm run test:sidecar` currently shells to `run-tests.ps1`, which hardcodes
+`.venv\Scripts\python.exe` — a layout that can never exist on
+`ubuntu-latest`, so the runner would SKIP and exit 0 forever.
+
+**Files:**
+- Create: `scripts/run-sidecar-tests.mjs`
+- Create: `scripts/tests/run-sidecar-tests.test.mjs`
+- Modify: `package.json` (`test:sidecar`)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `resolveVenvPython(sidecarDir, platform)` → absolute path string
+  or `null`. Task 4's CI job invokes `npm run test:sidecar`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/tests/run-sidecar-tests.test.mjs`:
+
+```js
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveVenvPython } from '../run-sidecar-tests.mjs';
+
+function fixture(relPath) {
+  const dir = mkdtempSync(join(tmpdir(), 'sidecar-'));
+  const abs = join(dir, ...relPath.split('/'));
+  mkdirSync(join(abs, '..'), { recursive: true });
+  writeFileSync(abs, '', 'utf8');
+  return dir;
+}
+
+test('resolveVenvPython finds the POSIX venv layout', () => {
+  const dir = fixture('.venv/bin/python');
+  assert.equal(resolveVenvPython(dir, 'linux'), join(dir, '.venv', 'bin', 'python'));
+});
+
+test('resolveVenvPython finds the Windows venv layout', () => {
+  const dir = fixture('.venv/Scripts/python.exe');
+  assert.equal(resolveVenvPython(dir, 'win32'), join(dir, '.venv', 'Scripts', 'python.exe'));
+});
+
+test('resolveVenvPython returns null when no venv exists', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'sidecar-'));
+  assert.equal(resolveVenvPython(dir, 'linux'), null);
+});
+
+// A POSIX venv must not be found by the Windows probe and vice versa —
+// otherwise the runner would report a venv it cannot execute.
+test('resolveVenvPython does not cross platforms', () => {
+  const posix = fixture('.venv/bin/python');
+  assert.equal(resolveVenvPython(posix, 'win32'), null);
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `node --test scripts/tests/run-sidecar-tests.test.mjs`
+Expected: FAIL — `Cannot find module '../run-sidecar-tests.mjs'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `scripts/run-sidecar-tests.mjs`:
+
+```js
+#!/usr/bin/env node
+// Cross-platform pytest entry point for the TTS sidecar.
+//
+// Replaces the PowerShell-only path for CI: run-tests.ps1 hardcodes
+// .venv\Scripts\python.exe, a Windows layout that can never exist on
+// ubuntu-latest — so a CI leg calling it would take the SKIP branch and exit
+// 0 forever, i.e. be vacuously green (#2119 review, defect C).
+//
+// Local behaviour is unchanged: no venv still means SKIP + exit 0, so a
+// fresh clone doesn't fail the gate. CI passes --require-venv to turn that
+// same condition into a hard failure, because on CI a missing venv means the
+// bootstrap broke, not that the developer hasn't run it yet.
+
+import { existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SIDECAR_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'server', 'tts-sidecar');
+
+// platform is injected rather than read from process.platform so the layout
+// probe is testable on either OS.
+export function resolveVenvPython(sidecarDir, platform = process.platform) {
+  const rel = platform === 'win32'
+    ? ['.venv', 'Scripts', 'python.exe']
+    : ['.venv', 'bin', 'python'];
+  const candidate = join(sidecarDir, ...rel);
+  return existsSync(candidate) ? candidate : null;
+}
+
+export function main(argv = process.argv.slice(2), sidecarDir = SIDECAR_DIR) {
+  const requireVenv = argv.includes('--require-venv');
+  const python = resolveVenvPython(sidecarDir);
+
+  if (!python) {
+    const msg = `sidecar pytest -- venv not found under ${sidecarDir}`;
+    if (requireVenv) {
+      process.stderr.write(`ERROR: ${msg}\n`);
+      process.stderr.write('CI runs with --require-venv: a missing venv means the bootstrap step failed.\n');
+      return 1;
+    }
+    process.stdout.write(`\nSKIP: ${msg}\n`);
+    process.stdout.write('      Bootstrap once to enable this block in the gate:\n');
+    process.stdout.write('        cd server/tts-sidecar\n');
+    process.stdout.write('        python -m venv .venv\n');
+    process.stdout.write('        .venv/bin/python -m pip install -r requirements.txt -r requirements-dev.txt\n\n');
+    return 0;
+  }
+
+  // -m "not golden" mirrors the existing runner: the opt-in golden-audio tier
+  // must never load a model here.
+  const passthrough = argv.filter((a) => a !== '--require-venv');
+  const result = spawnSync(
+    python,
+    ['-m', 'pytest', '-m', 'not golden', ...passthrough],
+    { cwd: sidecarDir, stdio: 'inherit' },
+  );
+  if (result.error) {
+    process.stderr.write(`run-sidecar-tests: failed to spawn python: ${result.error.message}\n`);
+    return 1;
+  }
+  return result.status ?? 1;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`.replace(/\\/g, '/')) {
+  process.exit(main());
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `node --test scripts/tests/run-sidecar-tests.test.mjs`
+Expected: PASS, 4/4.
+
+- [ ] **Step 5: Rewire the npm script**
+
+In `package.json`, change `test:sidecar` from the `run-powershell.mjs` form
+to:
+
+```json
+    "test:sidecar": "node scripts/run-sidecar-tests.mjs",
+```
+
+- [ ] **Step 6: Verify local behaviour is unchanged**
+
+Run: `npm run test:sidecar`
+Expected: on a box with a bootstrapped venv, the suite runs. On one without,
+a SKIP banner and exit 0 — same as before.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/run-sidecar-tests.mjs scripts/tests/run-sidecar-tests.test.mjs package.json
+git commit -m "feat(ops): cross-platform sidecar pytest entry point"
+```
+
+---
+
+### Task 4: Wire the sidecar job into CI *and* into the gate
+
+**Files:**
+- Modify: `.github/workflows/verify.yml` (new job + aggregator `needs:`)
+
+**Interfaces:**
+- Consumes: `npm run test:sidecar --require-venv` from Task 3; the lean-collect
+  guarantee from Task 2.
+- Produces: a `sidecar-tests` job that A2's ↑ assertion will check.
+
+- [ ] **Step 1: Add the job**
+
+Insert after the `server-tests` job in `.github/workflows/verify.yml`:
+
+```yaml
+  sidecar-tests:
+    name: Sidecar tests (pytest)
+    needs: detect
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        if: needs.detect.outputs.sidecar == 'true' || needs.detect.outputs.shared == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      # The LEAN dependency set only: requirements/base.txt is vendor-neutral
+      # (fastapi/uvicorn/numpy/psutil) and requirements-dev.txt is pytest +
+      # httpx. The heavy ML stack (torch, coqui-tts, speechbrain) lives in the
+      # vendor overlay and speaker-qa.txt and is deliberately NOT installed —
+      # tests needing it use pytest.importorskip and report as skipped.
+      - name: Bootstrap sidecar venv
+        if: needs.detect.outputs.sidecar == 'true' || needs.detect.outputs.shared == 'true'
+        run: |
+          cd server/tts-sidecar
+          python -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install -r requirements/base.txt -r requirements-dev.txt
+
+      # --require-venv turns "no venv" from a SKIP into a hard failure: on CI a
+      # missing venv means the bootstrap above broke. Without it this leg would
+      # be vacuously green, which is worse than the hole it closes (#2119
+      # review, defect C).
+      - name: Sidecar tests
+        if: needs.detect.outputs.sidecar == 'true' || needs.detect.outputs.shared == 'true'
+        run: npm run test:sidecar -- --require-venv
+```
+
+- [ ] **Step 2: Add it to the aggregator's `needs:`**
+
+`verify.yml:435`. A job absent from this list can run, fail, and **not block
+merge**, because the ruleset requires only this aggregator's context.
+
+```yaml
+    needs: [lint-and-checks, frontend-tests, server-tests, sidecar-tests, e2e, e2e-visual, build]
+```
+
+- [ ] **Step 3: Verify the workflow parses**
+
+Run: `node -e "const y=require('js-yaml');const f=require('fs');const d=y.load(f.readFileSync('.github/workflows/verify.yml','utf8'));console.log(Object.keys(d.jobs));console.log('aggregator needs:',d.jobs.verify.needs);"`
+
+Expected: `sidecar-tests` appears in the job list **and** in the aggregator's
+needs array.
+
+If `js-yaml` is unavailable, use `npx --yes js-yaml .github/workflows/verify.yml > /dev/null && echo "parses"`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/verify.yml
+git commit -m "feat(ops): add a sidecar pytest leg that can actually fail"
+```
+
+- [ ] **Step 5: Open PR A1**
+
+```bash
+git push -u origin fix/ops-verify-scope-github-and-sidecar
+gh pr create --title "fix(ops): close the .github scope hole and add a real sidecar leg" --body "$(cat <<'EOF'
+## Summary
+
+Two purely additive fixes, neither of which changes how scope is computed.
+
+- **Defect D** — `.github/workflows/**` matched no scope at all, so a
+  workflow-only PR ran zero legs, in cloud and locally. It is now an input to
+  `test:hooks` and matches the `hooks` scope.
+- **Defect C** — `verify.yml` had no sidecar pytest leg. Adds one that can
+  genuinely fail: a cross-platform entry point, a lean venv bootstrap, and
+  `--require-venv` so a broken bootstrap is red rather than a silent SKIP.
+  Two tests gain `pytest.importorskip` so the suite collects without torch.
+
+Landing this first de-circularises PR A2: with `.github/**` in scope, A2's
+wiring assertions actually run on A2's own PR.
+
+## Test plan
+
+- `node --test scripts/tests/verify-cache.test.mjs` — two new scope tests
+- `node --test scripts/tests/run-sidecar-tests.test.mjs` — 4 layout tests
+- `pytest --collect-only` under a `base.txt + requirements-dev.txt` venv:
+  exits 0 (was exit 2, two collection errors)
+
+Refs #2119
+
+Design: `docs/superpowers/specs/2026-08-05-verify-scope-map-unification-design.md`
+EOF
+)"
+```
+
+- [ ] **Step 6: Confirm the sidecar leg actually gates (mutation M13)**
+
+On the PR, temporarily break a sidecar test (e.g. `assert False` in
+`test_smoke.py`), push, and confirm the **`npm run verify` context** — not
+merely the `sidecar-tests` job — reports red. Revert the break before merge.
+
+Record the observed context name. Watching the job's own status instead is
+the exact confusion the ↑ assertion exists to prevent.
+
+---
+
+# PHASE A2 — the derivation (Closes #2119)
+
+Branch: `feat/ops-verify-scope-derivation`, cut from `main` after A1 merges.
+
+---
+
+### Task 5: `scripts/ci-scope.mjs`
+
+**Files:**
+- Create: `scripts/ci-scope.mjs`
+- Create: `scripts/tests/ci-scope.test.mjs`
+
+**Interfaces:**
+- Consumes: `STEPS`, `stepTouchedByDiff`, `computeShared` from
+  `./verify-cache.mjs`.
+- Produces:
+  - `slugFor(stepName)` → string, e.g. `test:e2e:visual` → `step_test_e2e_visual`
+  - `computeScopes(files, { eventName })` → `{ [key: string]: boolean }`
+  - `render(scopes)` → string in `GITHUB_OUTPUT` format
+  - `main(argv, env)` → exit code number
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `scripts/tests/ci-scope.test.mjs`:
+
+```js
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { slugFor, computeScopes, render } from '../ci-scope.mjs';
+import { STEPS } from '../verify-cache.mjs';
+
+test('slugFor converts a step name to an output key', () => {
+  assert.equal(slugFor('test:hooks'), 'step_test_hooks');
+  assert.equal(slugFor('test:e2e:visual'), 'step_test_e2e_visual');
+  assert.equal(slugFor('config:check'), 'step_config_check');
+});
+
+test('computeScopes emits a key for every STEP plus openapi, shared and ok', () => {
+  const scopes = computeScopes(['src/app.tsx'], { eventName: 'pull_request' });
+  for (const step of STEPS) {
+    assert.ok(slugFor(step.name) in scopes, `missing ${slugFor(step.name)}`);
+  }
+  assert.ok('openapi' in scopes);
+  assert.ok('shared' in scopes);
+});
+
+// #2119's four cited paths. Each previously ran no leg that covers it.
+for (const path of [
+  'launch.mjs',
+  'server/tts-sidecar/scripts/install-qwen3.mjs',
+  'pinokio.js',
+  'eslint.config.mjs',
+]) {
+  test(`computeScopes routes ${path} to test:hooks`, () => {
+    const scopes = computeScopes([path], { eventName: 'pull_request' });
+    assert.equal(scopes.step_test_hooks, true, `${path} must run test:hooks`);
+  });
+}
+
+// Defect D.
+test('computeScopes routes a workflow diff to test:hooks', () => {
+  const scopes = computeScopes(['.github/workflows/verify.yml'], { eventName: 'pull_request' });
+  assert.equal(scopes.step_test_hooks, true);
+});
+
+// A root lockfile touches ZERO steps via stepTouchedByDiff — computeShared is
+// a separate global override. Without `shared`, a dependency bump runs nothing.
+test('computeScopes sets shared for a root lockfile diff', () => {
+  const scopes = computeScopes(['package-lock.json'], { eventName: 'pull_request' });
+  assert.equal(scopes.shared, true);
+});
+
+// workflow_dispatch has no PR base to diff. An empty file list is not an
+// error, so the fail-safe does not fire — without this branch the documented
+// clean-room full-battery run becomes a green no-op.
+test('computeScopes emits all-true for workflow_dispatch', () => {
+  const scopes = computeScopes([], { eventName: 'workflow_dispatch' });
+  for (const [key, value] of Object.entries(scopes)) {
+    assert.equal(value, true, `${key} must be true on workflow_dispatch`);
+  }
+});
+
+test('computeScopes is all-false for an unrelated diff on a PR', () => {
+  const scopes = computeScopes(['README.md'], { eventName: 'pull_request' });
+  assert.equal(scopes.step_test_hooks, false);
+  assert.equal(scopes.shared, false);
+});
+
+test('render emits GITHUB_OUTPUT lines plus the ok sentinel', () => {
+  const out = render({ step_test_hooks: true, shared: false });
+  assert.match(out, /^scopes=\{.*\}$/m);
+  assert.match(out, /^ok=true$/m);
+  const json = JSON.parse(out.match(/^scopes=(.*)$/m)[1]);
+  assert.equal(json.step_test_hooks, true);
+  assert.equal(json.shared, false);
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `node --test scripts/tests/ci-scope.test.mjs`
+Expected: FAIL — `Cannot find module '../ci-scope.mjs'`.
+
+- [ ] **Step 3: Implement**
+
+Create `scripts/ci-scope.mjs`:
+
+```js
+#!/usr/bin/env node
+// Derive per-step CI scope from verify-cache.mjs's STEPS[] — the single
+// source of truth for "which files does this step depend on".
+//
+// Emits ONE json output rather than one output per step. GitHub requires
+// every consumed output to be re-declared in the detect job's static
+// `outputs:` map (there is no wildcard), so per-step outputs would make that
+// map a THIRD artifact in the derivation chain: a key emitted here and
+// consumed by an `if:` but missing from that map evaluates to the empty
+// string, silently disabling a leg while both wiring directions still pass.
+// One json output makes that map a single static line.
+
+import { STEPS, stepTouchedByDiff, computeShared } from './verify-cache.mjs';
+
+export function slugFor(stepName) {
+  return `step_${stepName.replace(/[:-]/g, '_')}`;
+}
+
+// openapi gates the CI-only "OpenAPI types up to date" drift check and has no
+// cache step. shared is the root-manifest global override.
+const CI_ONLY = {
+  openapi: (files) => files.some((f) => f === 'openapi.yaml'),
+  shared: (files) => computeShared(files),
+};
+
+export function computeScopes(files, { eventName } = {}) {
+  const keys = [...STEPS.map((s) => slugFor(s.name)), ...Object.keys(CI_ONLY)];
+
+  // A manual dispatch has no PR base to diff against, so `files` is empty —
+  // which is NOT an error and therefore does not trip the fail-safe. Run the
+  // full battery, matching the behaviour the bash detector had.
+  if (eventName === 'workflow_dispatch') {
+    return Object.fromEntries(keys.map((k) => [k, true]));
+  }
+
+  const shared = computeShared(files);
+  const scopes = {};
+  for (const step of STEPS) {
+    // `shared` is a disjunct on EVERY step: stepTouchedByDiff has a lockfile
+    // branch for server/package-lock.json only — a ROOT lockfile diff touches
+    // zero steps, so without this a dependency bump would run nothing.
+    scopes[slugFor(step.name)] = shared || stepTouchedByDiff(step, files);
+  }
+  for (const [key, fn] of Object.entries(CI_ONLY)) {
+    scopes[key] = key === 'shared' ? shared : shared || fn(files);
+  }
+  return scopes;
+}
+
+export function render(scopes) {
+  return `scopes=${JSON.stringify(scopes)}\nok=true\n`;
+}
+
+function allTrue() {
+  const keys = [...STEPS.map((s) => slugFor(s.name)), ...Object.keys(CI_ONLY)];
+  return Object.fromEntries(keys.map((k) => [k, true]));
+}
+
+export function main(argv = process.argv.slice(2), env = process.env) {
+  let output;
+  try {
+    const files = (argv.find((a) => a.startsWith('--files='))?.slice('--files='.length) ?? '')
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    output = render(computeScopes(files, { eventName: env.GITHUB_EVENT_NAME }));
+  } catch (err) {
+    // FAIL SAFE: degrade to "run the whole battery", never to "skip
+    // everything". A crash here must not be able to produce a green required
+    // check that ran nothing.
+    process.stderr.write(`ci-scope: FAILED (${err?.message}) — emitting all-true\n`);
+    output = render(allTrue());
+  }
+  process.stdout.write(output);
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`.replace(/\\/g, '/')) {
+  process.exit(main());
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `node --test scripts/tests/ci-scope.test.mjs`
+Expected: PASS, all tests.
+
+- [ ] **Step 5: Prove the fail-safe (mutation M10)**
+
+Add to `scripts/tests/ci-scope.test.mjs`:
+
+```js
+import { main } from '../ci-scope.mjs';
+
+// M10: a thrown error must degrade to all-true + exit 0 — never to all-false
+// and never to a non-zero exit. A crash that skipped every leg would produce
+// a green required check that ran nothing, which is the whole failure class
+// this design exists to close.
+//
+// Trigger: passing a non-array as argv makes `argv.find(...)` throw a
+// TypeError inside the try block. In-process, no subprocess needed.
+test('main fails SAFE: all-true and exit 0 when computation throws', () => {
+  const chunks = [];
+  const origOut = process.stdout.write;
+  const origErr = process.stderr.write;
+  process.stdout.write = (s) => { chunks.push(s); return true; };
+  process.stderr.write = () => true;
+
+  let code;
+  try {
+    code = main({}, {});
+  } finally {
+    process.stdout.write = origOut;
+    process.stderr.write = origErr;
+  }
+
+  assert.equal(code, 0, 'must exit 0');
+  const out = chunks.join('');
+  assert.match(out, /^ok=true$/m);
+  const json = JSON.parse(out.match(/^scopes=(.*)$/m)[1]);
+  assert.ok(Object.keys(json).length > 0, 'must emit keys, not an empty object');
+  assert.ok(
+    Object.values(json).every(Boolean),
+    'every key must be true — degrading to all-FALSE would skip every leg',
+  );
+});
+```
+
+- [ ] **Step 5b: Prove the fail-safe is not a placebo**
+
+Run: `node --test scripts/tests/ci-scope.test.mjs`
+Expected: PASS.
+
+Then temporarily replace the `catch` body in `ci-scope.mjs` with
+`throw err;`.
+
+Run again. Expected: **RED**. Restore.
+
+If it stays green, the test never reached the catch — fix the trigger before
+proceeding.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/ci-scope.mjs scripts/tests/ci-scope.test.mjs
+git commit -m "feat(ops): derive per-step CI scope from verify-cache STEPS"
+```
+
+---
+
+### Task 6: Rewire `verify.yml`'s detect job
+
+**Files:**
+- Modify: `.github/workflows/verify.yml:90-180`
+
+**Interfaces:**
+- Consumes: `scripts/ci-scope.mjs` from Task 5.
+- Produces: `needs.detect.outputs.scopes` (JSON string) and
+  `needs.detect.outputs.ok` for Tasks 7 and 9.
+
+- [ ] **Step 1: Replace the outputs block**
+
+`verify.yml:94-103` — nine hand-declared outputs become two:
+
+```yaml
+    outputs:
+      # ONE json blob rather than one output per step: GitHub has no wildcard
+      # for this map, so per-step outputs would be a third artifact that can
+      # silently drift from the emitted keys. Consumed via fromJSON below.
+      scopes: ${{ steps.changes.outputs.scopes }}
+      # Sentinel: proves ci-scope.mjs actually ran and wrote. The aggregator
+      # asserts this, catching the case where detect SUCCEEDS having written
+      # nothing — every `if:` false, every job green, required check green
+      # having run nothing.
+      ok: ${{ steps.changes.outputs.ok }}
+```
+
+- [ ] **Step 2: Replace the detection step body**
+
+Replace the `match()` block (`:142-180`) — keep the `MERGE_BASE`/`FILES`
+lines above it (`:137-141`) untouched:
+
+```yaml
+          node scripts/ci-scope.mjs --files="$FILES" >> "$GITHUB_OUTPUT"
+          echo "--- derived scope ---"
+          node scripts/ci-scope.mjs --files="$FILES"
+```
+
+- [ ] **Step 3: Ensure Node is available in detect**
+
+The `detect` job currently has no Node setup (the bash matcher needed none).
+Add before the detection step:
+
+```yaml
+      - name: Setup Node + deps
+        uses: ./.github/actions/setup
+```
+
+- [ ] **Step 4: Verify locally against a simulated diff**
+
+Run:
+
+```bash
+node scripts/ci-scope.mjs --files="$(printf 'launch.mjs')"
+```
+
+Expected: a `scopes=` line whose JSON has `"step_test_hooks":true`, and
+`ok=true`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/verify.yml
+git commit -m "feat(ops): detect job derives scope via ci-scope.mjs"
+```
+
+---
+
+### Task 7: Convert every `if:` to the derived form
+
+**Files:**
+- Modify: `.github/workflows/verify.yml` (all ~20 `if:` sites)
+
+**Interfaces:**
+- Consumes: `needs.detect.outputs.scopes`.
+- Produces: the `fromJSON(...).<key>` reference syntax Task 8 asserts on.
+
+- [ ] **Step 1: Convert the leg conditions**
+
+Mechanical, one per site. `shared` stays a disjunct everywhere. Examples —
+apply the same shape to every `if:`:
+
+```yaml
+      # Lint (was: frontend || server || scripts || shared)
+      - name: Lint
+        if: fromJSON(needs.detect.outputs.scopes).step_lint || fromJSON(needs.detect.outputs.scopes).shared
+
+      # Hooks tests (was: hooks || scripts || shared)
+      - name: Hooks tests
+        if: fromJSON(needs.detect.outputs.scopes).step_test_hooks || fromJSON(needs.detect.outputs.scopes).shared
+
+      # Server tests — test:server AND test:server-slow share this one step,
+      # so the condition is the union of both steps' keys.
+      - name: Server tests (fast + slow)
+        if: fromJSON(needs.detect.outputs.scopes).step_test_server || fromJSON(needs.detect.outputs.scopes).step_test_server_slow || fromJSON(needs.detect.outputs.scopes).shared
+```
+
+**Do not hoist any of these to job level** (Global Constraints).
+
+- [ ] **Step 2: Bind each setup step to the leg it supports**
+
+Seven `if:`-bearing steps are setup, not legs (3× Install ffmpeg, 2× Cache
+Playwright, 2× Install Playwright). Each gets a machine-readable declaration
+immediately above its `if:`, and its condition must be **string-identical**
+to that leg's:
+
+```yaml
+      # supports: test:e2e
+      - name: Install ffmpeg
+        if: fromJSON(needs.detect.outputs.scopes).step_test_e2e || fromJSON(needs.detect.outputs.scopes).shared
+```
+
+If the Playwright cache/install condition and the e2e run condition diverge,
+e2e runs without a browser. Task 8 asserts they cannot.
+
+- [ ] **Step 3: Verify the workflow still parses and references resolve**
+
+Run:
+
+```bash
+npx --yes js-yaml .github/workflows/verify.yml > /dev/null && echo "parses"
+grep -c "needs.detect.outputs.scopes" .github/workflows/verify.yml
+grep -c "needs.detect.outputs\.\(frontend\|server\|sidecar\|e2e\|scripts\|hooks\|pinokio\|openapi\)" .github/workflows/verify.yml
+```
+
+Expected: `parses`; a non-zero count for the first grep; **0** for the second
+(no legacy scope references left).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/verify.yml
+git commit -m "feat(ops): gate every verify leg on the derived scope map"
+```
+
+---
+
+### Task 8: The four wiring assertions
+
+**Files:**
+- Create: `scripts/tests/workflow-wiring.test.mjs`
+
+**Interfaces:**
+- Consumes: `computeScopes`, `slugFor` (Task 5); the parsed `verify.yml`.
+- Produces: nothing consumed downstream.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `scripts/tests/workflow-wiring.test.mjs`:
+
+```js
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { computeScopes, slugFor } from '../ci-scope.mjs';
+import { STEPS } from '../verify-cache.mjs';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const workflowPath = resolve(repoRoot, '.github', 'workflows', 'verify.yml');
+const source = readFileSync(workflowPath, 'utf8');
+
+// Every key ci-scope.mjs can emit.
+const emitted = new Set(Object.keys(computeScopes([], { eventName: 'pull_request' })));
+
+// Every key the workflow references. Pinned to the dotted fromJSON form the
+// workflow actually uses; a bracket or contains() form would slip this regex,
+// so the anti-vacuity floor below is what catches a syntax change.
+const referenced = [...source.matchAll(/fromJSON\(needs\.detect\.outputs\.scopes\)\.([A-Za-z0-9_]+)/g)]
+  .map((m) => m[1]);
+
+test('anti-vacuity: the workflow scan finds references', () => {
+  // Measured at authoring time: ~20 if: sites, most with two disjuncts.
+  assert.ok(
+    referenced.length >= 20,
+    `expected >= 20 fromJSON references, found ${referenced.length} — either the regex broke or the workflow changed shape`,
+  );
+});
+
+// -> direction: no reference to a key that is never emitted. GitHub resolves
+// an unknown reference to the empty string, so a typo'd key silently disables
+// a leg on the REQUIRED check while everything reports green.
+test('-> every referenced scope key is emitted by ci-scope.mjs', () => {
+  const unknown = [...new Set(referenced)].filter((k) => !emitted.has(k));
+  assert.deepEqual(unknown, [], `workflow references key(s) ci-scope.mjs never emits:\n${unknown.join('\n')}`);
+});
+
+// <- direction: no emitted key is orphaned. This is defect C's shape — a
+// verify-cache STEP with no CI home at all.
+test('<- every emitted scope key is referenced by the workflow', () => {
+  const refSet = new Set(referenced);
+  const orphaned = [...emitted].filter((k) => !refSet.has(k));
+  assert.deepEqual(orphaned, [], `emitted key(s) no workflow condition uses:\n${orphaned.join('\n')}`);
+});
+
+// ^ direction: a job carrying a derived if: but absent from the aggregator's
+// needs: can run, FAIL, and not block merge — main's ruleset pins only the
+// aggregator's context ('npm run verify'). The <- direction would still
+// certify its key as wired.
+test('^ every job with a derived condition is in the aggregator needs:', () => {
+  const jobBlocks = [...source.matchAll(/^ {2}([a-z][a-z0-9-]*):\n((?: {4}.*\n|\n)*)/gm)];
+  const aggregator = jobBlocks.find(([, name]) => name === 'verify');
+  assert.ok(aggregator, 'aggregator job `verify` not found');
+  const needs = (aggregator[2].match(/needs:\s*\[([^\]]*)\]/) ?? [, ''])[1]
+    .split(',').map((s) => s.trim()).filter(Boolean);
+
+  const missing = [];
+  for (const [, name, body] of jobBlocks) {
+    if (name === 'verify' || name === 'detect') continue;
+    if (!/fromJSON\(needs\.detect\.outputs\.scopes\)/.test(body)) continue;
+    if (!needs.includes(name)) missing.push(name);
+  }
+  assert.deepEqual(missing, [], `job(s) with derived conditions missing from the aggregator's needs:\n${missing.join('\n')}`);
+});
+
+// Setup steps (ffmpeg, Playwright cache/install) are not legs. Each declares
+// the leg it supports; its condition must be identical to that leg's, or e2e
+// runs without a browser.
+test('setup steps carry the same condition as the leg they support', () => {
+  const stepBlocks = [...source.matchAll(
+    /# supports: ([a-z:0-9-]+)\n\s*- name: ([^\n]+)\n\s*if: ([^\n]+)\n/g,
+  )];
+  assert.ok(stepBlocks.length >= 7, `expected >= 7 '# supports:' declarations, found ${stepBlocks.length}`);
+
+  // Build leg name -> its own if: condition.
+  const legConditions = new Map();
+  for (const step of STEPS) {
+    const key = slugFor(step.name);
+    const re = new RegExp(`- name: [^\\n]+\\n\\s*if: ([^\\n]*${key}[^\\n]*)\\n`);
+    const m = source.match(re);
+    if (m) legConditions.set(step.name, m[1].trim());
+  }
+
+  const mismatched = [];
+  for (const [, leg, stepName, condition] of stepBlocks) {
+    const expected = legConditions.get(leg);
+    if (!expected) { mismatched.push(`${stepName}: unknown leg '${leg}'`); continue; }
+    if (condition.trim() !== expected) {
+      mismatched.push(`${stepName}\n  supports ${leg}\n  has:      ${condition.trim()}\n  expected: ${expected}`);
+    }
+  }
+  assert.deepEqual(mismatched, [], `setup step condition(s) diverged from their leg:\n${mismatched.join('\n')}`);
+});
+```
+
+- [ ] **Step 2: Run to verify each assertion can fail**
+
+Run: `node --test scripts/tests/workflow-wiring.test.mjs`
+Expected: PASS once Tasks 6–7 are complete. If any fail, the workflow is
+genuinely mis-wired — fix the workflow, not the test.
+
+- [ ] **Step 3: Run the four mutations (M1, M2, M15, M16)**
+
+Each must go red, then be reverted:
+
+| Mutation | Edit | Expect red in |
+|---|---|---|
+| M1 | rename `test:hooks` → `test:hooks2` in `verify-cache.mjs` `STEPS[]` | → and ← |
+| M2 | add `if: fromJSON(needs.detect.outputs.scopes).step_nope` to any step | → |
+| M3 | delete the `if:` from the "Hooks tests" step entirely | ← only (fires alone, unlike M1) |
+| M15 | remove `sidecar-tests` from the aggregator's `needs:` | ↑ |
+| M16 | change one `# supports:`-tagged step's `if:` to a different key | setup-binding |
+
+M1 and M3 are both listed because they exercise *different* directions: M1
+trips → and ← together (the emitted key changes and the reference goes
+stale), while M3 leaves the key emitted with nothing referencing it, which
+only ← can see. A suite that catches M1 but not M3 has a half-working ←.
+
+Run after each: `node --test scripts/tests/workflow-wiring.test.mjs`
+Record which assertion caught it. If a mutation does **not** go red, the
+assertion is a placebo — fix it before proceeding.
+
+- [ ] **Step 4: Verify M4 (anti-vacuity)**
+
+Temporarily change the `referenced` regex to match nothing (e.g.
+`/fromJSONX\(/g`). Expected: the anti-vacuity test goes red; without it, →
+and ← would both pass vacuously. Revert.
+
+- [ ] **Step 5: Wire the new test into the cache step**
+
+In `scripts/verify-cache.mjs`, `test:hooks` already globs
+`scripts/**/*.{mjs,cjs}` so the test file itself is covered, and A1 added
+`.github/workflows/**`. Confirm:
+
+Run: `node -e "import('./scripts/verify-cache.mjs').then(({STEPS,stepTouchedByDiff})=>{const s=STEPS.find(x=>x.name==='test:hooks');console.log('test file:',stepTouchedByDiff(s,['scripts/tests/workflow-wiring.test.mjs']));console.log('workflow:',stepTouchedByDiff(s,['.github/workflows/verify.yml']));})"`
+
+Expected: both `true`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/tests/workflow-wiring.test.mjs
+git commit -m "test(ops): assert workflow wiring in four directions"
+```
+
+---
+
+### Task 9: The aggregator sentinel
+
+**Files:**
+- Modify: `.github/workflows/verify.yml:433-450`
+
+**Interfaces:**
+- Consumes: `needs.detect.outputs.ok` from Task 6.
+
+- [ ] **Step 1: Add `detect` to the aggregator's `needs:`**
+
+Without this the `needs` context does not expose `detect` at all, and
+`needs.detect.outputs.ok` is the empty string — the sentinel would fail on
+**every** PR. Safe against the `'skipped'` check: `detect` has no job-level
+`if:` and cannot skip.
+
+```yaml
+    needs: [detect, lint-and-checks, frontend-tests, server-tests, sidecar-tests, e2e, e2e-visual, build]
+```
+
+- [ ] **Step 2: Assert the sentinel**
+
+Add as the FIRST step of the aggregator, before "Check leg results":
+
+```yaml
+      # Consumer-side check on a DIFFERENT artifact from the one it validates.
+      # The producer-side fail-safe in ci-scope.mjs shares a failure mode with
+      # what it guards: it writes the fallback to the same GITHUB_OUTPUT
+      # handle. If that handle is unwritable, or detect exits 0 having written
+      # nothing, every `if:` is false, every job's STEPS skip, every job
+      # SUCCEEDS, and this aggregator would report green having run nothing.
+      # No job is skipped in that scenario, so the check below cannot catch it.
+      - name: Scope detection ran
+        run: |
+          if [[ "${{ needs.detect.result }}" != "success" ]]; then
+            echo "::error::detect job did not succeed: ${{ needs.detect.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.detect.outputs.ok }}" != "true" ]]; then
+            echo "::error::ci-scope.mjs did not report ok=true (got '${{ needs.detect.outputs.ok }}'). Scope detection produced no output; refusing to report green."
+            exit 1
+          fi
+          echo "Scope detection reported ok."
+```
+
+- [ ] **Step 3: Verify M12 by simulation**
+
+Locally confirm the shell logic both ways:
+
+```bash
+ok=""    ; [[ "$ok" != "true" ]] && echo "empty  -> FAILS (correct)"
+ok="true"; [[ "$ok" != "true" ]] || echo "true   -> PASSES (correct)"
+```
+
+Expected: both lines print.
+
+- [ ] **Step 4: Commit and open PR A2**
+
+```bash
+git add .github/workflows/verify.yml
+git commit -m "feat(ops): aggregator refuses to report green if scope detection did not run"
+git push -u origin feat/ops-verify-scope-derivation
+```
+
+PR body: `Closes #2119`, links the design doc, and states the manual
+inspection below.
+
+- [ ] **Step 5: Hand-inspect A2's own CI run**
+
+Self-validation is circular against a *computed-false*: if `ci-scope.mjs`
+wrongly computes `step_test_hooks=false`, the wiring assertion never runs on
+the PR introducing it. A1 removed this for defect D, not for the general case.
+
+Open A2's `detect` job log, read the `--- derived scope ---` block, and check
+by hand that the legs which ran match what the PR's own diff should trigger
+(it touches `scripts/**` and `.github/**`, so at minimum `step_test_hooks`
+must be `true` and the Hooks tests step must have executed).
+
+---
+
+# PHASE B — guard hardening (Closes #2120)
+
+Branch: `fix/ops-verify-cache-completeness-guard`, cut after A2 merges.
+
+---
+
+### Task 10: Comment stripping and the resolver
+
+**Files:**
+- Create: `scripts/lib/module-graph.mjs`
+- Create: `scripts/tests/module-graph.test.mjs`
+
+**Interfaces:**
+- Produces:
+  - `stripComments(source)` → string
+  - `extractRelativeSpecifiers(source)` → string[]
+  - `resolveSpecifier(fromFile, specifier)` → absolute path or `null`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `scripts/tests/module-graph.test.mjs`:
+
+```js
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { stripComments, extractRelativeSpecifiers, resolveSpecifier } from '../lib/module-graph.mjs';
+
+test('stripComments removes line comments', () => {
+  assert.equal(stripComments("const a = 1; // require('../x.js')\n").includes('../x.js'), false);
+});
+
+test('stripComments removes block comments', () => {
+  assert.equal(stripComments("/* require('../x.js') */\nconst a = 1;\n").includes('../x.js'), false);
+});
+
+// Guard against over-stripping: a // inside a string literal is not a comment.
+test('stripComments preserves // inside string literals', () => {
+  const out = stripComments(`const url = "https://example.com/x"; // gone\n`);
+  assert.ok(out.includes('https://example.com/x'), 'URL must survive');
+  assert.ok(!out.includes('gone'), 'trailing comment must be removed');
+});
+
+// This is why stripping is load-bearing rather than cosmetic:
+// verify-cache.mjs:107 has a literal require('../../pinokio.js') in a COMMENT
+// which resolves OUTSIDE the repo root. Under fail-closed resolution that is
+// a false failure.
+test('extractRelativeSpecifiers ignores a specifier inside a comment', () => {
+  const src = "// loads it via createRequire + require('../../pinokio.js')\nimport x from './real.mjs';\n";
+  assert.deepEqual(extractRelativeSpecifiers(src), ['./real.mjs']);
+});
+
+test('extractRelativeSpecifiers finds import, dynamic import and require', () => {
+  const src = `
+import a from './a.mjs';
+const b = await import('./b.mjs');
+const c = require('./c.js');
+import d from 'node:fs';
+`;
+  assert.deepEqual(extractRelativeSpecifiers(src).sort(), ['./a.mjs', './b.mjs', './c.js']);
+});
+
+function tree(files) {
+  const dir = mkdtempSync(join(tmpdir(), 'mg-'));
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = join(dir, ...rel.split('/'));
+    mkdirSync(join(abs, '..'), { recursive: true });
+    writeFileSync(abs, body, 'utf8');
+  }
+  return dir;
+}
+
+test('resolveSpecifier resolves an exact path', () => {
+  const d = tree({ 'a.mjs': '', 'b.mjs': '' });
+  assert.equal(resolveSpecifier(join(d, 'a.mjs'), './b.mjs'), join(d, 'b.mjs'));
+});
+
+test('resolveSpecifier tries extension candidates', () => {
+  const d = tree({ 'a.mjs': '', 'b.js': '' });
+  assert.equal(resolveSpecifier(join(d, 'a.mjs'), './b'), join(d, 'b.js'));
+});
+
+// TypeScript emits .js specifiers for .ts sources — scripts/diff-analysis-ab.mjs
+// imports ../server/src/handoff/schemas.js and only the .ts exists.
+test('resolveSpecifier maps a .js specifier onto a .ts source', () => {
+  const d = tree({ 'a.mjs': '', 'schemas.ts': '' });
+  assert.equal(resolveSpecifier(join(d, 'a.mjs'), './schemas.js'), join(d, 'schemas.ts'));
+});
+
+test('resolveSpecifier returns null when nothing resolves', () => {
+  const d = tree({ 'a.mjs': '' });
+  assert.equal(resolveSpecifier(join(d, 'a.mjs'), './nope.mjs'), null);
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `node --test scripts/tests/module-graph.test.mjs`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Create `scripts/lib/module-graph.mjs`:
+
+```js
+// Static module-graph helpers for the test:hooks completeness guard.
+//
+// Split out of verify-cache.test.mjs so each piece is independently
+// unit-testable: the guard's previous inline regexes could only be exercised
+// through the whole-repo assertion, which meant a synthetic case (an
+// unresolvable specifier, a depth-2 edge) had nowhere to live.
+
+import { existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+
+// Remove comments before extracting specifiers. Load-bearing: the extraction
+// regexes below match inside comments, and verify-cache.mjs's own comment
+// contains a literal require('../../pinokio.js') that resolves outside the
+// repo. Under fail-closed resolution that would be a false failure — and it
+// is exactly the git check-ignore exit-128 case.
+export function stripComments(source) {
+  let out = '';
+  let i = 0;
+  let state = 'code'; // code | line | block | single | double | template
+  while (i < source.length) {
+    const c = source[i];
+    const next = source[i + 1];
+    if (state === 'code') {
+      if (c === '/' && next === '/') { state = 'line'; i += 2; continue; }
+      if (c === '/' && next === '*') { state = 'block'; i += 2; continue; }
+      if (c === "'") state = 'single';
+      else if (c === '"') state = 'double';
+      else if (c === '`') state = 'template';
+      out += c; i += 1; continue;
+    }
+    if (state === 'line') {
+      if (c === '\n') { state = 'code'; out += c; }
+      i += 1; continue;
+    }
+    if (state === 'block') {
+      if (c === '*' && next === '/') { state = 'code'; i += 2; continue; }
+      if (c === '\n') out += c; // preserve line numbering
+      i += 1; continue;
+    }
+    // inside a string literal
+    if (c === '\\') { out += c + (next ?? ''); i += 2; continue; }
+    if ((state === 'single' && c === "'") || (state === 'double' && c === '"') || (state === 'template' && c === '`')) {
+      state = 'code';
+    }
+    out += c; i += 1;
+  }
+  return out;
+}
+
+const PATTERNS = [
+  /\bfrom\s+['"](\.\.?\/[^'"]+)['"]/g,
+  /\bimport\(\s*['"](\.\.?\/[^'"]+)['"]\s*\)/g,
+  /\brequire\(\s*['"](\.\.?\/[^'"]+)['"]\s*\)/g,
+];
+
+// Only dot- or dot-dot-prefixed specifiers are producers under test; bare
+// specifiers (node:fs, archiver) are dependencies, not code under test, and
+// following them would walk into node_modules.
+export function extractRelativeSpecifiers(source) {
+  const stripped = stripComments(source);
+  const found = new Set();
+  for (const pattern of PATTERNS) {
+    for (const match of stripped.matchAll(pattern)) found.add(match[1]);
+  }
+  return [...found];
+}
+
+const CANDIDATES = ['', '.js', '.mjs', '.cjs', '/index.js', '/index.mjs'];
+
+// Returns the candidate paths a specifier could denote, WITHOUT touching the
+// filesystem. Exported so the stop rule can classify each candidate before
+// any existence probe (see walk()).
+export function candidatePaths(fromFile, specifier) {
+  const base = resolve(dirname(fromFile), specifier);
+  const paths = CANDIDATES.map((ext) => base + ext);
+  // TypeScript convention: `./x.js` in source resolves to `./x.ts` on disk.
+  if (specifier.endsWith('.js')) paths.push(base.slice(0, -3) + '.ts');
+  return paths;
+}
+
+export function resolveSpecifier(fromFile, specifier) {
+  for (const candidate of candidatePaths(fromFile, specifier)) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `node --test scripts/tests/module-graph.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/module-graph.mjs scripts/tests/module-graph.test.mjs
+git commit -m "feat(scripts): comment-stripping and TS-aware specifier resolution"
+```
+
+---
+
+### Task 11: The `check-ignore` stop rule
+
+**Files:**
+- Modify: `scripts/lib/module-graph.mjs`
+- Modify: `scripts/tests/module-graph.test.mjs`
+
+**Interfaces:**
+- Produces: `classifyIgnored(absPaths, cwd)` → `Map<string, boolean>`.
+  Throws on any state that is not a clean ignored/not-ignored answer.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/tests/module-graph.test.mjs`:
+
+```js
+import { classifyIgnored } from '../lib/module-graph.mjs';
+import { execFileSync } from 'node:child_process';
+
+function gitRepo(files, ignore) {
+  const dir = tree(files);
+  execFileSync('git', ['init', '-q'], { cwd: dir });
+  writeFileSync(join(dir, '.gitignore'), ignore, 'utf8');
+  return dir;
+}
+
+test('classifyIgnored marks gitignored paths', () => {
+  const d = gitRepo({ 'src/a.js': '', 'dist/b.js': '' }, 'dist/\n');
+  const m = classifyIgnored([join(d, 'dist', 'b.js'), join(d, 'src', 'a.js')], d);
+  assert.equal(m.get(join(d, 'dist', 'b.js')), true);
+  assert.equal(m.get(join(d, 'src', 'a.js')), false);
+});
+
+// The property the rule depends on: check-ignore is pure pattern matching, so
+// it answers correctly for paths that do NOT exist. That is what makes the
+// rule clone-state independent — server/dist is present locally (1,812 files)
+// and absent on a fresh CI clone, and "untracked" would classify differently
+// in each, giving red on CI and green locally.
+test('classifyIgnored answers for a path that does not exist on disk', () => {
+  const d = gitRepo({ 'src/a.js': '' }, 'dist/\n');
+  const m = classifyIgnored([join(d, 'dist', 'never', 'existed.js')], d);
+  assert.equal(m.get(join(d, 'dist', 'never', 'existed.js')), true);
+});
+
+// M18: exit 128 (path outside the repo) and git-unavailable must FAIL CLOSED.
+// "Non-zero => not ignored" conflates 128 with 1; "non-zero => skip" would
+// classify everything as ignored wherever git is absent, making the guard
+// vacuously green — the "absent reads as clean" shape.
+test('classifyIgnored throws on a path outside the repository (exit 128)', () => {
+  const d = gitRepo({ 'src/a.js': '' }, 'dist/\n');
+  assert.throws(
+    () => classifyIgnored([resolve(d, '..', 'outside.js')], d),
+    /check-ignore/i,
+  );
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `node --test scripts/tests/module-graph.test.mjs`
+Expected: FAIL — `classifyIgnored` is not exported.
+
+- [ ] **Step 3: Implement**
+
+Append to `scripts/lib/module-graph.mjs`:
+
+```js
+import { spawnSync } from 'node:child_process';
+import { relative, sep } from 'node:path';
+
+const toPosix = (p) => p.split(sep).join('/');
+
+// Classify a batch of candidate paths as gitignored or not.
+//
+// BATCHED via --stdin, not one spawn per path: measured 81 individual spawns
+// = 3972 ms vs one batch = 60 ms (66x). test:hooks runs in pre-commit via
+// verify:fast:scoped, a path documented as sub-5s — per-query spawning would
+// roughly double it on every commit touching scripts/**.
+//
+// Paths are POSIX-normalised first: git normalises backslashes on Windows,
+// but on Linux 'server\dist\x.js' is ONE literal filename that matches
+// nothing — classified not-ignored, then fail-closed resolution turns it red
+// on CI only.
+//
+// FAILS CLOSED. git check-ignore is three-valued:
+//   0   = at least one path ignored
+//   1   = none ignored
+//   128 = error (e.g. path outside the repository)
+// 128, a spawn failure, or git being absent all THROW rather than defaulting
+// either way. Defaulting to "ignored" would silently empty the walk wherever
+// git is unavailable.
+export function classifyIgnored(absPaths, cwd) {
+  const result = new Map(absPaths.map((p) => [p, false]));
+  if (absPaths.length === 0) return result;
+
+  const posix = absPaths.map((p) => toPosix(relative(cwd, p)));
+  const proc = spawnSync('git', ['check-ignore', '--stdin'], {
+    cwd,
+    input: posix.join('\n'),
+    encoding: 'utf8',
+  });
+
+  if (proc.error) {
+    throw new Error(`check-ignore: failed to spawn git (${proc.error.message}) — refusing to guess`);
+  }
+  if (proc.status !== 0 && proc.status !== 1) {
+    throw new Error(
+      `check-ignore: git exited ${proc.status} — refusing to guess.\n${proc.stderr ?? ''}`,
+    );
+  }
+
+  const ignored = new Set(proc.stdout.split('\n').map((s) => s.trim()).filter(Boolean));
+  for (let i = 0; i < absPaths.length; i += 1) {
+    if (ignored.has(posix[i])) result.set(absPaths[i], true);
+  }
+  return result;
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `node --test scripts/tests/module-graph.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 4b: Run mutation M8 — the predicate itself**
+
+Temporarily reimplement `classifyIgnored` using `git ls-files` ("untracked")
+instead of `git check-ignore` ("ignored"), then simulate a fresh clone by
+renaming `server/dist` aside:
+
+```bash
+mv server/dist server/dist.bak
+node --test scripts/tests/verify-cache.test.mjs   # after Task 13 lands
+mv server/dist.bak server/dist
+```
+
+Expected under the "untracked" predicate: **7 unresolvable specifiers** from
+`scripts/repair-cast-id-drift.mjs`'s `../server/dist/**` imports — i.e. red
+on a fresh clone, green on this box. Under `check-ignore`: identical result
+either way. Revert the reimplementation.
+
+This is the mutation that proves the *predicate choice* is load-bearing, not
+merely the batching or the exit-code handling.
+
+- [ ] **Step 5: Verify the cost claim holds**
+
+Run:
+
+```bash
+node --input-type=module -e "
+import {execFileSync,execSync} from 'child_process';
+const paths=Array.from({length:81},(_,i)=>i%2?'server/dist/f'+i+'.js':'scripts/f'+i+'.mjs');
+let t=Date.now(); for(const p of paths){try{execSync('git check-ignore -q \"'+p+'\"',{stdio:'ignore'});}catch{}}
+const per=Date.now()-t;
+t=Date.now(); try{execFileSync('git',['check-ignore','--stdin'],{input:paths.join('\n'),stdio:['pipe','ignore','ignore']});}catch{}
+console.log('per-query',per+'ms','batched',(Date.now()-t)+'ms');
+"
+```
+
+Expected: batched is an order of magnitude faster. If not, investigate before
+proceeding — the pre-commit budget depends on it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/lib/module-graph.mjs scripts/tests/module-graph.test.mjs
+git commit -m "feat(scripts): batched, fail-closed gitignore classification"
+```
+
+---
+
+### Task 12: The transitive walk
+
+**Files:**
+- Modify: `scripts/lib/module-graph.mjs`
+- Modify: `scripts/tests/module-graph.test.mjs`
+
+**Interfaces:**
+- Produces: `walk({ entryFiles, repoRoot })` → `{ files: string[],
+  unresolvable: Array<{ specifier, from }> }`, repo-relative POSIX paths.
+
+- [ ] **Step 1: Write the failing test — including M17**
+
+Append to `scripts/tests/module-graph.test.mjs`:
+
+```js
+import { walk } from '../lib/module-graph.mjs';
+
+// M17 — the mutation the M5-pair alone cannot provide. In the real repo the
+// walk's live case is neutralised by the declarations landing in the same PR:
+// a depth-1 closure is a SUBSET of a zero-missing full closure, so it is also
+// zero-missing (measured: depth-1 = 56, floor = 50, missing = [] -> GREEN).
+// Deleting the walk would leave the whole battery green. This synthetic tree
+// is what actually pins recursion.
+test('walk follows a depth-2 edge (M17: deleting recursion must go red)', () => {
+  const d = gitRepo({
+    'test.mjs': "import a from './a.mjs';\n",
+    'a.mjs': "import b from './b.mjs';\n",
+    'b.mjs': "export default 1;\n",
+  }, '');
+  const { files } = walk({ entryFiles: [join(d, 'test.mjs')], repoRoot: d });
+  assert.ok(files.includes('a.mjs'), 'depth-1 edge must be found');
+  assert.ok(files.includes('b.mjs'), 'depth-2 edge must be found — recursion is load-bearing');
+});
+
+test('walk stops at gitignored paths', () => {
+  const d = gitRepo({
+    'test.mjs': "import a from './dist/a.mjs';\n",
+    'dist/a.mjs': "import b from './b.mjs';\n",
+    'dist/b.mjs': "export default 1;\n",
+  }, 'dist/\n');
+  const { files } = walk({ entryFiles: [join(d, 'test.mjs')], repoRoot: d });
+  assert.deepEqual(files, [], 'nothing under an ignored dir may enter the closure');
+});
+
+test('walk survives an import cycle', () => {
+  const d = gitRepo({
+    'test.mjs': "import a from './a.mjs';\n",
+    'a.mjs': "import b from './b.mjs';\n",
+    'b.mjs': "import a from './a.mjs';\n",
+  }, '');
+  const { files } = walk({ entryFiles: [join(d, 'test.mjs')], repoRoot: d });
+  assert.deepEqual(files.sort(), ['a.mjs', 'b.mjs']);
+});
+
+test('walk does not follow bare specifiers', () => {
+  const d = gitRepo({ 'test.mjs': "import fs from 'node:fs';\nimport x from 'archiver';\n" }, '');
+  const { files } = walk({ entryFiles: [join(d, 'test.mjs')], repoRoot: d });
+  assert.deepEqual(files, []);
+});
+
+// M9 — needs a synthetic fixture: post-hardening the real tree has ZERO
+// unresolvable specifiers (the count goes 1 -> 0 once comments are stripped),
+// so asserting against the real repo would be vacuous.
+test('walk reports an unresolvable specifier rather than skipping it', () => {
+  const d = gitRepo({ 'test.mjs': "import x from './missing.mjs';\n" }, '');
+  const { unresolvable } = walk({ entryFiles: [join(d, 'test.mjs')], repoRoot: d });
+  assert.equal(unresolvable.length, 1);
+  assert.equal(unresolvable[0].specifier, './missing.mjs');
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `node --test scripts/tests/module-graph.test.mjs`
+Expected: FAIL — `walk` is not exported.
+
+- [ ] **Step 3: Implement**
+
+Append to `scripts/lib/module-graph.mjs`. **Consolidate imports at the top of
+the file** as you go — Tasks 10, 11 and 12 each add some, and leaving three
+separate `import` blocks mid-file works (ESM hoists) but duplicates
+`node:fs`. The final header should read:
+
+```js
+import { existsSync, readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { resolve, dirname, relative, sep } from 'node:path';
+```
+
+Then the walk itself:
+
+```js
+// Breadth-first transitive walk over relative import edges.
+//
+// Ordering matters and is the answer to "classify or resolve first?": path
+// JOIN is pure string math; module RESOLUTION is extension-candidate probing
+// plus existsSync. They are different operations. Every candidate is
+// classified by check-ignore BEFORE any existence probe, so whether a build
+// artifact happens to be present on this box cannot change the result —
+// server/dist is present locally and absent on a fresh CI clone.
+//
+// Classification is per-CANDIDATE, not once-then-resolve: a file-specific
+// .gitignore pattern could otherwise disagree with what resolution lands on.
+export function walk({ entryFiles, repoRoot }) {
+  const seen = new Set();
+  const files = new Set();
+  const unresolvable = [];
+  let frontier = [...entryFiles];
+
+  while (frontier.length > 0) {
+    // Collect every candidate for this BFS level, then classify in ONE batch.
+    const edges = [];
+    for (const file of frontier) {
+      let source;
+      try {
+        source = readFileSync(file, 'utf8');
+      } catch {
+        continue;
+      }
+      for (const specifier of extractRelativeSpecifiers(source)) {
+        edges.push({ from: file, specifier, candidates: candidatePaths(file, specifier) });
+      }
+    }
+    if (edges.length === 0) break;
+
+    const allCandidates = [...new Set(edges.flatMap((e) => e.candidates))];
+    const ignoredMap = classifyIgnored(allCandidates, repoRoot);
+
+    const next = [];
+    for (const edge of edges) {
+      const live = edge.candidates.filter((c) => !ignoredMap.get(c));
+      if (live.length === 0) continue; // wholly ignored — stop, not an error
+      const resolved = live.find((c) => existsSync(c));
+      if (!resolved) {
+        // FAIL CLOSED: a specifier that resolves to nothing is reported, not
+        // silently skipped. The old guard's `continue` here meant a broken
+        // edge read as clean.
+        unresolvable.push({ specifier: edge.specifier, from: toPosix(relative(repoRoot, edge.from)) });
+        continue;
+      }
+      const rel = toPosix(relative(repoRoot, resolved));
+      files.add(rel);
+      if (!seen.has(resolved)) {
+        seen.add(resolved);
+        next.push(resolved);
+      }
+    }
+    frontier = next;
+  }
+
+  return { files: [...files].sort(), unresolvable };
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `node --test scripts/tests/module-graph.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 5: Prove M17 is not a placebo**
+
+Temporarily replace `frontier = next;` with `frontier = [];` (kills
+recursion after depth 1).
+
+Run: `node --test scripts/tests/module-graph.test.mjs`
+Expected: the depth-2 test goes **RED**. Revert.
+
+If it does not go red, the fixture is wrong — fix it before proceeding.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/lib/module-graph.mjs scripts/tests/module-graph.test.mjs
+git commit -m "feat(scripts): transitive module walk with a gitignore stop rule"
+```
+
+---
+
+### Task 13: Point the completeness guard at the walk
+
+**Files:**
+- Modify: `scripts/tests/verify-cache.test.mjs:478-565`
+- Modify: `scripts/verify-cache.mjs` (`test:hooks` extraFiles — 2 additions)
+
+**Interfaces:**
+- Consumes: `walk` from Task 12.
+
+- [ ] **Step 1: Replace the guard body**
+
+Replace the inline `extractRelativeImportSpecifiers` function and the
+completeness test (`:501-565`) with:
+
+```js
+import { walk } from '../lib/module-graph.mjs';
+
+test('test:hooks completeness guard: every producer a hooks test depends on is a cache input', () => {
+  const hooksStep = stepByName['test:hooks'];
+  const entryFiles = readdirSync(testsDir)
+    .filter((f) => f.endsWith('.test.mjs'))
+    .map((f) => join(testsDir, f));
+
+  const { files, unresolvable } = walk({ entryFiles, repoRoot });
+
+  // Fail closed on a specifier that resolves to nothing (defect A). The old
+  // guard's existsSync-then-continue silently dropped these.
+  assert.deepEqual(
+    unresolvable,
+    [],
+    `specifier(s) that resolve to nothing:\n${unresolvable.map((u) => `${u.specifier} <- ${u.from}`).join('\n')}`,
+  );
+
+  // Anti-vacuity on METRIC B (unique tracked closure files), NOT on the old
+  // occurrence counter — different units, and conflating them is how the old
+  // floor came to be 30 against a real 60. Measured at authoring time: 59.
+  // Floor 50 gives ~15% headroom: a legitimate one- or two-file removal must
+  // not go red, while a collapse toward zero (broken regex or resolver) must.
+  assert.ok(
+    files.length >= 50,
+    `expected >= 50 unique files in the hooks-test closure, found ${files.length} — either extraction/resolution broke, or hooks tests were legitimately removed`,
+  );
+
+  const missing = files.filter((f) => !stepTouchedByDiff(hooksStep, [f]));
+  assert.deepEqual(
+    missing,
+    [],
+    `producer(s) a hooks test depends on but not an input to test:hooks:\n${missing.join('\n')}`,
+  );
+});
+```
+
+- [ ] **Step 2: Run to verify it fails with exactly two names**
+
+Run: `node --test scripts/tests/verify-cache.test.mjs`
+Expected: FAIL listing exactly `pinokio-scripts/lib/menu.js` and
+`server/src/handoff/schemas.ts`.
+
+If more appear, **stop** — the stop rule is admitting build artifacts. If
+fewer, the walk is not recursing.
+
+- [ ] **Step 3: Add the two declarations**
+
+In `scripts/verify-cache.mjs`, `test:hooks` `extraFiles`:
+
+```js
+        // menu.js is a TRANSITIVE dep: pinokio-entry.test.mjs asserts on the
+        // menu() item list, which is implemented here and reached via
+        // pinokio.js. Editing it used to leave test:hooks [cached] locally,
+        // while in cloud it set pinokio=true — running test:pinokio, a
+        // DIFFERENT suite from the test that asserts on it (#2120a).
+        'pinokio-scripts/lib/menu.js',
+        // schemas.ts is reached from diff-analysis-ab.mjs, which imports it
+        // with a .js specifier per the TypeScript convention.
+        'server/src/handoff/schemas.ts',
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `node --test scripts/tests/verify-cache.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 5: Run mutation M5**
+
+Remove `'pinokio-scripts/lib/menu.js'` from `extraFiles`.
+Run: `node --test scripts/tests/verify-cache.test.mjs`
+Expected: RED, naming that exact path. Restore.
+
+- [ ] **Step 6: Run mutation M11**
+
+Temporarily break `PATTERNS` in `module-graph.mjs` (e.g. `\bfromX\s+`).
+Run: `node --test scripts/tests/verify-cache.test.mjs`
+Expected: RED on the Metric B floor, message citing observed vs expected.
+Revert.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/tests/verify-cache.test.mjs scripts/verify-cache.mjs
+git commit -m "fix(scripts): completeness guard walks transitive deps and fails closed"
+```
+
+---
+
+### Task 14: Split `check:budget-poll` into its own step
+
+**Files:**
+- Modify: `scripts/run-hooks-tests.mjs:22-33`
+- Modify: `scripts/verify-cache.mjs` (`STEPS[]`)
+- Modify: `package.json`
+- Modify: `.github/workflows/verify.yml`
+- Test: `scripts/tests/verify-cache.test.mjs`
+
+**Interfaces:**
+- Produces: a `check:budget-poll` STEP; A2's ← and ↑ assertions require it be
+  wired in the workflow.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `scripts/tests/verify-cache.test.mjs`:
+
+```js
+// The hole this closes: verify:fast:scoped runs --steps test:hooks,test,
+// test:server --scope-staged, and test:hooks' globs exclude server/src/**.
+// So on a server-only staged diff the budgeted-poll guardrail never ran on
+// the very commit introducing the pattern (#2120b).
+test('stepTouchedByDiff: a server test diff is in scope for check:budget-poll', () => {
+  assert.equal(stepTouchedByDiff(stepByName['check:budget-poll'], ['server/src/tts/foo.test.ts']), true);
+});
+
+test('stepTouchedByDiff: a server test diff still does NOT bust test:hooks', () => {
+  assert.equal(stepTouchedByDiff(stepByName['test:hooks'], ['server/src/tts/foo.test.ts']), false);
+});
+
+test('stepTouchedByDiff: editing the budget-poll script is in scope for its own step', () => {
+  assert.equal(stepTouchedByDiff(stepByName['check:budget-poll'], ['scripts/check-no-budget-poll.mjs']), true);
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `node --test scripts/tests/verify-cache.test.mjs`
+Expected: FAIL — `stepByName['check:budget-poll']` is undefined.
+
+- [ ] **Step 3: Add the STEP**
+
+In `scripts/verify-cache.mjs`, after the `test:hooks` entry:
+
+Note the shape: a STEP has **no `command` field**. `runStepProcess` runs
+`npm run <step.name>` (`verify-cache.mjs:674-676`), so the step name *is* the
+npm script name — which is why Step 4 below must add a script called exactly
+`check:budget-poll`.
+
+```js
+  {
+    name: 'check:budget-poll',
+    inputs: {
+      /* Its own step rather than widening test:hooks' inputs: this scans
+         server/src/**\/*.test.ts at RUNTIME, and server tests are the hottest
+         surface in the repo. Folding them into test:hooks would bust a ~25s
+         cache on every server test edit; as its own ~1s step it costs almost
+         nothing AND it runs on a server-only staged diff, which is exactly
+         the case verify:fast:scoped used to skip. */
+      globs: ['server/src/**/*.test.ts'],
+      extraFiles: ['scripts/check-no-budget-poll.mjs'],
+    },
+  },
+```
+
+- [ ] **Step 4: Add the npm script**
+
+In `package.json`:
+
+```json
+    "check:budget-poll": "node scripts/check-no-budget-poll.mjs",
+```
+
+- [ ] **Step 5: Remove the spawn from the hooks runner**
+
+In `scripts/run-hooks-tests.mjs`, delete lines 22-33 (the `check` spawn and
+its error handling) and replace the final lines with:
+
+```js
+if ((result.status ?? 1) !== 0) process.exit(result.status ?? 1);
+// check-no-budget-poll.mjs used to run here. It now has its own verify step
+// (`check:budget-poll`) with server/src/**/*.test.ts as its inputs, so a
+// server-only diff actually runs it — which this coupling prevented.
+process.exit(0);
+```
+
+- [ ] **Step 6: Run to verify pass**
+
+Run: `node --test scripts/tests/verify-cache.test.mjs && npm run test:hooks && npm run check:budget-poll`
+Expected: all pass.
+
+- [ ] **Step 7: Wire it into CI**
+
+In `.github/workflows/verify.yml`, in `lint-and-checks`, after "Hooks tests":
+
+```yaml
+      - name: Budgeted-poll guardrail
+        if: fromJSON(needs.detect.outputs.scopes).step_check_budget_poll || fromJSON(needs.detect.outputs.scopes).shared
+        run: npm run check:budget-poll
+```
+
+- [ ] **Step 8: Confirm A2's assertions still pass**
+
+Run: `node --test scripts/tests/workflow-wiring.test.mjs`
+Expected: PASS. The ← direction would have caught an unwired new step — this
+is the window the A2-before-B ordering exists to close.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add scripts/run-hooks-tests.mjs scripts/verify-cache.mjs package.json .github/workflows/verify.yml scripts/tests/verify-cache.test.mjs
+git commit -m "fix(scripts): give the budgeted-poll guardrail its own verify step"
+```
+
+---
+
+### Task 15: End-to-end acceptance through the real cache decision
+
+#2120 explicitly rejects `stepTouchedByDiff` as sufficient proof, because
+PR #2117 showed it and the real `[cached]`/`[run]` decision are different
+code paths.
+
+**Files:**
+- Modify: `scripts/tests/verify-cache.test.mjs`
+
+- [ ] **Step 1: Write the test**
+
+Exact signatures (verified against `verify-cache.mjs`): `decide(...)` returns
+the **string** `'run'` or `'skip'` (`:282-287`), *not* an object.
+`composeInputHash` takes **`sortedFileEntries`** (`:318`), and `hashEntries`
+consumes **`[path, hash]` tuples** (`:309-315`), not objects.
+
+```js
+import { selectStepFiles, composeInputHash, decide } from '../verify-cache.mjs';
+
+// Shared harness: builds a real input hash for a step from a file list,
+// letting the caller perturb one file's content hash.
+function hashFor(step, fileList, bump = () => 'h0') {
+  const entries = selectStepFiles({ fileList, step }).map((rel) => [rel, bump(rel)]);
+  return composeInputHash({
+    stepName: step.name,
+    sortedFileEntries: entries,
+    lockHashes: {},
+    nodeVer: 'v20.0.0',
+    schemaVer: 1,
+    toolFingerprint: 'test',
+  });
+}
+
+// #2120 rejects stepTouchedByDiff as sufficient proof: PR #2117 showed the
+// unit seam and the real decision are different code paths. This drives
+// selectStepFiles -> composeInputHash -> decide, the actual [cached]/[run]
+// path.
+test('acceptance #2120a: editing menu.js makes test:hooks RUN, not [cached]', () => {
+  const step = stepByName['test:hooks'];
+  const fileList = ['scripts/tests/pinokio-entry.test.mjs', 'pinokio-scripts/lib/menu.js'];
+
+  assert.ok(
+    selectStepFiles({ fileList, step }).includes('pinokio-scripts/lib/menu.js'),
+    'menu.js must be among the files whose content feeds the hash',
+  );
+
+  const base = hashFor(step, fileList);
+  const edited = hashFor(step, fileList, (rel) => (rel.endsWith('menu.js') ? 'h1' : 'h0'));
+  assert.notEqual(base, edited, 'a menu.js edit must change the input hash');
+
+  const cache = { steps: { [step.name]: { inputHash: base } } };
+  assert.equal(decide({ stepName: step.name, currentHash: edited, cache }), 'run');
+  assert.equal(decide({ stepName: step.name, currentHash: base, cache }), 'skip');
+});
+
+test('acceptance #2120b: adding a server test makes check:budget-poll RUN', () => {
+  const step = stepByName['check:budget-poll'];
+  const withoutTest = ['scripts/check-no-budget-poll.mjs'];
+  const withTest = ['scripts/check-no-budget-poll.mjs', 'server/src/tts/new.test.ts'];
+
+  assert.ok(selectStepFiles({ fileList: withTest, step }).includes('server/src/tts/new.test.ts'));
+
+  const base = hashFor(step, withoutTest);
+  const added = hashFor(step, withTest);
+  assert.notEqual(base, added, 'adding a server test must change the input hash');
+
+  const cache = { steps: { [step.name]: { inputHash: base } } };
+  assert.equal(decide({ stepName: step.name, currentHash: added, cache }), 'run');
+});
+```
+
+- [ ] **Step 2: Run**
+
+Run: `node --test scripts/tests/verify-cache.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 3: Full local battery**
+
+Run: `npm run verify:fast:branch`
+Expected: all in-scope legs green.
+
+- [ ] **Step 4: Commit and open PR B**
+
+```bash
+git add scripts/tests/verify-cache.test.mjs
+git commit -m "test(scripts): acceptance through the real cached/run decision"
+git push -u origin fix/ops-verify-cache-completeness-guard
+```
+
+PR body: `Closes #2120`.
+
+---
+
+## Mutation ledger
+
+The spec names 18 mutations. Each must be discharged somewhere in this plan,
+and a reviewer should be able to check that without grepping. Anything marked
+**run it** is an explicit mutate-observe-revert step; anything marked
+**pinned by test** is discharged by a test that fails if the behaviour
+regresses.
+
+| # | What it proves | Discharged by | How |
+|---|---|---|---|
+| M1 | renamed step key breaks wiring | Task 8 Step 3 | run it |
+| M2 | typo'd `if:` key is caught | Task 8 Step 3 | run it |
+| M3 | ← fires alone on an orphaned key | Task 8 Step 3 | run it |
+| M4 | wiring floor is not vacuous | Task 8 Step 4 | run it |
+| M5 | a dropped declaration is caught | Task 13 Step 5 | run it |
+| M6 | depth-1 is GREEN against the real repo — so M5 alone cannot prove recursion | Task 12 Step 5 (the inverse: killing recursion reddens the *fixture*) | pinned by test |
+| M7 | comment-stripping is load-bearing | Task 10 Step 1, `extractRelativeSpecifiers ignores a specifier inside a comment` | pinned by test |
+| M8 | the ignored-vs-untracked *predicate* is load-bearing | Task 11 Step 4b | run it |
+| M9 | unresolvable specifiers fail closed | Task 12 Step 1, `walk reports an unresolvable specifier` | pinned by test |
+| M10 | `ci-scope.mjs` fails safe, not silent | Task 5 Steps 5 + 5b | run it |
+| M11 | Metric B floor catches a dead regex | Task 13 Step 6 | run it |
+| M12 | the `ok` sentinel rejects an empty value | Task 9 Step 3 | run it |
+| M13 | the sidecar leg reddens the **pinned context** | Task 4 Step 6 | run it (on the PR) |
+| M14 | a workflow-only edit runs the assertions | Task 1 Steps 1–2 + Task 8 Step 5 | pinned by test |
+| M15 | a job outside `needs:` is caught | Task 8 Step 3 | run it |
+| M16 | a setup step diverging from its leg is caught | Task 8 Step 3 | run it |
+| M17 | recursion is load-bearing (synthetic) | Task 12 Step 5 | run it |
+| M18 | `check-ignore` exit 128 fails closed | Task 11 Step 1, `throws on a path outside the repository` | pinned by test |
+
+**M6 deserves a note.** It is the one "mutation" that is really a *measured
+claim*: against the real repo a depth-1 walk yields closure 56, clears the
+floor of 50, and reports `missing = []` — **green**. That is why M17's
+synthetic fixture exists at all. Do not try to make M6 red against the real
+tree; if it ever does go red there, the two declarations from Task 13 have
+been lost and M5 will say so.
+
+## Post-merge
+
+- [ ] Announce the ← tripwire: any future PR adding a `STEPS[]` entry is red
+      until it also wires `verify.yml`. Five PRs were open at design time
+      (#2116, #2118, #2122, #2124, #2125).
+- [ ] Fill the spec's **Ship notes** with dates + SHAs; set `status: stable`;
+      `git mv` it to `docs/features/archive/` if it is being retired there.
+- [ ] `docs/release-notes-next.md` + `RELEASE_NOTES.md` — CI-only change with
+      no user-visible delta; state that explicitly rather than omitting.
+- [ ] No on-box acceptance row is owed: nothing here needs a GPU, a real
+      sidecar model, a real analyzer, or a real book.

--- a/docs/superpowers/specs/2026-08-05-verify-scope-map-unification-design.md
+++ b/docs/superpowers/specs/2026-08-05-verify-scope-map-unification-design.md
@@ -282,8 +282,26 @@ leg's.
 
 ### Completeness guard, hardened (#2120)
 
-1. **Strip comments before extraction.** Load-bearing, not cosmetic:
-   `verify-cache.mjs:107` contains a literal `require('../../pinokio.js')`
+1. **Extract specifiers by PARSING, not by regex over stripped text.**
+
+   > **Superseded (plan review round 2).** This item originally specified a
+   > comment-stripping step. Two hand-rolled lexers were written for it and
+   > **both were defective** — the second retained a *re-closing* desync
+   > (`return /a\/*b/;` is read as division, `/*` opens a phantom comment, a
+   > later `*/` closes it) that silently swallowed imports while the terminal
+   > state finished clean, so the whole-repo detector could not see it.
+   > `acorn` is already resolvable (8.16.0, via eslint) and ignores comments
+   > natively. Measured: 0 parse failures across 59 hooks tests, and the only
+   > delta from the regex approach is that acorn correctly declines to
+   > extract `../../pinokio.js` from inside a **string literal** — a false
+   > positive that also happened to be the sole trigger of `check-ignore`'s
+   > exit-128 path. Parsing removes the desync class, the false positive and
+   > the 128 trigger together. **Parse failure throws** rather than yielding
+   > no edges.
+
+   The original rationale, retained because it explains what the parser
+   makes moot: `verify-cache.mjs:107` contains a literal
+   `require('../../pinokio.js')`
    inside a comment that resolves *outside the repo root*. Under fail-closed
    resolution (step 5) that is a false failure. Stripping also retires the
    rule at `verify-cache.test.mjs:498-500` ("do not spell out a literal

--- a/docs/superpowers/specs/2026-08-05-verify-scope-map-unification-design.md
+++ b/docs/superpowers/specs/2026-08-05-verify-scope-map-unification-design.md
@@ -7,6 +7,13 @@ date: 2026-08-05
 
 Closes the design work behind **#2119** (ops-19) and **#2120** (ops-20).
 
+> **Revision 2.** Revision 1 went through the mandatory adversarial review
+> gate and did not survive it: five of the mechanisms intended to make
+> per-step derivation safe each failed open under an input state the spec did
+> not consider, and one proposed mutation (M6) was a placebo. §Review
+> findings records what changed and why. Every number below has been
+> independently re-derived twice.
+
 ## Problem
 
 "Which files does this verify step depend on?" is currently answered in
@@ -14,21 +21,22 @@ three places, and nothing checks them against each other:
 
 | # | Representation | Consumer |
 |---|---|---|
-| 1 | `.github/workflows/verify.yml` bash regexes (`:142-180`) | cloud — **the required status check** |
+| 1 | `.github/workflows/verify.yml` bash regexes (`:142-176`) | cloud — **the required status check** |
 | 2 | `scripts/verify-cache.mjs` `STEPS[].inputs` | local `[cached]`/`[run]` decision |
 | 3 | The real module graph + runtime reads | reality |
 
-#2119 is "**1 disagrees with 3**": `launch.mjs` matches no regex at all, so a
-PR changing only that file runs no leg that tests it, and the required check
-reports green. `server/tts-sidecar/scripts/install-qwen3.mjs` sets
-`sidecar=true`, which runs pytest — not the `test:hooks` suite that actually
-covers it. `pinokio.js` sets `pinokio=true`, which runs `test:pinokio` — a
-different suite from the `pinokio-entry.test.mjs` that loads it.
-`eslint.config.mjs` sets only `frontend=true`, which does not gate the Hooks
-step at all.
+#2119 is "**1 disagrees with 3**". `launch.mjs` matches no regex at all.
+`server/tts-sidecar/scripts/install-qwen3.mjs` sets `sidecar=true`, which
+gates only the ffmpeg install and the server TS suite — and a sidecar-only
+diff runs **zero** tests there, because that step invokes `vitest --changed`
+and no server TS is affected. `pinokio.js` sets `pinokio=true`, which runs
+`test:pinokio` — a different suite from the `pinokio-entry.test.mjs` that
+loads it. `eslint.config.mjs` sets only `frontend=true`, which does not gate
+the Hooks step at all. In each case the required check reports green having
+run no leg that covers the change.
 
 #2120 is "**2 disagrees with 3, invisibly**". PR #2117's completeness guard
-asserts "every producer a hooks test imports is a cache input", but it scans
+asserts "every producer a hooks test imports is a cache input", but scans
 only test files for their own direct specifiers. It structurally cannot see
 transitive edges (`pinokio-scripts/lib/menu.js`, reached via `pinokio.js`) or
 runtime reads (`check-no-budget-poll.mjs` scanning `server/src/**/*.test.ts`).
@@ -37,59 +45,74 @@ Nobody checks **1 against 2** either. That gap is unowned by either issue and
 is the shared cause: fixing the two symptoms independently leaves three maps
 and guarantees a fourth instance.
 
-### Two further defects found while scoping this
+### Further defects found while scoping
 
-Neither appears in either issue.
+None of these appear in either issue. **D** is the most serious thing in this
+document.
 
 **A. The guard's resolution step fails open.** `verify-cache.test.mjs:538`
 does `if (!existsSync(absProducer)) continue;` — a specifier that does not
-resolve *as written* is silently dropped rather than reported. Currently
-latent (measured: 0 specifiers skipped), but it is the "absent reads as
-clean" shape that has bitten this repo repeatedly.
+resolve *as written* is silently dropped rather than reported. Latent today
+(measured: 0 dropped), but it is the "absent reads as clean" shape.
 
 **B. The anti-vacuity floor does not bound the failure it exists to catch.**
-The guard asserts `producersScanned >= 30`; the measured actual is **60
-occurrences**. A regression that silently dropped *half* the extraction
-coverage would still pass green.
+The guard asserts `producersScanned >= 30` (`verify-cache.test.mjs:555-558`);
+the measured actual is **60 occurrences**. A regression dropping half the
+extraction coverage still passes.
 
 **C. `verify.yml` has no sidecar pytest leg at all.** The `sidecar` scope
-gates only the ffmpeg install and the server TS suite. A sidecar-only PR runs
-zero `npm run test:sidecar` on the required check. This is a third instance
-of #2119's exact shape, found while enumerating the step↔scope mapping.
+gates only the ffmpeg install (`:297`) and the server TS suite (`:307`). A
+sidecar-only PR runs zero `npm run test:sidecar` on the required check.
+
+**D. `.github/workflows/verify.yml` is in NO step's scope.** Simulating all
+nine matchers against the literal path `.github/workflows/verify.yml` yields
+**zero matches**, and `.github/**` appears in no STEP's `globs`/`extraFiles`.
+So a workflow-only PR runs **no leg at all**, in cloud *or* locally. This is
+live today, independent of this work, and it is why revision 1's central
+guard would have been decoration: a guard that reads `verify.yml` as evidence
+cannot live in a step that never runs when `verify.yml` changes.
 
 ## Decisions taken
 
-Four decisions were made explicitly during design; this spec implements them
-as stated rather than re-opening them.
+Six decisions were made explicitly; this spec implements them as stated.
 
 1. **Unify at the cause**, not the two symptoms — one map, one guard.
 2. **Split `check-no-budget-poll` into its own verify step** rather than
-   widening `test:hooks`' inputs, so a server-test edit does not bust the
-   ~25s hooks cache.
-3. **Full per-step derivation** of `verify.yml` — the nine scope booleans are
-   retired; every `if:` references a derived per-step output. *(Flagged at
-   design time as the highest-blast-radius option, since it rewrites the
-   required check; chosen deliberately. §Risks states the containment.)*
-4. **Fix the missing sidecar leg in this work** rather than filing it.
+   widening `test:hooks`' inputs.
+3. **Full per-step derivation** of `verify.yml`. *Flagged at design time as
+   the highest-blast-radius option; chosen deliberately. §Risks states the
+   containment, which revision 2 substantially strengthens.*
+4. **Fix the missing sidecar leg (C) in this work** — reaffirmed after review
+   showed the naive version would be vacuously green (see §Sidecar leg).
+5. **Fold defect D into PR A**, since the wiring assertion is worthless
+   without it.
+6. Everything else the review surfaced is folded rather than deferred, except
+   where §Non-goals says otherwise.
 
 ## Goals
 
 - A single-file PR touching `launch.mjs`,
-  `server/tts-sidecar/scripts/install-qwen3.mjs`, `pinokio.js`, or
-  `eslint.config.mjs` runs the leg that covers it, on the required check.
+  `server/tts-sidecar/scripts/install-qwen3.mjs`, `pinokio.js`,
+  `eslint.config.mjs`, or `.github/workflows/verify.yml` runs the leg that
+  covers it, on the required check.
 - Editing `pinokio-scripts/lib/menu.js`, or adding a budgeted-poll loop to a
   `server/src` test, does not leave `test:hooks` reporting `[cached]`.
 - `verify.yml` and `verify-cache.mjs` cannot disagree about a step's inputs,
   because only one of them defines them.
-- Every verify-cache STEP is either wired to a CI step or *declared*
-  unwired — never silently unwired.
+- Every verify-cache STEP is either wired to a CI step or *declared* unwired.
+- **No path through the detector can produce a green required check having
+  run nothing.**
 
 ## Non-goals
 
-- Changing which tests exist, or what any suite asserts.
+- Changing which tests exist, or what any suite asserts (one exception: the
+  one-line `test_xtts_audio_io.py` import fix the sidecar leg requires).
 - Re-tuning cache granularity beyond the `check:budget-poll` split.
-- Solving dependency discovery for `server/`'s TS graph. This work covers the
+- Dependency discovery for `server/`'s TS graph. This covers the
   `scripts/tests/*.test.mjs` surface only.
+- Unifying *step membership*. `verify:fast:scoped` / `verify:fast:branch`
+  hard-code step lists in `package.json` — a fourth list this work does not
+  touch. Named in §Residual risk so it is not mistaken for covered.
 
 ## Architecture
 
@@ -104,220 +127,363 @@ scope and starts *reading* it.
                  +------------+------------+
                  |                         |
         stepTouchedByDiff          scripts/ci-scope.mjs
-        (local [cached]/[run])     (emits step_<slug>=bool)
+        (local [cached]/[run])     (emits ONE json output + ok sentinel)
                  |                         |
         npm run verify                 verify.yml
-        verify:fast:scoped             every `if:` reads an output
+        verify:fast:scoped             if: fromJSON(...).step_x || ...shared
         verify:fast:branch             (required status check)
 ```
 
 ### `scripts/ci-scope.mjs` (new)
 
-Imports `STEPS`, reads the changed-file list, and for each step emits
-`step_<slug>=true|false` in `GITHUB_OUTPUT` format, computed with the same
-`stepTouchedByDiff` + `computeShared` the local cache uses. Slug = step name
-lowercased with `:` and `-` → `_` (`test:e2e:visual` → `step_test_e2e_visual`).
+Imports `STEPS`, reads the changed-file list, and emits **two** outputs:
+
+- `scopes` — a single JSON object, `{"step_test_hooks":true,...}`, consumed
+  as `fromJSON(needs.detect.outputs.scopes).step_test_hooks`.
+- `ok` — the literal `true`, a sentinel (see below).
+
+**Why one JSON output rather than one output per step.** GitHub requires
+every consumed output to be re-declared in the `detect` job's static
+`outputs:` map (`verify.yml:94-103`); there is no wildcard. Per-step outputs
+would make that block a **third** artifact in the derivation chain, and a key
+that `ci-scope.mjs` emits and an `if:` consumes but whose `outputs:` line is
+missing or typo'd evaluates to the empty string — silently disabling a leg,
+with both directions of the wiring assertion still passing. A single JSON
+output makes that block one static line that cannot drift per-key, collapsing
+the chain from three artifacts to two.
 
 Two keys are **not** derived from STEPS and are declared explicitly in the
-same module, because they have no cache step:
+same module, because they have no cache step: `openapi` (gates the CI-only
+"OpenAPI types up to date" drift check) and `shared` (the root-manifest
+global escape hatch).
 
-- `openapi` — gates the "OpenAPI types up to date" drift check, which is
-  CI-only.
-- `shared` — the root-manifest global escape hatch.
+**`shared` must remain in every `if:`.** `stepTouchedByDiff` has a lockfile
+branch for `server/package-lock.json` only — there is no root-lockfile path,
+which is why `computeShared` exists as a separate global override consulted
+at `verify-cache.mjs:775`. Measured: a root `package-lock.json` diff touches
+**zero** steps; `package.json` touches only `test:pinokio`. So every
+condition is `fromJSON(...).step_x || ...shared == 'true'`. Dropping the
+`shared` disjunct would make a dependency bump run nothing.
 
-**Fail-safe (load-bearing).** On *any* internal error — unreadable file, bad
-parse, unknown step — `ci-scope.mjs` emits **every key true**, prints a
-warning to stderr, and exits **0**. It must never exit non-zero and must
-never emit all-false. A crash degrades to "run the whole battery", never to
-"skip everything". Without this, one bad commit to a script blocks merges
-repo-wide.
+**`workflow_dispatch` emits all-true.** `verify.yml:117-123` special-cases it
+today because a dispatch has no PR base to diff. An empty changed-file list
+is *not* an error, so the fail-safe below does not fire — without this,
+the documented clean-room full-battery run becomes a green no-op, and it is
+precisely the escape hatch reached for when scoping is already suspect.
 
-### The trap this creates, and how it is closed
+#### Failing safe, on both sides
 
-GitHub Actions evaluates an **unknown** `needs.detect.outputs.X` to the empty
-string. So `needs.detect.outputs.step_test_hooks_typo == 'true'` is simply
-`false`: the step never runs, the required check goes **green**, and nothing
-errors. Today a typo'd bash variable is at least visible in the `scope k=`
-echo; after derivation, a renamed step or fat-fingered `if:` silently
-disables a leg of the required check.
+**Producer side.** On any internal error, `ci-scope.mjs` emits every step
+true, warns on stderr, and exits 0. A crash degrades to "run the whole
+battery", never "skip everything".
 
-**Per-step derivation is strictly worse than the status quo unless this is
-closed in the same change.** It is closed by a bidirectional wiring assertion
-over the parsed workflow:
+**Consumer side — the part revision 1 missed.** The producer-side fail-safe
+shares a failure mode with the thing it guards: it writes the fallback to the
+same `GITHUB_OUTPUT` handle. If that handle is unset or unwritable, or the
+process exits 0 having written nothing, every output resolves to `''`, every
+`if:` is false, every job's *steps* skip, **every job succeeds**, and the
+aggregator reports green — it only fails on `failure`/`cancelled`/`skipped`
+at the **job** level, and no job is skipped in that scenario.
+
+So the aggregator job (`verify.yml:433`) asserts `needs.detect.outputs.ok ==
+'true'` and fails otherwise. This is a *consumer-side* check on a different
+artifact from the one it validates, which is what makes it independent.
+`fromJSON('')` also raises rather than yielding falsy, so a blank `scopes`
+fails loudly — a deliberate second line of defence, not the primary one.
+
+### The trap per-step derivation creates
+
+GitHub evaluates an unknown output reference to the empty string, so a
+fat-fingered `if:` silently disables a leg and the required check goes green.
+**Derivation is strictly worse than the status quo unless this is closed in
+the same change.** It is closed by a bidirectional assertion over the parsed
+workflow:
 
 | Direction | Assertion | Catches |
 |---|---|---|
-| **→** | every `needs.detect.outputs.X` in the YAML is a key `ci-scope.mjs` emits | typos, renamed steps, deleted steps |
+| **→** | every `fromJSON(...).X` in the YAML is a key `ci-scope.mjs` emits | typos, renamed/deleted steps |
 | **←** | every emitted key is referenced by ≥1 `if:`, or listed in `KNOWN_UNWIRED` with an issue ref | orphaned steps — defect **C**'s shape |
 
-`KNOWN_UNWIRED` is **empty** once the sidecar leg lands, so the ← direction
-starts fully strict. It exists so a future unwired step must be declared in a
-reviewed diff rather than going quietly missing.
+**This assertion only works because of the defect-D fix.** `.github/**` must
+become an input to the step that runs it *and* match a scope that runs that
+step. Without that, the guard cannot run on the PR that breaks it.
 
-Both directions carry an anti-vacuity floor calibrated to **measured**
-counts, not round numbers — see defect **B**.
+`KNOWN_UNWIRED` is **not empty on day one** — see the mapping table below.
+
+### The step↔CI mapping is N:M, not 1:1
+
+Revision 1 assumed a clean 1:1 map. It is not:
+
+| STEP | CI home | Note |
+|---|---|---|
+| `lint`, `typecheck`, `config:check`, `test:hooks`, `test:pinokio`, `test:scripts`, `build` | one step each | clean |
+| `test:server` + `test:server-slow` | **one** step, one `if:` (`:306-318`) | two STEPS share a condition |
+| `test:e2e` | **4-way matrix** (`:329`) | one STEP fans out |
+| `test:e2e:visual` | one step | clean |
+| `test` | frontend step (`:269-275`) runs `vitest --changed` **+** `test:a11y` | not `npm run test`; `test:a11y` has no STEP |
+| `test:sidecar` | **new** — see below | defect C |
+
+Seven further `if:`-bearing steps are **setup, not legs** (3× Install ffmpeg,
+2× Cache Playwright, 2× Install Playwright) and derive from no STEP. Each
+must derive from the **same key as the leg it supports** — if the Playwright
+cache/install condition and the e2e run condition diverge, e2e runs without a
+browser. These are listed explicitly rather than pattern-matched.
 
 ### Completeness guard, hardened (#2120)
 
-`scripts/tests/verify-cache.test.mjs`'s guard gains, in order:
-
-1. **Comment stripping before extraction.** Load-bearing, not cosmetic: the
-   existing regexes match specifiers inside comments, and
-   `verify-cache.mjs`'s own comment contains a literal
-   `require('../../pinokio.js')`. Under fail-closed resolution (step 4) that
-   would be a *false failure*. Stripping comments also retires the awkward
-   rule at `verify-cache.test.mjs:497` ("do not spell out a literal example
-   specifier in this comment") — the constraint disappears instead of being
-   documented around.
+1. **Strip comments before extraction.** Load-bearing, not cosmetic:
+   `verify-cache.mjs:108-109` contains a literal `require('../../pinokio.js')`
+   inside a comment that resolves *outside the repo root*. Under fail-closed
+   resolution (step 5) that is a false failure. Stripping also retires the
+   rule at `verify-cache.test.mjs:498-500` ("do not spell out a literal
+   example specifier in this comment") — the constraint disappears rather
+   than being documented around.
 2. **Resolution candidates**: exact → `.js`/`.mjs`/`.cjs` → **`.js` → `.ts`**
-   (TS emits `.js` specifiers for `.ts` sources; `scripts/diff-analysis-ab.mjs`
-   imports `../server/src/handoff/schemas.js`) → `/index.{js,mjs}`.
-3. **Transitive walk** with a visited-set cycle guard, following resolved
-   relative specifiers recursively. Bare specifiers (`node:fs`, `archiver`)
-   are never followed, so `node_modules` is never entered.
-4. **Stop rule: do not follow git-untracked paths.** This is what makes the
-   walk correct rather than merely complete —
-   `scripts/repair-cast-id-drift.mjs:1203` dynamically imports
-   `../server/dist/**` inside `main()`, and its test deliberately injects
-   stand-ins instead. `server/dist/` is gitignored build output; declaring it
-   as a cache input would be meaningless (missing on a clean checkout) and
-   noisy (regenerated by every build).
+   (`diff-analysis-ab.mjs:248` imports `../server/src/handoff/schemas.js`;
+   only the `.ts` exists) → `/index.{js,mjs}`.
+3. **Transitive walk**, visited-set cycle guard. Bare specifiers are never
+   followed, so `node_modules` is never entered.
+4. **Stop rule: `git check-ignore`, not `git ls-files`.** Revision 1 said
+   "untracked"; that is clone-state-dependent and wrong three ways. Measured:
+   `server/dist/` is gitignored but **present on this box (1,812 files)** and
+   **absent on a fresh CI clone**, and
+   `repair-cast-id-drift.mjs:1203-1209` statically imports seven
+   `../server/dist/**` specifiers. Under "untracked" those resolve locally
+   and *fail to resolve* in CI — 7 unresolvable specifiers, i.e. **red on CI,
+   green locally**. "Ignored" is a property of `.gitignore`, identical in
+   both. It also fixes: a new producer added but not yet `git add`ed (would
+   be silently exempt under "untracked", on exactly the commit introducing
+   it), `core.ignorecase` differing Windows↔Linux, and submodule gitlinks.
+   **Ordering is specified: classify by `check-ignore` FIRST, resolve
+   second.** An ignored path is skipped without ever being resolved, so its
+   presence or absence on disk cannot change the outcome.
 5. **Unresolvable ⇒ fail**, not `continue` — closes defect **A**. Safe only
-   because of step 1.
-6. **Floor recalibrated against the right metric** — closes defect **B**.
-   The current counter measures *occurrences* (one per `(test file,
-   specifier)` pair); the hardened guard walks a closure and should assert on
-   *unique tracked files*. These are different units and must not be
-   conflated — conflating them is how defect **B** arose. See §Measurements
-   for the unit-tagged values and the floor rule.
+   because of steps 1 and 4.
+6. **Floor recalibrated against the right metric** — closes defect **B**. The
+   current counter measures *occurrences*; the hardened guard walks a closure
+   and asserts on *unique files*. Different units; conflating them is how
+   defect B arose. See §Measurements.
 
 ### `check:budget-poll` split (#2120b)
 
 `check-no-budget-poll.mjs` moves out of `run-hooks-tests.mjs:24-28` into its
 own npm script, its own `STEPS[]` entry (globs `server/src/**/*.test.ts`,
-extraFiles the script itself), and its own CI step.
+extraFiles the script), and its own CI step.
 
-This is not merely bookkeeping. Today, on a **server-only staged diff**,
-`verify:fast:scoped` skips `test:hooks` outright — so the guardrail that
-exists to reject budgeted-poll loops never runs on the very commit
-introducing one. Splitting it fixes that, and costs ~1s instead of busting
-the ~25s hooks cache on the repo's hottest surface.
+Verified real: `verify:fast:scoped` runs `--steps test:hooks,test,test:server
+--scope-staged`, and `test:hooks`' globs (`verify-cache.mjs:56`) exclude
+`server/src/**`. So on a server-only staged diff the guardrail that exists to
+reject budgeted-poll loops never runs on the commit introducing one. The
+split fixes that at ~1s instead of busting the ~25s hooks cache.
 
-### Sidecar leg (defect C)
+### Sidecar leg (defect C) — built properly
 
-`verify.yml` gains a sidecar pytest step wired to `test:sidecar`. It reuses
-the existing venv-bootstrap path and retains `npm run test:sidecar`'s
-SKIP-and-exit-0 behaviour on an unbootstrapped venv, so it cannot become a
-new source of red on runners without the venv.
+Revision 1 claimed the leg "reuses the existing venv-bootstrap path" and
+"cannot become a new source of red". Both were false: there is **no** venv
+bootstrap in `.github/` at all, and `run-tests.ps1:15` hardcodes
+`.venv\Scripts\python.exe`, a Windows-only layout that can never exist on
+`ubuntu-latest` — the runner would take the SKIP branch and exit 0 forever.
+The ← assertion would then certify it as *wired*, converting a visible hole
+into an invisible one. The spec framed that vacuity as a safety property.
+
+The leg is nonetheless cheap, because the suite is designed to run without
+the heavy ML stack — `requirements-dev.txt` says so explicitly, and it holds:
+
+- `main.py` imports **no torch** at module level (numpy + fastapi only).
+- Of 67 test files, **12** import torch function-locally and **one**
+  (`test_xtts_audio_io.py:15`) does so at module scope — inconsistent with
+  that same file's own `pytest.importorskip` calls at `:81`, `:99`, `:229`.
+
+So it needs three things, and no GPU or torch:
+
+1. A **cross-platform test entry point** — resolve `.venv/Scripts/python.exe`
+   on Windows, `.venv/bin/python` on POSIX. `npm run test:sidecar`'s existing
+   SKIP-on-missing-venv behaviour is retained for *local* use only.
+2. **CI bootstrap**: `actions/setup-python`, venv, `pip install -r
+   requirements/base.txt -r requirements-dev.txt`, with pip caching.
+3. `test_xtts_audio_io.py:15` `import torch` → `pytest.importorskip("torch")`,
+   matching the file's own established pattern.
+
+**The leg must be able to fail.** Acceptance includes a mutation proving a
+deliberately broken sidecar test turns the required check red on ubuntu — not
+merely that the job is green.
 
 ## Measurements
 
-Taken against the tree at design time (commit `922cf129`). These are the
-numbers the floors and the expected-delta assertions are calibrated to; a
-plan step re-measures rather than trusting them.
+Taken at `922cf129`, independently re-derived at `a9f84e10`. A plan step
+re-measures rather than trusting these.
 
-> **Read the units.** Three of these values land on 59–60 while measuring
-> different things. Do not carry a number from one row into an assertion
-> about another — that conflation *is* defect **B**.
+> **Read the units.** Three values land on 59–60 while measuring different
+> things. Do not carry a number from one row into an assertion about another
+> — that conflation *is* defect **B**.
 
 | Quantity | Unit | Value |
 |---|---|---|
 | Hooks test files | files | 59 |
 | **Metric A** — imports scanned by today's guard | *occurrences* | 60 |
-| Today's anti-vacuity floor (asserts on Metric A) | occurrences | 30 |
-| Naive transitive closure, no stop rule | unique files | 81 |
+| Today's floor (asserts on Metric A) | occurrences | 30 |
+| Naive closure, no stop rule | unique files | 81 |
 | — missing from `test:hooks` | unique files | 24 |
-| — of those, gitignored `server/dist/**` artifacts | unique files | 22 |
-| **Metric B** — closure **with** git-tracked stop rule | unique files | 59 |
-| — genuinely missing from `test:hooks` | unique files | **2** |
-| Unresolvable specifiers (comment / `.js`→`.ts`) | specifiers | 2 |
+| — of those, gitignored `server/dist/**` | unique files | 22 |
+| **Metric B** — closure with the stop rule | unique files | 59 |
+| — genuinely missing | unique files | **2** |
+| Specifiers silently dropped today (defect A) | specifiers | 0 (latent) |
+| Unresolvable **pre-mitigation**, post-resolver | specifiers | 1 |
+| Unresolvable **post** comment-stripping | specifiers | **0** |
+| `server/dist` files present locally / on fresh clone | files | 1,812 / 0 |
+| Unresolvable under "untracked" rule, CI-simulated | specifiers | 7 |
 
 The two genuine additions are `pinokio-scripts/lib/menu.js` (the #2120(a)
 instance) and `server/src/handoff/schemas.ts`.
 
-**Floor rule.** The hardened guard asserts on **Metric B**. The floor exists
-to catch *extraction or resolution breakage*, whose signature is a collapse
-toward zero — not a legitimate one- or two-file removal. Set it at **50**
-(~15% headroom under the measured 59): low enough that removing a few hooks
-tests does not cause spurious red, high enough that losing even a fifth of
-the closure fails. The plan **re-measures** rather than trusting 59, and the
-assertion message states both the observed and expected values so a genuine
-drop is diagnosable rather than merely red.
+**Floor rule.** The hardened guard asserts on **Metric B**. The floor catches
+*extraction or resolution breakage*, whose signature is a collapse toward
+zero — not a legitimate one- or two-file removal. Set it at **50** (~15%
+headroom under 59). The assertion message states observed *and* expected, so
+a genuine drop is diagnosable rather than merely red.
+
+**Note for M9.** Post-hardening there is **no live unresolvable case** (the
+count goes 1 → 0). M9 therefore needs a synthetic fixture; asserting against
+the real tree would be vacuous.
 
 ## Testing
 
-Every new guard ships with a **named mutation** that makes it go red. A guard
-that cannot be shown failing is not a guard.
+Every new guard ships with a **named mutation** that makes it go red.
 
 | # | Mutation | Must go red with |
 |---|---|---|
-| M1 | rename an emitted key in `ci-scope.mjs` | → direction, naming the orphaned `if:` |
-| M2 | add `outputs.step_nope` to `verify.yml` | → direction |
+| M1 | rename an emitted key in `ci-scope.mjs` | → direction |
+| M2 | add `fromJSON(...).step_nope` to `verify.yml` | → direction |
 | M3 | unwire a step's CI home | ← direction (defect C's shape) |
-| M4 | make the YAML parse return nothing | anti-vacuity floor |
+| M4 | make the YAML parse return nothing | wiring anti-vacuity floor |
 | M5 | drop `pinokio-scripts/lib/menu.js` from extraFiles | completeness guard, naming that path |
-| M6 | limit the walk to depth 1 | same — proves recursion is load-bearing |
+| M6 | **M5 held, walk limited to depth 1** | guard goes **GREEN** — see below |
 | M7 | remove comment-stripping | false positive on `../../pinokio.js` |
-| M8 | follow git-untracked paths | 22 `server/dist/**` entries |
-| M9 | revert unresolvable→fail to `continue` | resolver unit test |
+| M8 | swap stop rule to "untracked", simulate fresh clone | 7 unresolvable `server/dist` specifiers |
+| M9 | revert unresolvable→fail to `continue` | resolver unit test, synthetic fixture |
 | M10 | throw inside `ci-scope.mjs` | fail-safe emits all-true, exit 0 |
 | M11 | break the extraction regex so it matches nothing | Metric B floor, message citing observed vs expected |
+| M12 | make `ci-scope.mjs` exit 0 writing nothing | **aggregator `ok` sentinel** |
+| M13 | make a sidecar test fail on ubuntu | the new sidecar leg turns the check red |
+| M14 | edit only `.github/workflows/verify.yml` | the wiring assertion actually runs (defect D) |
 
-M6 and M11 deliberately target *different* assertions: a depth-1 walk still
-clears the Metric B floor, so only the missing-input assertion catches it,
-while a dead regex collapses the closure and only the floor catches it.
-Neither alone demonstrates the guard works.
+**M6 is inverted from revision 1, which had it backwards.** Revision 1
+claimed a depth-1 walk goes red on its own. It cannot: a depth-1 closure is a
+*subset* of the full closure, the full closure has zero missing once the two
+declarations land, so the subset also has zero missing. Measured: depth-1
+closure = 56, clears the floor of 50, `missing = []` — **green**. That is the
+"detector shipped alongside the declaration that satisfies it" placebo shape.
+Recursion is load-bearing only in combination: **M5 under a full walk is RED;
+M5 under depth-1 is GREEN.** The pair is the proof; neither half alone is.
 
 ### Acceptance
 
-- **#2119** — table-driven over the four cited paths (`launch.mjs`,
+- **#2119** — table-driven over `launch.mjs`,
   `server/tts-sidecar/scripts/install-qwen3.mjs`, `pinokio.js`,
-  `eslint.config.mjs`): each must yield `step_test_hooks=true`.
+  `eslint.config.mjs`: each yields `step_test_hooks` true.
 - **#2120** — the issue explicitly rejects `stepTouchedByDiff` as sufficient
   proof, because PR #2117 showed it and the real decision are different code
-  paths. The test therefore drives the **real `[cached]`/`[run]` decision**
-  through `selectStepFiles` + `composeInputHash` + `decide`: editing
-  `menu.js`, and adding a budgeted-poll loop to a `server/src` test, must
-  both come back `[run]`.
-- **Defect C** — a sidecar-only diff yields `step_test_sidecar=true`.
+  paths. Tests drive the **real `[cached]`/`[run]` decision** through
+  `selectStepFiles` + `composeInputHash` + `decide`.
+- **Defect C** — a sidecar-only diff runs a sidecar leg that *can* fail (M13).
+- **Defect D** — a `.github/workflows/`-only diff runs the wiring assertion.
 
-New tests must be wired into the verify-cache `extraFiles` and `verify.yml`'s
-own coverage, or they are not gated.
+New tests must be wired into `extraFiles` **and** into a scope that runs
+them, or they are not gated.
 
 ## PR shape
 
-Two PRs, **sequential** — both touch `verify-cache.mjs` (A adds the `ci`
-field, B adds a STEP), so running them in parallel invites a conflict on the
-one file that must stay coherent.
+Two PRs, **sequential**.
 
 | PR | Closes | Contents |
 |---|---|---|
-| **A** | #2119 | `ci-scope.mjs`, `verify.yml` per-step derivation, bidirectional wiring assertion, sidecar pytest leg |
-| **B** | #2120 | comment-stripping, resolver, transitive walk + stop rule, fail-closed, floor recalibration, `check:budget-poll` split, the 2 new declarations |
+| **A** | #2119 | `ci-scope.mjs` (+ `ok` sentinel), `verify.yml` derivation, bidirectional wiring assertion, **defect D fix**, real sidecar leg |
+| **B** | #2120 | comment-stripping, resolver, transitive walk + `check-ignore` stop rule, fail-closed, floor recalibration, `check:budget-poll` split, the 2 declarations |
+
+**Why A first**, in strength order: (1) B adds a `STEPS[]` entry, and A
+introduces the ← assertion that would flag it as unwired — B-first opens a
+window where the new step is silently unwired; (2) B's floor is calibrated
+against a Metric B that A does not change, so the calibration is stable
+either way; (3) both touch `verify-cache.mjs`, so parallel work invites a
+conflict. Revision 1 gave only (3), the weakest of the three.
 
 ## Risks
 
-**PR A rewrites the required status check.** This is the dominant risk and it
-was accepted knowingly. Three things contain it:
+**PR A rewrites the required status check.** Containments:
 
-1. **The fail-safe** degrades any `ci-scope.mjs` failure to *run everything*,
-   never to *skip everything*.
-2. **PR A validates itself.** `pull_request` runs use the workflow file from
-   the PR's own merge ref, so the derived workflow is exercised on PR A
-   before it can affect any other PR. The PR touches `scripts/` and
-   `.github/`, so the hooks and scripts legs are in scope for its own run.
-3. **Rollback is one revert** of a self-contained commit.
+1. **Producer fail-safe** — any thrown error degrades to run-everything.
+2. **Consumer sentinel** — the aggregator fails if `ok != 'true'`, catching
+   the wrote-nothing class the producer fail-safe cannot.
+3. **PR A validates itself.** The GitHub semantics claim is correct:
+   `pull_request` (unlike `pull_request_target`) runs the workflow from the
+   PR's merge ref. **But it is circular against computed-false**: if
+   `ci-scope.mjs` computes `step_test_hooks=false` incorrectly, the assertion
+   never runs on the PR introducing it. The sentinel and the defect-D fix
+   narrow this; they do not eliminate it. Mitigation: PR A's own CI run is
+   inspected by hand against an expected leg list before merge.
+4. **Rollback is one revert.**
 
-**Residual risk:** a step whose `if:` is *correct* but whose derived inputs
-are *wrong* still skips silently. The bidirectional assertion proves wiring,
-not input correctness; input correctness is what the completeness guard in
-PR B covers, and only for the `scripts/tests` surface. Steps outside that
-surface (`test`, `test:server`, `build`) keep hand-maintained inputs and are
-out of scope here.
+**The pinned check name is a hard constraint.** `main`'s ruleset 17654264
+pins `required_status_checks` to the contexts `'npm run verify'` and
+`'Verify PR body links a GitHub issue'`. `'npm run verify'` is the aggregator
+job's `name:` (`verify.yml:434`). Therefore, **inviolably**:
 
-**Ordering risk:** if PR B lands first, the `check:budget-poll` STEP exists
-with no CI home and the ← assertion — which PR A introduces — is not yet
-present to catch it. Landing A first avoids the window entirely.
+- the aggregator job's `name:` must not change — renaming it detaches the
+  gate, and every subsequent PR merges with no check at all;
+- conditions stay at **step** level, never hoisted to **job** level. "Every
+  `if:` reads a derived output" reads as licence to hoist; hoisting makes
+  scoped-down PRs skip jobs, and the aggregator fails on `skipped`
+  (`:445`) — turning the required check red on every PR.
+
+Revision 1 mentioned neither, despite `verify.yml:49-54` warning about it
+in-file.
+
+**Merge tripwire for in-flight PRs.** Once A lands, the ← direction makes any
+future PR that adds a `STEPS[]` entry red until it also wires `verify.yml`.
+Five PRs are open (#2116, #2118, #2122, #2124, #2125). This is intended
+behaviour, but it is a repo-wide behaviour change and should be announced,
+not discovered.
+
+### Residual risk
+
+- A step whose `if:` is correct but whose *inputs* are wrong still skips
+  silently. The wiring assertion proves wiring, not input correctness; the
+  completeness guard covers input correctness only for `scripts/tests`.
+  `test`, `test:server`, `build` keep hand-maintained inputs.
+- **A fourth list survives.** `verify:fast:scoped` / `verify:fast:branch`
+  hard-code step *lists* in `package.json` (`verify:fast:branch` runs
+  `test:sidecar` but not `test:pinokio` or `test:scripts`). "One map" covers
+  step *inputs*, not step *membership*. Out of scope; recorded so it is not
+  mistaken for solved.
+
+## Review findings
+
+Revision 1 went through the mandatory Premium-tier `assumption-checker` gate.
+Findings folded, all independently verified against the tree before
+acceptance:
+
+| Finding | Severity | Disposition |
+|---|---|---|
+| Wiring assertion covered 2 of 3 artifacts (`outputs:` map) | Critical | single JSON output collapses the chain to 2 |
+| `verify.yml` in no step's scope (defect D) | Critical | folded into PR A |
+| Sidecar leg vacuously green on ubuntu | Critical | real leg: setup-python + venv + the `importorskip` fix |
+| Fail-safe had no consumer-side check | Critical | `ok` sentinel asserted by the aggregator |
+| `workflow_dispatch` unaddressed | Major | explicit all-true |
+| Stop rule clone-state-dependent | Major | `check-ignore`, classify-before-resolve |
+| M6 was a placebo | Major | inverted; M5-pair is the proof |
+| Mapping assumed 1:1 | Major | N:M table; `KNOWN_UNWIRED` non-empty |
+| `shared` dropped by per-step outputs | Major | `shared` disjunct mandatory |
+| Pinned check name unmentioned | Major | hard constraint in §Risks |
+| Self-validation circular | Significant | stated honestly + manual inspection |
+| Unresolvable-count unit ambiguity | Minor | split pre/post rows; M9 needs a fixture |
+| "`sidecar=true` runs pytest" contradicted defect C | — | corrected in §Problem |
+| `:497` off-by-one citation | — | corrected to `:498-500` |
+
+Claims that **survived** re-derivation: every measurement in revision 1's
+table; that comment-stripping and the `.js`→`.ts` resolver are load-bearing;
+that `launch.mjs`/`eslint.config.mjs`/`pinokio.js` are routed as described;
+that `pull_request` uses the PR's own workflow file; and that the
+`check:budget-poll` split fixes a real hole.
 
 ## Ship notes
 

--- a/docs/superpowers/specs/2026-08-05-verify-scope-map-unification-design.md
+++ b/docs/superpowers/specs/2026-08-05-verify-scope-map-unification-design.md
@@ -321,8 +321,17 @@ leg's.
    where a `.gitignore` pattern is file-specific rather than
    directory-prefixed, so classify-once could disagree with what resolution
    lands on. Verified: `git check-ignore server/dist/does/not/exist.js`
-   returns 0 — it is pure pattern matching and answers correctly for paths
-   that do not exist, which is exactly the property the rule needs.
+   returns 0 — it answers correctly for paths that do not exist, which is
+   the property the rule needs.
+
+   **Correction (plan review):** `check-ignore` is **index-aware**, not pure
+   `.gitignore` matching. Measured: a file matching an ignore rule but
+   force-added to the index reports exit 1 (*not* ignored); `--no-index`
+   reports 0. This is kept deliberately — a tracked file is a real producer
+   and belongs in the closure — but the simpler "property of `.gitignore`
+   alone" framing is wrong and would mislead anyone later tempted to add
+   `--no-index`. The `server/dist/**` conclusion is unaffected: never
+   tracked, so ignored in a fresh clone and a built tree alike.
 
    **Exit codes are three-valued, and the contract is explicit** (measured in
    this repo): `0` = ignored, `1` = not ignored, **`128` = error** (e.g.
@@ -447,12 +456,20 @@ re-measures rather than trusting these.
 | Unresolvable **post** comment-stripping | specifiers | **0** |
 | `server/dist` files present locally / on fresh clone | files | 1,812 / 0 |
 | Unresolvable under "untracked" rule, CI-simulated | specifiers | 7 |
-| Depth-1 closure (M6/M17 counterfactual) | unique files | 56 |
+| Depth-1 closure (M6/M17 counterfactual) | unique files | 56–57 |
 | `check-ignore` — 81 spawns vs one `--stdin` batch | ms | 3972 / 60 (66×) |
 | Module-scope test imports absent from the lean venv | modules | 2 (`torch`, `speechbrain`) |
 
 The two genuine additions are `pinokio-scripts/lib/menu.js` (the #2120(a)
 instance) and `server/src/handoff/schemas.ts`.
+
+**Metric B is 59–60 depending on predicate**, and the plan review measured
+the upper end. The difference is real and explainable: `ls-files` ("tracked")
+excludes a file that is untracked but *not* ignored, while `check-ignore`
+("ignored") includes it — so the shipped predicate counts marginally more.
+Immaterial against a floor of 50, but **do not assert an exact count**; the
+load-bearing assertion is the *identity* of the missing files (exactly two),
+which both measurements agree on.
 
 **Floor rule.** The hardened guard asserts on **Metric B**. The floor catches
 *extraction or resolution breakage*, whose signature is a collapse toward

--- a/docs/superpowers/specs/2026-08-05-verify-scope-map-unification-design.md
+++ b/docs/superpowers/specs/2026-08-05-verify-scope-map-unification-design.md
@@ -7,12 +7,15 @@ date: 2026-08-05
 
 Closes the design work behind **#2119** (ops-19) and **#2120** (ops-20).
 
-> **Revision 2.** Revision 1 went through the mandatory adversarial review
-> gate and did not survive it: five of the mechanisms intended to make
-> per-step derivation safe each failed open under an input state the spec did
-> not consider, and one proposed mutation (M6) was a placebo. §Review
-> findings records what changed and why. Every number below has been
-> independently re-derived twice.
+> **Revision 3.** This spec has been through **two** rounds of the mandatory
+> adversarial review gate. Round 1 found four Critical fail-open defects in
+> revision 1 and one placebo mutation. Round 2, briefed to attack round 1's
+> *fixes* rather than re-run it, found three more Criticals — including that
+> the `ok` sentinel and the new sidecar job were both wired into a `needs:`
+> list that does not contain them, so neither would have gated anything.
+> §Review findings records both rounds. Every number below has been
+> independently re-derived at least twice; every finding was verified against
+> the tree before folding.
 
 ## Problem
 
@@ -84,7 +87,7 @@ Six decisions were made explicitly; this spec implements them as stated.
    containment, which revision 2 substantially strengthens.*
 4. **Fix the missing sidecar leg (C) in this work** — reaffirmed after review
    showed the naive version would be vacuously green (see §Sidecar leg).
-5. **Fold defect D into PR A**, since the wiring assertion is worthless
+5. **Fold defect D into A1**, since the wiring assertions are worthless
    without it.
 6. Everything else the review surfaced is folded rather than deferred, except
    where §Non-goals says otherwise.
@@ -105,8 +108,9 @@ Six decisions were made explicitly; this spec implements them as stated.
 
 ## Non-goals
 
-- Changing which tests exist, or what any suite asserts (one exception: the
-  one-line `test_xtts_audio_io.py` import fix the sidecar leg requires).
+- Changing which tests exist, or what any suite asserts (**two** exceptions:
+  the one-line `pytest.importorskip` fixes in `test_xtts_audio_io.py` and
+  `test_speechbrain_disarm.py` that the sidecar leg requires).
 - Re-tuning cache granularity beyond the `check:budget-poll` split.
 - Dependency discovery for `server/`'s TS graph. This covers the
   `scripts/tests/*.test.mjs` surface only.
@@ -185,30 +189,62 @@ process exits 0 having written nothing, every output resolves to `''`, every
 aggregator reports green — it only fails on `failure`/`cancelled`/`skipped`
 at the **job** level, and no job is skipped in that scenario.
 
-So the aggregator job (`verify.yml:433`) asserts `needs.detect.outputs.ok ==
-'true'` and fails otherwise. This is a *consumer-side* check on a different
-artifact from the one it validates, which is what makes it independent.
-`fromJSON('')` also raises rather than yielding falsy, so a blank `scopes`
-fails loudly — a deliberate second line of defence, not the primary one.
+So the aggregator job (`verify.yml:433`) asserts
+`needs.detect.result == 'success' && needs.detect.outputs.ok == 'true'` and
+fails otherwise. This is a *consumer-side* check on a different artifact from
+the one it validates, which is what makes it independent. `fromJSON('')` also
+raises rather than yielding falsy, so a blank `scopes` fails loudly — a
+deliberate second line of defence, not the primary one.
+
+> **`detect` must be added to the aggregator's `needs:` for this to work at
+> all.** `verify.yml:435` is currently `needs: [lint-and-checks,
+> frontend-tests, server-tests, e2e, e2e-visual, build]` — `detect` is *not*
+> in it, and the `needs` context exposes only jobs listed there. Without the
+> addition, `needs.detect.outputs.ok` is the empty string, `'' == 'true'` is
+> false, and the sentinel fails on **every** PR. That is fail-closed and
+> self-revealing, but the reflex under a permanently-red required check is to
+> delete the sentinel — which silently restores the exact hole it exists to
+> close. Adding `detect` is safe against the `contains(needs.*.result,
+> 'skipped')` check at `:445`: `detect` carries no job-level `if:` and cannot
+> skip.
+
+**Blast radius the collapse creates.** A per-key typo previously disabled one
+leg; a broken `scopes` disables all of them at once. That makes the sentinel
+a *precondition* of the single-JSON design, not a belt-and-braces extra —
+which is why it is specified here rather than filed under containment.
 
 ### The trap per-step derivation creates
 
 GitHub evaluates an unknown output reference to the empty string, so a
 fat-fingered `if:` silently disables a leg and the required check goes green.
 **Derivation is strictly worse than the status quo unless this is closed in
-the same change.** It is closed by a bidirectional assertion over the parsed
-workflow:
+the same change.** It is closed by a set of assertions over the parsed
+workflow — two directions in revision 2, **four** after round 2:
 
 | Direction | Assertion | Catches |
 |---|---|---|
 | **→** | every `fromJSON(...).X` in the YAML is a key `ci-scope.mjs` emits | typos, renamed/deleted steps |
-| **←** | every emitted key is referenced by ≥1 `if:`, or listed in `KNOWN_UNWIRED` with an issue ref | orphaned steps — defect **C**'s shape |
+| **←** | every emitted key is referenced by ≥1 `if:` | orphaned steps — defect **C**'s shape |
+| **↑** | every **job** containing a derived `if:` appears in the aggregator's `needs:` | a leg that runs, goes red, and gates nothing |
 
-**This assertion only works because of the defect-D fix.** `.github/**` must
-become an input to the step that runs it *and* match a scope that runs that
+**The ↑ direction is not optional.** `main`'s ruleset pins only the contexts
+`'npm run verify'` and `'Verify PR body links a GitHub issue'`. A job absent
+from the aggregator's `needs:` can fail without blocking merge — while the ←
+direction still certifies its key as *wired* because an `if:` references it.
+That is revision 1's sidecar defect reproduced one level up: a leg that
+exists, is visible, is certified, and gates nothing. All three directions are
+checkable from the same parsed YAML and belong in one test.
+
+**No `KNOWN_UNWIRED` escape hatch.** Revision 2 claimed it would be non-empty
+on day one; the mapping table below accounts for all 13 STEPS and marks none
+unwired, so it would ship as an **empty, unexercised allowlist** — an
+untested bypass is where the next "just add it to `KNOWN_UNWIRED`" quietly
+reopens defect C. Unwiring a step therefore requires a code change to the
+assertion itself, in a reviewed diff.
+
+**These assertions only work because of the defect-D fix.** `.github/**` must
+become an input to the step that runs them *and* match a scope that runs that
 step. Without that, the guard cannot run on the PR that breaks it.
-
-`KNOWN_UNWIRED` is **not empty on day one** — see the mapping table below.
 
 ### The step↔CI mapping is N:M, not 1:1
 
@@ -221,18 +257,33 @@ Revision 1 assumed a clean 1:1 map. It is not:
 | `test:e2e` | **4-way matrix** (`:329`) | one STEP fans out |
 | `test:e2e:visual` | one step | clean |
 | `test` | frontend step (`:269-275`) runs `vitest --changed` **+** `test:a11y` | not `npm run test`; `test:a11y` has no STEP |
-| `test:sidecar` | **new** — see below | defect C |
+| `test:sidecar` | **a new JOB** (not a step) — see below | defect C |
+
+`test:sidecar` is a **job**, not a step in an existing job, because it needs
+its own Python/venv bootstrap. That distinction has opposite gating
+consequences and must be stated: a step inside `lint-and-checks` inherits the
+aggregator's gate for free; a new job does **not**, and must be added to the
+aggregator's `needs:`. The ↑ assertion enforces this.
 
 Seven further `if:`-bearing steps are **setup, not legs** (3× Install ffmpeg,
 2× Cache Playwright, 2× Install Playwright) and derive from no STEP. Each
 must derive from the **same key as the leg it supports** — if the Playwright
 cache/install condition and the e2e run condition diverge, e2e runs without a
-browser. These are listed explicitly rather than pattern-matched.
+browser.
+
+Revision 2 proposed listing these "explicitly rather than pattern-matched",
+which is a hand-maintained correspondence between two conditions that must
+agree, with nothing checking them — *the document's own thesis, reintroduced
+at smaller scale*. Four such pairs live at `verify.yml:346/350/360/364` and
+`:393/397/407/411`, each repeating the same disjunct by hand. Instead, each
+setup step declares the leg it supports (`# supports: test:e2e`) and a
+**fourth assertion** requires its condition to be string-identical to that
+leg's.
 
 ### Completeness guard, hardened (#2120)
 
 1. **Strip comments before extraction.** Load-bearing, not cosmetic:
-   `verify-cache.mjs:108-109` contains a literal `require('../../pinokio.js')`
+   `verify-cache.mjs:107` contains a literal `require('../../pinokio.js')`
    inside a comment that resolves *outside the repo root*. Under fail-closed
    resolution (step 5) that is a false failure. Stripping also retires the
    rule at `verify-cache.test.mjs:498-500` ("do not spell out a literal
@@ -254,9 +305,48 @@ browser. These are listed explicitly rather than pattern-matched.
    both. It also fixes: a new producer added but not yet `git add`ed (would
    be silently exempt under "untracked", on exactly the commit introducing
    it), `core.ignorecase` differing Windows↔Linux, and submodule gitlinks.
-   **Ordering is specified: classify by `check-ignore` FIRST, resolve
-   second.** An ignored path is skipped without ever being resolved, so its
-   presence or absence on disk cannot change the outcome.
+
+   **Precise ordering** (revision 2's "classify first, resolve second" read
+   as circular — you need a path to classify, and producing one is
+   resolution). The two operations are different and the distinction is what
+   makes it coherent: *path join* is pure string math; *module resolution* is
+   extension-candidate probing plus `existsSync`. So:
+
+   > compute each candidate path by **pure path math** (no filesystem) →
+   > normalise to POSIX → ask `check-ignore` about **each candidate** →
+   > discard ignored candidates → probe the survivors for existence →
+   > unresolvable ⇒ fail.
+
+   Classifying *each candidate* rather than once-then-resolving matters
+   where a `.gitignore` pattern is file-specific rather than
+   directory-prefixed, so classify-once could disagree with what resolution
+   lands on. Verified: `git check-ignore server/dist/does/not/exist.js`
+   returns 0 — it is pure pattern matching and answers correctly for paths
+   that do not exist, which is exactly the property the rule needs.
+
+   **Exit codes are three-valued, and the contract is explicit** (measured in
+   this repo): `0` = ignored, `1` = not ignored, **`128` = error** (e.g.
+   `'../pinokio.js' is outside repository`). The 128 case is *not*
+   hypothetical — it is triggered by precisely the comment-embedded specifier
+   that stripping exists to remove, which makes comment-stripping a
+   **precondition** of this rule rather than a peer of it. Treatment: `0` →
+   skip, `1` → keep, **`128` or git-unavailable → fail closed** (report, do
+   not skip). "Non-zero ⇒ skip" would fail *open*, classifying every
+   candidate as ignored wherever git is absent — the "absent reads as clean"
+   shape defect **A** is written against.
+
+   **Batched via `--stdin`.** Measured on this box: 81 individual spawns =
+   **3972 ms**; one `--stdin` batch = **60 ms** (66×). `test:hooks` runs in
+   pre-commit via `verify:fast:scoped`, a path documented as sub-5s — a ~4s
+   per-query regression would roughly double it on every commit touching
+   `scripts/**`. Batch per BFS level.
+
+   **Paths are POSIX-normalised before the query.** Verified: git normalises
+   `server\dist\...` on Windows (returns 0), but on Linux that string is one
+   literal filename, matches nothing, returns 1 → classified not-ignored →
+   red on CI only. The existing guard already routes through
+   `_internals.toPosix` (`verify-cache.test.mjs:544`); the hazard is
+   invisible locally by construction.
 5. **Unresolvable ⇒ fail**, not `continue` — closes defect **A**. Safe only
    because of steps 1 and 4.
 6. **Floor recalibrated against the right metric** — closes defect **B**. The
@@ -290,23 +380,48 @@ The leg is nonetheless cheap, because the suite is designed to run without
 the heavy ML stack — `requirements-dev.txt` says so explicitly, and it holds:
 
 - `main.py` imports **no torch** at module level (numpy + fastapi only).
-- Of 67 test files, **12** import torch function-locally and **one**
-  (`test_xtts_audio_io.py:15`) does so at module scope — inconsistent with
-  that same file's own `pytest.importorskip` calls at `:81`, `:99`, `:229`.
+- Enumerating **every** module-scope non-stdlib import across all collected
+  `test_*.py` files (`pytest.ini`: `testpaths = tests`, `python_files =
+  test_*.py`) yields exactly **two** that are absent from
+  `base.txt + requirements-dev.txt`: `torch`
+  (`test_xtts_audio_io.py:15`) and **`speechbrain`**
+  (`test_speechbrain_disarm.py:37`). Everything else resolves to
+  `fastapi`/`numpy`/`pytest`, a local sidecar module, or a sibling test
+  module.
 
-So it needs three things, and no GPU or torch:
+`speechbrain` is the one revision 2 missed, because that revision grepped for
+*torch specifically* rather than enumerating. It lives in
+`requirements/speaker-qa.txt:6`, whose own comment says it is placed there
+*"NOT base.txt … because speechbrain needs torch"*. Left alone it is a
+**collection error, exit 2, leg red on every PR** — worse than revision 1's
+green-forever, because the response to a permanently-red required check is to
+disable it.
+
+Revision 2 also mis-cited `requirements-dev.txt` as saying the suite runs
+lean. It says the heavy deps and test deps *"stay independently
+installable"* — a packaging claim, not a runtime one.
+
+So it needs four things, and no GPU or torch:
 
 1. A **cross-platform test entry point** — resolve `.venv/Scripts/python.exe`
    on Windows, `.venv/bin/python` on POSIX. `npm run test:sidecar`'s existing
    SKIP-on-missing-venv behaviour is retained for *local* use only.
 2. **CI bootstrap**: `actions/setup-python`, venv, `pip install -r
    requirements/base.txt -r requirements-dev.txt`, with pip caching.
-3. `test_xtts_audio_io.py:15` `import torch` → `pytest.importorskip("torch")`,
-   matching the file's own established pattern.
+3. `test_xtts_audio_io.py:15` and `test_speechbrain_disarm.py:37` →
+   `pytest.importorskip(...)`, matching the pattern those files already use
+   (`test_xtts_audio_io.py:81,99,229`; `test_speaker_embed.py:21`). This is
+   the "one exception" in §Non-goals, now **two**.
+4. **A hard plan gate: actually run `pytest --collect-only` against a real
+   `base.txt + requirements-dev.txt` venv** before the leg is declared cheap.
+   Static import inspection is what missed `speechbrain`; it does not get a
+   second chance to be the evidence.
 
-**The leg must be able to fail.** Acceptance includes a mutation proving a
-deliberately broken sidecar test turns the required check red on ubuntu — not
-merely that the job is green.
+**The leg must be able to fail, observed at the right place.** Acceptance
+includes a mutation proving a deliberately broken sidecar test turns the
+**`'npm run verify'` context** red — not the sidecar job's own status. A
+mutator watching the job would see red and wrongly conclude the leg gates,
+which is exactly the confusion the ↑ assertion exists to prevent.
 
 ## Measurements
 
@@ -332,6 +447,9 @@ re-measures rather than trusting these.
 | Unresolvable **post** comment-stripping | specifiers | **0** |
 | `server/dist` files present locally / on fresh clone | files | 1,812 / 0 |
 | Unresolvable under "untracked" rule, CI-simulated | specifiers | 7 |
+| Depth-1 closure (M6/M17 counterfactual) | unique files | 56 |
+| `check-ignore` — 81 spawns vs one `--stdin` batch | ms | 3972 / 60 (66×) |
+| Module-scope test imports absent from the lean venv | modules | 2 (`torch`, `speechbrain`) |
 
 The two genuine additions are `pinokio-scripts/lib/menu.js` (the #2120(a)
 instance) and `server/src/handoff/schemas.ts`.
@@ -364,8 +482,12 @@ Every new guard ships with a **named mutation** that makes it go red.
 | M10 | throw inside `ci-scope.mjs` | fail-safe emits all-true, exit 0 |
 | M11 | break the extraction regex so it matches nothing | Metric B floor, message citing observed vs expected |
 | M12 | make `ci-scope.mjs` exit 0 writing nothing | **aggregator `ok` sentinel** |
-| M13 | make a sidecar test fail on ubuntu | the new sidecar leg turns the check red |
-| M14 | edit only `.github/workflows/verify.yml` | the wiring assertion actually runs (defect D) |
+| M13 | make a sidecar test fail on ubuntu | the **`'npm run verify'` context** turns red (not merely the sidecar job) |
+| M14 | edit only `.github/workflows/verify.yml` | the wiring assertions actually run (defect D) |
+| M15 | remove a job from the aggregator's `needs:` | **↑ direction** |
+| M16 | diverge a setup step's `if:` from its leg's | **setup-binding assertion** |
+| M17 | **delete the transitive walk, both declarations left in place** | walk fixture (see below) |
+| M18 | make `check-ignore` return 128 / remove git | stop rule fails **closed**, not open |
 
 **M6 is inverted from revision 1, which had it backwards.** Revision 1
 claimed a depth-1 walk goes red on its own. It cannot: a depth-1 closure is a
@@ -375,6 +497,26 @@ closure = 56, clears the floor of 50, `missing = []` — **green**. That is the
 "detector shipped alongside the declaration that satisfies it" placebo shape.
 Recursion is load-bearing only in combination: **M5 under a full walk is RED;
 M5 under depth-1 is GREEN.** The pair is the proof; neither half alone is.
+
+**M17 exists because the M5-pair alone still leaves the walk unfalsifiable.**
+Run the counterfactual: if PR B declared both files in `extraFiles` and
+shipped **no walk at all**, the closure is depth-1 = 56, clears the floor of
+50, `missing = []` → green. So after PR B merges, the walk could be deleted
+at any time with the entire battery green. The placebo did not die in
+revision 2; it moved from a named mutation to the guard's *steady state*.
+
+The spec already applies the correct remedy elsewhere — §Measurements' note
+for M9 reasons that a live case neutralised by the fix needs a **synthetic
+fixture**. The identical reasoning applies here, and revision 2 failed to
+apply it. M17 is therefore a unit test over a **temp fixture tree** in which
+a depth-2 producer must be discovered, independent of the real repo's
+declarations.
+
+*(Rejected alternative: raising the floor to 57 would make the floor itself
+catch walk deletion, since 56 < 57. Rejected because it buys detection by
+removing all headroom — legitimately deleting two hooks tests would then go
+red. Worth naming, because choosing 50 is choosing to make the floor blind to
+the one regression it could otherwise catch cheaply.)*
 
 ### Acceptance
 
@@ -393,33 +535,48 @@ them, or they are not gated.
 
 ## PR shape
 
-Two PRs, **sequential**.
+**Three PRs, sequential.** Revision 2 had two; A was split because it
+contained both a guard and that guard's own precondition — which is why its
+Risks section had to concede self-validation circularity.
 
-| PR | Closes | Contents |
-|---|---|---|
-| **A** | #2119 | `ci-scope.mjs` (+ `ok` sentinel), `verify.yml` derivation, bidirectional wiring assertion, **defect D fix**, real sidecar leg |
-| **B** | #2120 | comment-stripping, resolver, transitive walk + `check-ignore` stop rule, fail-closed, floor recalibration, `check:budget-poll` split, the 2 declarations |
+| PR | Closes | Contents | Touches scope computation? |
+|---|---|---|---|
+| **A1** | Refs #2119 | **defect D fix** (`.github/**` into `test:hooks`' inputs + a matching scope) and the **sidecar job** (with `importorskip` fixes + aggregator `needs:`) | **No** — purely additive |
+| **A2** | Closes #2119 | `ci-scope.mjs`, `scopes`/`ok` outputs, `verify.yml` derivation, the **four** assertions (→ ← ↑ setup-binding) | **Yes** |
+| **B** | Closes #2120 | comment-stripping, resolver, transitive walk + `check-ignore` stop rule, fail-closed, floor recalibration, walk fixture, `check:budget-poll` split, the 2 declarations | No |
 
-**Why A first**, in strength order: (1) B adds a `STEPS[]` entry, and A
-introduces the ← assertion that would flag it as unwired — B-first opens a
-window where the new step is silently unwired; (2) B's floor is calibrated
-against a Metric B that A does not change, so the calibration is stable
-either way; (3) both touch `verify-cache.mjs`, so parallel work invites a
-conflict. Revision 1 gave only (3), the weakest of the three.
+**Why A1 first — it de-circularises A2.** With `.github/**` already in scope,
+A2's wiring assertions genuinely run on A2's own PR. Revision 2 could only
+*narrow* the circularity and fall back on "inspect PR A's run by hand"; A1
+removes it for the defect-D case outright. A1 is also purely additive —
+neither part changes how scope is *computed*, only what runs — so each half
+is independently revertable.
+
+**Why A2 before B**, in strength order: (1) B adds a `STEPS[]` entry that A2's
+← assertion requires be wired; B-first opens a window where it is silently
+unwired. (2) B's floor is calibrated against a Metric B that A2 does not
+change. (3) Both touch `verify-cache.mjs`. Revision 1 gave only (3), the
+weakest.
+
+**Revert units now match risk units.** Under revision 2's shape, reverting A
+after B landed would have reverted B's CI wiring with it, leaving B's step
+unwired against restored bash regexes. A1/A2/B does not have that coupling.
 
 ## Risks
 
-**PR A rewrites the required status check.** Containments:
+**A2 rewrites the required status check.** (A1 does not — it only adds.)
+Containments:
 
 1. **Producer fail-safe** — any thrown error degrades to run-everything.
 2. **Consumer sentinel** — the aggregator fails if `ok != 'true'`, catching
    the wrote-nothing class the producer fail-safe cannot.
-3. **PR A validates itself.** The GitHub semantics claim is correct:
+3. **A2 validates itself.** The GitHub semantics claim is correct:
    `pull_request` (unlike `pull_request_target`) runs the workflow from the
    PR's merge ref. **But it is circular against computed-false**: if
    `ci-scope.mjs` computes `step_test_hooks=false` incorrectly, the assertion
    never runs on the PR introducing it. The sentinel and the defect-D fix
-   narrow this; they do not eliminate it. Mitigation: PR A's own CI run is
+   narrow this; **A1 removes it for the defect-D case outright**, which is
+   the main reason the split exists. Residual mitigation: A2's own CI run is
    inspected by hand against an expected leg list before merge.
 4. **Rollback is one revert.**
 
@@ -433,10 +590,16 @@ job's `name:` (`verify.yml:434`). Therefore, **inviolably**:
 - conditions stay at **step** level, never hoisted to **job** level. "Every
   `if:` reads a derived output" reads as licence to hoist; hoisting makes
   scoped-down PRs skip jobs, and the aggregator fails on `skipped`
-  (`:445`) — turning the required check red on every PR.
+  (`:445`) — turning the required check red on every PR;
+- **every job carrying a derived `if:` is in the aggregator's `needs:`.**
+  Revision 2 stopped at the first two and thought them sufficient; they are
+  not. A job outside that list can run, fail, and not block merge, because
+  the ruleset requires only the aggregator's context. This is the ↑
+  assertion's whole reason for existing, and it is why the sidecar job —
+  added to *fix* a gating hole — would otherwise have reproduced it.
 
-Revision 1 mentioned neither, despite `verify.yml:49-54` warning about it
-in-file.
+Revision 1 mentioned none of these, despite `verify.yml:49-54` warning about
+the pinned name in-file.
 
 **Merge tripwire for in-flight PRs.** Once A lands, the ← direction makes any
 future PR that adds a `STEPS[]` entry red until it also wires `verify.yml`.
@@ -484,6 +647,32 @@ table; that comment-stripping and the `.js`→`.ts` resolver are load-bearing;
 that `launch.mjs`/`eslint.config.mjs`/`pinokio.js` are routed as described;
 that `pull_request` uses the PR's own workflow file; and that the
 `check:budget-poll` split fixes a real hole.
+
+### Round 2 — attacking revision 2's fixes
+
+Round 2 was briefed to attack the six fixes rather than re-run round 1. It
+found three Criticals, all verified here before folding.
+
+| Finding | Severity | Disposition |
+|---|---|---|
+| `detect` is **not** in the aggregator's `needs:` — the `ok` sentinel reads empty on every PR | Critical | add `detect`; assert `result == 'success'` too |
+| A new sidecar **job** outside `needs:` runs, fails, and gates nothing — while ← certifies it wired | Critical | ↑ assertion; sidecar declared a job; M13 pinned to the `'npm run verify'` context |
+| `speechbrain` is a module-scope import absent from the lean set → collection error, leg red forever | Critical | second `importorskip`; **plan gate: run real collection** |
+| The walk is still unfalsifiable — deleting it leaves the battery green | Major | M17 synthetic fixture; floor-57 alternative named and rejected |
+| Setup steps were a fourth unchecked map | Major | `# supports:` declaration + binding assertion |
+| `check-ignore` exit codes are three-valued (`128` real) | Major | explicit contract, fail closed on 128 |
+| Per-query `check-ignore` costs 3972 ms vs 60 ms batched (66×) | Major | `--stdin`, batched per BFS level |
+| `KNOWN_UNWIRED` contradicted the mapping table; would ship unexercised | Major | **removed** |
+| Windows path separators classify differently on Linux | Minor | POSIX-normalise before query |
+| `fromJSON` typo hole is relocated, not closed | Minor | → assertion pins the syntax form; first `fromJSON` use in the repo |
+| `:108-109` citation off by one | Minor | corrected to `:107` |
+
+Fixes that **survived** round 2: the single-JSON collapse (the narrower claim
+— that the third artifact disappears — holds); the `check-ignore` stop rule
+against the circularity charge (path-join and module-resolution are genuinely
+different operations, and `check-ignore` does answer for non-existent paths);
+the M6 inversion; the N:M mapping table; and `main.py` being genuinely
+torch-free at module scope.
 
 ## Ship notes
 

--- a/docs/superpowers/specs/2026-08-05-verify-scope-map-unification-design.md
+++ b/docs/superpowers/specs/2026-08-05-verify-scope-map-unification-design.md
@@ -1,0 +1,324 @@
+---
+status: draft
+date: 2026-08-05
+---
+
+# Verify scope-map unification: one dependency map, one guard
+
+Closes the design work behind **#2119** (ops-19) and **#2120** (ops-20).
+
+## Problem
+
+"Which files does this verify step depend on?" is currently answered in
+three places, and nothing checks them against each other:
+
+| # | Representation | Consumer |
+|---|---|---|
+| 1 | `.github/workflows/verify.yml` bash regexes (`:142-180`) | cloud — **the required status check** |
+| 2 | `scripts/verify-cache.mjs` `STEPS[].inputs` | local `[cached]`/`[run]` decision |
+| 3 | The real module graph + runtime reads | reality |
+
+#2119 is "**1 disagrees with 3**": `launch.mjs` matches no regex at all, so a
+PR changing only that file runs no leg that tests it, and the required check
+reports green. `server/tts-sidecar/scripts/install-qwen3.mjs` sets
+`sidecar=true`, which runs pytest — not the `test:hooks` suite that actually
+covers it. `pinokio.js` sets `pinokio=true`, which runs `test:pinokio` — a
+different suite from the `pinokio-entry.test.mjs` that loads it.
+`eslint.config.mjs` sets only `frontend=true`, which does not gate the Hooks
+step at all.
+
+#2120 is "**2 disagrees with 3, invisibly**". PR #2117's completeness guard
+asserts "every producer a hooks test imports is a cache input", but it scans
+only test files for their own direct specifiers. It structurally cannot see
+transitive edges (`pinokio-scripts/lib/menu.js`, reached via `pinokio.js`) or
+runtime reads (`check-no-budget-poll.mjs` scanning `server/src/**/*.test.ts`).
+
+Nobody checks **1 against 2** either. That gap is unowned by either issue and
+is the shared cause: fixing the two symptoms independently leaves three maps
+and guarantees a fourth instance.
+
+### Two further defects found while scoping this
+
+Neither appears in either issue.
+
+**A. The guard's resolution step fails open.** `verify-cache.test.mjs:538`
+does `if (!existsSync(absProducer)) continue;` — a specifier that does not
+resolve *as written* is silently dropped rather than reported. Currently
+latent (measured: 0 specifiers skipped), but it is the "absent reads as
+clean" shape that has bitten this repo repeatedly.
+
+**B. The anti-vacuity floor does not bound the failure it exists to catch.**
+The guard asserts `producersScanned >= 30`; the measured actual is **60
+occurrences**. A regression that silently dropped *half* the extraction
+coverage would still pass green.
+
+**C. `verify.yml` has no sidecar pytest leg at all.** The `sidecar` scope
+gates only the ffmpeg install and the server TS suite. A sidecar-only PR runs
+zero `npm run test:sidecar` on the required check. This is a third instance
+of #2119's exact shape, found while enumerating the step↔scope mapping.
+
+## Decisions taken
+
+Four decisions were made explicitly during design; this spec implements them
+as stated rather than re-opening them.
+
+1. **Unify at the cause**, not the two symptoms — one map, one guard.
+2. **Split `check-no-budget-poll` into its own verify step** rather than
+   widening `test:hooks`' inputs, so a server-test edit does not bust the
+   ~25s hooks cache.
+3. **Full per-step derivation** of `verify.yml` — the nine scope booleans are
+   retired; every `if:` references a derived per-step output. *(Flagged at
+   design time as the highest-blast-radius option, since it rewrites the
+   required check; chosen deliberately. §Risks states the containment.)*
+4. **Fix the missing sidecar leg in this work** rather than filing it.
+
+## Goals
+
+- A single-file PR touching `launch.mjs`,
+  `server/tts-sidecar/scripts/install-qwen3.mjs`, `pinokio.js`, or
+  `eslint.config.mjs` runs the leg that covers it, on the required check.
+- Editing `pinokio-scripts/lib/menu.js`, or adding a budgeted-poll loop to a
+  `server/src` test, does not leave `test:hooks` reporting `[cached]`.
+- `verify.yml` and `verify-cache.mjs` cannot disagree about a step's inputs,
+  because only one of them defines them.
+- Every verify-cache STEP is either wired to a CI step or *declared*
+  unwired — never silently unwired.
+
+## Non-goals
+
+- Changing which tests exist, or what any suite asserts.
+- Re-tuning cache granularity beyond the `check:budget-poll` split.
+- Solving dependency discovery for `server/`'s TS graph. This work covers the
+  `scripts/tests/*.test.mjs` surface only.
+
+## Architecture
+
+`scripts/verify-cache.mjs`'s `STEPS[]` becomes the single source of truth.
+Each STEP gains a `ci` field naming its CI home. `verify.yml` stops deciding
+scope and starts *reading* it.
+
+```
+                   STEPS[] in verify-cache.mjs
+                    (globs + extraFiles + ci)
+                              |
+                 +------------+------------+
+                 |                         |
+        stepTouchedByDiff          scripts/ci-scope.mjs
+        (local [cached]/[run])     (emits step_<slug>=bool)
+                 |                         |
+        npm run verify                 verify.yml
+        verify:fast:scoped             every `if:` reads an output
+        verify:fast:branch             (required status check)
+```
+
+### `scripts/ci-scope.mjs` (new)
+
+Imports `STEPS`, reads the changed-file list, and for each step emits
+`step_<slug>=true|false` in `GITHUB_OUTPUT` format, computed with the same
+`stepTouchedByDiff` + `computeShared` the local cache uses. Slug = step name
+lowercased with `:` and `-` → `_` (`test:e2e:visual` → `step_test_e2e_visual`).
+
+Two keys are **not** derived from STEPS and are declared explicitly in the
+same module, because they have no cache step:
+
+- `openapi` — gates the "OpenAPI types up to date" drift check, which is
+  CI-only.
+- `shared` — the root-manifest global escape hatch.
+
+**Fail-safe (load-bearing).** On *any* internal error — unreadable file, bad
+parse, unknown step — `ci-scope.mjs` emits **every key true**, prints a
+warning to stderr, and exits **0**. It must never exit non-zero and must
+never emit all-false. A crash degrades to "run the whole battery", never to
+"skip everything". Without this, one bad commit to a script blocks merges
+repo-wide.
+
+### The trap this creates, and how it is closed
+
+GitHub Actions evaluates an **unknown** `needs.detect.outputs.X` to the empty
+string. So `needs.detect.outputs.step_test_hooks_typo == 'true'` is simply
+`false`: the step never runs, the required check goes **green**, and nothing
+errors. Today a typo'd bash variable is at least visible in the `scope k=`
+echo; after derivation, a renamed step or fat-fingered `if:` silently
+disables a leg of the required check.
+
+**Per-step derivation is strictly worse than the status quo unless this is
+closed in the same change.** It is closed by a bidirectional wiring assertion
+over the parsed workflow:
+
+| Direction | Assertion | Catches |
+|---|---|---|
+| **→** | every `needs.detect.outputs.X` in the YAML is a key `ci-scope.mjs` emits | typos, renamed steps, deleted steps |
+| **←** | every emitted key is referenced by ≥1 `if:`, or listed in `KNOWN_UNWIRED` with an issue ref | orphaned steps — defect **C**'s shape |
+
+`KNOWN_UNWIRED` is **empty** once the sidecar leg lands, so the ← direction
+starts fully strict. It exists so a future unwired step must be declared in a
+reviewed diff rather than going quietly missing.
+
+Both directions carry an anti-vacuity floor calibrated to **measured**
+counts, not round numbers — see defect **B**.
+
+### Completeness guard, hardened (#2120)
+
+`scripts/tests/verify-cache.test.mjs`'s guard gains, in order:
+
+1. **Comment stripping before extraction.** Load-bearing, not cosmetic: the
+   existing regexes match specifiers inside comments, and
+   `verify-cache.mjs`'s own comment contains a literal
+   `require('../../pinokio.js')`. Under fail-closed resolution (step 4) that
+   would be a *false failure*. Stripping comments also retires the awkward
+   rule at `verify-cache.test.mjs:497` ("do not spell out a literal example
+   specifier in this comment") — the constraint disappears instead of being
+   documented around.
+2. **Resolution candidates**: exact → `.js`/`.mjs`/`.cjs` → **`.js` → `.ts`**
+   (TS emits `.js` specifiers for `.ts` sources; `scripts/diff-analysis-ab.mjs`
+   imports `../server/src/handoff/schemas.js`) → `/index.{js,mjs}`.
+3. **Transitive walk** with a visited-set cycle guard, following resolved
+   relative specifiers recursively. Bare specifiers (`node:fs`, `archiver`)
+   are never followed, so `node_modules` is never entered.
+4. **Stop rule: do not follow git-untracked paths.** This is what makes the
+   walk correct rather than merely complete —
+   `scripts/repair-cast-id-drift.mjs:1203` dynamically imports
+   `../server/dist/**` inside `main()`, and its test deliberately injects
+   stand-ins instead. `server/dist/` is gitignored build output; declaring it
+   as a cache input would be meaningless (missing on a clean checkout) and
+   noisy (regenerated by every build).
+5. **Unresolvable ⇒ fail**, not `continue` — closes defect **A**. Safe only
+   because of step 1.
+6. **Floor recalibrated against the right metric** — closes defect **B**.
+   The current counter measures *occurrences* (one per `(test file,
+   specifier)` pair); the hardened guard walks a closure and should assert on
+   *unique tracked files*. These are different units and must not be
+   conflated — conflating them is how defect **B** arose. See §Measurements
+   for the unit-tagged values and the floor rule.
+
+### `check:budget-poll` split (#2120b)
+
+`check-no-budget-poll.mjs` moves out of `run-hooks-tests.mjs:24-28` into its
+own npm script, its own `STEPS[]` entry (globs `server/src/**/*.test.ts`,
+extraFiles the script itself), and its own CI step.
+
+This is not merely bookkeeping. Today, on a **server-only staged diff**,
+`verify:fast:scoped` skips `test:hooks` outright — so the guardrail that
+exists to reject budgeted-poll loops never runs on the very commit
+introducing one. Splitting it fixes that, and costs ~1s instead of busting
+the ~25s hooks cache on the repo's hottest surface.
+
+### Sidecar leg (defect C)
+
+`verify.yml` gains a sidecar pytest step wired to `test:sidecar`. It reuses
+the existing venv-bootstrap path and retains `npm run test:sidecar`'s
+SKIP-and-exit-0 behaviour on an unbootstrapped venv, so it cannot become a
+new source of red on runners without the venv.
+
+## Measurements
+
+Taken against the tree at design time (commit `922cf129`). These are the
+numbers the floors and the expected-delta assertions are calibrated to; a
+plan step re-measures rather than trusting them.
+
+> **Read the units.** Three of these values land on 59–60 while measuring
+> different things. Do not carry a number from one row into an assertion
+> about another — that conflation *is* defect **B**.
+
+| Quantity | Unit | Value |
+|---|---|---|
+| Hooks test files | files | 59 |
+| **Metric A** — imports scanned by today's guard | *occurrences* | 60 |
+| Today's anti-vacuity floor (asserts on Metric A) | occurrences | 30 |
+| Naive transitive closure, no stop rule | unique files | 81 |
+| — missing from `test:hooks` | unique files | 24 |
+| — of those, gitignored `server/dist/**` artifacts | unique files | 22 |
+| **Metric B** — closure **with** git-tracked stop rule | unique files | 59 |
+| — genuinely missing from `test:hooks` | unique files | **2** |
+| Unresolvable specifiers (comment / `.js`→`.ts`) | specifiers | 2 |
+
+The two genuine additions are `pinokio-scripts/lib/menu.js` (the #2120(a)
+instance) and `server/src/handoff/schemas.ts`.
+
+**Floor rule.** The hardened guard asserts on **Metric B**. The floor exists
+to catch *extraction or resolution breakage*, whose signature is a collapse
+toward zero — not a legitimate one- or two-file removal. Set it at **50**
+(~15% headroom under the measured 59): low enough that removing a few hooks
+tests does not cause spurious red, high enough that losing even a fifth of
+the closure fails. The plan **re-measures** rather than trusting 59, and the
+assertion message states both the observed and expected values so a genuine
+drop is diagnosable rather than merely red.
+
+## Testing
+
+Every new guard ships with a **named mutation** that makes it go red. A guard
+that cannot be shown failing is not a guard.
+
+| # | Mutation | Must go red with |
+|---|---|---|
+| M1 | rename an emitted key in `ci-scope.mjs` | → direction, naming the orphaned `if:` |
+| M2 | add `outputs.step_nope` to `verify.yml` | → direction |
+| M3 | unwire a step's CI home | ← direction (defect C's shape) |
+| M4 | make the YAML parse return nothing | anti-vacuity floor |
+| M5 | drop `pinokio-scripts/lib/menu.js` from extraFiles | completeness guard, naming that path |
+| M6 | limit the walk to depth 1 | same — proves recursion is load-bearing |
+| M7 | remove comment-stripping | false positive on `../../pinokio.js` |
+| M8 | follow git-untracked paths | 22 `server/dist/**` entries |
+| M9 | revert unresolvable→fail to `continue` | resolver unit test |
+| M10 | throw inside `ci-scope.mjs` | fail-safe emits all-true, exit 0 |
+| M11 | break the extraction regex so it matches nothing | Metric B floor, message citing observed vs expected |
+
+M6 and M11 deliberately target *different* assertions: a depth-1 walk still
+clears the Metric B floor, so only the missing-input assertion catches it,
+while a dead regex collapses the closure and only the floor catches it.
+Neither alone demonstrates the guard works.
+
+### Acceptance
+
+- **#2119** — table-driven over the four cited paths (`launch.mjs`,
+  `server/tts-sidecar/scripts/install-qwen3.mjs`, `pinokio.js`,
+  `eslint.config.mjs`): each must yield `step_test_hooks=true`.
+- **#2120** — the issue explicitly rejects `stepTouchedByDiff` as sufficient
+  proof, because PR #2117 showed it and the real decision are different code
+  paths. The test therefore drives the **real `[cached]`/`[run]` decision**
+  through `selectStepFiles` + `composeInputHash` + `decide`: editing
+  `menu.js`, and adding a budgeted-poll loop to a `server/src` test, must
+  both come back `[run]`.
+- **Defect C** — a sidecar-only diff yields `step_test_sidecar=true`.
+
+New tests must be wired into the verify-cache `extraFiles` and `verify.yml`'s
+own coverage, or they are not gated.
+
+## PR shape
+
+Two PRs, **sequential** — both touch `verify-cache.mjs` (A adds the `ci`
+field, B adds a STEP), so running them in parallel invites a conflict on the
+one file that must stay coherent.
+
+| PR | Closes | Contents |
+|---|---|---|
+| **A** | #2119 | `ci-scope.mjs`, `verify.yml` per-step derivation, bidirectional wiring assertion, sidecar pytest leg |
+| **B** | #2120 | comment-stripping, resolver, transitive walk + stop rule, fail-closed, floor recalibration, `check:budget-poll` split, the 2 new declarations |
+
+## Risks
+
+**PR A rewrites the required status check.** This is the dominant risk and it
+was accepted knowingly. Three things contain it:
+
+1. **The fail-safe** degrades any `ci-scope.mjs` failure to *run everything*,
+   never to *skip everything*.
+2. **PR A validates itself.** `pull_request` runs use the workflow file from
+   the PR's own merge ref, so the derived workflow is exercised on PR A
+   before it can affect any other PR. The PR touches `scripts/` and
+   `.github/`, so the hooks and scripts legs are in scope for its own run.
+3. **Rollback is one revert** of a self-contained commit.
+
+**Residual risk:** a step whose `if:` is *correct* but whose derived inputs
+are *wrong* still skips silently. The bidirectional assertion proves wiring,
+not input correctness; input correctness is what the completeness guard in
+PR B covers, and only for the `scripts/tests` surface. Steps outside that
+surface (`test`, `test:server`, `build`) keep hand-maintained inputs and are
+out of scope here.
+
+**Ordering risk:** if PR B lands first, the `check:budget-poll` STEP exists
+with no CI home and the ← assertion — which PR A introduces — is not yet
+present to catch it. Landing A first avoids the window entirely.
+
+## Ship notes
+
+_(unfilled — to be completed when both PRs merge)_


### PR DESCRIPTION
## Summary

The design of record and the implementation plan for the `verify.yml` scope-map unification — the phase-1 (design-thread) output for **#2119** and **#2120**. No runtime code changes; the three implementation PRs (A1 / A2 / B) follow.

- `docs/superpowers/specs/2026-08-05-verify-scope-map-unification-design.md` — the design. One scope map derived from `verify-cache.mjs`'s `STEPS[]`, consumed by both the local cache runner and cloud `verify.yml`, replacing the hand-maintained nine-regex map that is the root of #2119.
- `docs/superpowers/plans/2026-08-05-verify-scope-map-unification.md` — 15 tasks, 101 steps, split into three sequential PRs.

**What measurement changed about the design.** Both issues propose a naive transitive walk. Built and measured, that walk demands **24 new declarations, 22 of them gitignored `server/dist/**` build artifacts** — so the plan adds a `git check-ignore` stop rule, which reduces the genuine gap to **2 files** (`pinokio-scripts/lib/menu.js`, `server/src/handoff/schemas.ts`).

**Four defects found while measuring**, all folded in:

| | |
|---|---|
| **A** | the guard's `existsSync(absProducer) continue` skips unresolved producers — latent fail-open |
| **B** | the anti-vacuity floor is 30 against a measured 60 — half the corpus could vanish undetected |
| **C** | no sidecar pytest leg exists in `verify.yml` at all |
| **D** | `.github/workflows/**` matches no scope, so a workflow-only PR runs **zero** legs |

Defect D is the same shape as #2119 one level up, and lands in PR A1.

## Test plan

Docs-only — no automated tests apply, and the doc-only CI fast-path covers it. Verification was of the *content*, not of a diff:

- Every measurement in the spec's table was produced by a script run against this checkout, not estimated; each row is unit-tagged after a self-review caught a count/unit conflation (60 *occurrences* vs 59 unique *files*).
- **Four adversarial review rounds** (spec ×2, plan ×2) at Premium tier: **12 Criticals**, each independently verified before folding. Notably a demonstrated fail-open in a hand-rolled comment-stripping lexer — a regex literal could open a phantom block comment that a later `*/` closed, swallowing imports with no observable signal — closed by replacing the lexer with `acorn` (0 parse failures across the 59 hooks tests).
- The `git check-ignore` exit-code contract (0/1/**128**) and its index-awareness were verified against this repo rather than assumed.

Refs #2119
Refs #2120

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011c1MfFziLGzwUDU4dX9SJe
