### PR TITLE
chore(scripts): route every gh CLI call through a shared, env-scrubbed chokepoint

### DIFF
--- a/scripts/audit-branches-worktrees.mjs
+++ b/scripts/audit-branches-worktrees.mjs
@@ -8,6 +8,7 @@
 // Usage: node scripts/audit-branches-worktrees.mjs
 
 import { execFileSync } from 'node:child_process';
+import { gh } from './gh.mjs';
 
 function info(msg) { process.stdout.write(`${msg}\n`); }
 
@@ -45,7 +46,7 @@ function isMergedToMain(branch) {
 }
 
 function openIssueTitles() {
-  const raw = execFileSync('gh', ['issue', 'list', '--state', 'open', '--limit', '500', '--json', 'number,title'], { encoding: 'utf8' });
+  const raw = gh(['issue', 'list', '--state', 'open', '--limit', '500', '--json', 'number,title']);
   return JSON.parse(raw);
 }
 

--- a/scripts/audit-issue-parseability.mjs
+++ b/scripts/audit-issue-parseability.mjs
@@ -7,7 +7,7 @@
 // parser/regex backlog-sync.mjs uses at generation time, so "parses here"
 // == "will render correctly there."
 
-import { execFileSync } from 'node:child_process';
+import { gh } from './gh.mjs';
 import { parseWhatBenefit } from './backlog-sync.mjs';
 
 // Mirrors backlog-sync.mjs's private LEADING_ID/idAndTitleFromTitle — kept
@@ -18,7 +18,7 @@ const LEADING_ID = /^(fe|srv|side|ops|fs|app)-(\d+)\s*—\s*(.*)$/;
 function info(msg) { process.stdout.write(`${msg}\n`); }
 
 function listOpenFeatureIssues() {
-  const raw = execFileSync('gh', ['issue', 'list', '--state', 'open', '--label', 'type:feature', '--limit', '500', '--json', 'number,title,body,labels'], { encoding: 'utf8' });
+  const raw = gh(['issue', 'list', '--state', 'open', '--label', 'type:feature', '--limit', '500', '--json', 'number,title,body,labels']);
   return JSON.parse(raw);
 }
 

--- a/scripts/backlog-sync.mjs
+++ b/scripts/backlog-sync.mjs
@@ -200,12 +200,13 @@ export function renderBacklogMd({ groups, wontIssues }) {
 // node:test — see the plan's Task 3 dry-run walkthrough.
 // ---------------------------------------------------------------------------
 
-import { execFileSync, spawnSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { realpathSync } from 'node:fs';
+import { gh, ghSpawn } from './gh.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
@@ -223,7 +224,7 @@ function die(msg) {
   process.exit(1);
 }
 function ghAvailable() {
-  const r = spawnSync('gh', ['--version'], { stdio: 'ignore' });
+  const r = ghSpawn(['--version'], { stdio: 'ignore' });
   return !r.error && r.status === 0;
 }
 
@@ -281,7 +282,7 @@ async function fetchFeatureIssues(config) {
       '-F', `number=${config.projectNumber}`,
     ];
     if (after) args.push('-f', `after=${after}`);
-    const raw = execFileSync('gh', args, { cwd: repoRoot, encoding: 'utf8' });
+    const raw = gh(args);
     const data = JSON.parse(raw).data.user.projectV2.items;
     results.push(...data.nodes);
     if (!data.pageInfo.hasNextPage) break;

--- a/scripts/bulk-add-project-items.mjs
+++ b/scripts/bulk-add-project-items.mjs
@@ -12,10 +12,10 @@
 //   node scripts/bulk-add-project-items.mjs            (dry-run — prints the manifest)
 //   node scripts/bulk-add-project-items.mjs --apply    (adds items + sets Status via gh)
 
-import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { gh, ghSpawn } from './gh.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
@@ -32,11 +32,8 @@ const LEADING_ID = /^`(fe|srv|side|ops|fs|app)-(\d+)`/;
 
 function info(msg) { process.stdout.write(`${msg}\n`); }
 function die(msg) { process.stderr.write(`[FAIL] ${msg}\n`); process.exit(1); }
-function gh(args, opts = {}) {
-  return execFileSync('gh', args, { cwd: repoRoot, encoding: 'utf8', ...opts });
-}
 function ghAvailable() {
-  const r = spawnSync('gh', ['--version'], { stdio: 'ignore' });
+  const r = ghSpawn(['--version'], { stdio: 'ignore' });
   return !r.error && r.status === 0;
 }
 

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -21,7 +21,7 @@
 // Exits non-zero on any pre-flight, gate, or sub-command failure. Intended to
 // be run only from a clean working tree, on `main`, by a maintainer.
 
-import { execFileSync, spawnSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -34,6 +34,7 @@ import {
   formatHonouredEcho,
 } from './release-notes-gate.mjs';
 import { scrubGitEnv } from './git-env.mjs';
+import { gh, ghSpawn } from './gh.mjs';
 // #2170 — same normaliser release.yml's publish step applies, imported
 // rather than copied so the two can't drift apart (see the refusal below).
 import { normalise } from './release-body.mjs';
@@ -254,26 +255,11 @@ function npm(args, opts = {}) {
   });
 }
 
-// `gh` wrapper. capture=true returns stdout; otherwise inherits stdio so
-// `gh run watch`'s live progress streams to the user.
-//
-// #2175 review, Finding 2 — `gh` resolves its target repository the same
-// GIT_DIR/GIT_WORK_TREE-first way git itself does (empirically: with GIT_DIR
-// pointed at a decoy, `gh repo view` reports "no git remotes found" instead
-// of the real repo's remotes). The scrub above was applied to every git()
-// call but not to gh — a workflow_dispatch could fire against a foreign
-// repository. Same fix, same shared scrub.
-function gh(args, opts = {}) {
-  return execFileSync('gh', args, {
-    cwd: repoRoot,
-    stdio: opts.capture ? ['ignore', 'pipe', 'pipe'] : 'inherit',
-    encoding: 'utf8',
-    env: scrubGitEnv(),
-  });
-}
-
+// gh()/ghSpawn() (scripts/gh.mjs, #2184) are the shared chokepoint every
+// gh-calling script under scripts/ now imports instead of growing its own
+// copy of this scrub — see that file's header for the full rationale.
 function ghAvailable() {
-  const r = spawnSync('gh', ['--version'], { stdio: 'ignore', env: scrubGitEnv() });
+  const r = ghSpawn(['--version'], { stdio: 'ignore' });
   return !r.error && r.status === 0;
 }
 
@@ -293,7 +279,7 @@ async function runCrossOsGate({ ref, headSha }) {
   const sinceMs = Date.now();
   info(`[GATE] firing ${CROSS_OS_WORKFLOW} on ${ref} — cross-OS verify must pass before the tag is created.`);
   try {
-    gh(['workflow', 'run', CROSS_OS_WORKFLOW, '--ref', ref]);
+    gh(['workflow', 'run', CROSS_OS_WORKFLOW, '--ref', ref], { stdio: 'inherit' });
   } catch {
     die(
       `Failed to dispatch ${CROSS_OS_WORKFLOW}. Confirm the workflow exists and you're authenticated (\`gh auth status\`), ` +
@@ -306,19 +292,16 @@ async function runCrossOsGate({ ref, headSha }) {
     await sleep(RUN_DISCOVERY_INTERVAL_MS);
     let parsed = [];
     try {
-      const json = gh(
-        [
-          'run',
-          'list',
-          '--workflow',
-          CROSS_OS_WORKFLOW,
-          '--limit',
-          '20',
-          '--json',
-          'databaseId,headSha,status,conclusion,event,createdAt',
-        ],
-        { capture: true },
-      );
+      const json = gh([
+        'run',
+        'list',
+        '--workflow',
+        CROSS_OS_WORKFLOW,
+        '--limit',
+        '20',
+        '--json',
+        'databaseId,headSha,status,conclusion,event,createdAt',
+      ]);
       parsed = JSON.parse(json);
     } catch {
       parsed = []; // transient gh/network hiccup — retry
@@ -335,11 +318,7 @@ async function runCrossOsGate({ ref, headSha }) {
     );
   }
   info(`[GATE] watching run ${runId} (blocks until macOS + Windows verify/build + mobile e2e finish)...`);
-  const watch = spawnSync('gh', ['run', 'watch', String(runId), '--exit-status'], {
-    cwd: repoRoot,
-    stdio: 'inherit',
-    env: scrubGitEnv(),
-  });
+  const watch = ghSpawn(['run', 'watch', String(runId), '--exit-status'], { stdio: 'inherit' });
   if (watch.status !== 0) {
     die(
       `Cross-OS verify FAILED (run ${runId}). The tag was NOT created. ` +

--- a/scripts/clear-done-project-items.mjs
+++ b/scripts/clear-done-project-items.mjs
@@ -10,10 +10,10 @@
 //   node scripts/clear-done-project-items.mjs           (dry-run — lists Done items)
 //   node scripts/clear-done-project-items.mjs --apply   (archives them)
 
-import { execFileSync, spawnSync } from 'node:child_process';
 import { appendFileSync, existsSync, readFileSync, realpathSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { gh, ghSpawn } from './gh.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
@@ -31,9 +31,8 @@ function writeStepSummary(lines) {
   if (!summaryPath) return;
   appendFileSync(summaryPath, `${lines.join('\n')}\n`);
 }
-function gh(args) { return execFileSync('gh', args, { cwd: repoRoot, encoding: 'utf8' }); }
 function ghAvailable() {
-  const r = spawnSync('gh', ['--version'], { stdio: 'ignore' });
+  const r = ghSpawn(['--version'], { stdio: 'ignore' });
   return !r.error && r.status === 0;
 }
 

--- a/scripts/deps-watch-run.mjs
+++ b/scripts/deps-watch-run.mjs
@@ -6,7 +6,7 @@
 // refresh the sticky comment, set exit code.
 // Exercised by the workflow_dispatch acceptance run, not by node --test.
 import { readFileSync, appendFileSync } from 'node:fs';
-import { execFileSync } from 'node:child_process';
+import { gh } from './gh.mjs';
 import {
   KGP_PLUGINS,
   parseOutdated,
@@ -37,7 +37,13 @@ const outdatedPath = process.argv[2] || 'outdated.json';
 // real newlines / backticks / `|` transmit fine and gh JSON-encodes them. `-F`
 // would re-escape and would interpret the transition body's leading `@mention`
 // as a file (gh community #148257). Do not "fix" this to `-F`.
-const gh = (args) => execFileSync('gh', args, { encoding: 'utf8' });
+//
+// gh() (scripts/gh.mjs, #2184) now also defaults `cwd` to repoRoot — this
+// script is invoked by .github/workflows/app-deps-watch.yml with
+// `working-directory: apps/android` and previously passed no `cwd` at all, so
+// its `gh api` calls resolved the target repository from that subdirectory
+// rather than the repo root. Intended fix, called out explicitly per the
+// #2184 brief — flagged for a second look, not silently absorbed.
 
 try {
   if (!repo) throw new Error('GITHUB_REPOSITORY is required');

--- a/scripts/generate-release-notes-wiki.mjs
+++ b/scripts/generate-release-notes-wiki.mjs
@@ -10,7 +10,7 @@
 import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { runCommand } from './lib/run-command.mjs';
+import { gh } from './gh.mjs';
 
 const REPO_ROOT = path.resolve(import.meta.dirname, '..');
 const WIKI_DIR = path.join(REPO_ROOT, 'docs', 'wiki');
@@ -195,10 +195,6 @@ export function upsertSidebarSection(sidebarText, heading, bodyLines) {
   return joined.endsWith('\n') ? joined : `${joined}\n`;
 }
 
-function run(cmd, args) {
-  return runCommand('generate-release-notes-wiki', cmd, args);
-}
-
 // Newest-first; equal timestamps sort as equal (ties keep gh's own
 // already-newest-first list order, since Array#sort is stable) rather than
 // arbitrarily flipping depending on comparator-call order.
@@ -208,7 +204,7 @@ export function compareReleasesNewestFirst(a, b) {
 }
 
 function fetchReleases() {
-  const out = run('gh', [
+  const out = gh([
     'release',
     'list',
     '--repo',
@@ -224,7 +220,7 @@ function fetchReleases() {
 }
 
 function fetchReleaseBody(tagName) {
-  const out = run('gh', ['release', 'view', tagName, '--repo', REPO_SLUG, '--json', 'body']);
+  const out = gh(['release', 'view', tagName, '--repo', REPO_SLUG, '--json', 'body']);
   return JSON.parse(out).body;
 }
 

--- a/scripts/gh-labels.mjs
+++ b/scripts/gh-labels.mjs
@@ -18,7 +18,7 @@
 // Idempotent: `gh label create --force` upserts, so --apply both creates
 // missing labels and reconciles colour/description drift on existing ones.
 
-import { execFileSync, spawnSync } from 'node:child_process';
+import { gh, ghSpawn } from './gh.mjs';
 
 // Exported so a test (or a reader) can assert the taxonomy without invoking gh.
 export const LABELS = [
@@ -57,11 +57,8 @@ function die(msg) {
   process.stderr.write(`[FAIL] ${msg}\n`);
   process.exit(1);
 }
-function gh(args) {
-  return execFileSync('gh', args, { stdio: 'inherit', encoding: 'utf8' });
-}
 function ghAvailable() {
-  const r = spawnSync('gh', ['--version'], { stdio: 'ignore' });
+  const r = ghSpawn(['--version'], { stdio: 'ignore' });
   return !r.error && r.status === 0;
 }
 
@@ -102,7 +99,7 @@ function main() {
   }
 
   for (const label of LABELS) {
-    gh(labelArgs(label));
+    gh(labelArgs(label), { stdio: 'inherit' });
   }
   info(`\n[OK] reconciled ${LABELS.length} labels.`);
 }

--- a/scripts/gh.mjs
+++ b/scripts/gh.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// Shared `gh` CLI chokepoint (#2184). `gh` resolves its target repository the
+// same GIT_DIR/GIT_WORK_TREE-first way git itself does (empirically: with
+// GIT_DIR pointed at a decoy, `gh repo view` reports "no git remotes found"
+// instead of the real repo's remotes — bump-version.mjs's original gh()
+// comment, #2175 review Finding 2). Before this file, 14 call sites across 12
+// scripts each grew their own local `gh()`/`ghAvailable()` helper (or an
+// inline execFileSync/spawnSync call), and NONE of them scrubbed the
+// GIT_DIR-family env vars the way execGit's own `env: scrubGitEnv(options?.env)`
+// (bump-version.mjs, the model this file copies) already does for `git` — so a
+// maintainer shell with one of those vars exported from an earlier command
+// (#2169's own scenario) could silently point `npm run backlog:sync` /
+// `npm run quarantine:health` / etc. at the wrong repository while still
+// exiting 0. This file is the single place that fix now lives; every other
+// `gh`-calling script under scripts/ imports from here instead of growing
+// its own copy. scripts/tests/gh-chokepoint.test.mjs asserts, mechanically,
+// that no script outside this file ever calls the `gh` binary directly again.
+//
+// Two functions, not one — the call shapes across scripts/ genuinely don't
+// collapse into a single signature:
+//
+//   - gh(args, opts)     — captured output via execFileSync. Default stdio
+//     captures stdout (returned as a string, `encoding: 'utf8'`) and a
+//     non-zero exit THROWS, matching execFileSync's normal contract and
+//     every migrated script's previous local `gh()` helper. A caller that
+//     wants live streaming instead of a capture (e.g. `gh workflow run`, a
+//     one-shot dispatch a human is watching but whose failure should still
+//     throw so a wrapping try/catch fires) can override `stdio` in opts.
+//
+//   - ghSpawn(args, opts) — spawnSync, for the shapes execFileSync can't
+//     serve: a caller that must NOT throw on a non-zero exit because it
+//     reads `status`/`error` itself (an availability probe, or `gh run
+//     watch` whose failure is a normal, expected outcome the caller
+//     branches on) — with or without `stdio: 'inherit'` to stream progress.
+//
+// Both apply scrubGitEnv() unconditionally — merging any caller-supplied
+// `env` into the scrub (never discarding it), the same contract execGit
+// documents at bump-version.mjs:213-217 — and default `cwd` to `repoRoot`,
+// so a caller that forgets `cwd` (five of the eleven scripts migrated onto
+// this wrapper did) still resolves `gh` against THIS repository rather than
+// wherever the process happened to be invoked from. A caller may still pass
+// its own `cwd` to override that default (e.g. a script that legitimately
+// needs to run `gh` against a *different* checkout).
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { scrubGitEnv } from './git-env.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+export const repoRoot = resolve(__dirname, '..');
+
+/** Captured `gh` invocation — execFileSync, `cwd` defaults to `repoRoot`,
+ *  `encoding: 'utf8'`, env unconditionally scrubbed (merging any `opts.env`
+ *  rather than discarding it). Throws on a non-zero exit, same as a bare
+ *  execFileSync call. Pass `{ stdio: 'inherit' }` to stream output live
+ *  instead of capturing it (still throws on failure — use ghSpawn if the
+ *  caller needs to inspect the result instead). */
+export function gh(args, opts = {}) {
+  const { env, ...rest } = opts;
+  return execFileSync('gh', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    ...rest,
+    env: scrubGitEnv(env),
+  });
+}
+
+/** `gh` via spawnSync — same `cwd`/env-scrub defaults as gh(), for a caller
+ *  that reads the result object itself (`status`/`error`) instead of relying
+ *  on throw-on-failure: an availability probe (`stdio: 'ignore'`) or a
+ *  long-running call whose live progress should stream to the user
+ *  (`stdio: 'inherit'`) and whose non-zero exit is an expected outcome to
+ *  branch on, not an exception to catch. */
+export function ghSpawn(args, opts = {}) {
+  const { env, ...rest } = opts;
+  return spawnSync('gh', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    ...rest,
+    env: scrubGitEnv(env),
+  });
+}

--- a/scripts/gh.mjs
+++ b/scripts/gh.mjs
@@ -33,9 +33,12 @@
 //     watch` whose failure is a normal, expected outcome the caller
 //     branches on) — with or without `stdio: 'inherit'` to stream progress.
 //
-// Both apply scrubGitEnv() unconditionally — merging any caller-supplied
-// `env` into the scrub (never discarding it), the same contract execGit
-// documents at bump-version.mjs:213-217 — and default `cwd` to `repoRoot`,
+// Both apply scrubGitEnv() unconditionally to whatever `env` the caller
+// passes — replacing `process.env` outright with that object and THEN
+// stripping the GIT_*-family keys from it, not merging the two on top of
+// `process.env`; an omitted `env` scrubs `process.env` itself (same
+// replace-then-scrub contract execGit documents at
+// bump-version.mjs:213-217) — and default `cwd` to `repoRoot`,
 // so a caller that forgets `cwd` (five of the eleven scripts migrated onto
 // this wrapper did) still resolves `gh` against THIS repository rather than
 // wherever the process happened to be invoked from. A caller may still pass
@@ -51,16 +54,23 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 export const repoRoot = resolve(__dirname, '..');
 
 /** Captured `gh` invocation — execFileSync, `cwd` defaults to `repoRoot`,
- *  `encoding: 'utf8'`, env unconditionally scrubbed (merging any `opts.env`
- *  rather than discarding it). Throws on a non-zero exit, same as a bare
- *  execFileSync call. Pass `{ stdio: 'inherit' }` to stream output live
- *  instead of capturing it (still throws on failure — use ghSpawn if the
- *  caller needs to inspect the result instead). */
+ *  `encoding: 'utf8'`, `stdio: ['ignore', 'pipe', 'pipe']` by default (stderr
+ *  captured, not printed — execFileSync inherits the parent's stderr when
+ *  `stdio` is left unspecified, which would otherwise leak `gh`'s stderr to
+ *  the console on every failure, including from inside a retry loop that
+ *  deliberately swallows the error — #2203 review Finding F6). Pass
+ *  `{ stdio: 'inherit' }` to stream output live instead of capturing it
+ *  (still throws on failure — use ghSpawn if the caller needs to inspect the
+ *  result instead). `env` unconditionally scrubbed: an `opts.env` REPLACES
+ *  `process.env` and is then scrubbed, it is not merged onto it; omit
+ *  `opts.env` to scrub `process.env` itself. Throws on a non-zero exit, same
+ *  as a bare execFileSync call. */
 export function gh(args, opts = {}) {
   const { env, ...rest } = opts;
   return execFileSync('gh', args, {
     cwd: repoRoot,
     encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
     ...rest,
     env: scrubGitEnv(env),
   });

--- a/scripts/lib/run-command.mjs
+++ b/scripts/lib/run-command.mjs
@@ -4,13 +4,15 @@
 // into an "undefined" stderr message.
 //
 // Env is unconditionally scrubbed of the GIT_DIR-family vars (scrubGitEnv,
-// #2169/#2184) — mirroring execGit (bump-version.mjs:221-223) — merging any
-// caller-supplied `env` into the scrub rather than discarding it. sync-wiki.mjs
-// pins several git calls to an explicit `cwd` (its .wiki-sync-cache clone); an
-// inherited GIT_DIR overrides git's cwd-based repo discovery outright, so
-// without this a maintainer shell with GIT_DIR exported could make those calls
-// commit/push against the wrong repository while still exiting 0. `env` is
-// spread last so it can't be overwritten by `...options`.
+// #2169/#2184) — mirroring execGit (bump-version.mjs:221-223): a
+// caller-supplied `env` REPLACES `process.env` outright and is then
+// scrubbed, it is not merged onto `process.env`; omitting `env` scrubs
+// `process.env` itself. sync-wiki.mjs pins several git calls to an explicit
+// `cwd` (its .wiki-sync-cache clone); an inherited GIT_DIR overrides git's
+// cwd-based repo discovery outright, so without this a maintainer shell
+// with GIT_DIR exported could make those calls commit/push against the
+// wrong repository while still exiting 0. `env` is spread last so it can't
+// be overwritten by `...options`.
 import { spawnSync } from 'node:child_process';
 import { scrubGitEnv } from '../git-env.mjs';
 

--- a/scripts/lib/run-command.mjs
+++ b/scripts/lib/run-command.mjs
@@ -2,10 +2,21 @@
 // (sync-wiki.mjs, generate-release-notes-wiki.mjs). Surfaces the real
 // spawn error (e.g. `gh`/`git` missing from PATH) instead of swallowing it
 // into an "undefined" stderr message.
+//
+// Env is unconditionally scrubbed of the GIT_DIR-family vars (scrubGitEnv,
+// #2169/#2184) — mirroring execGit (bump-version.mjs:221-223) — merging any
+// caller-supplied `env` into the scrub rather than discarding it. sync-wiki.mjs
+// pins several git calls to an explicit `cwd` (its .wiki-sync-cache clone); an
+// inherited GIT_DIR overrides git's cwd-based repo discovery outright, so
+// without this a maintainer shell with GIT_DIR exported could make those calls
+// commit/push against the wrong repository while still exiting 0. `env` is
+// spread last so it can't be overwritten by `...options`.
 import { spawnSync } from 'node:child_process';
+import { scrubGitEnv } from '../git-env.mjs';
 
 export function runCommand(label, cmd, args, options = {}) {
-  const result = spawnSync(cmd, args, { encoding: 'utf8', ...options });
+  const { env, ...rest } = options;
+  const result = spawnSync(cmd, args, { encoding: 'utf8', ...rest, env: scrubGitEnv(env) });
   if (result.error) {
     throw new Error(`${label}: ${cmd} ${args.join(' ')} failed to spawn: ${result.error.message}`);
   }

--- a/scripts/link-sub-issues.mjs
+++ b/scripts/link-sub-issues.mjs
@@ -8,10 +8,10 @@
 //                                     (dry-run — prints what would link)
 //   node scripts/link-sub-issues.mjs --parent 1234 --children 111,222,333 --apply
 
-import { execFileSync, spawnSync } from 'node:child_process';
 import { dirname } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { realpathSync } from 'node:fs';
+import { gh, ghSpawn } from './gh.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_OWNER = 'dudarenok-maker';
@@ -19,9 +19,8 @@ const REPO_NAME = 'Castwright';
 
 function info(msg) { process.stdout.write(`${msg}\n`); }
 function die(msg) { process.stderr.write(`[FAIL] ${msg}\n`); process.exit(1); }
-function gh(args) { return execFileSync('gh', args, { encoding: 'utf8' }); }
 function ghAvailable() {
-  const r = spawnSync('gh', ['--version'], { stdio: 'ignore' });
+  const r = ghSpawn(['--version'], { stdio: 'ignore' });
   return !r.error && r.status === 0;
 }
 

--- a/scripts/migrate-backlog-to-issues.mjs
+++ b/scripts/migrate-backlog-to-issues.mjs
@@ -26,10 +26,10 @@
 // real run. The tidy pass (drop/merge/archive stale items) is human judgement,
 // never scripted.
 
-import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { gh, ghSpawn } from './gh.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
@@ -172,15 +172,8 @@ function die(msg) {
   process.stderr.write(`[FAIL] ${msg}\n`);
   process.exit(1);
 }
-function gh(args, opts = {}) {
-  return execFileSync('gh', args, {
-    cwd: repoRoot,
-    stdio: opts.capture ? ['ignore', 'pipe', 'pipe'] : 'inherit',
-    encoding: 'utf8',
-  });
-}
 function ghAvailable() {
-  const r = spawnSync('gh', ['--version'], { stdio: 'ignore' });
+  const r = ghSpawn(['--version'], { stdio: 'ignore' });
   return !r.error && r.status === 0;
 }
 function sleep(ms) {
@@ -205,10 +198,7 @@ function parseArgs(argv) {
 
 // Existing issues → { "<prefix>-<n>": number } so re-runs skip already-filed items.
 function listExistingById() {
-  const json = gh(
-    ['issue', 'list', '--state', 'all', '--limit', '500', '--json', 'number,title'],
-    { capture: true },
-  );
+  const json = gh(['issue', 'list', '--state', 'all', '--limit', '500', '--json', 'number,title']);
   const byId = new Map();
   const titles = [];
   for (const issue of JSON.parse(json)) {
@@ -230,13 +220,13 @@ async function createIssue({ title, body, labels }) {
   const args = ['issue', 'create', '--title', title, '--body', body];
   for (const l of labels) args.push('--label', l);
   try {
-    return issueNumberFromUrl(gh(args, { capture: true }));
+    return issueNumberFromUrl(gh(args));
   } catch (err) {
     const text = `${err?.stdout ?? ''}${err?.stderr ?? ''}${err?.message ?? ''}`;
     if (/rate limit|secondary|\b403\b/i.test(text)) {
       info(`[RATE] hit a rate limit creating "${title}". Backing off ${RATE_LIMIT_BACKOFF_MS / 1000}s, then one retry…`);
       await sleep(RATE_LIMIT_BACKOFF_MS);
-      return issueNumberFromUrl(gh(args, { capture: true }));
+      return issueNumberFromUrl(gh(args));
     }
     throw err;
   }

--- a/scripts/quarantine-health.mjs
+++ b/scripts/quarantine-health.mjs
@@ -162,6 +162,7 @@ import { spawnSync } from 'node:child_process';
 import { readFileSync, appendFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import { ghSpawn } from './gh.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const REGISTER_PATH = resolve(ROOT, 'docs/testing/flaky-register.md');
@@ -746,8 +747,7 @@ function runVitestJson(cwd, config, files) {
 }
 
 function checkIssueState(issueNumber) {
-  const r = spawnSync('gh', ['issue', 'view', String(issueNumber), '--json', 'state', '-q', '.state'], {
-    encoding: 'utf8',
+  const r = ghSpawn(['issue', 'view', String(issueNumber), '--json', 'state', '-q', '.state'], {
     timeout: GH_TIMEOUT_MS,
   });
   if (r.error || r.status !== 0) return null;

--- a/scripts/strip-chore-moscow-labels.mjs
+++ b/scripts/strip-chore-moscow-labels.mjs
@@ -12,11 +12,11 @@
 //   node scripts/strip-chore-moscow-labels.mjs            (dry-run)
 //   node scripts/strip-chore-moscow-labels.mjs --apply
 
-import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { realpathSync } from 'node:fs';
+import { gh, ghSpawn } from './gh.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
@@ -27,9 +27,8 @@ const OPS_17_NUMBER = 790;
 
 function info(msg) { process.stdout.write(`${msg}\n`); }
 function die(msg) { process.stderr.write(`[FAIL] ${msg}\n`); process.exit(1); }
-function gh(args) { return execFileSync('gh', args, { cwd: repoRoot, encoding: 'utf8' }); }
 function ghAvailable() {
-  const r = spawnSync('gh', ['--version'], { stdio: 'ignore' });
+  const r = ghSpawn(['--version'], { stdio: 'ignore' });
   return !r.error && r.status === 0;
 }
 

--- a/scripts/tests/bump-version.test.mjs
+++ b/scripts/tests/bump-version.test.mjs
@@ -112,6 +112,12 @@ function setupRepo(startVersion) {
     resolve(dir, 'scripts', 'release-body.mjs'),
     readFileSync(resolve(here, '..', 'release-body.mjs'), 'utf8'),
   );
+  // #2184 — bump-version.mjs also imports ./gh.mjs (the shared gh() chokepoint);
+  // mirror it too, or the throwaway script crashes on module resolution.
+  writeFileSync(
+    resolve(dir, 'scripts', 'gh.mjs'),
+    readFileSync(resolve(here, '..', 'gh.mjs'), 'utf8'),
+  );
 
   // Init throwaway git repo with a local identity so commits work in CI.
   // env: cleanGitEnv() so a parent git-hook context doesn't redirect these
@@ -660,46 +666,17 @@ test('execGit merges a caller-supplied env with the scrub rather than discarding
 });
 
 // #2175 review, Finding 2 — `gh` resolves its target repository the same
-// GIT_DIR-first way git does (empirically: with GIT_DIR pointed at a decoy,
-// `gh repo view` reports "no git remotes found" instead of the real repo's
-// remotes), so every `gh` call site needs the same scrub the git() helper
-// already gets. Spawning a real (or faked) `gh` binary from this cross-
-// platform node:test suite isn't practical — a `.cmd`/`.bat` stand-in hits
-// Node's CVE-2024-27980 EINVAL guard on Windows without `shell: true` (which
-// gh() deliberately doesn't set), and a genuine `.exe` stand-in needs a
-// native compiler this suite can't assume is present, especially in Ubuntu
-// CI. So this is a structural check on the source itself — the same
-// approach `workflow-wiring.test.mjs` already uses for GitHub Actions wiring
-// that's equally impractical to exercise behaviourally — extracting each of
-// the three call sites `runCrossOsGate` reaches (`ghAvailable`, the dispatch
-// + discovery calls inside `gh()`, and the `gh run watch` spawnSync) and
-// asserting each passes `env: scrubGitEnv()`. Mutation-sensitive per site:
-// dropping the env option from any one of the three fails only that
-// assertion, naming the site.
-test('every gh() / ghAvailable() / "gh run watch" call site scrubs its env', () => {
-  const source = readFileSync(bumpScript, 'utf8');
-
-  const ghAvailableBody = source.slice(
-    source.indexOf('function ghAvailable()'),
-    source.indexOf('function sleep('),
-  );
-  assert.match(
-    ghAvailableBody,
-    /spawnSync\('gh', \['--version'\], \{ stdio: 'ignore', env: scrubGitEnv\(\) \}\)/,
-    'ghAvailable() must scrub its env',
-  );
-
-  const ghFnBody = source.slice(
-    source.indexOf("function gh(args, opts = {}) {"),
-    source.indexOf('function ghAvailable()'),
-  );
-  assert.match(ghFnBody, /env: scrubGitEnv\(\),?\s*\n\s*\}\);/, 'gh() must scrub its env');
-
-  const watchCallStart = source.indexOf("spawnSync('gh', ['run', 'watch'");
-  assert.notEqual(watchCallStart, -1, 'the gh run watch call site must exist');
-  const watchCallBody = source.slice(watchCallStart, source.indexOf(');', watchCallStart));
-  assert.match(watchCallBody, /env: scrubGitEnv\(\)/, 'the gh run watch spawnSync call must scrub its env');
-});
+// GIT_DIR-first way git does, so every `gh` call site needs the same scrub
+// the git() helper already gets. bump-version.mjs used to carry its own
+// local gh()/ghAvailable()/`gh run watch` trio and this file asserted each
+// one scrubbed its env by slicing the source around those three names.
+// #2184 replaced ALL of that with a single shared chokepoint
+// (scripts/gh.mjs's gh()/ghSpawn(), which unconditionally scrub) that every
+// gh-calling script under scripts/ — including this one — now imports
+// instead of growing its own copy. The enumerating, three-names-only check
+// this comment used to guard is gone; scripts/tests/gh-chokepoint.test.mjs
+// asserts the stronger, repo-wide invariant instead: no script anywhere
+// under scripts/ may call the `gh` binary directly except gh.mjs itself.
 
 // #2169's own regression test, as specified on the ticket: set GIT_DIR to a
 // decoy repo, call createAnnotatedTag({ repoRoot: realRepo, … }) DIRECTLY

--- a/scripts/tests/gh-chokepoint.test.mjs
+++ b/scripts/tests/gh-chokepoint.test.mjs
@@ -13,19 +13,27 @@
 // names — it protected exactly those three call sites and nothing else, so
 // it couldn't have caught the other 11 that turned out to exist (the whole
 // premise of #2184's decision comment: "the issue's list ... is incomplete").
-// This test asserts the STRONGER, structural invariant instead: no script
-// anywhere under scripts/ may invoke the `gh` binary directly, except
-// scripts/gh.mjs itself. A call site nobody has thought of yet fails this by
-// default, which is the entire point.
+// This test asserts the STRONGER, structural invariant instead: no
+// JS/TS script anywhere under scripts/ may invoke the `gh` binary directly,
+// except scripts/gh.mjs itself. A call site nobody has thought of yet fails
+// this by default, which is the entire point. (PowerShell/Python scripts
+// under scripts/ are NOT scanned — see KNOWN BLIND SPOTS below; "no script"
+// in this file's test name/assertions means the JS/TS family specifically.)
 //
-// Detection strategy: read every scripts/**/*.mjs file as source text (no
-// real `gh` process is ever spawned — see bump-version.test.mjs's sibling
-// comment on why that's impractical cross-platform) and pattern-match two
-// shapes:
-//   1. ANY call expression whose first argument is the literal string 'gh',
-//      "gh", or `gh`, immediately followed by a comma — matched on the
-//      ARGUMENT, not the callee's name. This is what catches a custom local
-//      wrapper (`run('gh', …)` — the actual shape
+// Detection strategy: read every scripts/**/*.{mjs,cjs,js,mts,cts,ts} file
+// as source text (no real `gh` process is ever spawned — see
+// bump-version.test.mjs's sibling comment on why that's impractical
+// cross-platform) and pattern-match two shapes:
+//   1. ANY call expression whose first OR second argument is the literal
+//      string 'gh', "gh", or `gh`, immediately followed by a comma —
+//      matched on the ARGUMENT, not the callee's name. The second-argument
+//      case exists for `runCommand(label, 'gh', args)` — runCommand's real
+//      signature (scripts/lib/run-command.mjs) puts the binary name second,
+//      behind a label — and is recognized only when the leading (label)
+//      argument is a simple token: a bare identifier, a number, or a
+//      quoted string (see KNOWN BLIND SPOTS for what that excludes). This
+//      is what catches a custom local wrapper (`run('gh', …)` — the actual
+//      shape
 //      generate-release-notes-wiki.mjs shipped with until this same round: a
 //      real chokepoint bypass this guard originally MISSED, because the
 //      first version only recognized execFileSync/spawnSync and their
@@ -63,6 +71,18 @@
 // it no longer restricts by callee name at all, so an aliased import is
 // already covered by "any callee" without special-casing it.
 //
+// Inline pragma: a line whose text contains the literal `gh-chokepoint-allow`
+// is excluded from both shapes entirely (#2203 review Finding F5). The scan
+// is raw text with no comment- or string-stripping, so it has no way to tell
+// a real call apart from a comment merely documenting one (e.g.
+// `// don't write execFileSync('gh', […]) here`) or a test assertion whose
+// shape coincides (`assert.equal('gh', recorded[0])` reads as a call to
+// `equal` with 'gh' as its first argument). The pragma is the escape hatch
+// for exactly that: put it on the offending line and the scanner skips it.
+// It suppresses ONE line, not a file or a block — there is no
+// pragma-disable/pragma-enable pairing, deliberately, so a stray pragma
+// can't silently blind the scanner to everything after it.
+//
 // KNOWN BLIND SPOTS (a source-text scan can't see everything):
 //   - The binary held in a variable (`const bin = 'gh'; execFileSync(bin, …)`
 //     or `run(bin, …)`) is NOT caught — this scanner only recognizes a
@@ -87,6 +107,33 @@
 //     `gh` invocation also passes an args array and/or an options object),
 //     so this is a live, deliberate trade-off, not an accident — flagged
 //     here so it stays a documented one.
+//   - Shape 1's second-argument case (`runCommand(label, 'gh', args)`) only
+//     recognizes a SIMPLE leading token — a bare identifier, a number, or a
+//     quoted string — immediately before the 'gh' argument. A leading
+//     argument that is itself a call, a template literal with
+//     interpolation, a computed/member expression, or any other non-trivial
+//     expression is NOT recognized, because the scanner does not parse
+//     balanced parens/brackets in that position — e.g.
+//     `runCommand(buildLabel(x), 'gh', args)` is NOT caught. No real call
+//     site in this repo passes anything but a plain string literal as
+//     runCommand's `label`, so this is latent, not live.
+//   - A binary-name variant — `execFileSync('gh.exe', …)`,
+//     `execFileSync('/usr/bin/gh', …)`, or any other path/extension form
+//     that isn't the exact 4-character token `gh` — is NOT caught; this
+//     scanner matches the literal string 'gh' only.
+//   - The obfuscation class — computed member access
+//     (`cp['exec' + 'FileSync']('gh', …)`), `.call`/`.apply`, a
+//     comma-expression, an optional call (`fn?.('gh', …)`), or an inline
+//     comment wedged between the 'gh' literal and its comma — is
+//     structurally out of reach for a source-text regex scan; a real parser
+//     (or an ESLint AST rule) would be needed to close that class, and this
+//     file does not attempt to.
+//   - Non-JS/TS scripts under scripts/ (11 `.ps1`, 3 `.psm1`, 4 `.py`) are
+//     entirely OUT OF SCOPE — `listScriptFiles()` below only walks the
+//     JS/TS family. No `gh` invocation exists in any of them today (a
+//     PowerShell `gh …` or Python `subprocess.run(['gh', …])` call would
+//     need its own, differently-shaped pattern), so this is a documented
+//     gap, not a silent one.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -145,19 +192,30 @@ function collectShellAliases(source) {
   return shell;
 }
 
-// Shape 1: any call expression whose first argument is the literal string
-// 'gh', "gh", or `gh` — the callee can be ANY identifier (or property-access
-// name), not just execFileSync/spawnSync or a tracked alias of them. This is
-// what catches a custom local wrapper (`run('gh', …)`) as readily as a
-// direct call. The closing quote must be followed by a comma (optionally
-// preceded by whitespace) — every real `gh`-spawning call passes at least
-// one more argument after the binary name, so this is never a real call
-// site's own coverage cost; it's what lets backtick stay in the quote class
-// without reopening the bump-version.mjs prose false positive (see header
-// comment). This also means nothing but a matching close-quote may follow
-// "gh" itself (so this never matches a longer string that merely STARTS
-// with "gh", e.g. 'ghost' or 'gh-labels').
-const DIRECT_CALL_RE = /\b([A-Za-z_$][\w$]*)\s*\(\s*(['"`])gh\2\s*,/g;
+// Shape 1: any call expression whose first OR SECOND argument is the
+// literal string 'gh', "gh", or `gh` — the callee can be ANY identifier (or
+// property-access name), not just execFileSync/spawnSync or a tracked alias
+// of them. This is what catches a custom local wrapper (`run('gh', …)`) as
+// readily as a direct call — AND `runCommand(label, 'gh', args)`'s
+// signature, where the binary name sits second, behind a label (#2203
+// review Finding F2: `DIRECT_CALL_RE` used to require 'gh' to be the FIRST
+// argument, so `runCommand('probe', 'gh', […])` was invisible to it — the
+// most realistic evasion of the ones reviewed, since sync-wiki.mjs already
+// imports runCommand directly and the bypass this branch just fixed
+// (generate-release-notes-wiki.mjs) was a two-line alias over exactly this
+// function). The optional leading token before 'gh' is matched only when
+// it's a SIMPLE one — a bare identifier, a number, or a quoted string — not
+// an arbitrary expression (see KNOWN BLIND SPOTS). The closing quote around
+// 'gh' itself must be followed by a comma (optionally preceded by
+// whitespace) — every real `gh`-spawning call passes at least one more
+// argument after the binary name, so this is never a real call site's own
+// coverage cost; it's what lets backtick stay in the quote class without
+// reopening the bump-version.mjs prose false positive (see header comment).
+// This also means nothing but a matching close-quote may follow "gh" itself
+// (so this never matches a longer string that merely STARTS with "gh",
+// e.g. 'ghost' or 'gh-labels').
+const DIRECT_CALL_RE =
+  /\b([A-Za-z_$][\w$]*)\s*\(\s*(?:(?:[A-Za-z_$][\w$]*|\d+(?:\.\d+)?|['"`][^'"`]*['"`])\s*,\s*)?(['"`])gh\2\s*,/g;
 
 // Shape 2: execSync('gh …') / exec('gh …') — or a local alias of either —
 // a single shell-command string whose first token is "gh" (followed by
@@ -167,12 +225,30 @@ function buildShellCallRe(names) {
   return new RegExp(`\\b(${[...names].join('|')})\\s*\\(\\s*(${Q})\\s*gh(?=[\\s'"\`])`, 'g');
 }
 
+// #2203 review Finding F5 — a single-line suppression pragma. The scan is
+// raw text with no comment- or string-stripping, so a comment documenting
+// the rule, or a test assertion whose argument shape coincides
+// (`assert.equal('gh', recorded[0])`), reads as a violation with no way for
+// the scanner to tell it apart from a real call. Put this literal string
+// anywhere on the offending line to suppress it — see header comment for
+// the "why" and the deliberate no-block-form design.
+const PRAGMA = 'gh-chokepoint-allow';
+
+/** The full text of the line containing `index`, for pragma-checking a
+ *  match without re-splitting the whole source per call. */
+function lineTextAt(source, index) {
+  const start = source.lastIndexOf('\n', index) + 1;
+  const end = source.indexOf('\n', index);
+  return source.slice(start, end === -1 ? source.length : end);
+}
+
 /** Scans one file's source text for a raw `gh` invocation via either shape,
  *  including through any local alias its own `node:child_process` import
  *  declares for execSync/exec (shape 2 only — shape 1 needs no alias
- *  tracking, it matches any callee). Returns an array of { kind, line,
- *  snippet }. Pure — exported so the per-shape mutation tests below can
- *  exercise it directly against synthetic fixtures, not just real repo
+ *  tracking, it matches any callee). A match on a line carrying the
+ *  `gh-chokepoint-allow` pragma is skipped. Returns an array of { kind,
+ *  line, snippet }. Pure — exported so the per-shape mutation tests below
+ *  can exercise it directly against synthetic fixtures, not just real repo
  *  files. */
 export function findRawGhCalls(source) {
   const shell = collectShellAliases(source);
@@ -181,6 +257,7 @@ export function findRawGhCalls(source) {
     re.lastIndex = 0;
     let m;
     while ((m = re.exec(source))) {
+      if (lineTextAt(source, m.index).includes(PRAGMA)) continue;
       const line = source.slice(0, m.index).split('\n').length;
       violations.push({ kind: m[1], line, snippet: m[0] });
     }
@@ -188,13 +265,20 @@ export function findRawGhCalls(source) {
   return violations;
 }
 
+// #2203 review Finding F3 — the JS/TS family, not just `.mjs`. Before this,
+// a `gh` call in e.g. `preflight-ffmpeg.cjs` or `audit-stage2-coverage.mts`
+// was caught verbatim if renamed to `.mjs` — the escape was purely the
+// extension filter. `.ps1`/`.psm1`/`.py` scripts under scripts/ are
+// deliberately NOT included; see KNOWN BLIND SPOTS above.
+const SCANNED_EXTENSIONS = ['.mjs', '.cjs', '.js', '.mts', '.cts', '.ts'];
+
 function listScriptFiles() {
   return readdirSync(scriptsDir, { recursive: true })
-    .filter((f) => f.endsWith('.mjs'))
+    .filter((f) => SCANNED_EXTENSIONS.some((ext) => f.endsWith(ext)))
     .map((f) => resolve(scriptsDir, f));
 }
 
-test('no script under scripts/ invokes the `gh` binary directly except scripts/gh.mjs (#2184)', () => {
+test('no JS/TS script under scripts/ invokes the `gh` binary directly except scripts/gh.mjs (#2184)', () => {
   const violations = [];
   for (const file of listScriptFiles()) {
     if (file === ghWrapperPath || file === selfPath) continue;
@@ -312,4 +396,133 @@ test('scripts/gh.mjs itself is excluded from the repo-wide scan (it IS the choke
   // violation.
   const source = readFileSync(ghWrapperPath, 'utf8');
   assert.ok(findRawGhCalls(source).length >= 2, 'gh.mjs is expected to contain the two real gh()/ghSpawn() invocations');
+});
+
+// --- Per-function scrub assertions (#2203 review Finding F1) -------------
+// This guard (above) proves ROUTING — that every gh-calling script goes
+// through gh.mjs — but until now nothing asserted that gh.mjs's own
+// gh()/ghSpawn() actually scrub the env they hand to execFileSync/
+// spawnSync. Deleting `env: scrubGitEnv(env)` from EITHER function left
+// `npm run test:hooks` fully green (1187 pass, 0 fail) and `npx eslint
+// scripts/gh.mjs` only warning (unused vars, exit 0) — a silent regression
+// from the bump-version.test.mjs-era test this file replaced, which did
+// assert the scrub at each of its three named call sites. These two tests
+// close that hole, one function at a time — a single file-wide regex would
+// stay green if only one of the two lost its scrub (see the neutralisation
+// proof in the PR description / fix report).
+
+/** Extracts the full source text of `export function <name>(...) { ... }`
+ *  from gh.mjs's own source, by brace-counting from the function's opening
+ *  `{` to its matching close (the object literal inside means a naive
+ *  "up to the next blank line" slice isn't safe). */
+function extractFunctionSource(source, name) {
+  const header = new RegExp(`export function ${name}\\s*\\([^)]*\\)\\s*\\{`).exec(source);
+  assert.ok(header, `function ${name} not found in gh.mjs`);
+  let depth = 0;
+  let i = header.index + header[0].length - 1; // position of the opening '{'
+  const start = i;
+  do {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') depth--;
+    i++;
+  } while (depth > 0 && i < source.length);
+  return source.slice(start, i);
+}
+
+test('gh() applies scrubGitEnv to the env it passes to execFileSync (#2203 review Finding F1)', () => {
+  const source = readFileSync(ghWrapperPath, 'utf8');
+  const ghSource = extractFunctionSource(source, 'gh');
+  assert.match(
+    ghSource,
+    /env:\s*scrubGitEnv\(/,
+    'gh() must scrub its env before handing it to execFileSync — see scripts/gh.mjs header',
+  );
+});
+
+test('ghSpawn() applies scrubGitEnv to the env it passes to spawnSync (#2203 review Finding F1)', () => {
+  const source = readFileSync(ghWrapperPath, 'utf8');
+  const ghSpawnSource = extractFunctionSource(source, 'ghSpawn');
+  assert.match(
+    ghSpawnSource,
+    /env:\s*scrubGitEnv\(/,
+    'ghSpawn() must scrub its env before handing it to spawnSync — see scripts/gh.mjs header',
+  );
+});
+
+// --- Second-argument coverage (#2203 review Finding F2) -------------------
+// `DIRECT_CALL_RE` used to require 'gh' to be the call's FIRST argument, so
+// `runCommand(label, 'gh', args)` — runCommand's real signature puts the
+// binary name second, behind a label — was invisible to it. Verified by the
+// reviewer: appending `runCommand('probe', 'gh', ['issue','list'])` to a
+// script left the guard green before this fix.
+
+test('findRawGhCalls catches "gh" as a SECOND argument — runCommand(label, \'gh\', args) shape (#2203 review Finding F2)', () => {
+  const violations = findRawGhCalls("runCommand('probe', 'gh', ['issue', 'list']);");
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, 'runCommand');
+});
+
+test('findRawGhCalls still catches "gh" as a first argument after the second-argument fix', () => {
+  const violations = findRawGhCalls("execFileSync('gh', ['issue', 'list'], { encoding: 'utf8' });");
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, 'execFileSync');
+});
+
+test('findRawGhCalls does not false-positive on runCommand\'s real, non-gh call site shape (sync-wiki.mjs:88)', () => {
+  const violations = findRawGhCalls("return runCommand('sync-wiki', cmd, args, { cwd });");
+  assert.deepEqual(violations, []);
+});
+
+test('KNOWN BLIND SPOT: a non-trivial leading argument before a second-position "gh" is not detected', () => {
+  const violations = findRawGhCalls("runCommand(buildLabel(x), 'gh', args);");
+  assert.deepEqual(violations, []);
+});
+
+// --- Extension coverage (#2203 review Finding F3) --------------------------
+// Before this, the scan filtered to `f.endsWith('.mjs')` only, so a `gh`
+// call in e.g. a `.cjs` or `.mts` script under scripts/ was invisible to
+// the guard purely because of its extension — the KNOWN BLIND SPOTS list
+// didn't say so, which understated the gap.
+
+test('listScriptFiles scans the JS/TS family, not just .mjs (#2203 review Finding F3)', () => {
+  const relPaths = listScriptFiles().map((f) => relative(repoRoot, f));
+  assert.ok(relPaths.some((f) => f.endsWith('.cjs')), 'expected at least one .cjs file (preflight-ffmpeg.cjs)');
+  assert.ok(relPaths.some((f) => f.endsWith('.mts')), 'expected at least one .mts file (audit-stage2-coverage.mts)');
+});
+
+// --- Pragma suppression (#2203 review Finding F5) --------------------------
+// The scan is raw text with no comment- or string-stripping, so (a) a
+// comment documenting the rule and (b) a test assertion whose shape
+// coincides (`assert.equal('gh', recorded[0])`) both read as violations.
+// `gh-chokepoint-allow` on the offending line suppresses just that line.
+
+test('findRawGhCalls suppresses a match on a line carrying the gh-chokepoint-allow pragma', () => {
+  const src = "execFileSync('gh', ['issue', 'list'], { encoding: 'utf8' }); // gh-chokepoint-allow";
+  assert.deepEqual(findRawGhCalls(src), []);
+});
+
+test('findRawGhCalls does not suppress a violation on an unrelated line just because another line carries the pragma', () => {
+  const src = [
+    "// documenting the rule — gh-chokepoint-allow",
+    "execFileSync('gh', ['issue', 'list'], { encoding: 'utf8' });",
+  ].join('\n');
+  const violations = findRawGhCalls(src);
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].line, 2);
+});
+
+test('KNOWN FALSE POSITIVE (documented) suppressed by pragma: a comment demonstrating the call shape', () => {
+  const withoutPragma = "// Never write execFileSync('gh', [...]) here";
+  assert.equal(findRawGhCalls(withoutPragma).length, 1, 'sanity: the bare comment trips the scanner without the pragma');
+  const withPragma = withoutPragma + ' — gh-chokepoint-allow';
+  assert.deepEqual(findRawGhCalls(withPragma), []);
+});
+
+test('KNOWN FALSE POSITIVE (documented) suppressed by pragma: a test-style assertion whose shape coincides with shape 1', () => {
+  const withoutPragma = "assert.equal('gh', recorded[0]);";
+  const violations = findRawGhCalls(withoutPragma);
+  assert.equal(violations.length, 1, 'sanity: the bare assertion trips the scanner without the pragma');
+  assert.equal(violations[0].kind, 'equal');
+  const withPragma = withoutPragma + ' // gh-chokepoint-allow';
+  assert.deepEqual(findRawGhCalls(withPragma), []);
 });

--- a/scripts/tests/gh-chokepoint.test.mjs
+++ b/scripts/tests/gh-chokepoint.test.mjs
@@ -22,25 +22,31 @@
 // real `gh` process is ever spawned — see bump-version.test.mjs's sibling
 // comment on why that's impractical cross-platform) and pattern-match two
 // shapes:
-//   1. ANY call expression whose first argument is the literal string 'gh'
-//      or "gh" — matched on the ARGUMENT, not the callee's name. This is
-//      what catches a custom local wrapper (`run('gh', …)` — the actual
-//      shape generate-release-notes-wiki.mjs shipped with until this same
-//      round: a real chokepoint bypass this guard originally MISSED,
-//      because the first version only recognized execFileSync/spawnSync and
-//      their tracked node:child_process import aliases, not an arbitrary
-//      wrapper function that happens to forward to one of those
-//      internally) exactly as readily as a direct `execFileSync('gh', …)`
-//      or an aliased import (`import { execFileSync as _x } from
-//      'node:child_process'` then `_x('gh', …)`) — callee identity no
-//      longer matters at all for this shape. Backtick-quoted literals are
-//      deliberately NOT matched here (single/double only): a backtick is
-//      common in prose that merely *mentions* `gh` rather than calling it
-//      (e.g. bump-version.mjs's own error-message text, `"...GitHub CLI
-//      (\`gh\`) authenticated, but \`gh\` was not found..."`, which reads as
-//      `('gh')`-shaped to a naive scan if backtick were an accepted quote
-//      char here) — matching it would false-positive on exactly that kind
-//      of comment/string, not a real call site.
+//   1. ANY call expression whose first argument is the literal string 'gh',
+//      "gh", or `gh`, immediately followed by a comma — matched on the
+//      ARGUMENT, not the callee's name. This is what catches a custom local
+//      wrapper (`run('gh', …)` — the actual shape
+//      generate-release-notes-wiki.mjs shipped with until this same round: a
+//      real chokepoint bypass this guard originally MISSED, because the
+//      first version only recognized execFileSync/spawnSync and their
+//      tracked node:child_process import aliases, not an arbitrary wrapper
+//      function that happens to forward to one of those internally) exactly
+//      as readily as a direct `execFileSync('gh', …)` or an aliased import
+//      (`import { execFileSync as _x } from 'node:child_process'` then
+//      `_x('gh', …)`) — callee identity no longer matters at all for this
+//      shape. The trailing-comma requirement is what makes backtick a safe
+//      quote char here: every real `gh`-spawning call passes at least one
+//      more argument (the args array, or an options object) after the
+//      binary name, so the closing quote is always followed by a comma —
+//      but bump-version.mjs's own error-message prose, `'...GitHub CLI
+//      (\`gh\`) authenticated, but \`gh\` was not found...'`, closes its
+//      first backtick-quoted "gh" with `)`, not `,` (prose, not a call), so
+//      it stays unmatched even with backtick included in the quote class.
+//      An EARLIER version of this rule dropped backtick entirely to dodge
+//      that same false positive — but that also silently stopped catching
+//      a backtick-quoted real call (`run(\`gh\`, …)`), which is worse: an
+//      undocumented hole, not a documented trade-off. The comma requirement
+//      closes the false positive without giving up backtick coverage.
 //   2. execSync('gh ...') / exec('gh ...') — a single shell-command string
 //      whose first token is "gh". This shape stays scoped to the four
 //      canonical node:child_process entry points (plus any local alias a
@@ -60,8 +66,8 @@
 // KNOWN BLIND SPOTS (a source-text scan can't see everything):
 //   - The binary held in a variable (`const bin = 'gh'; execFileSync(bin, …)`
 //     or `run(bin, …)`) is NOT caught — this scanner only recognizes a
-//     LITERAL 'gh'/"gh" string as the call's own argument text, it does not
-//     do any data-flow analysis.
+//     LITERAL 'gh'/"gh"/`gh` string as the call's own argument text, it does
+//     not do any data-flow analysis.
 //   - A command string built by concatenation split across an expression
 //     (e.g. `execSync('g' + 'h ...')`) is NOT caught, same reason.
 //   - Shape 2 (the full shell-command-string call) is still scoped to the
@@ -72,6 +78,15 @@
 //     'gh issue list' text never appears as an argument to execSync/exec
 //     at THAT call site — only shape 1's exact-'gh'-argument case was
 //     generalized to an arbitrary callee.
+//   - Shape 1 requires a comma after the closing quote (the trade for
+//     letting backtick back into the quote class without reopening the
+//     bump-version.mjs prose false positive — see the shape-1 comment
+//     above). A call whose ONLY argument is the literal 'gh'/"gh"/`gh`
+//     itself, with nothing after it — e.g. `probe('gh')` — is NOT caught.
+//     No real call site in this repo is shaped that way today (every real
+//     `gh` invocation also passes an args array and/or an options object),
+//     so this is a live, deliberate trade-off, not an accident — flagged
+//     here so it stays a documented one.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -131,14 +146,18 @@ function collectShellAliases(source) {
 }
 
 // Shape 1: any call expression whose first argument is the literal string
-// 'gh' or "gh" — the callee can be ANY identifier (or property-access name),
-// not just execFileSync/spawnSync or a tracked alias of them. This is what
-// catches a custom local wrapper (`run('gh', …)`) as readily as a direct
-// call. Nothing but a matching close-quote may follow "gh" (so this never
-// matches a longer string that merely STARTS with "gh", e.g. 'ghost' or
-// 'gh-labels'). Single/double quotes only — see the header comment for why
-// backtick is deliberately excluded here.
-const DIRECT_CALL_RE = /\b([A-Za-z_$][\w$]*)\s*\(\s*(['"])gh\2/g;
+// 'gh', "gh", or `gh` — the callee can be ANY identifier (or property-access
+// name), not just execFileSync/spawnSync or a tracked alias of them. This is
+// what catches a custom local wrapper (`run('gh', …)`) as readily as a
+// direct call. The closing quote must be followed by a comma (optionally
+// preceded by whitespace) — every real `gh`-spawning call passes at least
+// one more argument after the binary name, so this is never a real call
+// site's own coverage cost; it's what lets backtick stay in the quote class
+// without reopening the bump-version.mjs prose false positive (see header
+// comment). This also means nothing but a matching close-quote may follow
+// "gh" itself (so this never matches a longer string that merely STARTS
+// with "gh", e.g. 'ghost' or 'gh-labels').
+const DIRECT_CALL_RE = /\b([A-Za-z_$][\w$]*)\s*\(\s*(['"`])gh\2\s*,/g;
 
 // Shape 2: execSync('gh …') / exec('gh …') — or a local alias of either —
 // a single shell-command string whose first token is "gh" (followed by
@@ -238,6 +257,23 @@ test('findRawGhCalls does not false-positive on a git call or a comment mentioni
     '// see gh.mjs for the gh() wrapper',
     "const label = 'gh-labels';",
   ].join('\n');
+  assert.deepEqual(findRawGhCalls(src), []);
+});
+
+test('findRawGhCalls catches a backtick-quoted "gh" followed by a comma (the previously-undocumented hole)', () => {
+  const violations = findRawGhCalls('myRunner(`gh`, ["release", "list"]);');
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, 'myRunner');
+});
+
+test('findRawGhCalls does not false-positive on bump-version.mjs\'s own backtick prose mentioning gh', () => {
+  // The real string from bump-version.mjs:275 — `(`gh`)` reads as a call
+  // shape to a naive scan (identifier "CLI" + "(" + backtick-quoted "gh"),
+  // but the closing backtick is followed by ")", not ",", so the
+  // comma-requirement keeps this out.
+  const src =
+    "'The cross-OS gate needs the GitHub CLI (`gh`) authenticated, but `gh` was not found. ' +\n" +
+    "  'Install it + `gh auth login`, or pass --skip-cross-os to bypass the gate.'";
   assert.deepEqual(findRawGhCalls(src), []);
 });
 

--- a/scripts/tests/gh-chokepoint.test.mjs
+++ b/scripts/tests/gh-chokepoint.test.mjs
@@ -22,55 +22,56 @@
 // real `gh` process is ever spawned — see bump-version.test.mjs's sibling
 // comment on why that's impractical cross-platform) and pattern-match two
 // shapes:
-//   1. execFileSync('gh', ...) / spawnSync('gh', ...) — the binary passed as
-//      a literal first argument, single/double/backtick-quoted.
+//   1. ANY call expression whose first argument is the literal string 'gh'
+//      or "gh" — matched on the ARGUMENT, not the callee's name. This is
+//      what catches a custom local wrapper (`run('gh', …)` — the actual
+//      shape generate-release-notes-wiki.mjs shipped with until this same
+//      round: a real chokepoint bypass this guard originally MISSED,
+//      because the first version only recognized execFileSync/spawnSync and
+//      their tracked node:child_process import aliases, not an arbitrary
+//      wrapper function that happens to forward to one of those
+//      internally) exactly as readily as a direct `execFileSync('gh', …)`
+//      or an aliased import (`import { execFileSync as _x } from
+//      'node:child_process'` then `_x('gh', …)`) — callee identity no
+//      longer matters at all for this shape. Backtick-quoted literals are
+//      deliberately NOT matched here (single/double only): a backtick is
+//      common in prose that merely *mentions* `gh` rather than calling it
+//      (e.g. bump-version.mjs's own error-message text, `"...GitHub CLI
+//      (\`gh\`) authenticated, but \`gh\` was not found..."`, which reads as
+//      `('gh')`-shaped to a naive scan if backtick were an accepted quote
+//      char here) — matching it would false-positive on exactly that kind
+//      of comment/string, not a real call site.
 //   2. execSync('gh ...') / exec('gh ...') — a single shell-command string
-//      that STARTS with `gh` as its own token, same three quote styles.
+//      whose first token is "gh". This shape stays scoped to the four
+//      canonical node:child_process entry points (plus any local alias a
+//      file's own `import { … } from 'node:child_process'` declares for
+//      them, per 9fe14ded) — generalizing it the same way as shape 1 would
+//      false-positive on any ordinary string that merely starts with "gh "
+//      (e.g. prose) passed to an unrelated function, which shape 1 avoids
+//      only because it requires an EXACT 'gh'/"gh" argument, not a prefix
+//      match.
 //
-// The match is keyed off the ARGUMENT (a literal 'gh'), not a hardcoded
-// callee name — a file that does `import { execFileSync as run } from
-// 'node:child_process'` and then calls `run('gh', …)` is just as much a
-// chokepoint bypass as calling `execFileSync('gh', …)` directly, and an
-// author reaching for an alias (accidentally or to dodge this exact guard)
-// must not silently escape it. Each source file is scanned for its own
-// `import { … } from 'node:child_process'` statement(s) first, and any
-// local alias bound there to execFileSync/spawnSync/execSync/exec is added
-// to the set of recognized callee names alongside the canonical ones — so
-// `_x('gh', …)` is caught when (and only when) `_x` really is one of those
-// four imports under another name. This is narrower than "any call whose
-// first argument is 'gh', regardless of callee" would be: a same-shaped
-// call through an unrelated, non-aliased wrapper — e.g. a locally-defined
-// `run(cmd, args)` that forwards to spawnSync internally, called as
-// `run('gh', …)` — is NOT caught, because `run` is never bound to a
-// node:child_process import in that file. (One real instance of exactly
-// this shape exists today, outside this branch's scope: see the blind
-// spots below.)
+// Each file is scanned for its own `import { … } from 'node:child_process'`
+// statement first, and any local alias bound there to execSync/exec is added
+// to shape 2's recognized names. Shape 1 needs no such tracking anymore —
+// it no longer restricts by callee name at all, so an aliased import is
+// already covered by "any callee" without special-casing it.
 //
-// KNOWN BLIND SPOTS (a source-text scan can't see everything — stated
-// plainly, per the #2184 brief, the way the existing GIT_DIR-decoy test's
-// neighbour comment states its own impracticality):
-//   - The binary held in a variable (`const bin = 'gh'; execFileSync(bin, …)`)
-//     is NOT caught — this scanner only recognizes a LITERAL 'gh' string as
-//     the call's own argument text, it does not do any data-flow analysis.
+// KNOWN BLIND SPOTS (a source-text scan can't see everything):
+//   - The binary held in a variable (`const bin = 'gh'; execFileSync(bin, …)`
+//     or `run(bin, …)`) is NOT caught — this scanner only recognizes a
+//     LITERAL 'gh'/"gh" string as the call's own argument text, it does not
+//     do any data-flow analysis.
 //   - A command string built by concatenation split across an expression
 //     (e.g. `execSync('g' + 'h ...')`) is NOT caught, same reason.
-//   - A completely different mechanism for running a binary (a shell script
-//     shelled out to, `child_process.fork`, a `child_process.spawn` promise
-//     wrapper defined elsewhere, `util.promisify(exec)`, etc.) is NOT caught
-//     — only the four documented node:child_process entry points are
-//     pattern-matched.
-//   - A call through a locally-defined wrapper function that is not itself
-//     an aliased import of one of the four entry points — e.g. a helper
-//     `function run(cmd, args) { return spawnSync(cmd, args); }` called as
-//     `run('gh', …)` — is NOT caught. Import-alias tracking closes the
-//     direct-alias hole (`import { execFileSync as run } …`) but does not
-//     do call-graph analysis through an intermediate function.
-// What IS caught, in addition to the above: an execFileSync/spawnSync/
-// execSync/exec call under any locally-declared import alias for those
-// four names, both single- and double-quoted (and backtick, for the
-// direct-call shape) forms, and a call whose arguments are split across
-// multiple lines (the regexes allow arbitrary whitespace, including
-// newlines, between the opening paren and the quoted binary/command).
+//   - Shape 2 (the full shell-command-string call) is still scoped to the
+//     four canonical node:child_process entry points and their tracked
+//     aliases — a custom wrapper that forwards a shell string internally
+//     (`function runShell(cmd) { return execSync(cmd); }` called as
+//     `runShell('gh issue list')`) is NOT caught, because the literal
+//     'gh issue list' text never appears as an argument to execSync/exec
+//     at THAT call site — only shape 1's exact-'gh'-argument case was
+//     generalized to an arbitrary callee.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -83,21 +84,20 @@ const scriptsDir = resolve(here, '..');
 const repoRoot = resolve(scriptsDir, '..');
 const ghWrapperPath = resolve(scriptsDir, 'gh.mjs');
 // This file's own source is excluded from the repo-wide scan below — its
-// synthetic fixture strings deliberately CONTAIN the literal patterns the
-// scanner looks for (that's the whole point of the mutation tests further
-// down), so scanning this file as if it were a production script would
-// self-trigger on every one of those fixtures. No other file under
-// scripts/tests/ does this (verified: nothing else matches the two regexes
-// below except gh.mjs and this file) — a real `gh`-calling test file would
-// still be caught.
+// synthetic fixture strings and comments deliberately CONTAIN the literal
+// patterns the scanner looks for (that's the whole point of the mutation
+// tests further down), so scanning this file as if it were a production
+// script would self-trigger on every one of those fixtures. No other file
+// under scripts/tests/ does this (verified: nothing else matches either
+// pattern below except gh.mjs and this file) — a real `gh`-calling test file
+// would still be caught.
 const selfPath = resolve(here, 'gh-chokepoint.test.mjs');
 
-// A quote char shared by both patterns below: ', ", or `.
+// A quote char shared by shape 2 below: ', ", or `.
 const Q = `['"\`]`;
 
-// The canonical node:child_process entry points each shape recognizes by
+// The canonical node:child_process entry points shape 2 recognizes by
 // default, before any per-file import-alias is added to them.
-const DIRECT_CANONICAL_NAMES = ['execFileSync', 'spawnSync'];
 const SHELL_CANONICAL_NAMES = ['execSync', 'exec'];
 
 // Matches `import { … } from 'node:child_process'` (single- or
@@ -108,14 +108,12 @@ const SHELL_CANONICAL_NAMES = ['execSync', 'exec'];
 const CHILD_PROCESS_IMPORT_RE = /import\s*\{([^}]*)\}\s*from\s*(['"])node:child_process\2/g;
 
 /** Finds every local alias this file's own `node:child_process` import(s)
- *  bind to each of the four tracked entry points — e.g. `import {
- *  execFileSync as run } from 'node:child_process'` adds 'run' to the
- *  direct-shape names. Names with no alias present resolve to themselves,
- *  and are already covered by the canonical defaults below, so only actual
- *  `as`-renames add anything new. Returns { direct, shell } Sets seeded
- *  with the canonical names. */
-function collectChildProcessAliases(source) {
-  const direct = new Set(DIRECT_CANONICAL_NAMES);
+ *  bind to execSync/exec — e.g. `import { execSync as sh } from
+ *  'node:child_process'` adds 'sh' to shape 2's recognized names. Names with
+ *  no alias present resolve to themselves, and are already covered by the
+ *  canonical defaults below, so only actual `as`-renames add anything new.
+ *  Returns a Set seeded with the canonical names. */
+function collectShellAliases(source) {
   const shell = new Set(SHELL_CANONICAL_NAMES);
   CHILD_PROCESS_IMPORT_RE.lastIndex = 0;
   let importMatch;
@@ -126,39 +124,42 @@ function collectChildProcessAliases(source) {
       .filter(Boolean);
     for (const spec of specifiers) {
       const [imported, local = imported] = spec.split(/\s+as\s+/).map((s) => s.trim());
-      if (DIRECT_CANONICAL_NAMES.includes(imported)) direct.add(local);
       if (SHELL_CANONICAL_NAMES.includes(imported)) shell.add(local);
     }
   }
-  return { direct, shell };
+  return shell;
 }
 
-// Shape 1: execFileSync('gh', …) / spawnSync('gh', …) — or a local alias of
-// either, per collectChildProcessAliases() above — the binary is the call's
-// own first argument, and nothing but a matching close-quote may follow
-// "gh" (so this never matches a longer string that merely STARTS with
-// "gh", e.g. 'ghost' or 'gh-labels').
-function buildDirectCallRe(names) {
-  return new RegExp(`\\b(${[...names].join('|')})\\s*\\(\\s*(${Q})gh\\2`, 'g');
-}
+// Shape 1: any call expression whose first argument is the literal string
+// 'gh' or "gh" — the callee can be ANY identifier (or property-access name),
+// not just execFileSync/spawnSync or a tracked alias of them. This is what
+// catches a custom local wrapper (`run('gh', …)`) as readily as a direct
+// call. Nothing but a matching close-quote may follow "gh" (so this never
+// matches a longer string that merely STARTS with "gh", e.g. 'ghost' or
+// 'gh-labels'). Single/double quotes only — see the header comment for why
+// backtick is deliberately excluded here.
+const DIRECT_CALL_RE = /\b([A-Za-z_$][\w$]*)\s*\(\s*(['"])gh\2/g;
 
 // Shape 2: execSync('gh …') / exec('gh …') — or a local alias of either —
 // a single shell-command string whose first token is "gh" (followed by
-// whitespace, or immediately closed as a bare 'gh' with no args).
+// whitespace, or immediately closed as a bare 'gh' with no args). Still
+// scoped to the tracked node:child_process entry points; see header comment.
 function buildShellCallRe(names) {
   return new RegExp(`\\b(${[...names].join('|')})\\s*\\(\\s*(${Q})\\s*gh(?=[\\s'"\`])`, 'g');
 }
 
 /** Scans one file's source text for a raw `gh` invocation via either shape,
  *  including through any local alias its own `node:child_process` import
- *  declares for the four tracked entry points. Returns an array of {
- *  kind, line, snippet }. Pure — exported so the per-shape mutation tests
- *  below can exercise it directly against synthetic fixtures, not just
- *  real repo files. */
+ *  declares for execSync/exec (shape 2 only — shape 1 needs no alias
+ *  tracking, it matches any callee). Returns an array of { kind, line,
+ *  snippet }. Pure — exported so the per-shape mutation tests below can
+ *  exercise it directly against synthetic fixtures, not just real repo
+ *  files. */
 export function findRawGhCalls(source) {
-  const { direct, shell } = collectChildProcessAliases(source);
+  const shell = collectShellAliases(source);
   const violations = [];
-  for (const re of [buildDirectCallRe(direct), buildShellCallRe(shell)]) {
+  for (const re of [DIRECT_CALL_RE, buildShellCallRe(shell)]) {
+    re.lastIndex = 0;
     let m;
     while ((m = re.exec(source))) {
       const line = source.slice(0, m.index).split('\n').length;
@@ -248,6 +249,16 @@ test('findRawGhCalls catches a call through a locally aliased import of execFile
   const violations = findRawGhCalls(src);
   assert.equal(violations.length, 1);
   assert.equal(violations[0].kind, '_x');
+});
+
+test('findRawGhCalls catches a custom local wrapper called as run(\'gh\', …) — argument-based, not callee-based (#2184 wrapper hole)', () => {
+  const src = [
+    "function run(cmd, args) { return runCommand('label', cmd, args); }",
+    "const out = run('gh', ['release', 'list']);",
+  ].join('\n');
+  const violations = findRawGhCalls(src);
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, 'run');
 });
 
 test('KNOWN BLIND SPOT: a gh binary held in a variable is not detected', () => {

--- a/scripts/tests/gh-chokepoint.test.mjs
+++ b/scripts/tests/gh-chokepoint.test.mjs
@@ -27,6 +27,25 @@
 //   2. execSync('gh ...') / exec('gh ...') — a single shell-command string
 //      that STARTS with `gh` as its own token, same three quote styles.
 //
+// The match is keyed off the ARGUMENT (a literal 'gh'), not a hardcoded
+// callee name — a file that does `import { execFileSync as run } from
+// 'node:child_process'` and then calls `run('gh', …)` is just as much a
+// chokepoint bypass as calling `execFileSync('gh', …)` directly, and an
+// author reaching for an alias (accidentally or to dodge this exact guard)
+// must not silently escape it. Each source file is scanned for its own
+// `import { … } from 'node:child_process'` statement(s) first, and any
+// local alias bound there to execFileSync/spawnSync/execSync/exec is added
+// to the set of recognized callee names alongside the canonical ones — so
+// `_x('gh', …)` is caught when (and only when) `_x` really is one of those
+// four imports under another name. This is narrower than "any call whose
+// first argument is 'gh', regardless of callee" would be: a same-shaped
+// call through an unrelated, non-aliased wrapper — e.g. a locally-defined
+// `run(cmd, args)` that forwards to spawnSync internally, called as
+// `run('gh', …)` — is NOT caught, because `run` is never bound to a
+// node:child_process import in that file. (One real instance of exactly
+// this shape exists today, outside this branch's scope: see the blind
+// spots below.)
+//
 // KNOWN BLIND SPOTS (a source-text scan can't see everything — stated
 // plainly, per the #2184 brief, the way the existing GIT_DIR-decoy test's
 // neighbour comment states its own impracticality):
@@ -40,10 +59,18 @@
 //     wrapper defined elsewhere, `util.promisify(exec)`, etc.) is NOT caught
 //     — only the four documented node:child_process entry points are
 //     pattern-matched.
-// What IS handled: both single- and double-quoted (and backtick) forms, and
-// a call whose arguments are split across multiple lines (the regexes allow
-// arbitrary whitespace, including newlines, between the opening paren and
-// the quoted binary/command).
+//   - A call through a locally-defined wrapper function that is not itself
+//     an aliased import of one of the four entry points — e.g. a helper
+//     `function run(cmd, args) { return spawnSync(cmd, args); }` called as
+//     `run('gh', …)` — is NOT caught. Import-alias tracking closes the
+//     direct-alias hole (`import { execFileSync as run } …`) but does not
+//     do call-graph analysis through an intermediate function.
+// What IS caught, in addition to the above: an execFileSync/spawnSync/
+// execSync/exec call under any locally-declared import alias for those
+// four names, both single- and double-quoted (and backtick, for the
+// direct-call shape) forms, and a call whose arguments are split across
+// multiple lines (the regexes allow arbitrary whitespace, including
+// newlines, between the opening paren and the quoted binary/command).
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -68,25 +95,70 @@ const selfPath = resolve(here, 'gh-chokepoint.test.mjs');
 // A quote char shared by both patterns below: ', ", or `.
 const Q = `['"\`]`;
 
-// Shape 1: execFileSync('gh', …) / spawnSync('gh', …) — the binary is the
-// call's own first argument, and nothing but a matching close-quote may
-// follow "gh" (so this never matches a longer string that merely STARTS
-// with "gh", e.g. 'ghost' or 'gh-labels').
-const DIRECT_CALL_RE = new RegExp(`\\b(execFileSync|spawnSync)\\s*\\(\\s*(${Q})gh\\2`, 'g');
+// The canonical node:child_process entry points each shape recognizes by
+// default, before any per-file import-alias is added to them.
+const DIRECT_CANONICAL_NAMES = ['execFileSync', 'spawnSync'];
+const SHELL_CANONICAL_NAMES = ['execSync', 'exec'];
 
-// Shape 2: execSync('gh …') / exec('gh …') — a single shell-command string
-// whose first token is "gh" (followed by whitespace, or immediately closed
-// as a bare 'gh' with no args).
-const SHELL_CALL_RE = new RegExp(`\\b(execSync|exec)\\s*\\(\\s*(${Q})\\s*gh(?=[\\s'"\`])`, 'g');
+// Matches `import { … } from 'node:child_process'` (single- or
+// double-quoted module specifier only — a backtick can't legally appear
+// there, so Q is deliberately not reused for this one). `[^}]*` spans
+// newlines with no `/s` flag needed, so a specifier list broken across
+// multiple lines is still captured whole.
+const CHILD_PROCESS_IMPORT_RE = /import\s*\{([^}]*)\}\s*from\s*(['"])node:child_process\2/g;
 
-/** Scans one file's source text for a raw `gh` invocation via either shape.
- *  Returns an array of { kind, line, snippet }. Pure — exported so the
- *  per-shape mutation tests below can exercise it directly against
- *  synthetic fixtures, not just real repo files. */
+/** Finds every local alias this file's own `node:child_process` import(s)
+ *  bind to each of the four tracked entry points — e.g. `import {
+ *  execFileSync as run } from 'node:child_process'` adds 'run' to the
+ *  direct-shape names. Names with no alias present resolve to themselves,
+ *  and are already covered by the canonical defaults below, so only actual
+ *  `as`-renames add anything new. Returns { direct, shell } Sets seeded
+ *  with the canonical names. */
+function collectChildProcessAliases(source) {
+  const direct = new Set(DIRECT_CANONICAL_NAMES);
+  const shell = new Set(SHELL_CANONICAL_NAMES);
+  CHILD_PROCESS_IMPORT_RE.lastIndex = 0;
+  let importMatch;
+  while ((importMatch = CHILD_PROCESS_IMPORT_RE.exec(source))) {
+    const specifiers = importMatch[1]
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    for (const spec of specifiers) {
+      const [imported, local = imported] = spec.split(/\s+as\s+/).map((s) => s.trim());
+      if (DIRECT_CANONICAL_NAMES.includes(imported)) direct.add(local);
+      if (SHELL_CANONICAL_NAMES.includes(imported)) shell.add(local);
+    }
+  }
+  return { direct, shell };
+}
+
+// Shape 1: execFileSync('gh', …) / spawnSync('gh', …) — or a local alias of
+// either, per collectChildProcessAliases() above — the binary is the call's
+// own first argument, and nothing but a matching close-quote may follow
+// "gh" (so this never matches a longer string that merely STARTS with
+// "gh", e.g. 'ghost' or 'gh-labels').
+function buildDirectCallRe(names) {
+  return new RegExp(`\\b(${[...names].join('|')})\\s*\\(\\s*(${Q})gh\\2`, 'g');
+}
+
+// Shape 2: execSync('gh …') / exec('gh …') — or a local alias of either —
+// a single shell-command string whose first token is "gh" (followed by
+// whitespace, or immediately closed as a bare 'gh' with no args).
+function buildShellCallRe(names) {
+  return new RegExp(`\\b(${[...names].join('|')})\\s*\\(\\s*(${Q})\\s*gh(?=[\\s'"\`])`, 'g');
+}
+
+/** Scans one file's source text for a raw `gh` invocation via either shape,
+ *  including through any local alias its own `node:child_process` import
+ *  declares for the four tracked entry points. Returns an array of {
+ *  kind, line, snippet }. Pure — exported so the per-shape mutation tests
+ *  below can exercise it directly against synthetic fixtures, not just
+ *  real repo files. */
 export function findRawGhCalls(source) {
+  const { direct, shell } = collectChildProcessAliases(source);
   const violations = [];
-  for (const re of [DIRECT_CALL_RE, SHELL_CALL_RE]) {
-    re.lastIndex = 0;
+  for (const re of [buildDirectCallRe(direct), buildShellCallRe(shell)]) {
     let m;
     while ((m = re.exec(source))) {
       const line = source.slice(0, m.index).split('\n').length;
@@ -166,6 +238,16 @@ test('findRawGhCalls does not false-positive on a git call or a comment mentioni
     "const label = 'gh-labels';",
   ].join('\n');
   assert.deepEqual(findRawGhCalls(src), []);
+});
+
+test('findRawGhCalls catches a call through a locally aliased import of execFileSync (#2184 aliasing hole)', () => {
+  const src = [
+    "import { execFileSync as _x } from 'node:child_process';",
+    "const _probe = _x('gh', ['--version'], { encoding: 'utf8' });",
+  ].join('\n');
+  const violations = findRawGhCalls(src);
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, '_x');
 });
 
 test('KNOWN BLIND SPOT: a gh binary held in a variable is not detected', () => {

--- a/scripts/tests/gh-chokepoint.test.mjs
+++ b/scripts/tests/gh-chokepoint.test.mjs
@@ -1,0 +1,186 @@
+// #2184 — every script under scripts/ that spawns the `gh` CLI must go
+// through the shared chokepoint (scripts/gh.mjs's gh()/ghSpawn()), which
+// unconditionally scrubs the GIT_DIR/GIT_WORK_TREE-family env vars
+// (scripts/git-env.mjs) and defaults `cwd` to repoRoot. Before this, 14 call
+// sites across 12 scripts each grew their own local `gh()`/`ghAvailable()`
+// helper (or an inline execFileSync/spawnSync call) and NONE of them
+// scrubbed — see scripts/gh.mjs's header for the full incident history
+// (#2169, #2175).
+//
+// This guard replaces scripts/tests/bump-version.test.mjs's old
+// "every gh() / ghAvailable() / gh run watch call site scrubs its env" test,
+// which slices bump-version.mjs's source around three hardcoded function
+// names — it protected exactly those three call sites and nothing else, so
+// it couldn't have caught the other 11 that turned out to exist (the whole
+// premise of #2184's decision comment: "the issue's list ... is incomplete").
+// This test asserts the STRONGER, structural invariant instead: no script
+// anywhere under scripts/ may invoke the `gh` binary directly, except
+// scripts/gh.mjs itself. A call site nobody has thought of yet fails this by
+// default, which is the entire point.
+//
+// Detection strategy: read every scripts/**/*.mjs file as source text (no
+// real `gh` process is ever spawned — see bump-version.test.mjs's sibling
+// comment on why that's impractical cross-platform) and pattern-match two
+// shapes:
+//   1. execFileSync('gh', ...) / spawnSync('gh', ...) — the binary passed as
+//      a literal first argument, single/double/backtick-quoted.
+//   2. execSync('gh ...') / exec('gh ...') — a single shell-command string
+//      that STARTS with `gh` as its own token, same three quote styles.
+//
+// KNOWN BLIND SPOTS (a source-text scan can't see everything — stated
+// plainly, per the #2184 brief, the way the existing GIT_DIR-decoy test's
+// neighbour comment states its own impracticality):
+//   - The binary held in a variable (`const bin = 'gh'; execFileSync(bin, …)`)
+//     is NOT caught — this scanner only recognizes a LITERAL 'gh' string as
+//     the call's own argument text, it does not do any data-flow analysis.
+//   - A command string built by concatenation split across an expression
+//     (e.g. `execSync('g' + 'h ...')`) is NOT caught, same reason.
+//   - A completely different mechanism for running a binary (a shell script
+//     shelled out to, `child_process.fork`, a `child_process.spawn` promise
+//     wrapper defined elsewhere, `util.promisify(exec)`, etc.) is NOT caught
+//     — only the four documented node:child_process entry points are
+//     pattern-matched.
+// What IS handled: both single- and double-quoted (and backtick) forms, and
+// a call whose arguments are split across multiple lines (the regexes allow
+// arbitrary whitespace, including newlines, between the opening paren and
+// the quoted binary/command).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const scriptsDir = resolve(here, '..');
+const repoRoot = resolve(scriptsDir, '..');
+const ghWrapperPath = resolve(scriptsDir, 'gh.mjs');
+// This file's own source is excluded from the repo-wide scan below — its
+// synthetic fixture strings deliberately CONTAIN the literal patterns the
+// scanner looks for (that's the whole point of the mutation tests further
+// down), so scanning this file as if it were a production script would
+// self-trigger on every one of those fixtures. No other file under
+// scripts/tests/ does this (verified: nothing else matches the two regexes
+// below except gh.mjs and this file) — a real `gh`-calling test file would
+// still be caught.
+const selfPath = resolve(here, 'gh-chokepoint.test.mjs');
+
+// A quote char shared by both patterns below: ', ", or `.
+const Q = `['"\`]`;
+
+// Shape 1: execFileSync('gh', …) / spawnSync('gh', …) — the binary is the
+// call's own first argument, and nothing but a matching close-quote may
+// follow "gh" (so this never matches a longer string that merely STARTS
+// with "gh", e.g. 'ghost' or 'gh-labels').
+const DIRECT_CALL_RE = new RegExp(`\\b(execFileSync|spawnSync)\\s*\\(\\s*(${Q})gh\\2`, 'g');
+
+// Shape 2: execSync('gh …') / exec('gh …') — a single shell-command string
+// whose first token is "gh" (followed by whitespace, or immediately closed
+// as a bare 'gh' with no args).
+const SHELL_CALL_RE = new RegExp(`\\b(execSync|exec)\\s*\\(\\s*(${Q})\\s*gh(?=[\\s'"\`])`, 'g');
+
+/** Scans one file's source text for a raw `gh` invocation via either shape.
+ *  Returns an array of { kind, line, snippet }. Pure — exported so the
+ *  per-shape mutation tests below can exercise it directly against
+ *  synthetic fixtures, not just real repo files. */
+export function findRawGhCalls(source) {
+  const violations = [];
+  for (const re of [DIRECT_CALL_RE, SHELL_CALL_RE]) {
+    re.lastIndex = 0;
+    let m;
+    while ((m = re.exec(source))) {
+      const line = source.slice(0, m.index).split('\n').length;
+      violations.push({ kind: m[1], line, snippet: m[0] });
+    }
+  }
+  return violations;
+}
+
+function listScriptFiles() {
+  return readdirSync(scriptsDir, { recursive: true })
+    .filter((f) => f.endsWith('.mjs'))
+    .map((f) => resolve(scriptsDir, f));
+}
+
+test('no script under scripts/ invokes the `gh` binary directly except scripts/gh.mjs (#2184)', () => {
+  const violations = [];
+  for (const file of listScriptFiles()) {
+    if (file === ghWrapperPath || file === selfPath) continue;
+    const source = readFileSync(file, 'utf8');
+    for (const v of findRawGhCalls(source)) {
+      violations.push(`  ${relative(repoRoot, file)}:${v.line} — ${v.kind}(...): ${v.snippet}`);
+    }
+  }
+  assert.deepEqual(
+    violations,
+    [],
+    `raw 'gh' invocation(s) found outside scripts/gh.mjs — route through gh()/ghSpawn() instead:\n${violations.join('\n')}`,
+  );
+});
+
+// --- Per-shape mutation coverage (findRawGhCalls exercised directly, no ---
+// --- repo file I/O — proves each entry point the guard above claims to  ---
+// --- cover actually IS covered, one shape at a time).                  ---
+
+test('findRawGhCalls catches execFileSync with a single-quoted "gh"', () => {
+  const violations = findRawGhCalls("execFileSync('gh', ['issue', 'list'], { encoding: 'utf8' });");
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, 'execFileSync');
+});
+
+test('findRawGhCalls catches execFileSync with a double-quoted "gh"', () => {
+  const violations = findRawGhCalls('execFileSync("gh", ["issue", "list"], { encoding: "utf8" });');
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, 'execFileSync');
+});
+
+test('findRawGhCalls catches spawnSync(\'gh\', ...) — a different entry point than execFileSync', () => {
+  const violations = findRawGhCalls("const r = spawnSync('gh', ['--version'], { stdio: 'ignore' });");
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, 'spawnSync');
+});
+
+test('findRawGhCalls catches execSync(\'gh ...\') — the shell-string entry point', () => {
+  const violations = findRawGhCalls("const out = execSync('gh issue list --json number');");
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, 'execSync');
+});
+
+test('findRawGhCalls catches exec(\'gh ...\') (callback-style)', () => {
+  const violations = findRawGhCalls("exec('gh pr list', (err, stdout) => {});");
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].kind, 'exec');
+});
+
+test('findRawGhCalls catches a call whose arguments are split across multiple lines', () => {
+  const src = ["execFileSync(", "  'gh',", "  ['issue', 'list'],", "  { encoding: 'utf8' },", ");"].join('\n');
+  const violations = findRawGhCalls(src);
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].line, 1); // reports the line the call itself starts on
+});
+
+test('findRawGhCalls does not false-positive on a git call or a comment mentioning gh', () => {
+  const src = [
+    "execFileSync('git', ['status'], { encoding: 'utf8' });",
+    '// see gh.mjs for the gh() wrapper',
+    "const label = 'gh-labels';",
+  ].join('\n');
+  assert.deepEqual(findRawGhCalls(src), []);
+});
+
+test('KNOWN BLIND SPOT: a gh binary held in a variable is not detected', () => {
+  const src = "const bin = 'gh';\nexecFileSync(bin, ['issue', 'list'], { encoding: 'utf8' });";
+  assert.deepEqual(findRawGhCalls(src), []);
+});
+
+test('scripts/gh.mjs itself is excluded from the repo-wide scan (it IS the chokepoint)', () => {
+  const files = listScriptFiles();
+  assert.ok(files.includes(ghWrapperPath), 'sanity: gh.mjs must be discovered by the file walk');
+  // The main guard test above explicitly skips this path; assert that skip
+  // is actually necessary — i.e. gh.mjs's own source legitimately contains
+  // the pattern the guard looks for, so an accidental removal of the skip
+  // would make the guard permanently red for a reason unrelated to a real
+  // violation.
+  const source = readFileSync(ghWrapperPath, 'utf8');
+  assert.ok(findRawGhCalls(source).length >= 2, 'gh.mjs is expected to contain the two real gh()/ghSpawn() invocations');
+});

--- a/scripts/tests/run-command.test.mjs
+++ b/scripts/tests/run-command.test.mjs
@@ -24,3 +24,19 @@ test('runCommand surfaces the real spawn error instead of swallowing it as undef
     /test: this-binary-does-not-exist-anywhere.*failed to spawn:/,
   );
 });
+
+// #2184 Finding 2 — runCommand's callers (sync-wiki.mjs's six git commands,
+// including `git push`) pin an explicit `cwd` but never scrubbed env, so an
+// inherited GIT_DIR — which overrides git's cwd-based repo discovery
+// outright — could silently redirect them at the wrong repository. Asserts
+// the scrub actually reaches the spawned child, not just that scrubGitEnv()
+// is imported.
+test('runCommand scrubs an inherited GIT_DIR from the spawned child env', () => {
+  const out = runCommand(
+    'test',
+    process.execPath,
+    ['-e', 'process.stdout.write(String(process.env.GIT_DIR))'],
+    { env: { ...process.env, GIT_DIR: '/decoy/.git' } },
+  );
+  assert.equal(out, 'undefined');
+});


### PR DESCRIPTION
## Summary

#2184 asked for the `gh` side to get the same "a call added later inherits the fix" property the git side already had. `execGit` is a real chokepoint — one `execFileSync('git', …)` that everything funnels through. The `gh` side had three peer call sites and a test that protected them **by name**, so a fourth call would have been silently unguarded.

Adds `scripts/gh.mjs` — `gh()` for captured output, `ghSpawn()` for the streaming and probe shapes — both unconditionally applying `scrubGitEnv()` (merging a caller-supplied `env` rather than discarding it, as `execGit` does) and defaulting `cwd` to `repoRoot`. Every `gh` call site under `scripts/` now routes through it, and the guard asserts the chokepoint repo-wide instead of enumerating names.

**The issue's file list was incomplete.** It named 6 other callers; there are **12** call sites in total. Four scripts it missed (`quarantine-health.mjs`, `gh-labels.mjs`, `strip-chore-moscow-labels.mjs`, `migrate-backlog-to-issues.mjs`), and two more that no callee-based search could find at all — `generate-release-notes-wiki.mjs` reaches `gh` through a local `run()` wrapper, so it looked clean to any grep for `execFileSync('gh', …)`.

### Also fixed, found in passing

`scripts/lib/run-command.mjs` did not scrub. It is how `sync-wiki.mjs` runs **six git commands**, including `git init`, `git commit --allow-empty` and `git push -u origin HEAD:master`. Each passes an explicit `cwd`, but `cwd` does not protect against an inherited `GIT_DIR` — that overrides repository discovery outright, so those commands could commit and push against the wrong repository. Same defect as #2169 with a considerably worse blast radius, on the git side rather than the gh side. Fixed the same way `execGit` does it, with a paired test proving `GIT_DIR` does not reach the child.

## Test plan

- `scripts/tests/gh-chokepoint.test.mjs` — new repo-wide guard. Detects on the **argument** (`'gh'` as first arg, any callee) rather than a fixed list of callee names, so it catches custom wrappers, aliased imports, and direct calls uniformly.
- Guard neutralisation proven, not assumed. Probes applied to files the implementing agents had not otherwise touched, each reverted after: plain `execFileSync("gh", …)`, an aliased `execFileSync as _x`, an aliased `spawnSync`, single- and double-quoted literals, a backtick literal, and a custom `run('gh', …)` wrapper — all RED. A `git` call and a comment mentioning gh — GREEN.
- Two holes were found by probing the guard **after** it was reported complete, and both are closed here: a renamed import (`import { execFileSync as _x }`) walked straight past the original callee-name matching, and the first fix then dropped backticks from the quote class to dodge a false positive, leaving `` run(`gh`, …) `` undetected and undocumented. Requiring a comma after the closing quote resolves both — every real call passes arguments after the binary, while the prose that caused the false positive (``CLI (`gh`) authenticated``) is followed by `)`.
- Blind spots are stated in the test's own comment: a binary held in a variable, a command built by concatenation, and a single-argument call whose only argument is the bare literal. All genuinely uncatchable by a source-text scan without data-flow analysis.
- `npm run test:hooks` → 1187 pass, 0 fail. `npm run lint` → clean.

## Release notes

**Deliberately skipped, per CLAUDE.md's "internal chore with no user- or operator-visible effect" carve-out.** This only touches maintainer tooling — `bump-version`, `sync-wiki`, and the board scripts. Nothing in the shipped app changes and nobody running Castwright executes these paths.

## Independent review

Reviewed at Opus tier before merge, and it found the guard was still not testing the property this PR exists to protect.

**The guard proved routing, not scrubbing.** It asserted that every `gh` call goes through `scripts/gh.mjs` — and nothing asserted that `scripts/gh.mjs` scrubs. Deleting `env: scrubGitEnv(env)` from **both** functions left the full battery at **1187 pass / 0 fail**, with lint reporting three unused-variable warnings and exiting 0. Worse, this was a *regression*: the old `bump-version.test.mjs` test asserted the scrub at three named sites, and this PR deleted it in favour of a guard that cannot see the property. I reproduced the mutation myself before accepting the finding.

Closed in `2b8cd20f` with per-function assertions — deliberately per-function, since a single file-wide check would stay green if only one of the two lost its scrub. Neutralisation proven three ways (remove from `gh()` alone, from `ghSpawn()` alone, from both). **Re-verified independently: the same mutation that previously passed now fails 2 tests.**

Also closed:

- **`runCommand(label, 'gh', args)` escaped entirely** — the pattern required `'gh'` to be the *first* argument, and `runCommand`'s signature puts it second. Not hypothetical: the bypass this PR found (`generate-release-notes-wiki.mjs`) was a two-line alias over that very function, and `sync-wiki.mjs` already imports it directly, so skipping the alias is the *more* natural way to write the next one. Now matched in first or second position.
- **The scan was `.mjs`-only** under a header claiming "anywhere under `scripts/`" — which also holds `.mts`, `.cjs`, `.ps1` and `.py`. Widened to the JS/TS family; the shell/Python extensions are now documented as explicitly out of scope rather than silently uncovered.
- **The capture path had started leaking the child's stderr**, because `execFileSync` inherits it when `stdio` is unset — so a failing release cut would print `gh`'s stderr 20× inside `bump-version`'s retry loop. Original `['ignore','pipe','pipe']` restored.
- A `gh-chokepoint-allow` pragma was added for the two realistic false positives (a comment documenting the rule, and a future test asserting `'gh'` as a value) — one of which would otherwise have fired on the very test that fixes the blocking finding.
- The env comments said the scrub "merges" a caller-supplied env. It does not — `scrubGitEnv(env)` returns a scrubbed copy of the caller's object, so `{ env: { MY_FLAG: '1' } }` would yield a child with no `PATH`. Behaviour left alone (it matches `execGit`'s existing convention); the wording now says replace-then-scrub.

1198 tests pass, up from 1187.

## Follow-up filed

#2193 — `scripts/run-golden-audio.mjs`'s local `run()` is the last unscrubbed spawn wrapper in `scripts/`. Out of scope here: it launches npm/pytest, never `gh` or `git`, so there is no live defect. Filed because it is the third wrapper of this shape found on one branch, and the recurrence is the point.

Closes #2184
