### PR TITLE
docs(docs): add the ninth cast-id-history write site to plan 280 + spec

### DIFF
--- a/docs/features/280-cast-identity-followups.md
+++ b/docs/features/280-cast-identity-followups.md
@@ -516,6 +516,22 @@ describe('#2128 — seq and recordedAt markers', () => {
     expect(h.recordedAtSeq).toEqual({});
   });
 
+  // Amended 2026-08-06 — the mirror of the test above, for the ninth write site.
+  // The two drop primitives are mirror images (one prunes an entry whose KEY was
+  // reclaimed, the other one whose TARGET died), so a marker-cleanup test for
+  // only one of them leaves the other's deletion path unproven.
+  it('deletes both markers when dropSupersededTargetsNoLongerLive drops a key', async () => {
+    // `dir` is the file's own module-level temp dir, fresh per beforeEach.
+    await retireCharacterId(dir, 'mayrin', 'mairin');   // seq 1, supersededBy {mayrin: mairin}
+    const before = (await loadCastIdHistory(dir)).seq!;
+    await dropSupersededTargetsNoLongerLive(dir, []);   // 'mairin' not live — entry drops
+    const h = await loadCastIdHistory(dir);
+    expect(h.supersededBy).toEqual({});
+    expect(h.recordedAtSeq).toEqual({});
+    expect(h.recordedAtIso).toEqual({});
+    expect(h.seq!).toBeGreaterThan(before);             // the write bumps seq like any other
+  });
+
   it('restoreSupersededId stamps the CURRENT seq, never a replayed one', async () => {
     // `dir` is the file's own module-level temp dir, fresh per beforeEach.
     await retireCharacterId(dir, 'mayrin', 'mairin');  // seq 1
@@ -539,13 +555,14 @@ describe('#2128 — seq and recordedAt markers', () => {
     expect(after.recordedAtIso).toEqual(before.recordedAtIso);
   });
 
-  it('bumps seq on the four writes that touch no supersededBy key', async () => {
+  it('bumps seq on the five writes that touch no supersededBy key', async () => {
     // `dir` is the file's own module-level temp dir, fresh per beforeEach.
     await rejectOrphanedId(dir, 'a');                     // 1
     await rejectOrphanedPair(dir, 'b', 'c');              // 2
     await unrejectOrphanedPair(dir, 'b', 'c');            // 3
     await dropSupersededIdsReclaimedByLiveCast(dir, []);  // 4 — writes unconditionally
-    expect((await loadCastIdHistory(dir)).seq).toBe(4);
+    await dropSupersededTargetsNoLongerLive(dir, []);     // 5 — likewise (amended 2026-08-06)
+    expect((await loadCastIdHistory(dir)).seq).toBe(5);
   });
 
   it('holds keys(recordedAtSeq) === keys(supersededBy) bidirectionally', async () => {
@@ -558,6 +575,13 @@ describe('#2128 — seq and recordedAt markers', () => {
       () => restoreSupersededId(dir, 'a', 'c'),
       () => dropSupersededIdsReclaimedByLiveCast(dir, ['b']),
       () => retireCharacterId(dir, 'd', 'c'),
+      // Amended 2026-08-06 — the ninth write site. Both arms, because they fail
+      // differently: the first writes while dropping NOTHING (proving seq bumps
+      // on an empty drop, the shape that makes "strictly increasing" testable),
+      // the second drops every surviving entry (proving the markers go with the
+      // keys rather than being left for the next write to self-heal).
+      () => dropSupersededTargetsNoLongerLive(dir, ['c']), // 'c' live — drops nothing, still writes
+      () => dropSupersededTargetsNoLongerLive(dir, []),    // 'c' dead — drops a and d
     ];
     let seq = 0;
     for (const step of script) {
@@ -781,18 +805,54 @@ function bumpSeqAndStamp(history: CastIdHistory, stampedKeys: readonly string[])
 }
 ```
 
-Then wire all eight write sites. The keys each one establishes:
+Then wire all **nine** write sites. The keys each one establishes:
 
 | Site | `stampedKeys` |
 |---|---|
-| `retireCharacterId` direct-reversal (before `:300`) | `[from, ...repointed]` |
-| `retireCharacterId` normal (before `:329`) | `[from, ...repointed]` |
-| `dropSupersededIdsReclaimedByLiveCast` (before `:427`) | `[]` — deletions only |
-| `forgetSupersededId` (before `:492`) | `[]` — deletion only |
-| `restoreSupersededId` (before `:541`) | `[id]` |
-| `rejectOrphanedId` (before `:569`) | `[]` |
-| `rejectOrphanedPair` (before `:607`) | `[]` |
-| `unrejectOrphanedPair` (before `:635`) | `[]` |
+| `retireCharacterId` direct-reversal | `[from, ...repointed]` |
+| `retireCharacterId` normal | `[from, ...repointed]` |
+| `dropSupersededIdsReclaimedByLiveCast` | `[]` — deletions only |
+| `dropSupersededTargetsNoLongerLive` | `[]` — deletions only |
+| `forgetSupersededId` | `[]` — deletion only |
+| `restoreSupersededId` | `[id]` |
+| `rejectOrphanedId` | `[]` |
+| `rejectOrphanedPair` | `[]` |
+| `unrejectOrphanedPair` | `[]` |
+
+> **Amended 2026-08-06 — the ninth site, and why the line citations are gone.**
+>
+> This table said "all eight write sites" and omitted
+> **`dropSupersededTargetsNoLongerLive`**. That primitive did not exist when this
+> plan was written: #2110 introduced it in PR #2163, the same PR the "What actually
+> shipped" section above reconciles after the fact — and that reconciliation did not
+> revisit this table. It deletes `supersededBy[k]` and writes the file, so under
+> Global Constraint 6 it is a write site like any other.
+>
+> **What goes wrong if it stays unwired.** Not stale-marker inheritance — the
+> `stampAndBump` helper above already self-heals that, pruning keys absent from
+> `supersededBy` (and back-filling missing ones at the *current* seq, which is the
+> conservative direction). The actual hole is upstream of the markers: an unwired
+> write changes the history state **without incrementing `seq`**, so two different
+> history states share one counter value. `castHistorySeq` exists to record *the
+> state a render resolved against*; once two states share a value it cannot.
+>
+> > `supersededBy['anton'] = 'антон'` at `seq=3`. Chapter X renders and stamps
+> > `castHistorySeq=3`, resolving through the alias to Антон — correct.
+> > `'антон'` then stops being live, so `dropSupersededTargetsNoLongerLive` removes
+> > the entry — leaving `seq=3`. Chapter Y renders and also stamps
+> > `castHistorySeq=3`, but `'anton'` no longer resolves through history at all.
+> > Two renders, two different resolutions, one indistinguishable stamp.
+>
+> It also breaks the plan's own two testable invariants directly: "seq strictly
+> increases across every write", and `keys(recordedAtSeq) === keys(supersededBy)`
+> at rest between the drop and the next write.
+>
+> **Line citations removed from this table deliberately.** Every `(before :NNN)`
+> here was stale — #2110/#2133 shifted `cast-id-history.ts` by ~50-100 lines in
+> PR #2163, so `:427`, `:492`, `:541` and the rest no longer point at the writes
+> they name. Cite by symbol, as the linked spec already resolved to do for the same
+> reason (its F2 note: "a line citation here was stale the moment it was written
+> twice already").
 
 Both repoint loops must now collect what they touched. The direct-reversal branch becomes:
 

--- a/docs/superpowers/specs/2026-08-06-cast-identity-followups-design.md
+++ b/docs/superpowers/specs/2026-08-06-cast-identity-followups-design.md
@@ -171,10 +171,10 @@ carry the rule: `…Seq` is authoritative, `…Iso` is display.
 stamps `recordedAtSeq[k]` and `recordedAtIso[k]`. Every delete of
 `supersededBy[k]` deletes both.**
 
-The increment is on *every* write, not only key-changing ones — four paths write
-without touching a key (`rejectOrphanedPair:607`, `unrejectOrphanedPair:635`,
-`rejectOrphanedId:569`, and `dropSupersededIdsReclaimedByLiveCast`'s
-unconditional write at `:427`, documented as "Always writes, even when nothing was
+The increment is on *every* write, not only key-changing ones — five paths write
+without touching a key (`rejectOrphanedPair`, `unrejectOrphanedPair`,
+`rejectOrphanedId`, and BOTH drop primitives'
+unconditional writes, each documented as "Always writes, even when nothing was
 dropped"). Picking the broader rule makes "seq strictly increases across every
 write" a testable invariant rather than an ambiguous one.
 
@@ -188,12 +188,32 @@ merge-repoint hole:
 > while the alias pointed at `sourceId` used `sourceId`'s voice, so its bytes are
 > stale. Under the uniform rule the repoint restamps and the row lists.
 
-The six mutation sites, all uniform: `retireCharacterId`; its direct-reversal
-branch (`:291-298`); its repoint loop (`:317-321`); `forgetSupersededId`
-(`:475-491`); `dropSupersededIdsReclaimedByLiveCast` (`:417`); and
-`restoreSupersededId` (`:526`), which **stamps the current seq like every other
+The **seven** mutation sites, all uniform: `retireCharacterId`; its direct-reversal
+branch; its repoint loop; `forgetSupersededId`;
+`dropSupersededIdsReclaimedByLiveCast`; `dropSupersededTargetsNoLongerLive`; and
+`restoreSupersededId`, which **stamps the current seq like every other
 writer**. Nothing is preserved into `displaced` — it has zero readers outside this
 module.
+
+> **Rev 5 → 6 (2026-08-06, post-merge correction).**
+> `dropSupersededTargetsNoLongerLive` was missing from both enumerations above —
+> it did not exist when revisions 1-5 were written. #2110 added it in PR #2163,
+> which merged after this spec, and plan 280's after-the-fact reconciliation of
+> that PR did not revisit these lists. It deletes `supersededBy[k]` and writes
+> unconditionally, so it is a mutation site under the uniform rule like any other.
+>
+> The consequence of leaving it unwired is **not** stale-marker inheritance — the
+> `stampAndBump` helper self-heals that by pruning keys absent from
+> `supersededBy`. It is that a write which changes history state *without*
+> incrementing `seq` lets two distinct states share one counter value, which
+> defeats the thing `castHistorySeq` exists to record: the state a render actually
+> resolved against. A render before the drop and a render after it stamp the same
+> seq while resolving differently.
+>
+> Line citations in this section were removed at the same time. Every one was
+> stale by ~50-100 lines after #2110/#2133 reshaped `cast-id-history.ts` in
+> PR #2163 — the same drift this document already called out for `analysis.ts`
+> (F2) and resolved by citing symbols instead.
 
 `restoreSupersededId`'s two early returns (`:534-539`) write nothing and therefore
 stamp nothing; the guard test must assert those paths leave markers **untouched**,
@@ -699,6 +719,20 @@ each. Closed as a shape rather than by enumeration:
 - citation fixes: `cast.tsx:304-307`, `finalize-chapter-write.ts:106`,
   `aggregate.ts:485` was a comment, and the guard regex must not fire on
   `cast-reject-orphan.ts:357`'s `===`.
+
+**Rev 5 → 6** (post-merge correction, 2026-08-06 — after PR #2163 shipped
+#2110/#2129/#2133 and left #2128 open). The uniform-stamp rule enumerated **six**
+mutation sites and **four** keyless writes; both counts predate
+`dropSupersededTargetsNoLongerLive`, which #2110 introduced in PR #2163 — i.e.
+after this spec was written, and not caught by plan 280's after-the-fact
+reconciliation of that PR. Now seven and five. The failure it would have caused is
+subtler than a missing marker (the `stampAndBump` helper self-heals those): an
+unwired write changes history state without moving `seq`, so two distinct states
+share one counter and `castHistorySeq` stops identifying the state a render
+resolved against. Line citations in the affected sections were dropped rather than
+re-derived — #2110/#2133 shifted `cast-id-history.ts` by ~50-100 lines, so every
+one of them pointed at the wrong write, the same drift this document already
+resolved for `analysis.ts` by citing symbols (F2).
 
 ## Handover
 


### PR DESCRIPTION
## Summary

Plan 280's uniform-stamp rule enumerated **"all eight write sites"**; the linked
spec enumerated **"six mutation sites"** and **"four keyless writes"**. All three
counts predate `dropSupersededTargetsNoLongerLive`, which #2110 introduced in
PR #2163 — after the spec was written, and not revisited by plan 280's
after-the-fact reconciliation of that same PR.

That primitive deletes `supersededBy[k]` and writes unconditionally, so under the
plan's Global Constraint 6 it is a mutation site like any other. Now nine / seven /
five.

**What would have gone wrong is subtler than a missing marker.** The `stampAndBump`
helper already self-heals stale markers, pruning keys absent from `supersededBy`.
The real hole is that a write which changes history state *without* incrementing
`seq` lets two distinct states share one counter value — which defeats exactly what
`castHistorySeq` exists to record, the state a render resolved against:

> `supersededBy['anton'] = 'антон'` at `seq=3`. Chapter X renders, stamps
> `castHistorySeq=3`, resolves through the alias — correct. `'антон'` stops being
> live, `dropSupersededTargetsNoLongerLive` removes the entry, `seq` stays 3.
> Chapter Y renders, also stamps `castHistorySeq=3`, but `'anton'` no longer
> resolves through history at all. Two resolutions, one indistinguishable stamp.

It also breaks two invariants the plan states and tests: "seq strictly increases
across every write", and `keys(recordedAtSeq) === keys(supersededBy)` at rest.

**Found by** re-deriving a design for #2128 from the issue body and then
discovering plan 280 already existed. The issue text is stale — it still describes
the `recordedAt`/`synthesizedAt` timestamp scheme the spec moved away from a day
later — and plan 280 explicitly warns a future implementer not to re-derive from
it. #2128 has been updated to carry that warning at the top, so the next reader
hits it before designing anything.

## Changes

- **Plan 280** — ninth row in the write-site table; the site driven from the
  bidirectional guard-test script (**both** arms: an empty drop proves `seq` still
  bumps, a full drop proves markers go with the keys); keyless-write seq count
  four → five; a marker-cleanup test mirroring the one that already exists for the
  sibling drop primitive.
- **Spec** — six → seven mutation sites, four → five keyless writes, plus a
  `Rev 5 → 6` entry in the revision log recording why the omission existed.
- **Line citations dropped** from the affected sections rather than re-derived.
  #2110/#2133 shifted `cast-id-history.ts` by ~50–100 lines in PR #2163, so every
  `(before :NNN)` pointed at the wrong write. Cited by symbol, as the spec already
  resolved to do for `analysis.ts` (finding F2).

No task checkboxes were rewritten — Tasks 2–9 stand as originally designed. This
adds a site to their tables and tests, per the plan's own instruction not to
silently edit tasks to match reality.

## Test plan

Docs-only; no runtime surface. The tests described above are specifications inside
plan 280, to be implemented when Tasks 2–9 run — this PR makes the ninth site part
of what they must cover, which is the point.

- [x] Verified `dropSupersededTargetsNoLongerLive` appears nowhere in plan 280's
      task breakdown, site tables, or guard-test scripts before this change (single
      pre-existing occurrence, in the "What actually shipped" prose).
- [x] Verified it writes unconditionally and deletes `supersededBy` keys
      (`server/src/store/cast-id-history.ts`).
- [x] Verified the stale line citations against the current file.
- [x] `pre-push` docs-only fast-path (no runtime surface to exercise).

Refs #2128
