### PR TITLE
test(server,sidecar): guard that a substituting engine can never reach the batch path

### DIFF
--- a/server/src/tts/index.ts
+++ b/server/src/tts/index.ts
@@ -117,13 +117,27 @@ export interface SynthesizeBatchInput {
     not an oversight (#2033, rescoped after premise check found no live
     defect). Only `CoquiEngine._synthesize_claimed` and `KokoroEngine.synthesize`
     (`server/tts-sidecar/main.py`) ever set `substituted_from`; batching is
-    Qwen-only (`isBatchable` in `synthesise-chapter.ts`, mirrored by the
-    sidecar's own `/synthesize-batch` engine gate), and `QwenEngine` never
-    substitutes. A per-item field here would carry a value that's structurally
-    always null. Guarded by `test_substituting_engines_cannot_batch`
-    (`server/tts-sidecar/tests/test_batch_synthesis.py`) — pins that neither
-    substituting engine can ever expose `synthesizeBatch`, so this stays true
-    rather than silently going stale. */
+    Qwen-only, and `QwenEngine` never substitutes. A per-item field here would
+    carry a value that's structurally always null.
+
+    What actually enforces "Qwen-only" on the Node side is the
+    `route.engine === 'qwen'` arm of `isBatchable` (`synthesise-chapter.ts:2687`)
+    — NOT a feature-detect on this method. `synthesizeBatch` is an
+    UNCONDITIONAL method on `SidecarTtsProvider` (`server/src/tts/sidecar.ts:322`);
+    every route, Coqui/Kokoro/Qwen alike, gets one, so
+    `typeof route.provider.synthesizeBatch === 'function'` is true for all
+    three today and detects nothing. Covered by
+    `synthesise-chapter.test.ts:1597` ("keeps non-Qwen sentences one-per-call
+    while batching the Qwen ones").
+
+    On the Python side, `test_substituting_engines_cannot_batch`
+    (`server/tts-sidecar/tests/test_batch_synthesis.py`) pins that neither
+    `CoquiEngine` nor `KokoroEngine` exposes a usable `synthesize_batch`
+    (note the Python name — a different symbol on a different object from
+    the Node method above). `test_qwen_engine_never_constructs_a_substituted_synth_result`
+    covers the other arm: that `QwenEngine` never sets `substituted_from` in
+    the first place, since `SynthBatchResult` (unlike `SynthResult`) has
+    nowhere to carry that signal if it ever did. */
 export interface SynthesizeBatchOutput {
   /** One PCM blob per input item, SAME order. */
   pcms: Buffer[];

--- a/server/src/tts/index.ts
+++ b/server/src/tts/index.ts
@@ -113,6 +113,17 @@ export interface SynthesizeBatchInput {
   signal?: AbortSignal;
 }
 
+/** No `voiceSubstitutedFrom` here, unlike `SynthesizeOutput` — deliberate,
+    not an oversight (#2033, rescoped after premise check found no live
+    defect). Only `CoquiEngine._synthesize_claimed` and `KokoroEngine.synthesize`
+    (`server/tts-sidecar/main.py`) ever set `substituted_from`; batching is
+    Qwen-only (`isBatchable` in `synthesise-chapter.ts`, mirrored by the
+    sidecar's own `/synthesize-batch` engine gate), and `QwenEngine` never
+    substitutes. A per-item field here would carry a value that's structurally
+    always null. Guarded by `test_substituting_engines_cannot_batch`
+    (`server/tts-sidecar/tests/test_batch_synthesis.py`) — pins that neither
+    substituting engine can ever expose `synthesizeBatch`, so this stays true
+    rather than silently going stale. */
 export interface SynthesizeBatchOutput {
   /** One PCM blob per input item, SAME order. */
   pcms: Buffer[];

--- a/server/tts-sidecar/tests/test_batch_synthesis.py
+++ b/server/tts-sidecar/tests/test_batch_synthesis.py
@@ -555,6 +555,34 @@ def test_route_rejects_non_qwen_engine(qwen_batch_runtime) -> None:
     assert "qwen-only" in resp.json()["detail"]
 
 
+def test_substituting_engines_cannot_batch(qwen_batch_runtime) -> None:
+    """#2033 (rescoped, 2026-08-05) — latent-gap guard, not a live bug.
+    `substituted_from` is set in exactly two places today:
+    `CoquiEngine._synthesize_claimed` and `KokoroEngine.synthesize`.
+    `QwenEngine.synthesize_batch` never sets it (deliberately — see
+    main.py:2422-2424) and `/synthesize-batch` is Qwen-only at the route
+    level (`test_route_rejects_non_qwen_engine` above pins THAT gate).
+
+    This test pins the gate one layer deeper, at the class itself: neither
+    `CoquiEngine` nor `KokoroEngine` — the only two engines that can ever
+    produce a substitution — exposes a `synthesize_batch` method at all, so
+    batching can't reach a substituting engine even if the route's
+    `engine_id != "qwen"` string check were ever loosened or bypassed. If
+    either engine grows one, this goes red before anything reaches the wire.
+
+    It also pins that the wire object itself has nowhere to put the signal:
+    `SynthBatchResult.__slots__` has no `substituted_from` (unlike
+    `SynthResult`, which does) — assigning one raises `AttributeError`
+    immediately rather than silently dropping it later at the response
+    frame."""
+    assert not hasattr(main.CoquiEngine, "synthesize_batch")
+    assert not hasattr(main.KokoroEngine, "synthesize_batch")
+    assert "substituted_from" not in main.SynthBatchResult.__slots__
+    result = main.SynthBatchResult([b""], 24000)
+    with pytest.raises(AttributeError):
+        result.substituted_from = "x"  # type: ignore[attr-defined]
+
+
 def test_route_validates_items(qwen_batch_runtime) -> None:
     client = TestClient(main.app)
     base = {"engine": "qwen", "model": "0.6b"}

--- a/server/tts-sidecar/tests/test_batch_synthesis.py
+++ b/server/tts-sidecar/tests/test_batch_synthesis.py
@@ -555,32 +555,115 @@ def test_route_rejects_non_qwen_engine(qwen_batch_runtime) -> None:
     assert "qwen-only" in resp.json()["detail"]
 
 
-def test_substituting_engines_cannot_batch(qwen_batch_runtime) -> None:
+def _is_interface_stub(func: Any) -> bool:
+    """True if `func`'s body is exactly a bare `raise NotImplementedError`
+    (a docstring, if any, doesn't count) — the shape of `Engine.synthesize`'s
+    interface stub. Anything else (a real body, even one that still ends in
+    `raise NotImplementedError` after doing work) is NOT a stub."""
+    import ast
+    import inspect
+    import textwrap
+
+    src = textwrap.dedent(inspect.getsource(func))
+    fn_def = ast.parse(src).body[0]
+    assert isinstance(fn_def, (ast.FunctionDef, ast.AsyncFunctionDef))
+    stmts = [
+        s
+        for s in fn_def.body
+        if not (isinstance(s, ast.Expr) and isinstance(s.value, ast.Constant))
+    ]
+    return (
+        len(stmts) == 1
+        and isinstance(stmts[0], ast.Raise)
+        and isinstance(stmts[0].exc, ast.Name)
+        and stmts[0].exc.id == "NotImplementedError"
+    )
+
+
+def _has_usable_synthesize_batch(engine_cls: type) -> bool:
+    """`hasattr` alone walks the MRO, so it goes true the moment the shared
+    `Engine` base picks up a symmetric `synthesize_batch` interface stub
+    (an obvious, harmless completion of `Engine.synthesize`'s existing
+    stub) — a false positive with no substitution risk behind it. Treat a
+    method as unusable if it's absent OR it's just that stub; anything else
+    (a real inherited or overridden implementation) counts as usable."""
+    method = getattr(engine_cls, "synthesize_batch", None)
+    return method is not None and not _is_interface_stub(method)
+
+
+def test_substituting_engines_cannot_batch() -> None:
     """#2033 (rescoped, 2026-08-05) — latent-gap guard, not a live bug.
     `substituted_from` is set in exactly two places today:
     `CoquiEngine._synthesize_claimed` and `KokoroEngine.synthesize`.
-    `QwenEngine.synthesize_batch` never sets it (deliberately — see
-    main.py:2422-2424) and `/synthesize-batch` is Qwen-only at the route
-    level (`test_route_rejects_non_qwen_engine` above pins THAT gate).
+    `QwenEngine`'s five `SynthResult(...)` constructions (main.py:6206,
+    :6274, :6497, :6827, :6861) never set it, and `/synthesize-batch` is
+    Qwen-only at the route level (`test_route_rejects_non_qwen_engine` above
+    pins THAT gate). The other arm of this invariant — Qwen never setting
+    `substituted_from` in the first place — is pinned separately by
+    `test_qwen_engine_never_constructs_a_substituted_synth_result` below.
 
     This test pins the gate one layer deeper, at the class itself: neither
     `CoquiEngine` nor `KokoroEngine` — the only two engines that can ever
-    produce a substitution — exposes a `synthesize_batch` method at all, so
+    produce a substitution — exposes a USABLE `synthesize_batch` method, so
     batching can't reach a substituting engine even if the route's
     `engine_id != "qwen"` string check were ever loosened or bypassed. If
-    either engine grows one, this goes red before anything reaches the wire.
+    either engine grows a real one, this goes red before anything reaches
+    the wire. `_has_usable_synthesize_batch` deliberately does NOT use a bare
+    `hasattr` — see its docstring for the base-class-stub false positive
+    that would otherwise cause."""
+    assert not _has_usable_synthesize_batch(main.CoquiEngine)
+    assert not _has_usable_synthesize_batch(main.KokoroEngine)
 
-    It also pins that the wire object itself has nowhere to put the signal:
-    `SynthBatchResult.__slots__` has no `substituted_from` (unlike
-    `SynthResult`, which does) — assigning one raises `AttributeError`
-    immediately rather than silently dropping it later at the response
-    frame."""
-    assert not hasattr(main.CoquiEngine, "synthesize_batch")
-    assert not hasattr(main.KokoroEngine, "synthesize_batch")
-    assert "substituted_from" not in main.SynthBatchResult.__slots__
-    result = main.SynthBatchResult([b""], 24000)
-    with pytest.raises(AttributeError):
-        result.substituted_from = "x"  # type: ignore[attr-defined]
+
+def test_qwen_engine_never_constructs_a_substituted_synth_result() -> None:
+    """Arm B of the #2033 invariant. Arm A (above) covers a substituting
+    engine growing a batch entry point; this covers the other direction —
+    Qwen, the only engine that CAN batch, growing a substitution. Qwen is
+    the default generation engine, so this is the more likely arm, and it's
+    the one #2033 actually worried about: `SynthBatchResult` (unlike
+    `SynthResult`) has no `substituted_from` slot at all, so if
+    `QwenEngine.synthesize_batch` — or anything it calls into — ever set
+    one, the signal would have nowhere to go and would be dropped silently
+    rather than raising.
+
+    All five of `QwenEngine`'s `SynthResult(...)` constructions (main.py:6206,
+    :6274, :6497, :6827, :6861) leave `substituted_from` at its `None`
+    default today. Parse the class source and assert that stays true: no
+    call passes a `substituted_from` argument (positional or keyword) other
+    than the literal `None`. A future call passing anything else — a real
+    substitution, or even a variable whose value we can't prove is `None` —
+    goes red here, before it can reach `synthesize_batch`'s caller."""
+    import ast
+    import inspect
+
+    src_lines, start_line = inspect.getsourcelines(main.QwenEngine)
+    tree = ast.parse("".join(src_lines))
+    ast.increment_lineno(tree, start_line - 1)  # report REAL main.py line numbers
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "SynthResult"
+        ):
+            continue
+        # SynthResult.__init__(self, pcm, sample_rate, substituted_from=None)
+        # — 3rd positional OR the `substituted_from` keyword.
+        candidates = list(node.args[2:3]) + [
+            kw.value for kw in node.keywords if kw.arg == "substituted_from"
+        ]
+        for value in candidates:
+            if not (isinstance(value, ast.Constant) and value.value is None):
+                violations.append(f"main.py:{node.lineno}: {ast.dump(value)}")
+
+    assert not violations, (
+        "QwenEngine now constructs a SynthResult with a non-None "
+        "substituted_from:\n" + "\n".join(violations) + "\n"
+        "SynthBatchResult has no slot for this signal (unlike SynthResult) "
+        "— either add one (and a matching Node-side voiceSubstitutedFrom "
+        "field on SynthesizeBatchOutput) or this silently drops a real "
+        "substitution."
+    )
 
 
 def test_route_validates_items(qwen_batch_runtime) -> None:


### PR DESCRIPTION
## Summary

Round 3 triage found #2033 described a defect that cannot occur. This PR ships the guard that keeps it that way, plus the doc comment that stops it being refiled.

**#2033 does not reproduce.** `substituted_from` is set in exactly two places — `CoquiEngine._synthesize_claimed` (`main.py:2456`, `:2458`) and `KokoroEngine.synthesize` (`:3127`, `:3129`). `QwenEngine` never sets it: all five of its `SynthResult(...)` constructions (`main.py:6206`, `:6274`, `:6497`, `:6827`, `:6861`) omit the argument. `/synthesize-batch` additionally hardcodes `engine = ENGINES["qwen"]` (`:10873`) on top of its route gate at `:10822`. So `SynthesizeBatchOutput` has no `voiceSubstitutedFrom` field because the only engine that batches never emits one.

The stale-value variant was checked separately and is also unreachable: the batched scatter feeds a segment record rebuilt from scratch at `synthesise-chapter.ts:3323`, so `undefined` is written explicitly rather than a prior render's value surviving.

The one path that would have broken the premise — a Qwen character falling back to Kokoro, a *substituting* engine — is closed: the fallback resolves before partitioning (`synthesise-chapter.ts:2352-2356`) and renders as a single, not a batch.

## What ships

The defect isn't real but the invariant is, and it has **two arms**. Both are now guarded, in `server/tts-sidecar/tests/test_batch_synthesis.py`:

- **Arm A — a substituting engine gains batching.** `test_substituting_engines_cannot_batch` asserts neither `CoquiEngine` nor `KokoroEngine` has a *usable* `synthesize_batch`. Deliberately not a bare `hasattr`: that walks the MRO and would go red the moment the shared `Engine` base gained a symmetric interface stub — a harmless completion of `Engine.synthesize`'s existing stub. The helper treats a bare `raise NotImplementedError` body as unusable and anything else as usable.
- **Arm B — the batching engine gains substitution.** `test_qwen_engine_never_constructs_a_substituted_synth_result` parses `QwenEngine`'s source and asserts no `SynthResult(...)` within it ever passes a non-`None` `substituted_from`, positionally or by keyword. **This is the arm #2033 actually worried about and the more likely one** — Qwen is the default generation engine, and `SynthBatchResult` has no slot for the signal, so a Qwen fallback would drop it silently.

## Review-driven rework

The first revision of this PR was reviewed and **not merged as-is**. Three substantive corrections, all folded in:

1. **The doc comment was factually false.** It claimed the pytest pinned that neither substituting engine can expose `synthesizeBatch`. But `synthesizeBatch` is an **unconditional** method on `SidecarTtsProvider` (`server/src/tts/sidecar.ts:322`), and `selectTtsProvider` returns one for coqui, kokoro and qwen alike — so `typeof route.provider.synthesizeBatch === 'function'` is true for a Coqui route *today*. The pytest pins the Python `synthesize_batch`, a different symbol on a different object. The real Node-side protection is the `route.engine === 'qwen'` arm of `isBatchable` (`synthesise-chapter.ts:2687`), already covered by `synthesise-chapter.test.ts:1597`. The comment now says that, and cites it.
2. **A misattributed citation was committed.** The test docstring cited `main.py:2422-2424` as the reason Qwen never substitutes. Those lines are inside `CoquiEngine._synthesize_claimed` and are about Coqui. Replaced with the five real `SynthResult` sites.
3. **Two assertions were inverted and are gone.** `assert "substituted_from" not in SynthBatchResult.__slots__` and its `pytest.raises(AttributeError)` partner pinned the current shape *against its own fix* — adding that slot is the remedy if the risk ever materialises, and it turned them red. They also added no coverage.

## Mutation verification

Every assertion, mutated against the real `main.py`, restored byte-identically each time (`git diff --stat` empty after each restore). Run twice by different parties on different arms, so no proof only exercises the branch its author wrote.

| Mutation | Result |
|---|---|
| real `synthesize_batch` on `CoquiEngine` | RED — `_has_usable_synthesize_batch(CoquiEngine)` |
| real `synthesize_batch` on `KokoroEngine` | RED — `_has_usable_synthesize_batch(KokoroEngine)` |
| bare `NotImplementedError` stub on base `Engine` | **GREEN** (false positive fixed; the old `hasattr` check went red here) |
| `substituted_from=voice` at `main.py:6861` | RED — arm B, reports the real line |
| `substituted_from="stock-voice"` at `main.py:6827` | RED — arm B, string literal, positional-and-keyword shapes both walked |
| all restored | GREEN, 41 passed |

**Caveat, stated plainly:** these are sidecar pytests, and per #1950 `verify.yml` has no pytest job at all — the `sidecar` scope flag is consumed only to gate the *server TypeScript* legs (`:297`, `:307`). `release.yml`/`cross-os.yml` do invoke `test:sidecar` but always hit `run-tests.ps1`'s SKIP-and-`exit 0` on a runner with no venv. So until PR A1 of the verify scope-map unification lands, these guards are enforced locally and on-box only. Every mutation above was run against the real bootstrapped venv, not the skip path.

## What was NOT done, and why

**#1808 item g was investigated and deliberately not implemented.** No route-reachable path creates a `consent` block on a non-cloned entry — `/clone` sets `provenance: 'cloned'` (`voice-library.ts:1301`) and `consent` (`:1308`) in one literal, `PatchBody` (`:537-544`) has no `consent` key and 400s any `provenance` change, and there is no migration, import or restore path. So the proposed condition has no reachable case to catch, and #1808 itself scoped it as "harmless, but could restrict to cloned."

The review corrected the *reasoning* originally given here, and the correction is recorded on #1808: `assertConsentForClone` (`workspace/voice-library.ts:164-165`) is **one-directional** — it enforces cloned⇒consent, never consent⇒cloned — and several write sites blind-spread `...fresh`, propagating a consent block across provenance. That read/write asymmetry is a real finding, filed separately rather than folded in.

#1808 is closed on that evidence.

## Test plan

- `npx pytest server/tts-sidecar/tests/test_batch_synthesis.py -q` → **41 passed**.
- Five mutations above, each reverted byte-identically and re-run green.
- `synthesise-chapter.test.ts:1597` verified to exist and say what the comment now cites.
- Full server suite green in the worktree: **475 files / 6489 tests passed**.
- No regression plan applies — the issue body plus the paired tests is the spec for a change this size.
- No release-notes entry: guard tests and a doc comment have no user- or operator-visible delta.

Closes #2033

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTZUvh6h1e2eRsLMDM7aS8
