### PR TITLE
fix(scripts): probe every GPU for contention, not just the first

### DIFF
--- a/scripts/run-golden-audio.mjs
+++ b/scripts/run-golden-audio.mjs
@@ -62,7 +62,13 @@
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { dirname, resolve } from 'node:path';
-import { parseNvidiaSmiUtil } from './verify-cache.mjs';
+import { parseNvidiaSmiUtil, maxNvidiaSmiUtil } from './verify-cache.mjs';
+
+// Re-exported for backward compatibility: scripts/tests/run-golden-audio.test.mjs
+// imports maxNvidiaSmiUtil from this module. The implementation itself moved to
+// verify-cache.mjs (#2164) so scripts/verify-cache.mjs's own detectGpuContention
+// can use it too — see that file for the real definition and its doc comment.
+export { maxNvidiaSmiUtil };
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const args = process.argv.slice(2);
@@ -98,25 +104,9 @@ if (assemblyOnly && sidecarOnly) {
 // behind it — file a follow-up if that changes.
 const GPU_BUSY_THRESHOLD = 40; // % utilization -- mirrors verify-cache.mjs's own threshold
 
-// #2036: `parseNvidiaSmiUtil` (verify-cache.mjs) only returns the FIRST GPU's
-// utilization line. On a multi-GPU box (this dev box is cuda:0 4070 8GB /
-// cuda:1 5070 Ti 16GB) a busy second card is invisible to a first-line read —
-// exactly the #1995 scenario the warning exists to catch. Take a local max()
-// over every parsed line here rather than widening the shared parser, which
-// has other callers with their own semantics (#2036).
-export function maxNvidiaSmiUtil(stdout) {
-  if (!stdout) return null;
-  const lines = stdout
-    .split(/\r?\n/)
-    .map((s) => s.trim())
-    .filter(Boolean);
-  let max = null;
-  for (const line of lines) {
-    const util = parseNvidiaSmiUtil(line);
-    if (util !== null && (max === null || util > max)) max = util;
-  }
-  return max;
-}
+// #2164: maxNvidiaSmiUtil moved to verify-cache.mjs (imported above) so
+// scripts/verify-cache.mjs's own GPU-contention probe can share it instead of
+// keeping a second copy — see that file for the implementation and comment.
 
 // #2036 review round 2: an absent/unparseable/failed probe used to return
 // `null` from `gpuBusyWarningFor` — indistinguishable at the console from "GPU

--- a/scripts/run-golden-audio.mjs
+++ b/scripts/run-golden-audio.mjs
@@ -62,7 +62,7 @@
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { dirname, resolve } from 'node:path';
-import { maxNvidiaSmiUtil } from './verify-cache.mjs';
+import { maxNvidiaSmiUtil, GPU_BUSY_THRESHOLD } from './verify-cache.mjs';
 
 // Re-exported for backward compatibility: scripts/tests/run-golden-audio.test.mjs
 // imports maxNvidiaSmiUtil from this module. The implementation itself moved to
@@ -102,7 +102,11 @@ if (assemblyOnly && sidecarOnly) {
 // would need a background timer/interval this deliberately one-shot script
 // doesn't otherwise carry, to catch a narrower case with no reported incident
 // behind it — file a follow-up if that changes.
-const GPU_BUSY_THRESHOLD = 40; // % utilization -- mirrors verify-cache.mjs's own threshold
+//
+// GPU_BUSY_THRESHOLD is imported from verify-cache.mjs (above), not
+// redeclared — #2164 review finding 4: two independent `= 40`s meant raising
+// one could silently leave the bless-time warning here firing at the old
+// value while a comment merely claimed they mirror.
 
 // #2164: maxNvidiaSmiUtil moved to verify-cache.mjs (imported above) so
 // scripts/verify-cache.mjs's own GPU-contention probe can share it instead of

--- a/scripts/run-golden-audio.mjs
+++ b/scripts/run-golden-audio.mjs
@@ -62,7 +62,7 @@
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { dirname, resolve } from 'node:path';
-import { parseNvidiaSmiUtil, maxNvidiaSmiUtil } from './verify-cache.mjs';
+import { maxNvidiaSmiUtil } from './verify-cache.mjs';
 
 // Re-exported for backward compatibility: scripts/tests/run-golden-audio.test.mjs
 // imports maxNvidiaSmiUtil from this module. The implementation itself moved to

--- a/scripts/tests/verify-cache.test.mjs
+++ b/scripts/tests/verify-cache.test.mjs
@@ -31,6 +31,8 @@ import {
   stepTouchedByDiff,
   computeShared,
   parseNvidiaSmiUtil,
+  maxNvidiaSmiUtil,
+  gpuContentionFor,
   isVitestPoolCrash,
   branchDiffFiles,
   sidecarFingerprint,
@@ -885,6 +887,51 @@ test('parseNvidiaSmiUtil returns null on empty / unparseable output', () => {
   assert.equal(parseNvidiaSmiUtil(''), null);
   assert.equal(parseNvidiaSmiUtil('\n'), null);
   assert.equal(parseNvidiaSmiUtil('N/A\n'), null);
+});
+
+// #2164: the contention probe used to read only the FIRST GPU line
+// (parseNvidiaSmiUtil above), which on a dual-GPU box misses a busy SECOND
+// card entirely — this dev box is cuda:0 (4070 8GB) idle / cuda:1 (5070 Ti
+// 16GB) busy, and the busy card sits at index 1. maxNvidiaSmiUtil takes the
+// max across every parseable line instead.
+
+test('maxNvidiaSmiUtil takes the max across a two-GPU output, not just the first line', () => {
+  assert.equal(maxNvidiaSmiUtil('3\n97\n'), 97);
+  // Order shouldn't matter.
+  assert.equal(maxNvidiaSmiUtil('97\n3\n'), 97);
+});
+
+test('maxNvidiaSmiUtil returns null on empty / unparseable output', () => {
+  assert.equal(maxNvidiaSmiUtil(''), null);
+  assert.equal(maxNvidiaSmiUtil('\n'), null);
+  assert.equal(maxNvidiaSmiUtil('N/A\nN/A\n'), null);
+});
+
+test('maxNvidiaSmiUtil ignores unparseable lines but keeps the max of the rest', () => {
+  assert.equal(maxNvidiaSmiUtil('N/A\n85\n'), 85);
+});
+
+// The actual regression test (#2164): a two-GPU stdout whose SECOND card is
+// over threshold must be detected as contention. Before the fix,
+// detectGpuContention called parseNvidiaSmiUtil (first-line-only) here, read
+// cuda:0's idle 3%, and returned busy:false — missing the busy cuda:1 card
+// entirely. That is the exact bug that let six commits die to co-running
+// generations tonight.
+test('gpuContentionFor: busy SECOND GPU (not the first) is detected as contention', () => {
+  assert.deepEqual(gpuContentionFor('3\n97\n'), { busy: true, util: 97 });
+});
+
+test('gpuContentionFor: idle when every GPU is under threshold', () => {
+  assert.deepEqual(gpuContentionFor('3\n12\n'), { busy: false, util: 12 });
+});
+
+test('gpuContentionFor: falls back to busy:false, util:null on unparseable output', () => {
+  // Mirrors detectGpuContention's own fallback for an absent/errored nvidia-smi
+  // (e.g. CI ubuntu runners, non-NVIDIA boxes) — the spawn failure itself is
+  // handled in detectGpuContention, but an empty/garbage stdout reaching this
+  // pure function must resolve the same way.
+  assert.deepEqual(gpuContentionFor(''), { busy: false, util: null });
+  assert.deepEqual(gpuContentionFor('N/A\n'), { busy: false, util: null });
 });
 
 // --- Branch-diff scope filter (verify/CI rebalance, 2026-07-06) --------

--- a/scripts/tests/verify-cache.test.mjs
+++ b/scripts/tests/verify-cache.test.mjs
@@ -42,6 +42,12 @@ import {
 
 const { SCHEMA_VERSION } = _internals;
 
+// Resolve relative to THIS file, not the process cwd — same rationale as
+// scripts/tests/run-golden-audio.test.mjs's own HERE/SRC_PATH.
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC_PATH = join(HERE, '..', 'verify-cache.mjs');
+const src = readFileSync(SRC_PATH, 'utf8');
+
 test('isVitestPoolCrash: true for fork-pool worker crashes, false for red tests', () => {
   // Transient fork-pool process crashes — warrant ONE auto-retry.
   assert.equal(isVitestPoolCrash('Error: [vitest-pool]: Worker forks emitted error.'), true);
@@ -932,6 +938,58 @@ test('gpuContentionFor: falls back to busy:false, util:null on unparseable outpu
   // pure function must resolve the same way.
   assert.deepEqual(gpuContentionFor(''), { busy: false, util: null });
   assert.deepEqual(gpuContentionFor('N/A\n'), { busy: false, util: null });
+});
+
+// #2164 review finding 1: `gpuContentionFor` itself is fully unit-tested
+// above, but `detectGpuContention` — the actual production wire, which spawns
+// a real nvidia-smi and is not exported — was never asserted to actually call
+// it. A one-line revert of detectGpuContention's body back to
+// `parseNvidiaSmiUtil(r.stdout)` (the pre-#2164 first-line-only bug) left
+// every other test in this file green. Since detectGpuContention isn't
+// directly testable without spawning a real nvidia-smi, this pins the
+// production wire at the source level instead — same technique as
+// BLESS_ENV_SHAPE in scripts/tests/run-golden-audio.test.mjs.
+function detectGpuContentionBody() {
+  const match = src.match(/function detectGpuContention\(\) \{[\s\S]*?\n\}/);
+  assert.ok(match, "could not locate detectGpuContention's function body in verify-cache.mjs");
+  return match[0];
+}
+
+test('detectGpuContention routes through gpuContentionFor, not parseNvidiaSmiUtil directly', () => {
+  const body = detectGpuContentionBody();
+  assert.match(
+    body,
+    /return gpuContentionFor\(r\.stdout\);/,
+    'detectGpuContention must return gpuContentionFor(r.stdout) — the pure decision seam — ' +
+      'not inline its own threshold check',
+  );
+  assert.doesNotMatch(
+    body,
+    /parseNvidiaSmiUtil\(/,
+    'detectGpuContention must not call parseNvidiaSmiUtil directly — that is the first-line-only ' +
+      'parser this fix moved away from; calling it here silently reintroduces the #2164 bug ' +
+      'even though gpuContentionFor itself stays correct',
+  );
+});
+
+// #2164 review finding 2: the `--query-gpu` argument is unpinned and silently
+// determines correctness. parseNvidiaSmiUtil/maxNvidiaSmiUtil both read the
+// FIRST CSV field as the utilization percentage, which is only true because
+// the query requests utilization.gpu ALONE. Widening it — e.g. to
+// `index,utilization.gpu`, the richer shape #2164's own issue body pastes
+// ("1, NVIDIA GeForce RTX 5070 Ti, 91 %, 15455 MiB") — shifts the first field
+// to the GPU index (0 or 1, always under GPU_BUSY_THRESHOLD), reintroducing
+// #2164's always-idle bug through the query string instead of the parser,
+// with every existing test still green (they all pass CSV directly, not
+// through a real nvidia-smi query).
+test('detectGpuContention pins the --query-gpu=utilization.gpu flag the parsers depend on', () => {
+  const body = detectGpuContentionBody();
+  assert.match(
+    body,
+    /'--query-gpu=utilization\.gpu'/,
+    "detectGpuContention must query ONLY utilization.gpu — adding a field (e.g. 'index,') " +
+      'shifts the first CSV column the parsers read away from the utilization percentage',
+  );
 });
 
 // --- Branch-diff scope filter (verify/CI rebalance, 2026-07-06) --------

--- a/scripts/verify-cache.mjs
+++ b/scripts/verify-cache.mjs
@@ -761,7 +761,12 @@ export function branchDiffFiles(cwd) {
 // pressure (that incident also had Ollama holding ~14GB of system RAM) is
 // real contention neither utilisation nor VRAM occupancy measures — known
 // out of scope, not implemented.
-const GPU_BUSY_THRESHOLD = 40; // % utilization
+//
+// Exported so run-golden-audio.mjs's own bless-time contention warning shares
+// this exact value instead of redeclaring it (#2164 review finding 4) — two
+// independent `= 40`s meant raising one could silently leave the other
+// stale despite a comment claiming they mirror.
+export const GPU_BUSY_THRESHOLD = 40; // % utilization
 
 // Parse the first GPU's utilization (%) from nvidia-smi CSV output. Returns a
 // number, or null if unparseable / no GPU line.
@@ -777,15 +782,16 @@ export function parseNvidiaSmiUtil(stdout) {
 }
 
 // Max utilization (%) across EVERY GPU line in nvidia-smi CSV output — unlike
-// parseNvidiaSmiUtil above, which deliberately stays a single-line parser (see
-// its own doc comment; #2036 chose not to widen it, since it has its own
-// callers with first-line semantics). On a multi-GPU box the busy card is not
-// always index 0 (#2164: this dev box is cuda:0 4070 8GB idle / cuda:1 5070 Ti
-// 16GB busy) — a first-line-only read misses exactly the contention this guard
-// exists to catch. Lives here (moved from a local copy in run-golden-audio.mjs,
-// #2036) so both callers share one implementation; run-golden-audio.mjs now
-// imports this rather than keeping its own. Returns the max over every
-// parseable line, or null when none parse.
+// parseNvidiaSmiUtil above, which deliberately stays a single-line parser: that
+// is its documented contract (see its own doc comment; #2036 chose not to
+// widen it), and this function composes over it rather than duplicating it —
+// re-applying parseNvidiaSmiUtil one line at a time and taking the max. On a
+// multi-GPU box the busy card is not always index 0 (#2164: this dev box is
+// cuda:0 4070 8GB idle / cuda:1 5070 Ti 16GB busy) — a first-line-only read
+// misses exactly the contention this guard exists to catch. Lives here (moved
+// from a local copy in run-golden-audio.mjs, #2036) so both callers share one
+// implementation; run-golden-audio.mjs now imports this rather than keeping
+// its own. Returns the max over every parseable line, or null when none parse.
 export function maxNvidiaSmiUtil(stdout) {
   if (!stdout) return null;
   const lines = stdout
@@ -811,6 +817,16 @@ export function gpuContentionFor(stdout) {
 
 // Returns { busy, util }. nvidia-smi absent / errors → { busy:false, util:null }
 // (e.g. CI ubuntu runners, non-NVIDIA boxes). Cheap (~100ms).
+//
+// The `--query-gpu=utilization.gpu` argument is load-bearing and must request
+// ONLY that field: both parseNvidiaSmiUtil and maxNvidiaSmiUtil blindly read
+// the FIRST CSV column of each line as the utilization percentage. Widening
+// the query — e.g. to `index,utilization.gpu`, the richer shape #2164's own
+// issue body pastes ("1, NVIDIA GeForce RTX 5070 Ti, 91 %, 15455 MiB") — would
+// shift that first column to the GPU index (0/1, always under threshold) and
+// silently reintroduce #2164's always-idle bug through the query string
+// instead of the parser. Pinned by a source-regex test in
+// scripts/tests/verify-cache.test.mjs.
 function detectGpuContention() {
   const r = spawnSync(
     'nvidia-smi',

--- a/scripts/verify-cache.mjs
+++ b/scripts/verify-cache.mjs
@@ -749,6 +749,18 @@ export function branchDiffFiles(cwd) {
 // the test legs. When we detect a busy GPU we throttle test concurrency (soft —
 // warn + dial down, never block).
 
+// Utilisation-only, deliberately (#2164): VRAM occupancy does NOT count as
+// contention. The failure this guard prevents is fs/tmpdir and CPU
+// contention from *active* work (docs/features/archive/45-vitest-pool-tuning.md:
+// tmpdir contention, AV/OneDrive interleaving, pool pressure) — a model
+// parked in VRAM burns no CPU and touches no tmpdir. This box deliberately
+// keeps models resident (PRELOAD_KOKORO, the button-loaded Qwen Base), so a
+// residency trigger would pin LOW_CONCURRENCY=1 near-permanently while
+// preventing no crash. The #2164 incident's busy card was at 91% util —
+// squarely inside what max-across-GPUs already catches below. Host RAM
+// pressure (that incident also had Ollama holding ~14GB of system RAM) is
+// real contention neither utilisation nor VRAM occupancy measures — known
+// out of scope, not implemented.
 const GPU_BUSY_THRESHOLD = 40; // % utilization
 
 // Parse the first GPU's utilization (%) from nvidia-smi CSV output. Returns a
@@ -764,6 +776,39 @@ export function parseNvidiaSmiUtil(stdout) {
   return Number.isFinite(n) ? n : null;
 }
 
+// Max utilization (%) across EVERY GPU line in nvidia-smi CSV output — unlike
+// parseNvidiaSmiUtil above, which deliberately stays a single-line parser (see
+// its own doc comment; #2036 chose not to widen it, since it has its own
+// callers with first-line semantics). On a multi-GPU box the busy card is not
+// always index 0 (#2164: this dev box is cuda:0 4070 8GB idle / cuda:1 5070 Ti
+// 16GB busy) — a first-line-only read misses exactly the contention this guard
+// exists to catch. Lives here (moved from a local copy in run-golden-audio.mjs,
+// #2036) so both callers share one implementation; run-golden-audio.mjs now
+// imports this rather than keeping its own. Returns the max over every
+// parseable line, or null when none parse.
+export function maxNvidiaSmiUtil(stdout) {
+  if (!stdout) return null;
+  const lines = stdout
+    .split(/\r?\n/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  let max = null;
+  for (const line of lines) {
+    const util = parseNvidiaSmiUtil(line);
+    if (util !== null && (max === null || util > max)) max = util;
+  }
+  return max;
+}
+
+// Pure decision seam (#2164): given raw nvidia-smi stdout, decide contention.
+// Split out from detectGpuContention so the decision is unit-testable without
+// spawning a real nvidia-smi — mirrors how run-golden-audio.mjs already splits
+// gpuBusyWarningFor out of warnIfGpuBusyForBless.
+export function gpuContentionFor(stdout) {
+  const util = maxNvidiaSmiUtil(stdout);
+  return { busy: util !== null && util >= GPU_BUSY_THRESHOLD, util };
+}
+
 // Returns { busy, util }. nvidia-smi absent / errors → { busy:false, util:null }
 // (e.g. CI ubuntu runners, non-NVIDIA boxes). Cheap (~100ms).
 function detectGpuContention() {
@@ -773,8 +818,7 @@ function detectGpuContention() {
     { encoding: 'utf8', timeout: 5000 },
   );
   if (r.error || r.status !== 0) return { busy: false, util: null };
-  const util = parseNvidiaSmiUtil(r.stdout);
-  return { busy: util !== null && util >= GPU_BUSY_THRESHOLD, util };
+  return gpuContentionFor(r.stdout);
 }
 
 // Tool fingerprints — strings that change when the relevant tool's


### PR DESCRIPTION
## Summary

**The contention throttle can now actually see the busy card.**

`verify-cache.mjs` throttles test concurrency (`LOW_CONCURRENCY=1`) when it detects a busy GPU, because a co-running generation is the documented cause of `Worker exited unexpectedly` fork-pool crashes in the test legs. On this dual-GPU dev box it could never fire: `nvidia-smi --query-gpu=utilization.gpu` emits **one line per GPU**, and `detectGpuContention` passed the whole stdout to `parseNvidiaSmiUtil`, which reads only the first line. The heavy card here is index **1** — so the probe read the idle 4070, returned `busy:false`, and left the throttle off while the 5070 Ti sat at 91% with 15.4 GB resident. The guard was blind in exactly the situation it exists for. Six commits died to that last night, each one an infra crash a human had to diagnose by hand.

**`parseNvidiaSmiUtil` is deliberately unchanged.** Its name and doc comment accurately describe a single-line parser, and #2036 already considered and rejected widening it. Instead `maxNvidiaSmiUtil` — which already existed, fully written and fully tested, as a local workaround in `run-golden-audio.mjs` — moves into `verify-cache.mjs` so both callers share one implementation, and `detectGpuContention` uses it. `run-golden-audio.mjs` now imports it rather than keeping a second copy. Its existing test file keeps working unchanged via a re-export, so no coverage moved or was lost.

A pure `gpuContentionFor(stdout)` seam is split out of `detectGpuContention` so the decision is testable without spawning a real `nvidia-smi` — mirroring how `run-golden-audio.mjs` already splits `gpuBusyWarningFor` out of `warnIfGpuBusyForBless`.

### The VRAM question, decided rather than omitted

The issue asked whether VRAM occupancy should count as contention alongside `utilization.gpu`. **Decision: utilisation only**, recorded in a comment at the threshold so the next reader inherits the reasoning instead of the question:

- The failure this guard prevents is fs/tmpdir and CPU contention from *active* work (`docs/features/archive/45-vitest-pool-tuning.md`: tmpdir contention, AV/OneDrive interleaving, pool pressure). A model parked in VRAM burns no CPU and touches no tmpdir.
- This box deliberately keeps models resident (`PRELOAD_KOKORO`, the button-loaded Qwen Base), so a residency trigger would pin `LOW_CONCURRENCY=1` near-permanently while preventing no crash.
- The motivating incident's busy card was at **91% util** — squarely inside what max-across-GPUs catches.

The comment also names the one signal that stays genuinely uncovered, so it is not lost by silence: **host RAM pressure** (that same incident had Ollama holding ~14 GB of system RAM) is real contention that neither utilisation nor VRAM occupancy measures. Knowingly out of scope, not implemented.

## Test plan

`scripts/tests/verify-cache.test.mjs` (node:test, runs under `npm run test:hooks`):

- `maxNvidiaSmiUtil` in its new home — busy second GPU, order-independence, `null` on empty/`'\n'`/all-unparseable, and unparseable-lines-ignored.
- **The regression test**: `gpuContentionFor('3\n97\n')` → `{ busy: true, util: 97 }`. Pre-fix this read cuda:0's idle 3% and returned `busy:false`.
- The `{ busy:false, util:null }` fallback stays covered for absent/unparseable `nvidia-smi` (CI runners with no NVIDIA device).
- `parseNvidiaSmiUtil`'s existing tests are untouched, including the one that deliberately pins first-line behaviour.

**Mutation-verified.** Pointing `gpuContentionFor` back at the first-line parser turns the new regression test **red** (reproducing the exact bug: reads 3%, misses 97%); reverting returns 93/93 green. Full `npm run test:hooks`: 1179/1179.

A live probe on the real box returns `{ busy: false, util: 0 }` from raw stdout `"0\r\n0\r\n"`. **That confirms the plumbing does not throw and nothing more** — with both cards idle, first-line and max-across-cards return the identical answer, so the observation has no power to discriminate the fix from the bug. An earlier draft of this PR body claimed it as verification of the fix; it isn't, and the claim is withdrawn. The evidence for the fix is the mutation-proven regression test above, plus the two production-wire pins added after review.

## Review findings folded in

The independent review returned APPROVE WITH NITS and found two holes worth closing before merge, both of the "silent today, green forever" kind:

- **The production wire was untested.** `detectGpuContention` is not exported and no test reached it, so reverting its body to the pre-fix first-line read left all 93 tests passing — the regression test pinned the new helper, not the path that carried the bug. Now pinned by a source-level assertion that `detectGpuContention` routes through `gpuContentionFor` and never calls `parseNvidiaSmiUtil` directly, mutation-proven against that exact revert.
- **The `nvidia-smi` query string silently determines correctness.** `parseNvidiaSmiUtil` reads the *first CSV field*, which is right only while the query is `--query-gpu=utilization.gpu` alone. Adding `index,` — precisely the richer output shape #2164's own issue body pastes — would make both parsers return the GPU index, always under threshold, `busy:false` forever, every test green: this bug reintroduced through a different door. The flag string is now pinned by assertion, with the dependency spelled out.

Two smaller ones also folded in: the hoist had falsified `parseNvidiaSmiUtil`'s own doc comment (it justified staying single-line by citing callers the hoist removed), and `GPU_BUSY_THRESHOLD` was still declared independently in both files despite a comment claiming they mirror — now exported and imported, so they cannot drift apart.

## Also fixed, found in passing

The hoist orphaned `run-golden-audio.mjs`'s `parseNvidiaSmiUtil` import — it had no remaining use once `maxNvidiaSmiUtil` moved out. Removed in a follow-up commit; `pre-push` lint caught it, which is the gate working.

## Notes

- **Release notes: skipped deliberately.** Dev tooling only — no user- or operator-visible delta (CLAUDE.md step 5 carve-out).
- **Regression plan: none.** Small and localized; the issue body plus the paired tests are the spec.
- **On-box acceptance: none owed.** The behaviour is provable from a pure function over captured `nvidia-smi` stdout, plus the live two-GPU read above.

Closes #2164
