### PR TITLE
fix(server): make the UNREADABLE tests self-verifying and render every sentinel safely

### DIFF
--- a/server/src/workspace/cast-fingerprint.test.ts
+++ b/server/src/workspace/cast-fingerprint.test.ts
@@ -33,8 +33,15 @@ function setReadFileImpl(fn: ReadFileUtf8 | null): void {
 
 /* Import AFTER vi.mock so cast-fingerprint.ts picks up the mocked readFile. */
 const { readFile } = await import('node:fs/promises');
-const { ABSENT, UNREADABLE, hashBytes, readJsonWithFingerprint, fingerprintOfWrite } =
-  await import('./cast-fingerprint.js');
+const {
+  ABSENT,
+  UNREADABLE,
+  FINGERPRINT_SENTINELS,
+  hashBytes,
+  readJsonWithFingerprint,
+  fingerprintOfWrite,
+  describeFingerprintForLog,
+} = await import('./cast-fingerprint.js');
 
 function tmpDir(): string {
   return mkdtempSync(join(tmpdir(), 'castwright-fingerprint-'));
@@ -167,5 +174,27 @@ describe('fingerprintOfWrite — coupling guard against writeJsonAtomic', () => 
     expect(UNREADABLE).not.toMatch(/^[0-9a-f]{64}$/);
     expect(UNREADABLE.startsWith(String.fromCharCode(0))).toBe(true);
     expect(UNREADABLE).not.toBe(ABSENT);
+  });
+});
+
+describe('describeFingerprintForLog - every sentinel renders safe text (#2186)', () => {
+  it('renders every member of FINGERPRINT_SENTINELS as non-empty text with no NUL byte', () => {
+    /* Iterates the actual sentinel SET, not two hardcoded literals: a future
+       third sentinel added to FINGERPRINT_SENTINELS without a matching label
+       in describeFingerprintForLog falls through to the raw-hex-prefix
+       branch, which still carries the leading NUL and fails the assertions
+       below. That is the whole point: this test breaks the day someone adds
+       sentinel three and forgets to teach the renderer about it. */
+    const nul = String.fromCharCode(0);
+    for (const sentinel of FINGERPRINT_SENTINELS) {
+      const rendered = describeFingerprintForLog(sentinel);
+      expect(rendered).not.toContain(nul);
+      expect(rendered.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('still renders a real sha256 digest as a 12-char prefix (unaffected by the sentinel table)', () => {
+    const digest = hashBytes('{"characters":[]}');
+    expect(describeFingerprintForLog(digest)).toBe(digest.slice(0, 12));
   });
 });

--- a/server/src/workspace/cast-fingerprint.test.ts
+++ b/server/src/workspace/cast-fingerprint.test.ts
@@ -184,7 +184,9 @@ describe('describeFingerprintForLog - every sentinel renders safe text (#2186)',
        in describeFingerprintForLog falls through to the raw-hex-prefix
        branch, which still carries the leading NUL and fails the assertions
        below. That is the whole point: this test breaks the day someone adds
-       sentinel three and forgets to teach the renderer about it. */
+       a sentinel to FINGERPRINT_SENTINELS and forgets to teach the renderer
+       about it — a sentinel declared but never added to that array is still
+       not caught. */
     const nul = String.fromCharCode(0);
     for (const sentinel of FINGERPRINT_SENTINELS) {
       const rendered = describeFingerprintForLog(sentinel);
@@ -196,5 +198,20 @@ describe('describeFingerprintForLog - every sentinel renders safe text (#2186)',
   it('still renders a real sha256 digest as a 12-char prefix (unaffected by the sentinel table)', () => {
     const digest = hashBytes('{"characters":[]}');
     expect(describeFingerprintForLog(digest)).toBe(digest.slice(0, 12));
+  });
+
+  it('never resolves through Object.prototype for a prototype-shaped input (review finding 1)', () => {
+    /* A plain-object lookup table resolves 'constructor', 'toString',
+       '__proto__', 'hasOwnProperty' etc. through the prototype chain instead
+       of failing the lookup — despite the table's declared `string` value
+       type, which is only a compile-time claim TypeScript cannot verify
+       against a runtime index. Each of these must fall through to the
+       raw-hex-prefix branch like any other non-sentinel string, and the
+       result must always be a string. */
+    for (const input of ['constructor', 'toString', '__proto__', 'hasOwnProperty']) {
+      const rendered = describeFingerprintForLog(input);
+      expect(typeof rendered).toBe('string');
+      expect(rendered).toBe(input.slice(0, 12));
+    }
   });
 });

--- a/server/src/workspace/cast-fingerprint.ts
+++ b/server/src/workspace/cast-fingerprint.ts
@@ -40,20 +40,27 @@ export type CastFingerprint = string | typeof ABSENT | null;
     that test instead of silently reaching a log consumer un-rendered. */
 export const FINGERPRINT_SENTINELS = [ABSENT, UNREADABLE] as const;
 
-const SENTINEL_LOG_LABELS: Partial<Record<string, string>> = {
+const SENTINEL_LOG_LABELS: Record<(typeof FINGERPRINT_SENTINELS)[number], string> = {
   [ABSENT]: 'ABSENT',
   [UNREADABLE]: 'UNREADABLE',
 };
 
 /** Render a fingerprint value for a log line. Every member of
     `FINGERPRINT_SENTINELS` is mapped to safe literal text here so its raw
-    NUL-prefixed encoding never reaches a log consumer. Everything else is a
-    real sha256 hex digest; a 12-char prefix is enough to eyeball a match
-    without spamming the log line. Takes a plain `string` (not
+    NUL-prefixed encoding never reaches a log consumer — the table is typed
+    by the sentinel union itself, so a sentinel added to `FINGERPRINT_SENTINELS`
+    without a matching label here fails `npm run typecheck`, not just a test.
+    The lookup is guarded by `Object.hasOwn` so an arbitrary string (e.g.
+    `'constructor'`, `'toString'`, `'__proto__'`) can never resolve through
+    the object's prototype chain instead of its own properties. Everything
+    else is a real sha256 hex digest; a 12-char prefix is enough to eyeball a
+    match without spamming the log line. Takes a plain `string` (not
     `CastFingerprint`) because callers here already hold the
     `String(...)`-converted conflict fields, not the typed union. */
 export function describeFingerprintForLog(value: string): string {
-  return SENTINEL_LOG_LABELS[value] ?? value.slice(0, 12);
+  return Object.hasOwn(SENTINEL_LOG_LABELS, value)
+    ? SENTINEL_LOG_LABELS[value as (typeof FINGERPRINT_SENTINELS)[number]]
+    : value.slice(0, 12);
 }
 
 export function hashBytes(raw: string): string {

--- a/server/src/workspace/cast-fingerprint.ts
+++ b/server/src/workspace/cast-fingerprint.ts
@@ -31,16 +31,29 @@ export const UNREADABLE = '\0UNREADABLE' as const;
 /** Three states, never two — see design §1a. */
 export type CastFingerprint = string | typeof ABSENT | null;
 
-/** Render a fingerprint value for a log line. The NUL-prefixed `ABSENT`
-    encoding exists purely as an internal collision guard (see the comment
-    above) — it must never reach a log consumer raw, since a leading 0x00
-    byte truncates some log pipelines right after `expected=`/`observed=`.
-    Everything else is a real sha256 hex digest; a 12-char prefix is enough
-    to eyeball a match without spamming the log line. Takes a plain `string`
-    (not `CastFingerprint`) because callers here already hold the
+/** All fingerprint sentinels that must never reach a log line raw — each is
+    NUL-prefixed by construction (see the two doc comments above), and a
+    leading 0x00 byte truncates some log pipelines right after
+    `expected=`/`observed=`. `cast-fingerprint.test.ts` iterates this array
+    (not two hardcoded string literals) so a future third sentinel added
+    here without a matching label in `describeFingerprintForLog` below fails
+    that test instead of silently reaching a log consumer un-rendered. */
+export const FINGERPRINT_SENTINELS = [ABSENT, UNREADABLE] as const;
+
+const SENTINEL_LOG_LABELS: Partial<Record<string, string>> = {
+  [ABSENT]: 'ABSENT',
+  [UNREADABLE]: 'UNREADABLE',
+};
+
+/** Render a fingerprint value for a log line. Every member of
+    `FINGERPRINT_SENTINELS` is mapped to safe literal text here so its raw
+    NUL-prefixed encoding never reaches a log consumer. Everything else is a
+    real sha256 hex digest; a 12-char prefix is enough to eyeball a match
+    without spamming the log line. Takes a plain `string` (not
+    `CastFingerprint`) because callers here already hold the
     `String(...)`-converted conflict fields, not the typed union. */
 export function describeFingerprintForLog(value: string): string {
-  return value === ABSENT ? 'ABSENT' : value.slice(0, 12);
+  return SENTINEL_LOG_LABELS[value] ?? value.slice(0, 12);
 }
 
 export function hashBytes(raw: string): string {

--- a/server/src/workspace/cast-merge-base.test.ts
+++ b/server/src/workspace/cast-merge-base.test.ts
@@ -248,6 +248,15 @@ describe('createCastMergeBase — a not-checkable (UNREADABLE) read (#2185 revie
       const baselineBefore = base.value;
       expect(typeof baselineBefore).toBe('string');
 
+      /* Self-verification (#2186): land a foreign write here, before the
+         mocked failure is installed. If the vi.mock below ever silently
+         stopped applying, writeChecked's pre-write read would succeed for
+         real, observe THIS content, and find it mismatches `baselineBefore`
+         — firing onConflict and failing the assertion below, instead of the
+         mock's absence going unnoticed because a same-baseline real read
+         would have produced "no conflict" either way. */
+      writeFileSync(castJsonPath(dir), JSON.stringify({ characters: [{ id: 'foreign' }] }, null, 2));
+
       /* Simulates an AV scanner / OneDrive / the Windows indexer briefly
          locking cast.json mid-analysis — the exact shape #2185's review
          confirmed empirically. */
@@ -308,6 +317,12 @@ describe('createCastMergeBase — a not-checkable (UNREADABLE) read (#2185 revie
       writeFileSync(castJsonPath(dir), JSON.stringify({ characters: [{ id: 'a' }] }, null, 2));
       const base = createCastMergeBase(dir, await captureOf(dir));
       const onConflict = vi.fn();
+
+      /* Self-verification (#2186): same reasoning as the test above — a
+         foreign write here means a silently-disarmed mock's real read at
+         site 1 would observe a mismatch and fire onConflict, failing the
+         assertion below rather than passing it for the wrong reason. */
+      writeFileSync(castJsonPath(dir), JSON.stringify({ characters: [{ id: 'foreign' }] }, null, 2));
 
       // Site 1: the pre-write read fails with a transient, non-ENOENT error.
       const err = Object.assign(new Error('resource busy or locked'), { code: 'EBUSY' });


### PR DESCRIPTION
## Summary

Two residuals from PR #2185's final review. Neither was a defect; both were ways a guard could go quiet without anyone noticing.

**1. The `UNREADABLE` tests carried no proof their injection was live.**

`cast-merge-base.test.ts` proves that a transient `EBUSY`/`EPERM` on `cast.json` does *not* fire a false `cast_merge_base_stale` advisory, by injecting a non-`ENOENT` read failure through `vi.mock('node:fs/promises')`.

If that mock ever silently stopped applying — say `cast-fingerprint.ts` switched to the bare `fs/promises` specifier — **both tests would still have passed**: site 1 would read the real file, whose hash already equals the baseline, so "no conflict" either way. The assertion would be satisfied for the wrong reason and the regression lock against a false *"someone edited your cast"* advisory would evaporate in silence.

Each test now seeds a **foreign write before the mock is installed**, so a successful real read would observe a mismatch and fire `onConflict`. A disarmed mock now fails the test instead of passing it.

**2. `describeFingerprintForLog` didn't know about `UNREADABLE`.**

That helper exists so a raw `0x00` never reaches a log line — some consumers truncate at NUL. It mapped `ABSENT` to safe text but not `UNREADABLE`, which is NUL-prefixed too. Unreachable today (the comparison is suppressed before any `onConflict` log call), so a latent edge rather than a bug — but the next person to log a fingerprint from a different site inherits the trap.

Sentinels now live in an exported `FINGERPRINT_SENTINELS` array with a label table, and the test **iterates that set** rather than naming `ABSENT` and `UNREADABLE` by hand. A test that names two literals is precisely the failure mode this ticket exists to close: it would pass unchanged on the day someone adds sentinel three.

## Test plan

`server/src/workspace/cast-fingerprint.test.ts` + `cast-merge-base.test.ts` — 24 tests, green at `--retry=0`.

**Both hardenings were watched to fail, which is the entire point of the ticket:**

| Neutralisation | Result |
|---|---|
| Point `vi.mock` at a specifier that cannot match (`node:fs/promises__DISARMED`) | **Both** `UNREADABLE` tests go red — *"does not fire onConflict, and the baseline still advances"* and *"does NOT cause a phantom conflict at the NEXT site"*. Pre-#2186 they passed regardless. |
| Add a third NUL-prefixed sentinel to `FINGERPRINT_SENTINELS` without a label | The set-based test goes red — and the raw NUL leaks into the runner's own output, which is the hazard made visible. |

Both restored to green afterwards.

## Notes

- **Release notes: skipped deliberately.** Internal test hardening plus a currently-unreachable log branch — no user- or operator-visible delta (CLAUDE.md step 5 carve-out).
- **Regression plan: none.** Small and localized; the issue body plus the paired tests are the spec.
- **On-box acceptance: none owed.**
- One residual limit worth naming rather than leaving implied: the set-based test catches a new sentinel that is *added to `FINGERPRINT_SENTINELS`* without a label. It cannot catch a sentinel declared and never added to that array. The array is the contract; that is the seam to keep honest.

Closes #2186
