### PR TITLE
docs(docs): design the onnxruntime pip-consistency marker for #2192

### DIFF
--- a/docs/superpowers/plans/2026-08-07-ort-pip-consistency-marker.md
+++ b/docs/superpowers/plans/2026-08-07-ort-pip-consistency-marker.md
@@ -1,0 +1,1530 @@
+# ONNX Runtime pip-consistency marker — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop every pip call into the sidecar venv from clobbering `onnxruntime-gpu`, by recording that `onnxruntime-gpu` provides the `onnxruntime` package.
+
+**Architecture:** `planOrtSwap` gains a `marker` action that rides the plan its two consumers already execute. `install-ort.mjs` gains pure-fs primitives to write, identify and delete a minimal `onnxruntime-<version>.dist-info` marker. A boot-time `ensureOrtMarker` heals venvs bootstrapped before this change. No new dependencies, no subprocesses, no network.
+
+**Tech Stack:** Node ESM (`.mjs`) for the sidecar scripts, TypeScript for `server/src`, Vitest for both. Server tests import the `.mjs` directly — the established pattern in `server/src/tts/install-ort-helpers.test.ts`.
+
+**Design of record:** [`docs/superpowers/specs/2026-08-07-qwen-ort-namespace-chokepoint-design.md`](../specs/2026-08-07-qwen-ort-namespace-chokepoint-design.md) (revision 6, five adversarial review rounds). Issue: **#2192**.
+
+## Global Constraints
+
+- **No new dependencies.** Everything is `node:fs` / `node:path`.
+- **No subprocess, no network, no `import onnxruntime`.** Every predicate is a file read. A provider probe would misread a GPU box whose CUDA DLLs fail to load, and would memory-map the very DLL #2192 is about.
+- **Never match a distribution by directory name alone.** On cpu/amd/apple the *real* plain distribution has a byte-identical directory name to our marker.
+- **Marker identity is `INSTALLER == "castwright-ort-marker"` AND an empty `RECORD`.** Both, always, before any delete or overwrite.
+- **`RECORD` must stay empty** — that is what makes `pip uninstall` a safe no-op on it (spike-verified).
+- Branch: `docs/docs-2192-qwen-ort-chokepoint` (already cut, worktree `C:\Claude\Projects\wt-2192-qwen-ort-chokepoint`). Rename to `fix/side-2192-ort-marker` before opening the PR.
+- Commit convention: `<type>(<scope>): <subject>`. Scopes here: `side` (sidecar scripts), `server`, `docs`.
+- Every assertion is mutation-checked: change the assertion's own line, confirm it fails, revert.
+
+---
+
+### Task 1: Venv path + distribution-name primitives
+
+**Files:**
+- Modify: `server/tts-sidecar/scripts/install-ort.mjs`
+- Test: `server/src/tts/ort-marker-paths.test.ts`
+
+**Interfaces:**
+- Consumes: `installRecipe` from `./accelerator-profile.mjs` (already imported).
+- Produces: `SWAP_ORT_PACKAGES: string[]`, `escapeDistName(name: string): string`, `sitePackagesDir(venvDir: string): string | null`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// server/src/tts/ort-marker-paths.test.ts
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SWAP_ORT_PACKAGES, escapeDistName, sitePackagesDir } from '../../tts-sidecar/scripts/install-ort.mjs';
+
+describe('escapeDistName', () => {
+  it('escapes per PEP 427 so the glob matches the real directory', () => {
+    // pip writes onnxruntime_gpu-1.27.0.dist-info — underscore, not hyphen.
+    expect(escapeDistName('onnxruntime-gpu')).toBe('onnxruntime_gpu');
+    expect(escapeDistName('onnxruntime-directml')).toBe('onnxruntime_directml');
+    expect(escapeDistName('onnxruntime')).toBe('onnxruntime');
+  });
+});
+
+describe('SWAP_ORT_PACKAGES', () => {
+  it('is derived from installRecipe, not hand-typed', () => {
+    expect(SWAP_ORT_PACKAGES).toContain('onnxruntime-gpu');
+    expect(SWAP_ORT_PACKAGES).not.toContain('onnxruntime');
+  });
+});
+
+describe('sitePackagesDir', () => {
+  it('finds the Windows layout', () => {
+    const venv = mkdtempSync(join(tmpdir(), 'venv-'));
+    mkdirSync(join(venv, 'Lib', 'site-packages'), { recursive: true });
+    expect(sitePackagesDir(venv)).toBe(join(venv, 'Lib', 'site-packages'));
+  });
+
+  it('finds the posix layout without needing the minor version', () => {
+    const venv = mkdtempSync(join(tmpdir(), 'venv-'));
+    mkdirSync(join(venv, 'lib', 'python3.12', 'site-packages'), { recursive: true });
+    expect(sitePackagesDir(venv)).toBe(join(venv, 'lib', 'python3.12', 'site-packages'));
+  });
+
+  it('returns null on a venv with no site-packages (half-built box)', () => {
+    const venv = mkdtempSync(join(tmpdir(), 'venv-'));
+    expect(sitePackagesDir(venv)).toBeNull();
+  });
+
+  it('returns null when the posix layout is ambiguous', () => {
+    const venv = mkdtempSync(join(tmpdir(), 'venv-'));
+    mkdirSync(join(venv, 'lib', 'python3.11', 'site-packages'), { recursive: true });
+    mkdirSync(join(venv, 'lib', 'python3.12', 'site-packages'), { recursive: true });
+    expect(sitePackagesDir(venv)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/tts/ort-marker-paths.test.ts`
+Expected: FAIL — `SWAP_ORT_PACKAGES is not exported` / import error.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `server/tts-sidecar/scripts/install-ort.mjs` (it already imports `installRecipe`; add `readdirSync`, `existsSync`, `join` imports as needed):
+
+```js
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { installRecipe, PROFILES } from './accelerator-profile.mjs';
+
+/** Distribution names that OWN the onnxruntime namespace on some profile.
+ *  DERIVED from installRecipe, never hand-typed — a hand-typed list is a second
+ *  source of truth for a set installRecipe already determines, and would miss a
+ *  future onnxruntime-directml re-enable. */
+export const SWAP_ORT_PACKAGES = [
+  ...new Set(
+    PROFILES.flatMap((p) =>
+      ['win32', 'linux', 'darwin'].map((plat) => installRecipe(p, plat).ortPackage),
+    ).filter((pkg) => pkg !== 'onnxruntime'),
+  ),
+];
+
+/** PEP 427 escaping: pip writes `onnxruntime-gpu` to disk as `onnxruntime_gpu`.
+ *  Globbing the UNESCAPED name matches zero directories — which, combined with
+ *  the fail-loudly rule, would break every NVIDIA bootstrap. */
+export function escapeDistName(name) {
+  return name.replace(/[-_.]+/g, '_');
+}
+
+/** Resolve site-packages inside a venv dir. Pure fs — no interpreter spawn.
+ *  Returns null when absent or ambiguous; callers treat null as "do nothing". */
+export function sitePackagesDir(venvDir) {
+  const win = join(venvDir, 'Lib', 'site-packages');
+  if (existsSync(win)) return win;
+  const libDir = join(venvDir, 'lib');
+  if (!existsSync(libDir)) return null;
+  const hits = readdirSync(libDir)
+    .filter((d) => d.startsWith('python'))
+    .map((d) => join(libDir, d, 'site-packages'))
+    .filter((p) => existsSync(p));
+  return hits.length === 1 ? hits[0] : null;
+}
+```
+
+Check `accelerator-profile.mjs` exports `PROFILES`; it does (`export const PROFILES = ['nvidia','amd','apple','cpu']`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/tts/ort-marker-paths.test.ts`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Mutation-check**
+
+Change `escapeDistName`'s regex to `/-/g` — the `onnxruntime-gpu` case must still pass but add a temporary assertion `expect(escapeDistName('a.b')).toBe('a_b')` and confirm it fails. Revert. Then change `sitePackagesDir`'s `hits.length === 1` to `>= 1` and confirm the ambiguous test fails. Revert.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/tts-sidecar/scripts/install-ort.mjs server/src/tts/ort-marker-paths.test.ts
+git commit -m "feat(side): add venv path and distribution-name primitives for the ORT marker
+
+Refs #2192"
+```
+
+---
+
+### Task 2: Marker write, identity and delete
+
+**Files:**
+- Modify: `server/tts-sidecar/scripts/install-ort.mjs`
+- Test: `server/src/tts/ort-marker-io.test.ts`
+
+**Interfaces:**
+- Consumes: `escapeDistName` (Task 1).
+- Produces: `MARKER_INSTALLER: string`, `isOurMarker(distInfoDir: string): boolean`, `writeOrtMarker(sitePackages: string, version: string): void`, `deleteOrtMarkerIfOurs(sitePackages: string): boolean`, `findPlainOrtDistInfos(sitePackages: string): string[]`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// server/src/tts/ort-marker-io.test.ts
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  MARKER_INSTALLER, isOurMarker, writeOrtMarker, deleteOrtMarkerIfOurs, findPlainOrtDistInfos,
+} from '../../tts-sidecar/scripts/install-ort.mjs';
+
+function sp() { return mkdtempSync(join(tmpdir(), 'sp-')); }
+
+/** A REAL plain onnxruntime distribution — byte-identical directory name to ours. */
+function realPlainDist(root: string, version = '1.28.0') {
+  const d = join(root, `onnxruntime-${version}.dist-info`);
+  mkdirSync(d, { recursive: true });
+  writeFileSync(join(d, 'METADATA'), `Metadata-Version: 2.1\nName: onnxruntime\nVersion: ${version}\n`);
+  writeFileSync(join(d, 'INSTALLER'), 'pip\n');
+  writeFileSync(join(d, 'RECORD'), 'onnxruntime/capi/_pybind_state.pyd,sha256=abc,123\n');
+  return d;
+}
+
+describe('isOurMarker', () => {
+  it('accepts a marker we wrote', () => {
+    const root = sp();
+    writeOrtMarker(root, '1.27.0');
+    expect(isOurMarker(join(root, 'onnxruntime-1.27.0.dist-info'))).toBe(true);
+  });
+
+  it('REFUSES the real plain distribution (name is identical — identity is not)', () => {
+    const root = sp();
+    const real = realPlainDist(root);
+    expect(isOurMarker(real)).toBe(false);
+  });
+
+  it('refuses a dir with our INSTALLER but a non-empty RECORD', () => {
+    const root = sp();
+    const d = join(root, 'onnxruntime-9.9.9.dist-info');
+    mkdirSync(d, { recursive: true });
+    writeFileSync(join(d, 'INSTALLER'), `${MARKER_INSTALLER}\n`);
+    writeFileSync(join(d, 'RECORD'), 'something\n');
+    expect(isOurMarker(d)).toBe(false);
+  });
+});
+
+describe('writeOrtMarker', () => {
+  it('writes METADATA, INSTALLER and an EMPTY RECORD', () => {
+    const root = sp();
+    writeOrtMarker(root, '1.27.0');
+    const d = join(root, 'onnxruntime-1.27.0.dist-info');
+    expect(readFileSync(join(d, 'METADATA'), 'utf8')).toContain('Name: onnxruntime');
+    expect(readFileSync(join(d, 'METADATA'), 'utf8')).toContain('Version: 1.27.0');
+    expect(readFileSync(join(d, 'INSTALLER'), 'utf8').trim()).toBe(MARKER_INSTALLER);
+    expect(readFileSync(join(d, 'RECORD'), 'utf8')).toBe('');
+  });
+
+  it('overwrites a STALE marker rather than skipping it', () => {
+    const root = sp();
+    writeOrtMarker(root, '1.26.0');
+    writeOrtMarker(root, '1.27.0');
+    expect(existsSync(join(root, 'onnxruntime-1.27.0.dist-info'))).toBe(true);
+    expect(existsSync(join(root, 'onnxruntime-1.26.0.dist-info'))).toBe(false);
+  });
+});
+
+describe('deleteOrtMarkerIfOurs', () => {
+  it('removes our marker and reports true', () => {
+    const root = sp();
+    writeOrtMarker(root, '1.27.0');
+    expect(deleteOrtMarkerIfOurs(root)).toBe(true);
+    expect(existsSync(join(root, 'onnxruntime-1.27.0.dist-info'))).toBe(false);
+  });
+
+  it('REFUSES to delete the real plain distribution', () => {
+    const root = sp();
+    const real = realPlainDist(root);
+    expect(deleteOrtMarkerIfOurs(root)).toBe(false);
+    expect(existsSync(real)).toBe(true);
+  });
+
+  it('is a no-op when nothing is present', () => {
+    expect(deleteOrtMarkerIfOurs(sp())).toBe(false);
+  });
+
+  it('deletes ours even when a real distribution sits beside it', () => {
+    const root = sp();
+    const real = realPlainDist(root, '1.28.0');
+    writeOrtMarker(root, '1.27.0');
+    expect(deleteOrtMarkerIfOurs(root)).toBe(true);
+    expect(existsSync(real)).toBe(true);
+  });
+});
+
+describe('findPlainOrtDistInfos', () => {
+  it('identity-tests EVERY match, not just the first', () => {
+    const root = sp();
+    writeOrtMarker(root, '1.27.0');          // ours, sorts first
+    const real = realPlainDist(root, '1.28.0');
+    expect(findPlainOrtDistInfos(root)).toEqual([real]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/tts/ort-marker-io.test.ts`
+Expected: FAIL — exports not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `install-ort.mjs` (extend the `node:fs` import with `mkdirSync`, `writeFileSync`, `readFileSync`, `rmSync`, `statSync`):
+
+```js
+export const MARKER_INSTALLER = 'castwright-ort-marker';
+
+/** Every `onnxruntime-<version>.dist-info` in site-packages — ours AND real ones.
+ *  The trailing `-\d` is what excludes `onnxruntime_gpu-…` (underscore at index 11). */
+function ortDistInfoDirs(sitePackages) {
+  if (!existsSync(sitePackages)) return [];
+  return readdirSync(sitePackages)
+    .filter((d) => /^onnxruntime-\d.*\.dist-info$/.test(d))
+    .map((d) => join(sitePackages, d));
+}
+
+/** Ours ONLY if the INSTALLER is our sentinel AND the RECORD is empty.
+ *  Name is never sufficient: the real plain distribution's directory name is
+ *  byte-identical to ours. */
+export function isOurMarker(distInfoDir) {
+  try {
+    const installer = readFileSync(join(distInfoDir, 'INSTALLER'), 'utf8').trim();
+    if (installer !== MARKER_INSTALLER) return false;
+    return readFileSync(join(distInfoDir, 'RECORD'), 'utf8').trim() === '';
+  } catch {
+    return false;
+  }
+}
+
+/** Real (non-marker) plain onnxruntime distributions. Tests EVERY match — ours
+ *  and a real one can coexist, so answering from the first is a false negative. */
+export function findPlainOrtDistInfos(sitePackages) {
+  return ortDistInfoDirs(sitePackages).filter((d) => !isOurMarker(d));
+}
+
+/** Write (or overwrite) the marker. Removes any stale marker first so the
+ *  version can never lag the installed runtime. */
+export function writeOrtMarker(sitePackages, version) {
+  deleteOrtMarkerIfOurs(sitePackages);
+  const dir = join(sitePackages, `onnxruntime-${version}.dist-info`);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'METADATA'),
+    `Metadata-Version: 2.1\nName: onnxruntime\nVersion: ${version}\n` +
+      `Summary: Provided by ${SWAP_ORT_PACKAGES.join('/')} (same namespace, same API).\n`,
+  );
+  writeFileSync(join(dir, 'INSTALLER'), `${MARKER_INSTALLER}\n`);
+  writeFileSync(join(dir, 'RECORD'), ''); // MUST stay empty — see the spec's Spike 2
+}
+
+/** Delete the marker if (and only if) we wrote it. Returns whether it removed one. */
+export function deleteOrtMarkerIfOurs(sitePackages) {
+  let removed = false;
+  for (const dir of ortDistInfoDirs(sitePackages)) {
+    if (!isOurMarker(dir)) continue;
+    rmSync(dir, { recursive: true, force: true });
+    removed = true;
+  }
+  return removed;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/tts/ort-marker-io.test.ts`
+Expected: PASS, 10 tests.
+
+- [ ] **Step 5: Mutation-check the safety-critical assertions**
+
+One at a time, revert after each:
+1. In `isOurMarker`, drop the `RECORD` check (`return true` after the INSTALLER match) → the non-empty-RECORD test must fail.
+2. In `isOurMarker`, drop the INSTALLER check → "REFUSES the real plain distribution" and "REFUSES to delete the real plain distribution" must both fail.
+3. In `findPlainOrtDistInfos`, return only `[dirs[0]]` filtered → the every-match test must fail.
+
+If any mutation leaves the suite green, the test is not testing what it claims.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/tts-sidecar/scripts/install-ort.mjs server/src/tts/ort-marker-io.test.ts
+git commit -m "feat(side): add ORT marker write, identity and guarded delete
+
+Identity is INSTALLER + empty RECORD, never the directory name — the real
+plain onnxruntime distribution has a byte-identical name.
+
+Refs #2192"
+```
+
+---
+
+### Task 3: Namespace ownership detection
+
+**Files:**
+- Modify: `server/tts-sidecar/scripts/install-ort.mjs`
+- Test: `server/src/tts/ort-owner-detect.test.ts`
+
+**Interfaces:**
+- Consumes: `SWAP_ORT_PACKAGES` (Task 1).
+- Produces: `detectOrtOwner(sitePackages: string): 'swap' | 'plain' | 'none'`.
+
+Ownership comes from `onnxruntime/capi/build_and_package_info.py`, whose first line is
+`package_name = 'onnxruntime-gpu'` on a GPU wheel (verified on the live dev venv). **Never**
+from `get_available_providers()`: `__version__` is identical across builds, and a GPU install
+whose CUDA DLLs fail to load reports CPU providers — which would delete a correct marker on
+every boot.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// server/src/tts/ort-owner-detect.test.ts
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { detectOrtOwner } from '../../tts-sidecar/scripts/install-ort.mjs';
+
+function venvWith(info: string | null, extra: string[] = []) {
+  const root = mkdtempSync(join(tmpdir(), 'sp-'));
+  const capi = join(root, 'onnxruntime', 'capi');
+  mkdirSync(capi, { recursive: true });
+  if (info !== null) writeFileSync(join(capi, 'build_and_package_info.py'), info);
+  for (const f of extra) writeFileSync(join(capi, f), 'x');
+  return root;
+}
+
+describe('detectOrtOwner', () => {
+  it('reads the GPU wheel as a swap distribution', () => {
+    const root = venvWith("package_name = 'onnxruntime-gpu'\n__version__ = '1.27.0'\n");
+    expect(detectOrtOwner(root)).toBe('swap');
+  });
+
+  it('reads the CPU wheel as plain', () => {
+    const root = venvWith("package_name = 'onnxruntime'\n__version__ = '1.28.0'\n");
+    expect(detectOrtOwner(root)).toBe('plain');
+  });
+
+  it('falls back to the CUDA provider DLL when the info file is missing', () => {
+    const root = venvWith(null, ['onnxruntime_providers_cuda.dll']);
+    expect(detectOrtOwner(root)).toBe('swap');
+  });
+
+  it('reports plain when neither signal says GPU but the namespace exists', () => {
+    const root = venvWith(null, ['_pybind_state.pyd']);
+    expect(detectOrtOwner(root)).toBe('plain');
+  });
+
+  it('reports none for an ABSENT namespace — the interrupted-swap state', () => {
+    const root = mkdtempSync(join(tmpdir(), 'sp-'));
+    expect(detectOrtOwner(root)).toBe('none');
+  });
+
+  it('reports none for a gutted namespace (dir exists, capi empty)', () => {
+    const root = mkdtempSync(join(tmpdir(), 'sp-'));
+    mkdirSync(join(root, 'onnxruntime', 'capi'), { recursive: true });
+    expect(detectOrtOwner(root)).toBe('none');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/tts/ort-owner-detect.test.ts`
+Expected: FAIL — `detectOrtOwner is not exported`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```js
+/** Who owns site-packages/onnxruntime/ — decided from FILES the wheel ships.
+ *  'swap'  → a swap distribution (onnxruntime-gpu / -directml)
+ *  'plain' → the CPU build
+ *  'none'  → absent or gutted (nothing importable)
+ *  NEVER uses import/get_available_providers(): __version__ is identical across
+ *  builds, and a GPU install with unloadable CUDA DLLs reports CPU providers. */
+export function detectOrtOwner(sitePackages) {
+  const capi = join(sitePackages, 'onnxruntime', 'capi');
+  if (!existsSync(capi)) return 'none';
+  let entries;
+  try {
+    entries = readdirSync(capi);
+  } catch {
+    return 'none';
+  }
+  if (entries.length === 0) return 'none';
+
+  const infoPath = join(capi, 'build_and_package_info.py');
+  if (existsSync(infoPath)) {
+    try {
+      const m = readFileSync(infoPath, 'utf8').match(/package_name\s*=\s*['"]([^'"]+)['"]/);
+      if (m) return SWAP_ORT_PACKAGES.includes(m[1]) ? 'swap' : 'plain';
+    } catch {
+      /* fall through to the DLL signal */
+    }
+  }
+  if (entries.some((e) => /^onnxruntime_providers_(cuda|rocm)\./.test(e))) return 'swap';
+  return 'plain';
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/tts/ort-owner-detect.test.ts`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Mutation-check**
+
+Change the `entries.length === 0` guard to `false` → the gutted-namespace test must fail. Change `SWAP_ORT_PACKAGES.includes(m[1])` to `m[1] !== 'onnxruntime'` and confirm the GPU/CPU tests still pass but add `expect(detectOrtOwner(venvWith("package_name = 'onnxruntime-silly'"))).toBe('plain')` — it must fail under the mutation. Revert both.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/tts-sidecar/scripts/install-ort.mjs server/src/tts/ort-owner-detect.test.ts
+git commit -m "feat(side): detect ORT namespace ownership from wheel files, not a provider probe
+
+Refs #2192"
+```
+
+---
+
+### Task 4: Version read + `planOrtSwap` carries the marker action
+
+**Files:**
+- Modify: `server/tts-sidecar/scripts/install-ort.mjs`
+- Test: `server/src/tts/install-ort-helpers.test.ts` (extend), `server/src/tts/ort-version-read.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `escapeDistName` (Task 1).
+- Produces: `readInstalledOrtVersion(sitePackages: string, ortPackage: string): string | null`; `planOrtSwap` return gains `marker: { action: 'write' | 'delete' }`. The **skip** variant gains `marker` but still carries **no** `ortPackage`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// server/src/tts/ort-version-read.test.ts
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { readInstalledOrtVersion } from '../../tts-sidecar/scripts/install-ort.mjs';
+
+function distInfo(root: string, dirName: string, version: string) {
+  const d = join(root, dirName);
+  mkdirSync(d, { recursive: true });
+  writeFileSync(join(d, 'METADATA'), `Metadata-Version: 2.1\nName: x\nVersion: ${version}\n`);
+}
+
+describe('readInstalledOrtVersion', () => {
+  it('resolves the ESCAPED directory name from the bare package name', () => {
+    const root = mkdtempSync(join(tmpdir(), 'sp-'));
+    distInfo(root, 'onnxruntime_gpu-1.27.0.dist-info', '1.27.0');
+    // The input is the bare name with a HYPHEN; the directory has an UNDERSCORE.
+    expect(readInstalledOrtVersion(root, 'onnxruntime-gpu')).toBe('1.27.0');
+  });
+
+  it('returns null when absent', () => {
+    expect(readInstalledOrtVersion(mkdtempSync(join(tmpdir(), 'sp-')), 'onnxruntime-gpu')).toBeNull();
+  });
+
+  it('returns null when AMBIGUOUS (a stale dist beside the current one)', () => {
+    const root = mkdtempSync(join(tmpdir(), 'sp-'));
+    distInfo(root, 'onnxruntime_gpu-1.26.0.dist-info', '1.26.0');
+    distInfo(root, 'onnxruntime_gpu-1.27.0.dist-info', '1.27.0');
+    expect(readInstalledOrtVersion(root, 'onnxruntime-gpu')).toBeNull();
+  });
+});
+```
+
+Append to `server/src/tts/install-ort-helpers.test.ts`:
+
+```ts
+describe('planOrtSwap marker action', () => {
+  it('nvidia → write', () => {
+    expect(planOrtSwap('nvidia', 'win32').marker).toEqual({ action: 'write' });
+  });
+
+  it('cpu, amd and apple → delete (they are NOT GPU-swap profiles)', () => {
+    for (const p of ['cpu', 'amd', 'apple']) {
+      expect(planOrtSwap(p, 'win32').marker).toEqual({ action: 'delete' });
+    }
+  });
+
+  it('the skip variant carries NO ortPackage — a write there would glob undefined', () => {
+    expect(planOrtSwap('cpu', 'win32').ortPackage).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd server && npx vitest run src/tts/ort-version-read.test.ts src/tts/install-ort-helpers.test.ts`
+Expected: FAIL — `readInstalledOrtVersion` undefined; `.marker` is `undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```js
+/** Version of the installed swap distribution, read from its dist-info METADATA.
+ *  null when absent OR ambiguous — the caller treats null as fatal for a swap
+ *  (better a loud install failure than a marker whose version is a guess). */
+export function readInstalledOrtVersion(sitePackages, ortPackage) {
+  if (!existsSync(sitePackages)) return null;
+  const prefix = `${escapeDistName(ortPackage)}-`;
+  const hits = readdirSync(sitePackages).filter(
+    (d) => d.startsWith(prefix) && d.endsWith('.dist-info'),
+  );
+  if (hits.length !== 1) return null;
+  try {
+    const meta = readFileSync(join(sitePackages, hits[0], 'METADATA'), 'utf8');
+    const m = meta.match(/^Version:\s*(.+)$/m);
+    return m ? m[1].trim() : null;
+  } catch {
+    return null;
+  }
+}
+```
+
+In `planOrtSwap`, add `marker` to both variants:
+
+```js
+  if (ortPackage === 'onnxruntime') {
+    return {
+      action: 'skip',
+      reason: 'plain onnxruntime from the overlay is correct; no swap',
+      marker: { action: 'delete' },
+    };
+  }
+  return {
+    action: 'swap',
+    ortPackage,
+    marker: { action: 'write' },
+    steps: [ /* unchanged */ ],
+  };
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd server && npx vitest run src/tts/ort-version-read.test.ts src/tts/install-ort-helpers.test.ts`
+Expected: PASS. The pre-existing `planOrtSwap` assertions must still pass unchanged.
+
+- [ ] **Step 5: Mutation-check**
+
+Change `hits.length !== 1` to `hits.length === 0` → the ambiguous test must fail. Change the skip variant's marker to `{ action: 'write' }` → the cpu/amd/apple test must fail. Revert both.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/tts-sidecar/scripts/install-ort.mjs server/src/tts/ort-version-read.test.ts server/src/tts/install-ort-helpers.test.ts
+git commit -m "feat(side): read the installed ORT version and carry a marker action in the swap plan
+
+Refs #2192"
+```
+
+---
+
+### Task 5: `applyOrtMarkerWrite` / `applyOrtMarkerDelete` — the plan-driven entry points
+
+**Files:**
+- Modify: `server/tts-sidecar/scripts/install-ort.mjs`
+- Test: `server/src/tts/ort-marker-apply.test.ts`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–4.
+- Produces: `applyOrtMarkerDelete(venvDir: string, plan): void`, `applyOrtMarkerWrite(venvDir: string, plan): void` (throws when the version is unreadable).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// server/src/tts/ort-marker-apply.test.ts
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  applyOrtMarkerWrite, applyOrtMarkerDelete, planOrtSwap, writeOrtMarker,
+} from '../../tts-sidecar/scripts/install-ort.mjs';
+
+function venv(withGpuDist = false) {
+  const root = mkdtempSync(join(tmpdir(), 'venv-'));
+  const sp = join(root, 'Lib', 'site-packages');
+  mkdirSync(sp, { recursive: true });
+  if (withGpuDist) {
+    const d = join(sp, 'onnxruntime_gpu-1.27.0.dist-info');
+    mkdirSync(d, { recursive: true });
+    writeFileSync(join(d, 'METADATA'), 'Metadata-Version: 2.1\nName: onnxruntime-gpu\nVersion: 1.27.0\n');
+  }
+  return { root, sp };
+}
+
+describe('applyOrtMarkerWrite', () => {
+  it('writes the marker at the INSTALLED version', () => {
+    const { root, sp } = venv(true);
+    applyOrtMarkerWrite(root, planOrtSwap('nvidia', 'win32'));
+    expect(existsSync(join(sp, 'onnxruntime-1.27.0.dist-info'))).toBe(true);
+  });
+
+  it('is a NO-OP when the plan says delete — a write on cpu has no ortPackage', () => {
+    const { root, sp } = venv();
+    applyOrtMarkerWrite(root, planOrtSwap('cpu', 'win32'));
+    expect(existsSync(join(sp, 'onnxruntime-1.27.0.dist-info'))).toBe(false);
+  });
+
+  it('THROWS when the version cannot be read — never writes a guessed version', () => {
+    const { root } = venv(false);
+    expect(() => applyOrtMarkerWrite(root, planOrtSwap('nvidia', 'win32'))).toThrow(/version/i);
+  });
+});
+
+describe('applyOrtMarkerDelete', () => {
+  it('removes our marker on a delete plan', () => {
+    const { root, sp } = venv();
+    writeOrtMarker(sp, '1.27.0');
+    applyOrtMarkerDelete(root, planOrtSwap('cpu', 'win32'));
+    expect(existsSync(join(sp, 'onnxruntime-1.27.0.dist-info'))).toBe(false);
+  });
+
+  it('also removes it on a SWAP plan — the failure path calls this before rethrowing', () => {
+    const { root, sp } = venv(true);
+    writeOrtMarker(sp, '1.27.0');
+    applyOrtMarkerDelete(root, planOrtSwap('nvidia', 'win32'));
+    expect(existsSync(join(sp, 'onnxruntime-1.27.0.dist-info'))).toBe(false);
+  });
+
+  it('never throws on a venv with no site-packages', () => {
+    const root = mkdtempSync(join(tmpdir(), 'venv-'));
+    expect(() => applyOrtMarkerDelete(root, planOrtSwap('cpu', 'win32'))).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/tts/ort-marker-apply.test.ts`
+Expected: FAIL — exports not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```js
+/** Delete our marker. Safe on every plan and every venv shape — the failure
+ *  path calls it with a SWAP plan before re-throwing. */
+export function applyOrtMarkerDelete(venvDir, _plan) {
+  const sp = sitePackagesDir(venvDir);
+  if (!sp) return;
+  deleteOrtMarkerIfOurs(sp);
+}
+
+/** Write the marker. NO-OP unless the plan says write — the skip variant has no
+ *  ortPackage, so a write there would glob `undefined-*` and either resolve
+ *  nothing or overwrite the REAL plain distribution. */
+export function applyOrtMarkerWrite(venvDir, plan) {
+  if (plan?.marker?.action !== 'write') return;
+  const sp = sitePackagesDir(venvDir);
+  if (!sp) throw new Error(`ORT marker: no site-packages under ${venvDir}`);
+  const version = readInstalledOrtVersion(sp, plan.ortPackage);
+  if (!version) {
+    throw new Error(
+      `ORT marker: could not read the installed ${plan.ortPackage} version (absent or ambiguous)`,
+    );
+  }
+  writeOrtMarker(sp, version);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/tts/ort-marker-apply.test.ts`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Mutation-check**
+
+Remove the `plan?.marker?.action !== 'write'` guard → the cpu no-op test must fail. Replace the `if (!version) throw` with `writeOrtMarker(sp, version ?? '0.0.0')` → the throw test must fail. Revert both.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/tts-sidecar/scripts/install-ort.mjs server/src/tts/ort-marker-apply.test.ts
+git commit -m "feat(side): add plan-gated marker write/delete entry points
+
+Refs #2192"
+```
+
+---
+
+### Task 6: `ensureOrtMarker` — the boot-time self-heal
+
+**Files:**
+- Modify: `server/tts-sidecar/scripts/install-ort.mjs`
+- Test: `server/src/tts/ort-ensure-marker.test.ts`
+
+**Interfaces:**
+- Consumes: Tasks 1–3.
+- Produces: `ensureOrtMarker(venvDir: string, log?: (m: string) => void): 'wrote' | 'deleted' | 'clobbered' | 'noop'`. **Never throws.**
+
+The five states from the spec, and the required outcome for each:
+
+| Namespace owner | Real plain dist present? | Our marker present? | Outcome |
+|---|---|---|---|
+| swap | no | no | `wrote` |
+| swap | no | yes | `noop` |
+| swap | **yes** | either | `clobbered` — refuse, log the remedy |
+| plain | — | yes | `deleted` |
+| none (interrupted swap) | — | yes | `deleted` |
+| none | — | no | `noop` |
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// server/src/tts/ort-ensure-marker.test.ts
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ensureOrtMarker, writeOrtMarker } from '../../tts-sidecar/scripts/install-ort.mjs';
+
+function venv({ owner, realDist }: { owner: 'swap' | 'plain' | 'none'; realDist?: boolean }) {
+  const root = mkdtempSync(join(tmpdir(), 'venv-'));
+  const sp = join(root, 'Lib', 'site-packages');
+  mkdirSync(sp, { recursive: true });
+  if (owner !== 'none') {
+    const capi = join(sp, 'onnxruntime', 'capi');
+    mkdirSync(capi, { recursive: true });
+    const name = owner === 'swap' ? 'onnxruntime-gpu' : 'onnxruntime';
+    writeFileSync(join(capi, 'build_and_package_info.py'), `package_name = '${name}'\n`);
+  }
+  if (owner === 'swap') {
+    const d = join(sp, 'onnxruntime_gpu-1.27.0.dist-info');
+    mkdirSync(d, { recursive: true });
+    writeFileSync(join(d, 'METADATA'), 'Metadata-Version: 2.1\nName: onnxruntime-gpu\nVersion: 1.27.0\n');
+  }
+  if (realDist) {
+    const d = join(sp, 'onnxruntime-1.28.0.dist-info');
+    mkdirSync(d, { recursive: true });
+    writeFileSync(join(d, 'METADATA'), 'Metadata-Version: 2.1\nName: onnxruntime\nVersion: 1.28.0\n');
+    writeFileSync(join(d, 'INSTALLER'), 'pip\n');
+    writeFileSync(join(d, 'RECORD'), 'onnxruntime/x,sha256=a,1\n');
+  }
+  return { root, sp };
+}
+
+describe('ensureOrtMarker', () => {
+  it('writes a marker on a healthy GPU venv bootstrapped before this change', () => {
+    const { root, sp } = venv({ owner: 'swap' });
+    expect(ensureOrtMarker(root)).toBe('wrote');
+    expect(existsSync(join(sp, 'onnxruntime-1.27.0.dist-info'))).toBe(true);
+  });
+
+  it('is idempotent — second run is a no-op', () => {
+    const { root } = venv({ owner: 'swap' });
+    ensureOrtMarker(root);
+    expect(ensureOrtMarker(root)).toBe('noop');
+  });
+
+  it('REFUSES on a clobbered venv and names the remedy', () => {
+    const { root, sp } = venv({ owner: 'plain', realDist: true });
+    mkdirSync(join(sp, 'onnxruntime_gpu-1.27.0.dist-info'), { recursive: true });
+    const lines: string[] = [];
+    expect(ensureOrtMarker(root, (m) => lines.push(m))).toBe('clobbered');
+    expect(existsSync(join(sp, 'onnxruntime-1.28.0.dist-info'))).toBe(true);
+    expect(lines.join('\n')).toContain('install-ort.mjs');
+  });
+
+  it('deletes a lying marker when the CPU build owns the namespace', () => {
+    const { root, sp } = venv({ owner: 'plain' });
+    writeOrtMarker(sp, '1.27.0');
+    expect(ensureOrtMarker(root)).toBe('deleted');
+    expect(existsSync(join(sp, 'onnxruntime-1.27.0.dist-info'))).toBe(false);
+  });
+
+  it('deletes a lying marker after an INTERRUPTED SWAP — no runtime at all', () => {
+    const { root, sp } = venv({ owner: 'none' });
+    writeOrtMarker(sp, '1.27.0');
+    expect(ensureOrtMarker(root)).toBe('deleted');
+    expect(existsSync(join(sp, 'onnxruntime-1.27.0.dist-info'))).toBe(false);
+  });
+
+  it('never throws on a venv that does not exist', () => {
+    const gone = join(tmpdir(), 'definitely-not-a-venv-2192');
+    rmSync(gone, { recursive: true, force: true });
+    expect(() => ensureOrtMarker(gone)).not.toThrow();
+    expect(ensureOrtMarker(gone)).toBe('noop');
+  });
+
+  it('never creates a site-packages tree on a half-built venv', () => {
+    const root = mkdtempSync(join(tmpdir(), 'venv-'));
+    ensureOrtMarker(root);
+    expect(existsSync(join(root, 'Lib', 'site-packages'))).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/tts/ort-ensure-marker.test.ts`
+Expected: FAIL — `ensureOrtMarker is not exported`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```js
+/** Boot-time self-heal for venvs bootstrapped before the marker existed.
+ *  Pure fs: no pip, no network, no subprocess, no `import onnxruntime`.
+ *  NEVER throws — its caller runs during server startup. */
+export function ensureOrtMarker(venvDir, log = () => {}) {
+  try {
+    const sp = sitePackagesDir(venvDir);
+    if (!sp) return 'noop';
+    const owner = detectOrtOwner(sp);
+    const realPlain = findPlainOrtDistInfos(sp);
+
+    if (owner === 'swap' && realPlain.length > 0) {
+      log(
+        '[ort-marker] This venv has a real plain onnxruntime installed over the GPU runtime ' +
+          '(GPU Kokoro is disabled). Refusing to write a marker over it. Repair with:\n' +
+          '  CASTWRIGHT_ACCELERATOR_PROFILE=<profile> node server/tts-sidecar/scripts/install-ort.mjs <venv-python>',
+      );
+      return 'clobbered';
+    }
+    if (owner === 'swap') {
+      const existing = ortMarkerVersion(sp);
+      if (existing !== null) return 'noop';
+      const pkg = SWAP_ORT_PACKAGES.find((p) => readInstalledOrtVersion(sp, p) !== null);
+      const version = pkg ? readInstalledOrtVersion(sp, pkg) : null;
+      if (!version) return 'noop';
+      writeOrtMarker(sp, version);
+      log(`[ort-marker] recorded onnxruntime ${version} as provided by ${pkg}.`);
+      return 'wrote';
+    }
+    // owner is 'plain' or 'none' — any marker of ours is a lie.
+    return deleteOrtMarkerIfOurs(sp) ? 'deleted' : 'noop';
+  } catch {
+    return 'noop';
+  }
+}
+
+/** Version recorded by OUR marker, or null when we have not written one. */
+function ortMarkerVersion(sitePackages) {
+  for (const dir of ortDistInfoDirs(sitePackages)) {
+    if (!isOurMarker(dir)) continue;
+    const m = /onnxruntime-(.+)\.dist-info$/.exec(dir.replace(/\\/g, '/').split('/').pop());
+    if (m) return m[1];
+  }
+  return null;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/tts/ort-ensure-marker.test.ts`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Mutation-check the two states that killed earlier revisions**
+
+1. Remove the `realPlain.length > 0` branch → the clobbered test must fail (and note the marker would have been written over the real distribution).
+2. Change the final branch to `if (owner === 'plain')` only → the interrupted-swap test must fail.
+3. Remove the outer `try/catch` → the nonexistent-venv test must fail.
+
+Revert each.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/tts-sidecar/scripts/install-ort.mjs server/src/tts/ort-ensure-marker.test.ts
+git commit -m "feat(side): add ensureOrtMarker boot-time self-heal
+
+Covers the clobbered and interrupted-swap venv states; refuses rather than
+writing a marker over a real plain distribution.
+
+Refs #2192"
+```
+
+---
+
+### Task 7: Wire `bootstrap-venv.mjs`
+
+**Files:**
+- Modify: `server/tts-sidecar/scripts/bootstrap-venv.mjs`
+- Test: `server/src/tts/bootstrap-venv-helpers.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `applyOrtMarkerDelete`, `applyOrtMarkerWrite` (Task 5).
+- Produces: no new exports. `installForProfile` gains an injectable marker seam as its last positional parameter, defaulting to the real implementations.
+
+Ordering, from the spec and non-negotiable:
+- **delete** at `installForProfile`'s **function entry** — before the AMD torch pre-install, the AMD→CPU fallback (`cpu.txt` carries an explicit `onnxruntime` line), the nvidia torch pre-install, and both overlay installs.
+- **write** as the **last statement inside** the `if (ort.action === 'swap')` block.
+- **delete** again on the swap-failure path, before re-throwing.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/src/tts/bootstrap-venv-helpers.test.ts`:
+
+```ts
+describe('installForProfile ORT marker wiring', () => {
+  function harness(profile: string, { failSwap = false } = {}) {
+    const calls: string[] = [];
+    const runPip = (args: string[]) => {
+      calls.push(`pip ${args.join(' ')}`);
+      if (failSwap && args[0] === 'install' && args.includes('--force-reinstall')) return false;
+      return true;
+    };
+    const marker = {
+      del: () => { calls.push('marker:delete'); },
+      write: () => { calls.push('marker:write'); },
+    };
+    return { calls, runPip, marker, profile };
+  }
+
+  it('deletes the marker BEFORE any overlay install', () => {
+    const h = harness('cpu');
+    installForProfile('py', 'cpu', h.runPip, 'win32', '/venv', h.marker);
+    const firstPip = h.calls.findIndex((c) => c.startsWith('pip install -r'));
+    expect(h.calls.indexOf('marker:delete')).toBeLessThan(firstPip);
+  });
+
+  it('writes the marker only after a successful nvidia swap', () => {
+    const h = harness('nvidia');
+    installForProfile('py', 'nvidia', h.runPip, 'win32', '/venv', h.marker);
+    const swapIdx = h.calls.findIndex((c) => c.includes('--force-reinstall'));
+    expect(h.calls.indexOf('marker:write')).toBeGreaterThan(swapIdx);
+  });
+
+  it('never writes on cpu', () => {
+    const h = harness('cpu');
+    installForProfile('py', 'cpu', h.runPip, 'win32', '/venv', h.marker);
+    expect(h.calls).not.toContain('marker:write');
+  });
+
+  it('deletes the marker when the swap FAILS, before rethrowing', () => {
+    const h = harness('nvidia', { failSwap: true });
+    expect(() => installForProfile('py', 'nvidia', h.runPip, 'win32', '/venv', h.marker)).toThrow();
+    // one delete at entry, one on the failure path
+    expect(h.calls.filter((c) => c === 'marker:delete')).toHaveLength(2);
+    expect(h.calls).not.toContain('marker:write');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/tts/bootstrap-venv-helpers.test.ts`
+Expected: FAIL — `marker:delete` never recorded (the parameter is ignored).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `bootstrap-venv.mjs`, import the entry points and add the seam:
+
+```js
+import { planOrtSwap, applyOrtMarkerDelete, applyOrtMarkerWrite } from './install-ort.mjs';
+
+const REAL_MARKER = { del: applyOrtMarkerDelete, write: applyOrtMarkerWrite };
+```
+
+Change the signature and body:
+
+```js
+function installForProfile(venvPy, profile, runPip = defaultRunPip, platform = process.platform, venvDir = null, marker = REAL_MARKER) {
+  const plan = planOrtSwap(profile, platform);
+  // Delete FIRST: cpu.txt carries an explicit `onnxruntime` line, and the
+  // AMD->CPU fallback below installs it. A stale marker present at that moment
+  // makes pip skip the real install.
+  if (venvDir) marker.del(venvDir, plan);
+
+  /* …existing torch pre-install / overlay install / AMD fallback, unchanged… */
+
+  const ort = plan;
+  if (ort.action === 'swap') {
+    log(`swapping ONNX runtime → the ${profile} GPU build`);
+    for (const step of ort.steps) {
+      if (!runPip(step)) {
+        if (venvDir) marker.del(venvDir, ort);
+        throw new Error(`ONNX runtime swap failed (pip ${step.join(' ')}) for the ${profile} overlay`);
+      }
+    }
+    if (venvDir) marker.write(venvDir, ort);
+  }
+  return profile;
+}
+```
+
+Replace the existing `const ort = planOrtSwap(profile, platform);` line with the hoisted `plan` above — one plan, computed once, used by both halves.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/tts/bootstrap-venv-helpers.test.ts`
+Expected: PASS — new tests plus all pre-existing ones.
+
+- [ ] **Step 5: Mutation-check**
+
+Move the entry `marker.del` to just before the swap block → the "before any overlay install" test must fail. Remove the failure-path `marker.del` → the swap-failure test must fail. Revert both.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/tts-sidecar/scripts/bootstrap-venv.mjs server/src/tts/bootstrap-venv-helpers.test.ts
+git commit -m "feat(side): apply the ORT marker from bootstrap-venv, delete-first ordering
+
+Refs #2192"
+```
+
+---
+
+### Task 8: Wire `upgrade/apply.ts` (with the injection seam it lacks)
+
+**Files:**
+- Modify: `server/src/upgrade/apply.ts`
+- Test: `server/src/upgrade/apply-ort-marker.test.ts`
+
+**Interfaces:**
+- Consumes: `applyOrtMarkerDelete`, `applyOrtMarkerWrite` (Task 5).
+- Produces: `createApplySteps` accepts an optional `deps` object `{ run?, markerDel?, markerWrite? }`. Default behaviour is unchanged.
+
+`pipInstall`'s real body has **zero** test coverage today — `apply.test.ts` replaces the whole
+member with a stub. Without this seam the apply half ships untested.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// server/src/upgrade/apply-ort-marker.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { createApplySteps } from './apply.js';
+
+function harness(profile: 'nvidia' | 'cpu') {
+  const calls: string[] = [];
+  process.env.ACCELERATOR = profile;
+  const deps = {
+    run: vi.fn(async (_py: string, args: string[]) => { calls.push(`pip ${args.join(' ')}`); }),
+    markerDel: vi.fn(() => { calls.push('marker:delete'); }),
+    markerWrite: vi.fn(() => { calls.push('marker:write'); }),
+  };
+  const steps = createApplySteps({ venvDir: '/venv', log: () => {} }, deps);
+  return { calls, steps, deps };
+}
+
+describe('pipInstall ORT marker wiring', () => {
+  it('deletes before the first pip call', async () => {
+    const h = harness('cpu');
+    await h.steps.pipInstall('/rel');
+    expect(h.calls[0]).toBe('marker:delete');
+  });
+
+  it('writes after the swap on nvidia', async () => {
+    const h = harness('nvidia');
+    await h.steps.pipInstall('/rel');
+    expect(h.calls[h.calls.length - 1]).toBe('marker:write');
+  });
+
+  it('never writes on cpu', async () => {
+    const h = harness('cpu');
+    await h.steps.pipInstall('/rel');
+    expect(h.calls).not.toContain('marker:write');
+  });
+
+  it('deletes and does not write when a swap step throws', async () => {
+    const h = harness('nvidia');
+    h.deps.run.mockImplementation(async (_py: string, args: string[]) => {
+      h.calls.push(`pip ${args.join(' ')}`);
+      if (args.includes('--force-reinstall')) throw new Error('boom');
+    });
+    await expect(h.steps.pipInstall('/rel')).rejects.toThrow('boom');
+    expect(h.calls.filter((c) => c === 'marker:delete')).toHaveLength(2);
+    expect(h.calls).not.toContain('marker:write');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/upgrade/apply-ort-marker.test.ts`
+Expected: FAIL — `createApplySteps` takes one argument; `deps` ignored.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+import { applyOrtMarkerDelete, applyOrtMarkerWrite } from '../../tts-sidecar/scripts/install-ort.mjs';
+
+export interface ApplyStepDeps {
+  run?: (py: string, args: string[], cwd: string) => Promise<void>;
+  markerDel?: (venvDir: string, plan: unknown) => void;
+  markerWrite?: (venvDir: string, plan: unknown) => void;
+}
+
+export function createApplySteps(opts: CreateApplyStepsOpts, deps: ApplyStepDeps = {}): ApplySteps {
+  const runFn = deps.run ?? run;
+  const markerDel = deps.markerDel ?? applyOrtMarkerDelete;
+  const markerWrite = deps.markerWrite ?? applyOrtMarkerWrite;
+  // …
+    pipInstall: async (releaseDir) => {
+      const profile = effectiveProfile();
+      const sidecar = join(releaseDir, 'server', 'tts-sidecar');
+      const plan = planOrtSwap(profile, process.platform);
+      markerDel(venvDir, plan);                       // BEFORE the first pip call
+
+      const torch = planTorchPreinstall(profile, process.platform);
+      if (torch.action === 'install') {
+        await runFn(venvPython, ['-m', 'pip', 'install', '--no-cache-dir', ...torch.wheels], releaseDir);
+      }
+      await runFn(venvPython, ['-m', 'pip', 'install', '-r', join(sidecar, 'requirements', overlayFileForProfile(profile))], releaseDir);
+
+      if (plan.action === 'swap') {
+        try {
+          for (const step of plan.steps) await runFn(venvPython, ['-m', 'pip', ...step], releaseDir);
+        } catch (err) {
+          markerDel(venvDir, plan);
+          throw err;
+        }
+        markerWrite(venvDir, plan);                   // LAST statement of pipInstall
+      }
+    },
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/upgrade/`
+Expected: PASS — new file plus the pre-existing `apply.test.ts`.
+
+- [ ] **Step 5: Mutation-check**
+
+Move `markerDel` to after the overlay install → the "deletes before the first pip call" test must fail. Remove the `catch` → the throw test must fail. Revert both.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/upgrade/apply.ts server/src/upgrade/apply-ort-marker.test.ts
+git commit -m "feat(server): apply the ORT marker on the upgrade path, with an injectable seam
+
+createApplySteps had no seam, so pipInstall's body was untested.
+
+Refs #2192"
+```
+
+---
+
+### Task 9: Wire the `install-ort.mjs` CLI and server boot
+
+**Files:**
+- Modify: `server/tts-sidecar/scripts/install-ort.mjs` (CLI block), `server/src/index.ts`, `server/src/diagnostics/venv.ts`
+- Test: `server/src/tts/ort-venv-resolver.test.ts`
+
+**Interfaces:**
+- Consumes: `ensureOrtMarker` (Task 6).
+- Produces: `resolveSidecarVenvDir(repoRoot: string): string` exported from `server/src/diagnostics/venv.ts`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// server/src/tts/ort-venv-resolver.test.ts
+import { describe, it, expect, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { resolveSidecarVenvDir, sidecarVenvPresent } from '../diagnostics/venv.js';
+
+const saved = process.env.SIDECAR_VENV_DIR;
+afterEach(() => {
+  if (saved === undefined) delete process.env.SIDECAR_VENV_DIR;
+  else process.env.SIDECAR_VENV_DIR = saved;
+});
+
+describe('resolveSidecarVenvDir', () => {
+  it('defaults to the in-repo venv', () => {
+    delete process.env.SIDECAR_VENV_DIR;
+    expect(resolveSidecarVenvDir('/repo')).toBe(join('/repo', 'server', 'tts-sidecar', '.venv'));
+  });
+
+  it('honours SIDECAR_VENV_DIR (the versioned-install override)', () => {
+    process.env.SIDECAR_VENV_DIR = '/opt/app/venv';
+    expect(resolveSidecarVenvDir('/repo')).toBe('/opt/app/venv');
+  });
+
+  it('sidecarVenvPresent still works after the extraction', () => {
+    delete process.env.SIDECAR_VENV_DIR;
+    expect(typeof sidecarVenvPresent('/nope')).toBe('boolean');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/tts/ort-venv-resolver.test.ts`
+Expected: FAIL — `resolveSidecarVenvDir` not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `server/src/diagnostics/venv.ts`:
+
+```ts
+export function resolveSidecarVenvDir(repoRoot: string): string {
+  return process.env.SIDECAR_VENV_DIR ?? join(repoRoot, 'server', 'tts-sidecar', '.venv');
+}
+
+export function sidecarVenvPresent(repoRoot: string): boolean {
+  const base = resolveSidecarVenvDir(repoRoot);
+  return existsSync(join(base, 'bin', 'python')) || existsSync(join(base, 'Scripts', 'python.exe'));
+}
+```
+
+In `server/src/index.ts`, inside `main()` and **before `app.listen`** (not inside its callback, which is downstream of an `enforceSingleSidecarOwner` that can `process.exit`):
+
+```ts
+import { ensureOrtMarker } from '../tts-sidecar/scripts/install-ort.mjs';
+import { resolveSidecarVenvDir } from './diagnostics/venv.js';
+
+// #2192 — record that onnxruntime-gpu provides `onnxruntime`, so no later pip
+// call clobbers the GPU runtime. Pure fs, never throws.
+ensureOrtMarker(resolveSidecarVenvDir(bootRepoRoot), (m) => console.log(m));
+```
+
+In `install-ort.mjs`'s CLI block, after the swap steps succeed and on the skip branch, so the hand-run invocation #2192's workaround publishes also maintains the marker:
+
+```js
+  const venvDir = join(dirname(python), '..');
+  if (plan.action === 'skip') {
+    process.stdout.write(`[install-ort] skip — ${plan.reason}.\n`);
+    applyOrtMarkerDelete(venvDir, plan);
+    process.exit(0);
+  }
+  // …after the step loop…
+  applyOrtMarkerWrite(venvDir, plan);
+```
+
+Note the skip branch currently returns **before** reading `argv[2]`; move the `python` read above it.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/tts/ort-venv-resolver.test.ts && npx vitest run src/diagnostics/`
+Expected: PASS, and `models-status` / `tts/venv-bootstrap` callers of `sidecarVenvPresent` unaffected.
+
+- [ ] **Step 5: Verify boot wiring by hand**
+
+Run: `cd server && npm run dev`
+Expected: server starts; on this dev box (healthy nvidia venv, no marker yet) the log shows
+`[ort-marker] recorded onnxruntime 1.27.0 as provided by onnxruntime-gpu.`
+Then confirm: `server/tts-sidecar/.venv/Scripts/python.exe -m pip check` → `No broken requirements found.`
+
+**This is the first end-to-end proof the fix works.** Stop and report if it does not appear.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/index.ts server/src/diagnostics/venv.ts server/tts-sidecar/scripts/install-ort.mjs server/src/tts/ort-venv-resolver.test.ts
+git commit -m "feat(server): ensure the ORT marker at boot and from the install-ort CLI
+
+Refs #2192"
+```
+
+---
+
+### Task 10: `install-whisper.mjs` — drop `-U`, add `-c`
+
+**Files:**
+- Modify: `server/tts-sidecar/scripts/install-whisper.mjs`
+- Test: `server/src/tts/install-whisper-steps.test.ts`
+
+**Interfaces:**
+- Produces: `whisperPipInstallArgs(constraintsPath: string): string[]`.
+
+Independent of the marker. `:96` runs `pip install -U faster-whisper` with no constraints
+against a package `base.txt:45` pins to `>=1.0,<2.0`; `-U` can walk it past its own pin, and
+where absent pip resolves to latest — a 2.x would install cleanly in violation.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// server/src/tts/install-whisper-steps.test.ts
+import { describe, it, expect } from 'vitest';
+import { whisperPipInstallArgs } from '../../tts-sidecar/scripts/install-whisper.mjs';
+
+describe('whisperPipInstallArgs', () => {
+  it('constrains the install and does NOT pass -U', () => {
+    const args = whisperPipInstallArgs('/tmp/constraints.txt');
+    expect(args).toEqual(['-m', 'pip', 'install', 'faster-whisper', '-c', '/tmp/constraints.txt']);
+    expect(args).not.toContain('-U');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/tts/install-whisper-steps.test.ts`
+Expected: FAIL — the module exports nothing, so the import fails.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `install-whisper.mjs`:
+
+```js
+import { writeSanitizedConstraintsFile } from './pip-constraints.mjs';
+
+/** Pip args for the faster-whisper install. No -U: base.txt pins
+ *  faster-whisper>=1.0,<2.0 and -U can walk it past that pin. */
+export function whisperPipInstallArgs(constraintsPath) {
+  return ['-m', 'pip', 'install', 'faster-whisper', '-c', constraintsPath];
+}
+```
+
+Replace the call site:
+
+```js
+  step('Installing faster-whisper (pinned via base.txt)...');
+  const constraints = writeSanitizedConstraintsFile(join(SIDECAR_DIR, 'requirements', 'base.txt'));
+  if (run(python, whisperPipInstallArgs(constraints), env) !== 0) {
+```
+
+Update the file header (`:12-13`) and the log line so they no longer claim "pulls ctranslate2 + av" — on a bootstrapped box this step is now a no-op.
+
+Guard the CLI so importing the module stays inert, matching `install-qwen3.mjs:434`:
+
+```js
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/tts/install-whisper-steps.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Mutation-check**
+
+Add `'-U'` back into the returned array → the test must fail. Revert.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/tts-sidecar/scripts/install-whisper.mjs server/src/tts/install-whisper-steps.test.ts
+git commit -m "fix(side): constrain the faster-whisper install and drop -U
+
+-U could walk faster-whisper past base.txt's >=1.0,<2.0 pin.
+
+Refs #2192"
+```
+
+---
+
+### Task 11: Widen the `windowsHide` guard without breaking it
+
+**Files:**
+- Modify: `server/src/spawn-windows-hide.test.ts`
+- Possibly modify: `server/tts-sidecar/scripts/ensure-python312.mjs`, `scripts/run-sidecar-tests.mjs`
+
+**Interfaces:** none.
+
+The guard's `EXTERNAL_FILES` is a hardcoded list. This change makes `install-ort.mjs` far more
+load-bearing, and moving spawns around a hardcoded list is how it goes vacuously green.
+**Keep the list as a floor and ADD a glob** — replacing it drops `launch.mjs` (repo root, and
+it contains no `pip` string at all).
+
+- [ ] **Step 1: Write the failing test**
+
+Extend the file so `EXTERNAL_FILES` becomes `[...EXTERNAL_FILES_FLOOR, ...pipSpawners()]`, where
+`pipSpawners()` globs `server/tts-sidecar/scripts/*.mjs` and `scripts/*.mjs` and keeps files
+whose **comment- and string-blanked** source matches `/-m['"]?\s*,?\s*['"]pip/`.
+
+- [ ] **Step 2: Run to see which files it newly selects**
+
+Run: `cd server && npx vitest run src/spawn-windows-hide.test.ts`
+Expected: FAIL, naming any newly-selected file that lacks `windowsHide`.
+
+- [ ] **Step 3: Fix the offenders**
+
+Add `windowsHide: true` to every spawn the guard now names. `scripts/run-sidecar-tests.mjs`
+(`:54`, `:70`) and `server/tts-sidecar/scripts/ensure-python312.mjs` (`:49`, `:65`, `:86`) are the
+expected candidates — fix them rather than excluding them; a hidden parent does not stop a
+grandchild popping a console on Windows, which is the rule the guard exists to enforce.
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `cd server && npx vitest run src/spawn-windows-hide.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Mutation-check the guard still bites**
+
+Temporarily delete `windowsHide: true` from `install-ort.mjs`'s pip spawn → the guard must
+fail, naming that file. Revert. **If it stays green, the glob is not selecting the file and
+the widening achieved nothing.**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/spawn-windows-hide.test.ts server/tts-sidecar/scripts/ensure-python312.mjs scripts/run-sidecar-tests.mjs
+git commit -m "test(server): widen the windowsHide guard to every pip spawner outside server/src
+
+Refs #2192"
+```
+
+---
+
+### Task 12: Docs, regression plan and release notes
+
+**Files:**
+- Create: `docs/features/282-ort-pip-consistency-marker.md` (from `docs/features/TEMPLATE.md`)
+- Modify: `docs/features/INDEX.md`, `docs/release-notes-next.md`, `RELEASE_NOTES.md`, `docs/testing/onbox-acceptance-register.md`, `docs/testing/onbox-acceptance-register-live-view.html`
+- Create: `docs/testing/ort-marker-onbox-acceptance.md`
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Write the regression plan**
+
+`docs/features/282-ort-pip-consistency-marker.md`, frontmatter `status: active`. Key files, the
+five venv states table, the invariants (identity = INSTALLER + empty RECORD; delete-first
+ordering; write gated on the plan), and the manual acceptance walkthrough.
+
+- [ ] **Step 2: Add the INDEX entry**
+
+Under the sidecar area in `docs/features/INDEX.md`.
+
+- [ ] **Step 3: Both release-notes documents**
+
+`docs/release-notes-next.md` — technical, PR-refed. `RELEASE_NOTES.md` — one brand-voice line
+in the in-progress version section, e.g. *"Installing Qwen3 or Whisper no longer disturbs your
+GPU speech runtime."*
+
+- [ ] **Step 4: On-box acceptance — all three surfaces**
+
+Add rows to `docs/testing/onbox-acceptance-register.md` for the six acceptance cases in the
+spec, create the run sheet, and hand-edit the live view. Then:
+
+```bash
+npm run check:onbox-register
+```
+
+Before publishing the live view, save the currently-live page locally and run
+`npm run check:onbox-register -- --against-published <file>`.
+
+- [ ] **Step 5: Verify**
+
+```bash
+npm run verify:fast:branch
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/ RELEASE_NOTES.md
+git commit -m "docs(docs): add plan 282, release notes and on-box rows for the ORT marker
+
+Refs #2192"
+```
+
+---
+
+## Self-review
+
+**Spec coverage.** Every §Components item maps to a task: marker primitives → 1–2, ownership
+→ 3, version + plan → 4, entry points → 5, self-heal → 6, `bootstrap-venv` → 7, `apply.ts`
+(with the seam) → 8, CLI + boot → 9, whisper → 10, guard → 11, docs → 12. The five venv states
+are each an assertion in Task 6. The delete-first ordering is asserted in Tasks 7 and 8.
+
+**Placeholders.** None — every code step carries real code, every test step real assertions.
+
+**Type consistency.** `applyOrtMarkerDelete`/`applyOrtMarkerWrite` are named identically in
+Tasks 5, 7, 8 and 9. `deleteOrtMarkerIfOurs` (not `deleteOrtMarker`) is used consistently from
+Task 2 onward. `sitePackagesDir` takes a **venv dir**, `readInstalledOrtVersion` /
+`detectOrtOwner` / `findPlainOrtDistInfos` take **site-packages** — Task 5 is the only place
+that converts between them.
+
+**Known gap, deliberate.** Task 9 Step 5 is the first end-to-end proof; Tasks 1–8 are unit-level
+only. That is intentional — the alternative is mutating a real venv in the unit suite.

--- a/docs/superpowers/specs/2026-08-07-qwen-ort-namespace-chokepoint-design.md
+++ b/docs/superpowers/specs/2026-08-07-qwen-ort-namespace-chokepoint-design.md
@@ -7,7 +7,7 @@ date: 2026-08-07
 
 Closes the design work behind **#2192**.
 
-> **Revision 5.** Four Premium adversarial rounds. Revisions 1–2 defended the symptom at
+> **Revision 6.** Five Premium adversarial rounds. Revisions 1–2 defended the symptom at
 > seven pip call sites and failed twice, with round 2 finding that round 1's fixes had
 > broken each other; revision 3 pivoted to attacking the root condition. **Round 3 cleared
 > the mechanism** — no runtime code reads onnxruntime distribution metadata, and no pip
@@ -163,27 +163,44 @@ this design. Deleting first costs nothing and removes the state entirely.
 
 ### Changed files
 
-**There are TWO call sites per consumer, not one.** A single `applyOrtMarker` call cannot
-express the ordering above; the verb is deliberately split so an implementer cannot collapse
-it back.
+**There are THREE call sites per consumer.** A single `applyOrtMarker` call cannot express
+the ordering; the verb is split so an implementer cannot collapse it back. The third is the
+failure path — the delete before re-throwing on a failed swap step, which in `apply.ts`
+needs a `try`/`catch` around the swap loop that does not exist today.
+
+**`writeOrtMarker` no-ops unless `plan.marker.action === 'write'`.** This is load-bearing
+and was missing: `planOrtSwap`'s skip variant returns **no `ortPackage`**
+(`install-ort.mjs:75-77`), so an ungated write on cpu/apple either (a) globs from
+`undefined`, resolves nothing, hits the fail-loudly rule and **breaks every CPU bootstrap**,
+or (b) writes a marker whose directory name is byte-identical to the *real* plain
+distribution and — per "overwrite a stale marker rather than skip it" — replaces that
+distribution's `RECORD` with an empty file and its `INSTALLER` with ours, making the real
+onnxruntime un-uninstallable and permanently "satisfied." The skip variant gains `marker`
+but still no `ortPackage`.
+
+**Anchors are expressed as positions relative to named code, not line numbers.** Line
+numbers in this spec have now drifted twice across review rounds — they are a second source
+of truth for something the code already defines, and the review that caught the second drift
+noted it was the same defect class as the first.
 
 | File | Change | Exact anchor |
 |---|---|---|
 | `install-ort.mjs` | `planOrtSwap` returns `marker`; add `SWAP_ORT_PACKAGES`, `readInstalledOrtVersion`, `writeOrtMarker`, `deleteOrtMarkerIfOurs`, `ensureOrtMarker` | — |
 | `install-ort.mjs` CLI block | Apply the same two calls, so the hand-run invocation #2192's workaround publishes also produces a marker | `:98-121` |
-| `bootstrap-venv.mjs` | `deleteOrtMarkerIfOurs` at `installForProfile`'s **function entry** — before the AMD torch pre-install *and* both overlay installs | before `:160` |
-| `bootstrap-venv.mjs` | `writeOrtMarker` after the swap steps succeed | after `:220` |
-| `upgrade/apply.ts` | `deleteOrtMarkerIfOurs` as `pipInstall`'s **first statement**, before the torch step | before `:257` |
-| `upgrade/apply.ts` | `writeOrtMarker` after the swap loop | after `:271` |
+| `bootstrap-venv.mjs` | `deleteOrtMarkerIfOurs` at `installForProfile`'s **function entry** — before the AMD torch pre-install, the AMD→CPU fallback, the nvidia torch pre-install, *and* both overlay installs | first statement of `installForProfile` |
+| `bootstrap-venv.mjs` | `writeOrtMarker` (gated) as the **last statement inside** the `if (ort.action === 'swap')` block, after the step loop | end of the swap block |
+| `upgrade/apply.ts` | `deleteOrtMarkerIfOurs` in `pipInstall`, **after** `profile`/`sidecar` are computed and **before** the torch pre-install | before the first `run(...)` in `pipInstall` |
+| `upgrade/apply.ts` | `writeOrtMarker` (gated) as the **last statement of `pipInstall`'s body** — *not* after the closing brace, which is `readReqHash` | end of `pipInstall` |
+| both consumers | `deleteOrtMarkerIfOurs` on the swap-failure path, before re-throwing | `catch` around the swap loop |
 | `upgrade/apply.ts` | **Add an injection seam to `createApplySteps`** — see §Testing; without it the apply half ships untested |
 | `index.ts` | `ensureOrtMarker` — the self-heal, below | in `main()`, before `app.listen` |
 | `install-whisper.mjs` | Drop `-U`, add `-c`; extract an exported arg builder | `:95-96`, header `:12-13` |
 | `spawn-windows-hide.test.ts` | Widen the guard, below | `:54-62` |
 
-`installForProfile` (`:148-154`) takes **positional** params and its `venvDir` defaults to
-`null` — four of its six existing call sites pass `null`. The marker path must therefore be
-derived from the venv python it already holds, not from `venvDir`, or the delete silently
-no-ops on those paths.
+`installForProfile` takes **positional** params and its `venvDir` defaults to `null`. Its
+one production caller (`runInstall`) does pass a real dir, so the null case is test-only —
+but the marker path is still derived from the venv python the function already holds rather
+than from `venvDir`, so a null can never make the delete silently no-op.
 
 ### The three venv states, and why dist-info presence cannot tell them apart
 
@@ -192,7 +209,9 @@ did: the already-clobbered box.
 
 | State | `onnxruntime_gpu-*.dist-info` | plain `onnxruntime-*.dist-info` | Files in the namespace |
 |---|---|---|---|
-| Healthy nvidia | present | absent | GPU |
+| Healthy nvidia (today) | present | absent | GPU |
+| Healthy nvidia (**after this ships**) | present | present (**ours**) | GPU |
+| **Interrupted swap** | absent | present (**ours**) | **none** |
 | Healthy cpu/amd/apple | absent | present (**real**) | CPU |
 | **Clobbered** | **present** | **present (real)** | **CPU** |
 
@@ -201,26 +220,57 @@ two collided (`install-ort.mjs:92-93` exists precisely because of this). **So di
 presence proves nothing about who owns the namespace**, and two predicates must be stated
 separately or an implementer will conflate them:
 
-- **Ownership** — decided from the namespace *contents*, not metadata: ask the venv
-  interpreter for `onnxruntime.__version__` and `get_available_providers()`. That
-  interpreter is already being spawned to resolve the posix `site-packages` layout, so this
-  costs nothing extra. `CUDAExecutionProvider` present ⟹ the GPU build owns it.
+- **Ownership** — read from a file the wheel ships:
+  `site-packages/onnxruntime/capi/build_and_package_info.py`, whose first line is
+  `package_name = 'onnxruntime-gpu'` (verified in the live venv). Plain text, no interpreter,
+  no DLL load, no CUDA. Fallback signal: `capi/onnxruntime_providers_cuda.dll`, present in
+  the GPU wheel and absent from the CPU one. **Absent or unreadable ⟹ not a swap build.**
+
+  **Do NOT probe via `import onnxruntime` + `get_available_providers()`.** `__version__` is
+  identical across builds, and a GPU install whose CUDA/cuDNN DLLs fail to load reports
+  `['AzureExecutionProvider','CPUExecutionProvider']` — so a provider probe reads a
+  correctly-installed GPU box as a CPU box and would delete a *correct* marker on every
+  boot, re-opening #2192 permanently. It would also memory-map
+  `onnxruntime_providers_shared.dll` — the exact file in #2192's `WinError 5` — on the
+  blocking path before `app.listen`.
 - **Marker identity** — a directory is ours **only** if its `INSTALLER` reads
   `castwright-ort-marker` **and** its `RECORD` is empty. Never by name: on cpu/amd/apple the
-  *real* plain distribution has a byte-identical directory name.
+  *real* plain distribution has a byte-identical directory name. **Every** glob match is
+  identity-tested, not the first: ours and a real plain distribution can coexist (Spike 2
+  proves pip leaves ours behind), and answering from the first match can report "no real
+  distribution" and then overwrite one.
 
 **`ensureOrtMarker` refuses to write when a real plain `onnxruntime-*.dist-info` exists.**
 That is the clobbered box, and writing a marker over it would stamp version 1.27.0 (read
 from the GPU dist) onto installed CPU 1.28.0 files, make `pip check` report clean, convince
 every future pip call the requirement is satisfied, and leave GPU Kokoro dead **with no path
 in this design that ever repairs it** — the delete branch is nvidia-excluded and the
-self-heal is write-only. That converts a loud, self-repairing bug into a permanent, silent
-one: exactly the failure class this design exists to close. A clobbered box takes the loud
-path instead — log what was found and name the command that fixes it.
+self-heal refuses. That converts a loud, self-repairing bug into a permanent, silent one:
+exactly the failure class this design exists to close. A clobbered box takes the loud path
+instead, and **the log must name the exact remedy**, not gesture at one — the only repair
+this design ships for that population is the hand-run CLI:
 
-**`ensureOrtMarker` may also delete**, but only a directory that passes the marker-identity
-test above, and only when ownership says plain CPU `onnxruntime` holds the namespace — i.e.
-the marker is provably lying. This closes the one hole in the `delete` branch's coverage: a
+```
+CASTWRIGHT_ACCELERATOR_PROFILE=<profile> node server/tts-sidecar/scripts/install-ort.mjs <venv-python>
+```
+
+Leaving that string unwritten would ship the entire remedy for the largest affected
+population as a TODO.
+
+**The interrupted-swap row has no other reaper.** The swap uninstalls both runtimes before
+reinstalling (`install-ort.mjs:92-93`), so a kill or power loss between the steps leaves a
+marker asserting a runtime that is not there. The in-consumer delete-before-rethrow cannot
+cover it — the process died — and `reqHash` is unchanged, so
+`bootstrap-venv.mjs:240-243` / `apply.ts:134` no-op forever. Without an explicit rule that
+lying marker is **permanent**: `pip check` green, `import onnxruntime` dead.
+
+**So the delete rule is stated by exclusion, not by naming CPU:** `ensureOrtMarker` deletes
+a *verified* marker whenever ownership is **not** a swap distribution — CPU files, no files
+at all, or an unreadable namespace. "Do nothing" is reserved for a genuinely inconclusive
+read, never for "nothing is installed."
+
+**`ensureOrtMarker` may therefore delete**, but only a directory that passes the
+marker-identity test above. This closes the one hole in the `delete` branch's coverage: a
 `noop` box (unchanged `reqHash`) runs neither `installForProfile` nor `pipInstall`
 (`bootstrap-venv.mjs:240-243`, `apply.ts:134`), so nothing else would ever reap a stale
 marker. It remains non-destructive by construction — it can only remove a file we wrote.
@@ -243,10 +293,19 @@ The rule is: `plan.ortPackage.replace(/[-_.]+/g, '_')`, then glob `<escaped>-*.d
 A unit assertion builds the glob from the literal `'onnxruntime-gpu'` and resolves a fixture
 directory, mutation-checked by removing the escape.
 
-**One list of swap distributions.** `ensureOrtMarker` takes no plan and no profile — it reads
-what is installed — so it cannot derive the swap-package set the way `readInstalledOrtVersion`
-does. `install-ort.mjs` exports `SWAP_ORT_PACKAGES` and both read it, so the
-`onnxruntime-directml` re-enable (`install-ort.mjs:9,21-23`) needs one edit, not two.
+**One list of swap distributions, derived not hand-maintained.** `ensureOrtMarker` takes no
+plan and no profile — it reads what is installed — so it needs the set of package names that
+count as "a swap distribution." That set is **derived** by mapping `installRecipe` over the
+four profiles and keeping every `ortPackage !== 'onnxruntime'`, exported from
+`install-ort.mjs` as `SWAP_ORT_PACKAGES`. A hand-typed constant would be a second source of
+truth for something `installRecipe` already determines — the exact drift
+`install-ort.mjs:66-70` warns about — and would silently miss the `onnxruntime-directml`
+re-enable.
+
+Note `readInstalledOrtVersion` globs from `plan.ortPackage` and does not need the list; the
+ownership check in §The three venv states does. State multiple-match behaviour explicitly:
+if more than one `<escaped>-*.dist-info` exists (a stale `onnxruntime_gpu-1.26.0` beside
+1.27.0), the read is **inconclusive** — fail the swap loudly rather than picking one.
 
 **On `null`, fail the swap loudly.** If the version cannot be read, the swap fails —
 `bootstrap-venv.mjs:217` already treats a swap failure as fatal ("better to fail the
@@ -288,12 +347,11 @@ venv states: write when a swap distribution owns the namespace and no plain
 CPU `onnxruntime` owns the namespace; **refuse and log loudly** when a real plain
 distribution is present alongside a swap one (the clobbered box). Otherwise do nothing.
 
-**Placement:** in `main()`, **before `app.listen`** — not at `index.ts:309`, which is inside
-the `app.listen` callback (opens at `:207`) and downstream of `enforceSingleSidecarOwner`
-(`:292`), which can `process.exit` first. It must also never run before it can succeed: on a
-box with no venv, or a half-built one, it is a no-op — it must never create a `site-packages`
-tree, and the interpreter probe it uses for ownership must be a `windowsHide: true` spawn
-that no-ops on failure rather than throwing inside server startup.
+**Placement:** in `main()`, **before `app.listen`** — not inside the `app.listen` callback,
+which is downstream of an `enforceSingleSidecarOwner` that can `process.exit` first. On a box
+with no venv, or a half-built one, it is a no-op: it must never create a `site-packages`
+tree, and every read is wrapped so an unreadable venv logs and continues rather than throwing
+inside server startup.
 
 **This is safe in a way the repair killed in rounds 1–2 was not.** It uninstalls nothing,
 downloads nothing, needs no network, touches no locked DLL, and needs no accelerator
@@ -302,8 +360,10 @@ profile — it reads what is *installed*, not what *should* be. Every Critical f
 directory with three small files.
 
 It is no longer strictly "write-only" — it may delete a directory it can prove it wrote —
-but it still never uninstalls a package, never downloads, and never touches a locked DLL,
-which is where every Critical in rounds 1–2 lived.
+but it still never uninstalls a package, never downloads, and (with the file-based ownership
+oracle, not a provider probe) never imports onnxruntime or touches a locked DLL. That is
+where every Critical in rounds 1–2 lived. It is also pure fs, so it adds no subprocess to
+server startup.
 
 It runs at server boot rather than per-spawn, so it is unaffected by the adopt/unfit-replace
 branching that round 2 showed makes `spawnSidecar` placement treacherous.
@@ -526,3 +586,18 @@ written"** — three Criticals in the fixes themselves, plus five Majors. All fo
 **A stale marker on a `noop` box** (unchanged `reqHash`, so neither consumer runs) had no
 reaper — the `delete` branch's coverage hole. Closed by letting `ensureOrtMarker` delete a
 *verified* marker when ownership proves it is lying.
+
+Round 5 was scoped to round 4's three Criticals only. It returned **Critical 3 RESOLVED**,
+Criticals 1 and 2 **not**:
+
+| Finding | Disposition |
+|---|---|
+| `get_available_providers()` cannot distinguish a GPU build from a CPU one — `__version__` is identical, and a GPU install with unloadable CUDA DLLs reports CPU providers. The probe would delete a *correct* marker on every boot | Ownership moved to `capi/build_and_package_info.py`'s `package_name` (verified live), pure fs — which also removes the interpreter spawn and the locked-DLL import from server startup |
+| A **fifth** state: marker present, **no onnxruntime files at all** (interrupted swap). No consumer runs, `reqHash` unchanged, and the delete rule named CPU specifically — so the lying marker was permanent | Delete rule restated by exclusion: delete a verified marker whenever ownership is **not** a swap distribution |
+| `writeOrtMarker` was never gated on `plan.marker.action`, and the skip variant carries no `ortPackage` — so cpu/apple either fail every bootstrap or overwrite the **real** plain distribution's `RECORD`/`INSTALLER` | Write is gated; skip variant carries `marker` but not `ortPackage` |
+| `apply.ts`'s write anchor was off by two and landed inside `readReqHash` | **All line-number anchors replaced with positions relative to named code** — they had now drifted twice |
+| The failure-path delete contradicted "TWO call sites per consumer" | Three call sites, with the `apply.ts` `try`/`catch` named |
+| Identity answered from the first glob match could miss a real distribution | Every match is identity-tested |
+| `SWAP_ORT_PACKAGES` would be a hand-maintained second source of truth | Derived from `installRecipe` across the four profiles |
+| "Name the command that fixes it" never named it | Exact command string written out |
+| The `installForProfile` null-`venvDir` rationale was false (its one production caller passes a real dir) | Corrected; the prescription stands on its own grounds |

--- a/docs/superpowers/specs/2026-08-07-qwen-ort-namespace-chokepoint-design.md
+++ b/docs/superpowers/specs/2026-08-07-qwen-ort-namespace-chokepoint-design.md
@@ -7,15 +7,18 @@ date: 2026-08-07
 
 Closes the design work behind **#2192**.
 
-> **Revision 4.** Three Premium adversarial rounds. Revisions 1–2 defended the symptom at
+> **Revision 5.** Four Premium adversarial rounds. Revisions 1–2 defended the symptom at
 > seven pip call sites and failed twice, with round 2 finding that round 1's fixes had
 > broken each other; revision 3 pivoted to attacking the root condition. **Round 3 cleared
 > the mechanism** — no runtime code reads onnxruntime distribution metadata, and no pip
 > mode in this repo defeats a marker — but found the *wiring* wrong in two Critical ways:
 > `install-ort.mjs` is never executed as a CLI in production, so the marker would have
 > fired on zero paths; and the claim that existing boxes self-heal via upgrade was false.
-> This revision fixes the wiring and restores the write-only self-heal. §Review findings
-> records all three rounds.
+> Revision 4 fixed the wiring and restored the self-heal; **round 4 then returned "not safe
+> to implement from"** — three Criticals in those fixes, including a venv state no revision
+> had ever named (the already-clobbered box, which #2192 says is the largest population) and
+> a version glob that would have failed every NVIDIA bootstrap. **Revision 5** folds all of
+> them. §Review findings records all four rounds.
 
 ## Problem
 
@@ -59,7 +62,7 @@ Doors onto this bug — a door is a pip call whose target depends on `onnxruntim
 | `install-qwen3.mjs:399` | `pip install qwen-tts` | Yes |
 | `install-whisper.mjs:96` | `pip install -U faster-whisper` | Yes |
 | `upgrade/apply.ts:254-269` | overlay install **plus** `pip uninstall -y onnxruntime onnxruntime-gpu` | Yes |
-| `routes/venv-bootstrap.ts:38-41` → `bootstrap-venv.mjs` | overlay install + swap | Yes |
+| `routes/venv-bootstrap.ts:38-41` → `tts/venv-bootstrap.ts:183-195` → `bootstrap-venv.mjs` | overlay install + swap | Yes |
 | `pinokio-scripts/install.js:80`, `update.js:73` | `bootstrap-venv.mjs` | **No** |
 
 The last two run with no server process at all, so no server-side chokepoint, quiesce, or
@@ -160,14 +163,67 @@ this design. Deleting first costs nothing and removes the state entirely.
 
 ### Changed files
 
-| File | Change |
-|---|---|
-| `install-ort.mjs` | `planOrtSwap` returns `marker`; add `applyOrtMarker`, `readInstalledOrtVersion`, `writeOrtMarker`, `deleteOrtMarker` |
-| `bootstrap-venv.mjs` | Call `applyOrtMarker` after the swap block, outside the gate. Needs its own injectable seam — `installForProfile` already injects `runPip` (`:151`), and an un-injected fs write there is untestable at that layer |
-| `upgrade/apply.ts` | Same call in `pipInstall`, outside the gate |
-| `index.ts` (server boot) | `ensureOrtMarker` — the write-only self-heal, below |
-| `install-whisper.mjs` | Drop `-U`, add `-c`; extract an exported arg builder |
-| `spawn-windows-hide.test.ts` | Widen the guard, below |
+**There are TWO call sites per consumer, not one.** A single `applyOrtMarker` call cannot
+express the ordering above; the verb is deliberately split so an implementer cannot collapse
+it back.
+
+| File | Change | Exact anchor |
+|---|---|---|
+| `install-ort.mjs` | `planOrtSwap` returns `marker`; add `SWAP_ORT_PACKAGES`, `readInstalledOrtVersion`, `writeOrtMarker`, `deleteOrtMarkerIfOurs`, `ensureOrtMarker` | — |
+| `install-ort.mjs` CLI block | Apply the same two calls, so the hand-run invocation #2192's workaround publishes also produces a marker | `:98-121` |
+| `bootstrap-venv.mjs` | `deleteOrtMarkerIfOurs` at `installForProfile`'s **function entry** — before the AMD torch pre-install *and* both overlay installs | before `:160` |
+| `bootstrap-venv.mjs` | `writeOrtMarker` after the swap steps succeed | after `:220` |
+| `upgrade/apply.ts` | `deleteOrtMarkerIfOurs` as `pipInstall`'s **first statement**, before the torch step | before `:257` |
+| `upgrade/apply.ts` | `writeOrtMarker` after the swap loop | after `:271` |
+| `upgrade/apply.ts` | **Add an injection seam to `createApplySteps`** — see §Testing; without it the apply half ships untested |
+| `index.ts` | `ensureOrtMarker` — the self-heal, below | in `main()`, before `app.listen` |
+| `install-whisper.mjs` | Drop `-U`, add `-c`; extract an exported arg builder | `:95-96`, header `:12-13` |
+| `spawn-windows-hide.test.ts` | Widen the guard, below | `:54-62` |
+
+`installForProfile` (`:148-154`) takes **positional** params and its `venvDir` defaults to
+`null` — four of its six existing call sites pass `null`. The marker path must therefore be
+derived from the venv python it already holds, not from `venvDir`, or the delete silently
+no-ops on those paths.
+
+### The three venv states, and why dist-info presence cannot tell them apart
+
+The design must name the state the issue says is **most common**, which revisions 3–4 never
+did: the already-clobbered box.
+
+| State | `onnxruntime_gpu-*.dist-info` | plain `onnxruntime-*.dist-info` | Files in the namespace |
+|---|---|---|---|
+| Healthy nvidia | present | absent | GPU |
+| Healthy cpu/amd/apple | absent | present (**real**) | CPU |
+| **Clobbered** | **present** | **present (real)** | **CPU** |
+
+The GPU dist-info survives a clobber because pip uninstalls by *name* and never knew the
+two collided (`install-ort.mjs:92-93` exists precisely because of this). **So dist-info
+presence proves nothing about who owns the namespace**, and two predicates must be stated
+separately or an implementer will conflate them:
+
+- **Ownership** — decided from the namespace *contents*, not metadata: ask the venv
+  interpreter for `onnxruntime.__version__` and `get_available_providers()`. That
+  interpreter is already being spawned to resolve the posix `site-packages` layout, so this
+  costs nothing extra. `CUDAExecutionProvider` present ⟹ the GPU build owns it.
+- **Marker identity** — a directory is ours **only** if its `INSTALLER` reads
+  `castwright-ort-marker` **and** its `RECORD` is empty. Never by name: on cpu/amd/apple the
+  *real* plain distribution has a byte-identical directory name.
+
+**`ensureOrtMarker` refuses to write when a real plain `onnxruntime-*.dist-info` exists.**
+That is the clobbered box, and writing a marker over it would stamp version 1.27.0 (read
+from the GPU dist) onto installed CPU 1.28.0 files, make `pip check` report clean, convince
+every future pip call the requirement is satisfied, and leave GPU Kokoro dead **with no path
+in this design that ever repairs it** — the delete branch is nvidia-excluded and the
+self-heal is write-only. That converts a loud, self-repairing bug into a permanent, silent
+one: exactly the failure class this design exists to close. A clobbered box takes the loud
+path instead — log what was found and name the command that fixes it.
+
+**`ensureOrtMarker` may also delete**, but only a directory that passes the marker-identity
+test above, and only when ownership says plain CPU `onnxruntime` holds the namespace — i.e.
+the marker is provably lying. This closes the one hole in the `delete` branch's coverage: a
+`noop` box (unchanged `reqHash`) runs neither `installForProfile` nor `pipInstall`
+(`bootstrap-venv.mjs:240-243`, `apply.ts:134`), so nothing else would ever reap a stale
+marker. It remains non-destructive by construction — it can only remove a file we wrote.
 
 **Version derivation.** Read from the dist-info the swap just installed, globbed from
 `plan.ortPackage` — **not** hardcoded, and **not** hardcoded to `onnxruntime_gpu-*` either:
@@ -176,6 +232,21 @@ this design. Deleting first costs nothing and removes the state entirely.
 `onnxruntime_gpu-*` dist. A hardcoded version silently starts lying the first time the pin
 is bumped, and `faster-whisper`'s `onnxruntime<2,>=1.14` bound means a sufficiently wrong
 version makes pip resolve *against* us.
+
+**The glob must escape the package name, or every NVIDIA bootstrap fails.** `plan.ortPackage`
+is the literal string `onnxruntime-gpu`; pip escapes distribution names per PEP 427
+(`re.sub(r"[-_.]+", "_", name)`), so the directory on disk is
+`onnxruntime_gpu-1.27.0.dist-info` — verified in the live venv. A naive
+`` `${plan.ortPackage}-*.dist-info` `` matches **zero** directories, returns `null`, and the
+fail-loudly rule below then escalates that into a failed bootstrap **on every NVIDIA box**.
+The rule is: `plan.ortPackage.replace(/[-_.]+/g, '_')`, then glob `<escaped>-*.dist-info`.
+A unit assertion builds the glob from the literal `'onnxruntime-gpu'` and resolves a fixture
+directory, mutation-checked by removing the escape.
+
+**One list of swap distributions.** `ensureOrtMarker` takes no plan and no profile — it reads
+what is installed — so it cannot derive the swap-package set the way `readInstalledOrtVersion`
+does. `install-ort.mjs` exports `SWAP_ORT_PACKAGES` and both read it, so the
+`onnxruntime-directml` re-enable (`install-ort.mjs:9,21-23`) needs one edit, not two.
 
 **On `null`, fail the swap loudly.** If the version cannot be read, the swap fails —
 `bootstrap-venv.mjs:217` already treats a swap failure as fatal ("better to fail the
@@ -211,15 +282,28 @@ required.reqHash`) gate on the requirements hash, and **this change touches no
 `requirements/*.txt`** — so nothing re-runs the swap and no existing box would ever get a
 marker.
 
-`ensureOrtMarker(venvDir)` runs once at server boot, before the supervisor starts
-(`index.ts:309`): if the namespace is owned by a swap distribution and no marker is
-present, write one. Otherwise do nothing.
+`ensureOrtMarker(venvDir)` runs once at server boot, using the two predicates in §The three
+venv states: write when a swap distribution owns the namespace and no plain
+`onnxruntime-*.dist-info` exists at all; delete when a *verified* marker is present but plain
+CPU `onnxruntime` owns the namespace; **refuse and log loudly** when a real plain
+distribution is present alongside a swap one (the clobbered box). Otherwise do nothing.
+
+**Placement:** in `main()`, **before `app.listen`** — not at `index.ts:309`, which is inside
+the `app.listen` callback (opens at `:207`) and downstream of `enforceSingleSidecarOwner`
+(`:292`), which can `process.exit` first. It must also never run before it can succeed: on a
+box with no venv, or a half-built one, it is a no-op — it must never create a `site-packages`
+tree, and the interpreter probe it uses for ownership must be a `windowsHide: true` spawn
+that no-ops on failure rather than throwing inside server startup.
 
 **This is safe in a way the repair killed in rounds 1–2 was not.** It uninstalls nothing,
 downloads nothing, needs no network, touches no locked DLL, and needs no accelerator
 profile — it reads what is *installed*, not what *should* be. Every Critical from rounds
 1–2 lived in a destructive repair whose mechanism no longer exists here. Worst case is a
 directory with three small files.
+
+It is no longer strictly "write-only" — it may delete a directory it can prove it wrote —
+but it still never uninstalls a package, never downloads, and never touches a locked DLL,
+which is where every Critical in rounds 1–2 lived.
 
 It runs at server boot rather than per-spawn, so it is unaffected by the adopt/unfit-replace
 branching that round 2 showed makes `spawnSidecar` placement treacherous.
@@ -248,18 +332,52 @@ Its `EXTERNAL_FILES` array (`:54-62`) enforces `windowsHide` on prod-reachable p
 outside `server/src` via a **hardcoded list** that names three installers. It omits
 `install-ort.mjs` (`:113`), `bootstrap-venv.mjs` (`:104`), and `install-torch.mjs` (`:59`,
 prod-reachable on the AMD path via `installForProfile`). Adding names keeps the list and the
-stated rule out of step. **Replace the enumeration with a glob** over
-`server/tts-sidecar/scripts/*.mjs` + `scripts/*.mjs`, selecting files that spawn pip.
+stated rule out of step.
+
+**Keep `EXTERNAL_FILES` as a floor and ADD a glob on top — do not replace it.** Replacing it
+loses coverage and lands red at the same time:
+
+- `launch.mjs` sits at the **repo root**, matching neither glob, and contains **zero**
+  occurrences of `pip` (verified) — as do all four current entries. A "spawns pip" filter
+  drops every one of them, including the versioned-dir launcher the test's own header
+  (`:22-24`) names as its motivating case.
+- `scripts/run-sidecar-tests.mjs` contains the string `pip` in help text and has **two
+  `spawnSync` calls with no `windowsHide`** (`:54`, `:70`). A naive
+  `readFileSync(f).includes('pip')` selector picks it up and the guard fails on landing.
+
+So: floor + glob over `server/tts-sidecar/scripts/*.mjs` and `scripts/*.mjs`, with the
+selector defined as *matches `-m['"]?\s*,?\s*['"]pip` in the source **after** the file's own
+`blankCommentsAndStrings` pass* — the helper the test already has. `ensure-python312.mjs`
+carries three unguarded spawns (`:49`, `:65`, `:86`) and no `pip` string: decide it
+explicitly in the PR — fix it or exclude it with a stated reason — rather than letting the
+selector decide by accident.
 
 ## Testing
 
 ### The test that would have caught round 3's Critical
 
-At the seam where the marker is actually applied — `installForProfile` and `pipInstall` —
-with the fs writer injected alongside the existing `runPip`: assert the marker action is
-**emitted** for nvidia and the delete for cpu/amd/apple. Revision 3's plan tested only
-isolated planners and writers, so it would have been fully green while the shipped change
-did nothing.
+At the seam where the marker is actually applied, asserting the action is **emitted** — and
+in the right order. Revision 3's plan tested only isolated planners and writers, so it would
+have been fully green while the shipped change did nothing.
+
+**The two consumers are not symmetric, and only one has a seam today.**
+
+- `installForProfile` (`bootstrap-venv.mjs:148-154`) already injects `runPip`, and
+  `bootstrap-venv-helpers.test.ts:44` drives it. Add the fs writer the same way.
+- `pipInstall` has **no seam**. It is a member of the injected `ApplySteps` interface
+  (`apply.ts:49`), and `apply.test.ts:29` replaces it wholesale with
+  `vi.fn(async () => {})`; the real body lives in `createApplySteps` (`:254-272`), calls a
+  module-private `run()` around real `spawn`, and has **zero** test coverage today. A test
+  written at the `applyUpgrade` level would be green while the real `pipInstall` did
+  nothing — round 3's Critical, recurring.
+
+  **So `createApplySteps` gains a `run`/`writeMarker` injection point**, listed in §Changed
+  files. If that is rejected as too invasive, the spec must instead say plainly that the
+  apply half is covered only by on-box acceptance — but it may not claim a seam test that
+  cannot be written.
+
+Ordering is asserted, not just presence: a test that only checks "delete was called" passes
+under the broken after-the-swap-block ordering.
 
 ### Regression (fail before, pass after)
 
@@ -276,7 +394,19 @@ did nothing.
   test that `null` **aborts the swap** rather than skipping the write.
 - `writeOrtMarker` overwrites a stale marker rather than skipping it — Spike 2 proved pip
   leaves stale markers behind, so create-if-missing would preserve a lie.
-- `deleteOrtMarker` is a no-op when absent and removes only the marker directory.
+- `deleteOrtMarkerIfOurs` is a no-op when absent, and **refuses to delete a directory whose
+  `INSTALLER` is not `castwright-ort-marker` or whose `RECORD` is non-empty** —
+  mutation-checked against a fixture of the *real* plain distribution, which a name-only
+  matcher would delete. That failure is concrete: cpu profile, `pip-in-place` re-run, box
+  offline → delete-at-entry removes the real `onnxruntime-1.28.0.dist-info`, then the
+  overlay install fails and throws (`bootstrap-venv.mjs:206`), leaving working files with
+  destroyed metadata from a run that today changes nothing.
+- **Swap-failure path:** the marker is deleted before re-throwing on any failed swap step,
+  in both consumers. Without it: marker present → the overlay install skips plain
+  `onnxruntime` (Spike 1) → swap step 1 uninstalls the real GPU build → step 2 fails → the
+  venv has *no* onnxruntime, a marker asserting it does, `pip check` green, and the
+  sidecar's `import onnxruntime` dead. Today that same failure self-repairs on the next pip
+  call. Asserted as "delete emitted on the throw path."
 - **Ordering**: on a non-swapping profile the delete is emitted **before** the overlay
   install, not after — asserted at the seam, with the AMD→CPU fallback as the case. A test
   that only checks "delete was called" passes under the broken ordering.
@@ -305,8 +435,13 @@ Every assertion is mutation-checked on its own line.
    round 3 proved nothing else covers.
 4. **Pinokio update path** — `pinokio-scripts/update.js` on a real Pinokio install, the
    deployment shape that reported the bug.
-5. **AMD box** — no marker is written, and one left over from a prior nvidia profile is
-   deleted.
+5. **AMD box** — no marker is written. (A leftover from a *prior nvidia profile* is not
+   reachable: a profile change returns `rebuild` → `needs-reinstall`, which exits without
+   touching the venv. The live case is the AMD→ROCm-failure→CPU fallback inside a single
+   `installForProfile` call, which is what the delete-at-entry ordering exists for.)
+6. **Clobbered box** — a venv with both dist-infos and CPU files in the namespace takes the
+   loud path on boot: no marker written, the condition logged, the fix named. This is the
+   population #2192 says is largest, and the state a wrong predicate would entomb.
 
 Register row, run sheet, and live view all move in the shipping PR per checklist step 3.
 
@@ -369,3 +504,25 @@ no pip mode defeats a marker; the `install-whisper` fix is safe) and found the w
 | Widened `windowsHide` rule still omits `install-torch.mjs` | Minor | Glob instead of enumeration |
 | `install-coqui.mjs` rows were padding — none of those packages needs `onnxruntime` | Minor | Removed from the doors table |
 | The "actionable message" half of the acceptance criterion is not delivered | Minor | Stated explicitly in §What this does not deliver |
+
+Round 4 attacked revision 4's wiring and returned **"not safe to implement from as
+written"** — three Criticals in the fixes themselves, plus five Majors. All folded here:
+
+| Finding | Severity | Disposition |
+|---|---|---|
+| The already-clobbered state (both dist-infos, CPU files) was never named; one reading of `ensureOrtMarker` writes a marker over the real CPU dist and entombs the bug permanently | Critical | §The three venv states added; ownership and marker-identity predicates specified separately; refuse-and-log on a clobbered box |
+| §Changed files said "after the swap block" while the prose two paragraphs above called that fatal | Critical | Table replaced with two named entry points and exact anchors |
+| The version glob uses `plan.ortPackage` verbatim; pip escapes to `onnxruntime_gpu-*`, so it resolves to nothing → `null` → fail-loudly → **every NVIDIA bootstrap fails** | Critical | PEP-427 escaping stated in §Version derivation, with a mutation-checked assertion |
+| Swap-failure path leaves a marker asserting a runtime that was just uninstalled | Major | Delete before re-throwing, in both consumers |
+| `createApplySteps` has no injection point; the apply half would ship untested | Major | Injection point added to §Changed files |
+| `deleteOrtMarker` could not tell the marker from the real plain distribution | Major | Identity check on `INSTALLER` + empty `RECORD`, mutation-checked against a real-dist fixture |
+| The widened `windowsHide` glob drops `launch.mjs` and lands red on `run-sidecar-tests.mjs` | Major | Floor + glob; selector defined against blanked source; `ensure-python312.mjs` decided explicitly |
+| `ensureOrtMarker` had no way to derive the swap-package set | Major | `SWAP_ORT_PACKAGES` exported from `install-ort.mjs` |
+| `index.ts:309` is inside the `app.listen` callback, downstream of a `process.exit` | Minor | Moved into `main()` before `app.listen`; no-venv behaviour specified |
+| The hand-run CLI (#2192's published workaround) produced no marker | Minor | CLI block wired |
+| Acceptance criterion 5 was unreachable | Minor | Rewritten; clobbered-box row added |
+| `venv-bootstrap` citation drift | Minor | Corrected |
+
+**A stale marker on a `noop` box** (unchanged `reqHash`, so neither consumer runs) had no
+reaper — the `delete` branch's coverage hole. Closed by letting `ensureOrtMarker` delete a
+*verified* marker when ownership proves it is lying.

--- a/docs/superpowers/specs/2026-08-07-qwen-ort-namespace-chokepoint-design.md
+++ b/docs/superpowers/specs/2026-08-07-qwen-ort-namespace-chokepoint-design.md
@@ -3,19 +3,23 @@ status: draft
 date: 2026-08-07
 ---
 
-# The onnxruntime namespace chokepoint: one guarded pip path into the sidecar venv
+# Make the sidecar venv pip-consistent: one marker, at one site
 
 Closes the design work behind **#2192**.
 
-> **Revision 2.** Revision 1 went through the mandatory adversarial review gate and did
-> not survive it. The gate found a **Critical defect in the fix itself**: revision 1's
-> boot-time self-heal would have silently converted healthy GPU boxes to CPU Kokoro —
-> the exact bug this spec exists to fix, fired on every boot, on machines that never had
-> the bug. It also found two more pip doors into the venv that revision 1 did not model,
-> a `--no-deps` rule justified by false reasoning, a placement citation that would have
-> run `pip uninstall` during the unit suite, and a guard that would have gone vacuously
-> green. Every finding was re-verified against the tree before folding. §Review findings
-> records the round in full.
+> **Revision 3 — architecture change.** Revisions 1 and 2 defended the symptom at every
+> pip call site. Both failed the adversarial review gate with Criticals, and round 2's
+> findings were largely round 1's *fixes* breaking: a repair rule that could no longer fire
+> on the states it existed to heal, a quiesce primitive that silently no-ops on an adopted
+> sidecar, a prefetch that still needed the network after uninstalling. The design had
+> grown to four layers over seven call sites and still could not reach the three
+> out-of-process Pinokio paths.
+>
+> This revision attacks the root condition instead, and was **empirically validated before
+> being written** — see §The spike. It replaces the chokepoint, the quiesce layer, the
+> boot-time repair, `--no-deps`, and `overlayDeclares` with a marker written at one site.
+> §Review findings records what both rounds found and which findings the pivot dissolves
+> rather than fixes.
 
 ## Problem
 
@@ -24,22 +28,20 @@ An alpha tester on a Pinokio install could not install Qwen3:
 ```
 install-qwen3.mjs exited with code 1. ERROR: Could not install packages due to an
 OSError: [WinError 5] Accès refusé:
-'E:\pinokio\api\Castwright.git\server\tts-sidecar\.venv\Lib\site-packages\onnxruntime\capi\onnxruntime_providers_shared.dll'
-Check the permissions.
+'…\server\tts-sidecar\.venv\Lib\site-packages\onnxruntime\capi\onnxruntime_providers_shared.dll'
 ```
 
-It is not a permissions problem. `WinError 5` on a `.dll` is Windows reporting a
-memory-mapped file held by a live process.
+`WinError 5` on a `.dll` is Windows reporting a memory-mapped file held by a live process.
 
-### The structural condition
+### The root condition
 
-`install-ort.mjs` deliberately replaces plain `onnxruntime` with `onnxruntime-gpu` on GPU
-profiles — they share the `site-packages/onnxruntime/` namespace directory and cannot
-co-exist. pip matches distributions by **name**, so `onnxruntime-gpu` never satisfies a
-requirement spelled `onnxruntime`.
+`install-ort.mjs` replaces plain `onnxruntime` with `onnxruntime-gpu` on GPU profiles —
+they share the `site-packages/onnxruntime/` namespace and cannot co-exist. **pip matches
+distributions by name**, so `onnxruntime-gpu` never satisfies a requirement spelled
+`onnxruntime`.
 
-Three installed distributions require plain `onnxruntime` unconditionally. `pip check` on
-a **correctly bootstrapped** NVIDIA box therefore reports (verified live, pip 25.0.1):
+Three installed distributions require plain `onnxruntime` unconditionally, so `pip check`
+on a **correctly bootstrapped** NVIDIA box reports (verified, pip 25.0.1) — and exits 1:
 
 ```
 faster-whisper 1.2.1 requires onnxruntime, which is not installed.
@@ -47,353 +49,268 @@ kokoro-onnx 0.5.0 requires onnxruntime, which is not installed.
 qwen-tts 0.1.1 requires onnxruntime, which is not installed.
 ```
 
-…and **exits 1**. (`transformers` also lists `onnxruntime`, but only behind the `onnx` /
-`onnxruntime` / `dev-*` extras, so it never participates in resolution.)
+**The venv is permanently in a state pip considers broken.** Any pip call whose target
+depends on `onnxruntime` tries to repair it by installing the CPU build — which either
+crashes on the sidecar's DLL lock (`main.py:9174`'s `_run_device_probe` runs
+`import onnxruntime` on every boot, wired at `main.py:668`) or, with the sidecar stopped,
+silently replaces the GPU runtime. The latter is worse: no error, no log line, and it
+drives past `install-ort.mjs`'s deliberate `>=1.27,<1.28` pin.
 
-**The venv is permanently in a state pip considers broken, by design.** Any pip call whose
-target depends on `onnxruntime` will try to repair it by installing the CPU build.
+### Why per-site defence failed
 
-### The two failure modes
+At least seven pip sites reach this venv, across five entry points:
 
-Both follow from that one condition; which you get depends only on whether the sidecar is
-running.
+| Door | Runs | Server in the loop? |
+|---|---|---|
+| `install-qwen3.mjs:399` | `pip install qwen-tts` | Yes |
+| `install-whisper.mjs:96` | `pip install -U faster-whisper` | Yes |
+| `install-coqui.mjs` ×3 (`:149`, `:154`, `:158-172`) | opt-in Coqui + CJK phonemizers | Yes |
+| `upgrade/apply.ts:254-269` | overlay install **plus** `pip uninstall -y onnxruntime onnxruntime-gpu` | Yes |
+| `routes/venv-bootstrap.ts:38-41` → `bootstrap-venv.mjs` | overlay install + ORT swap | Yes |
+| `pinokio-scripts/install.js:80`, `update.js:73` | `bootstrap-venv.mjs` | **No** |
+| `pinokio-scripts/reset.js:13` | `fs.rm` on the venv, no stop step | **No** |
 
-**A — the reported crash.** The sidecar's `_run_device_probe()` (`main.py:9174`, wired into
-the startup handler sequence at `main.py:668`) runs `import onnxruntime` on **every boot**,
-unconditionally. That maps `onnxruntime_providers_shared.dll` and Windows holds the lock
-for the process lifetime. Nothing stops or unloads the sidecar before the installers run.
-
-**B — the silent clobber, which is worse.** With the sidecar stopped the same step succeeds
-and installs CPU `onnxruntime` over `onnxruntime-gpu`. Verified with `--dry-run` on a fully
-bootstrapped NVIDIA box:
-
-```
-Using cached onnxruntime-1.28.0-cp312-cp312-win_amd64.whl (13.8 MB)
-Would install onnxruntime-1.28.0
-```
-
-That is the 2026-06-16 silent-CPU-Kokoro regression re-entering through a different door,
-and it drives past `install-ort.mjs`'s deliberate `>=1.27,<1.28` pin. No error, no log line.
-
-### Four doors, not one
-
-`install-qwen3.mjs` is simply the first one someone walked through.
-
-| # | Door | What it runs | Sidecar live? |
-|---|---|---|---|
-| 1 | `install-qwen3.mjs:399` | `pip install qwen-tts -c base.txt` | Yes — in-app installer |
-| 2 | `install-whisper.mjs:96` | `pip install -U faster-whisper`, **no constraints** | Yes — in-app installer |
-| 3 | `upgrade/apply.ts:254-269` | overlay install **plus** `pip uninstall -y onnxruntime onnxruntime-gpu` | **Yes** — in-app self-upgrade |
-| 4 | `POST /api/setup/venv/bootstrap` | `bootstrap-venv.mjs` — same overlay install + ORT swap | **Yes** — "Rebuild the voice engine runtime" |
-
-Doors 3 and 4 are the severe pair: they run `pip uninstall` on the ORT namespace **from
-inside the running server, against a live sidecar**. The upgrade gate refuses only on
-in-flight generation/analysis (`upgrade/busy-probe.ts`), not on "the sidecar is running,"
-and its teardown happens *after* the pip run (`apply.ts:155`). Door 3 can therefore break
-TTS during a routine upgrade, which is arguably more severe than the reported bug.
-
-`install-ort.mjs:11` calls itself "the SINGLE enforcement point for GPU Kokoro." It is not
-one, and cannot be, while four other paths pip-install into the same venv behind its back —
-the same one-door-in-a-many-door-building shape recorded in the #2040 wave.
+The last three run with no server process at all, so no server-side chokepoint, quiesce, or
+boot-time repair can ever reach them — and the Pinokio update path is the exact deployment
+shape that reported this bug.
 
 ## Approach
 
-Four layers. The door table above determines which layer covers which door: doors 1–2 can
-be prevented outright, doors 3–4 genuinely need full dependency resolution and so must be
-made safe instead.
+Record, once, the thing that is already true: **`onnxruntime-gpu` provides the
+`onnxruntime` package** — same import name, same API, same version line. A minimal
+`onnxruntime-<version>.dist-info` marker alongside the GPU distribution makes pip agree,
+and pip then stops trying to "repair" the venv from every door simultaneously.
 
-| Layer | Mechanism | Covers |
+Today's state is arguably the dishonest one: the venv asserts a requirement is unmet that
+is in fact met.
+
+### The spike
+
+Validated empirically on a bootstrapped NVIDIA box before this revision was written.
+Marker created, every path dry-run (writes nothing), marker removed, baseline confirmed
+restored.
+
+| Path | Before | With the marker |
 |---|---|---|
-| 0. Quiesce | Venv-mutating operations stop the sidecar first, restart after; refuse with an actionable message if they can't | Doors 3–4 |
-| 1. Prevention | `--no-deps` where the active overlay installs the package | Doors 1–2 |
-| 2. Repair | One-directional, prefetch-first ORT invariant check before the sidecar spawns | Residual B, and already-broken boxes |
-| 3. Honesty | `pip check` parsed and filtered after each install | A dependency `--no-deps` genuinely skipped |
+| `pip install qwen-tts` | `Would install onnxruntime-1.28.0` | `already satisfied: onnxruntime … (1.27.0)` |
+| `pip install faster-whisper` | same clobber | `already satisfied: onnxruntime<2,>=1.14 … (1.27.0)` |
+| `pip install -r nvidia-cuda.txt` (upgrade / rebuild / Pinokio) | same clobber | `already satisfied` |
+| `pip check` | 3 errors, **exit 1** | `No broken requirements found.` **exit 0** |
 
-### Layer 0 — quiesce, and the acceptance criterion revision 1 dropped
+No `Would install onnxruntime` on any path. Every door closes at once, including the three
+out-of-process ones.
 
-Revision 1 silently dropped #2192's option 3 (manage the sidecar around the install) and
-with it the issue's own acceptance criterion: *"either succeed, or fail with an actionable
-message — never a raw `WinError 5`."* With doors 3–4 in scope that criterion is
-unreachable any other way, because those doors must resolve dependencies.
+### The second spike result, which shapes the design
 
-A shared helper wraps any venv-mutating operation: stop the sidecar, run the operation,
-restart it. If the sidecar cannot be stopped — a generation is in flight — the operation
-**refuses with an actionable message** rather than proceeding into a `WinError 5`. Any
-lock error that still escapes is translated at the chokepoint into that same actionable
-message, so a raw `WinError 5` never reaches the UI.
+Tested separately in a throwaway venv, because `install-ort.mjs`'s swap **begins** with
+`pip uninstall -y onnxruntime onnxruntime-gpu`:
 
-### Layer 1 — the rule, restated correctly
+```
+Found existing installation: onnxruntime 1.27.0
+Can't uninstall 'onnxruntime'. No files were found to uninstall.
+uninstall exit=0                     ← the swap's step 1 does not break
+```
 
-Revision 1 justified `--no-deps` as *"the package's dependencies are already declared in
-the requirements overlay."* **That reasoning is false.** `qwen-tts==0.1.1` declares nine
-requirements (`transformers`, `accelerate`, `gradio`, `librosa`, `torchaudio`, `soundfile`,
-`sox`, `onnxruntime`, `einops`); only `transformers` (`base.txt:50`) and `torchaudio`
-(`nvidia-cuda.txt:32`) appear in any overlay. The overlays declare the **package**, not its
-dependencies.
+…**and the marker directory survived.** An empty `RECORD` means pip finds nothing to
+remove and leaves the `.dist-info` in place.
 
-`--no-deps` works for a different reason: `bootstrap-venv.mjs:204` runs
-`pip install -r <overlay>` **with** full resolution, so the other seven arrive there. The
-correct rule follows from that, and carries a precondition revision 1 lacked:
+Two consequences, both load-bearing:
 
-> `--no-deps` is safe only where the **active profile's overlay installs this exact
-> package**, so the bootstrap already resolved its tree. The chokepoint **refuses
-> `--no-deps` when the target is absent from the active overlay.**
+1. **Removal must be explicit.** pip will never delete the marker, so this design owns
+   both writing *and* deleting it. A `rm -rf` of the directory is the only mechanism.
+2. **A stale marker suppresses a legitimate install.** With the marker present,
+   `pip install onnxruntime` reports "already satisfied" and installs nothing. That is
+   exactly what a profile migration from `nvidia` to `cpu` needs to do — the CPU profile
+   requires real plain `onnxruntime`. **So the marker must be deleted whenever the swap is
+   not in effect**, not merely written when it is. `planOrtSwap`'s existing `skip` branch
+   (cpu / amd / apple) becomes an active *delete-if-present*, not an early return.
 
-That precondition matters immediately: **`cpu.txt` has no `qwen-tts` line at all** (Qwen is
-GPU-only), yet `install-qwen3.mjs:67` still ships a `--cpu` flag that
-`qwen-install-bootstrap.ts:56` documents forwarding. Under revision 1's rule that path
-would install `qwen_tts` alone and then die at `from qwen_tts import Qwen3TTSModel`
-(`install-qwen3.mjs:419`) on a missing `einops`, reporting "Check network, disk space."
-Under the corrected rule it is a clean, explicit skip. The same precondition survives a
-future `qwen-tts` version bump that adds a dependency.
-
-### Layer 2 — one-directional and prefetch-first
-
-Revision 1's repair was **the most dangerous thing in the spec**. Two independent defects:
-
-**It could fire in the destructive direction.** `spawn-sidecar.ts:526-529` resolves the
-profile as `envOverride → venv stamp → detected`, with `detected` hardcoded `'cpu'`, and
-`resolveProfile` falls through to `'cpu'` when nothing matches
-(`accelerator-profile.mjs:59-64`). A correctly-installed NVIDIA box with a missing or
-unreadable stamp — fresh worktree, partial Pinokio reset, `SIDECAR_VENV_DIR` pointing
-elsewhere — resolves to `cpu`. Revision 1's rule ("delegate to
-`installRecipe(profile).ortPackage`") would then see `onnxruntime-gpu` owning the namespace
-against an expected plain `onnxruntime`, call it broken, and repair it *away*. Revision 1's
-unit matrix never listed that cell.
-
-**And the repair is not recoverable.** `planOrtSwap`'s step 1 is
-`['uninstall','-y','onnxruntime', ortPackage]` — it removes **both** runtimes before step 2
-downloads the replacement (`install-ort.mjs:92-93`). A failed step 2 (offline, empty pip
-cache, disk full) leaves the venv with **no onnxruntime at all**. Revision 1 moved that
-sequence from install-time onto every boot and justified it as "degraded, not broken,"
-which was simply untrue.
-
-Three corrections, all required:
-
-1. **One-directional.** Repair **only** when plain `onnxruntime` is present on a GPU
-   profile. **Never** remove `onnxruntime-gpu` because the profile reads `cpu`. The
-   destructive direction is not a case to handle carefully; it is a case that must not
-   exist.
-2. **Positive profile signal required.** `resolveProfile`'s `'cpu'` fallthrough is an
-   absence of information, not an assertion that the box is CPU. The repair no-ops with a
-   log line unless there is a present, parseable venv stamp or an explicit `ACCELERATOR`.
-3. **Prefetch-first.** `applyOrtSwap(python, plan, { prefetch })` — with `prefetch: true`
-   the replacement is `pip download --no-deps`ed to a temp dir first, and the uninstall
-   only happens once the wheel is on disk. A network failure then aborts having touched
-   nothing. This mirrors the download-verify-install shape `install-qwen3.mjs` already uses
-   for the FA2 wheel. `install-ort.mjs`'s own CLI keeps today's ordering (`prefetch: false`)
-   — it runs at install time with the user watching and the network obviously up, where a
-   loud failure is the correct outcome.
-
-**Placement.** Revision 1 said "`spawn-sidecar.ts` (~530), before the child spawn." Line 530
-is inside **`buildSidecarEnv`** (459–534), a sync, side-effect-free function that unit tests
-call directly with a real `repoRoot` (`sidecar-env.test.ts:38,47,58,72,85`) — a pip-spawning
-repair there would fire `pip uninstall` against the developer's venv during
-`npm run test:server`. The correct site is inside `spawnSidecar` (from 540), **after** the
-adopt/probe decision and only on the branch that actually spawns; the adopt branch returns
-early when a fit sidecar already holds the port, and repairing there would run
-`pip uninstall` against a live adopted sidecar — the original bug. The resolved profile is
-passed in rather than re-derived.
-
-**Anti-storm guard.** Keyed on the detected owner-set, not once-per-process. A
-once-per-process guard is spent by the boot-time no-op check and would never fire for the
-canonical sequence: boot (nothing to fix) → in-app install clobbers ORT → sidecar restarts
-(`routes/sidecar-health.ts:636`) → repair already spent.
-
-**Totality and budget.** `assertOrtInvariantBeforeSpawn` never throws — its caller is
-fire-and-forget (`index.ts:309` `void`s `sidecarSupervisor.start()`), so a rejection would
-surface as an unhandled rejection. The repair carries an explicit time budget; its worst
-case is a ~250 MB download between server start and the sidecar existing, during which TTS
-is unavailable.
-
-**Scope honesty.** Layer 2 runs pre-spawn, so it is structurally blind to a clobber that
-happens while the server is up — which is every one of the four doors. It heals the
-already-broken population at next launch; it is not, and must not be described as, the
-thing that keeps the invariant during a session. Layers 0 and 1 do that.
-
-### Layer 3 — parse, don't trust the exit code
-
-`pip check` **exits 1** in the expected state on every GPU box (verified). The runner must
-therefore parse stdout and ignore the exit code for the classification; treating non-zero
-as failure would report failure on every install on every GPU box. The trio above, and only
-on a GPU profile, is expected; anything else is reported.
+Missing consequence 2 would convert this fix into a new silent-breakage bug on profile
+migration — the same class it exists to close.
 
 ## Components
 
-### New: `server/tts-sidecar/scripts/sidecar-pip.mjs`
-
-Pure planners plus a thin runner, matching the `install-torch.mjs` / `install-ort.mjs`
-house pattern.
-
-| Export | Kind | Purpose |
-|---|---|---|
-| `sidecarPipInstallArgs(specs, { constraints, noDeps })` | pure | Build the pip argv |
-| `overlayDeclares(packageName, profile, platform)` | pure | The Layer-1 precondition |
-| `parsePipCheck(stdout)` | pure | → `{ dist, requirement }[]` |
-| `expectedOrtInconsistencies(profile)` | pure | The trio, **GPU profiles only** |
-| `unexpectedInconsistencies(output, profile)` | pure | The cry-wolf filter |
-| `translateVenvLockError(stderr)` | pure | `WinError 5` on a venv path → actionable message |
-| `runSidecarPip(python, specs, opts)` | I/O | install → re-assert ORT if deps resolved → parse `pip check` |
-
 ### Changed: `server/tts-sidecar/scripts/install-ort.mjs`
 
-Export `applyOrtSwap(python, plan, { prefetch })`, extracted from the CLI block
-(`:98-121`). This is **a signature change, not pure motion**: the existing block is built
-around `process.exit(code)` and `stdio:'inherit'`, so the extracted function needs a return
-value and injectable I/O to be callable from the server and testable. `planOrtSwap` is
-unchanged.
+The single site. Both branches of `planOrtSwap` gain a marker action:
 
-### New: `server/src/tts/ort-invariant.ts`
+| Branch | Profiles | Marker action |
+|---|---|---|
+| `swap` | nvidia | **Write** (overwrite) after the force-reinstall succeeds |
+| `skip` | cpu, amd, apple | **Delete if present** — plain `onnxruntime` is correct there |
+
+`installRecipe(profile, platform).ortPackage !== 'onnxruntime'` is the mechanical predicate
+for "this profile swaps." AMD and Apple both resolve to plain `onnxruntime`
+(`accelerator-profile.mjs:178,189`) and must therefore take the **delete** branch — a
+"GPU profile" shorthand would wrongly group AMD with NVIDIA.
+
+New exports, pure planner plus thin writer, matching the file's existing shape:
 
 | Export | Kind | Purpose |
 |---|---|---|
-| `detectOrtNamespaceOwner(sitePackages)` | fs read | Which distributions claim the namespace |
-| `planOrtRepair({ profileSignal, platform, owners })` | pure | `ok` / `repair` / `no-signal` |
-| `assertOrtInvariantBeforeSpawn(deps)` | I/O | Detect, repair, log. Never throws |
+| `planOrtMarker(profile, platform)` | pure | `{ action: 'write' \| 'delete' }` |
+| `readInstalledOrtVersion(sitePackages)` | fs read | Version from the installed `onnxruntime_gpu-*.dist-info` |
+| `writeOrtMarker(sitePackages, version)` | fs write | Create/overwrite the marker |
+| `deleteOrtMarker(sitePackages)` | fs write | Remove it if present |
 
-**The matcher is specified, not left to the implementer:** `/^onnxruntime-\d/` against the
-normalized dist-info name. pip 25.0.1 normalizes the GPU distribution to
-`onnxruntime_gpu-1.27.0.dist-info` with an **underscore** (verified in the live venv), so a
-naive `startsWith('onnxruntime')` matches it and would fire a destructive repair on every
-healthy GPU box, every boot.
+**The version is derived, never hardcoded** — read from the `onnxruntime_gpu-*.dist-info`
+that the swap just installed. A hardcoded version silently starts lying the first time the
+`>=1.27,<1.28` pin is bumped, and `faster-whisper`'s `onnxruntime<2,>=1.14` bound means a
+sufficiently wrong version would make pip resolve *against* us.
 
-**Detection also probes the namespace, not just the dist-infos.** `install-ort.mjs:86-90`
-documents a third state the dist-info rule alone cannot see: a *gutted namespace*, where a
-`pip uninstall onnxruntime` after a clobber strips shared files via the CPU build's RECORD,
-leaving `onnxruntime_gpu-*.dist-info` present over a hollow `onnxruntime/`. `import
-onnxruntime` breaks entirely and the dist-info rule returns `ok`. A cheap presence check on
-`capi/` and the provider DLLs covers it.
+**Marker contents** — minimal and self-identifying, so it is greppable and obviously ours:
 
-### New: `server/src/tts/venv-quiesce.ts` (Layer 0)
+```
+METADATA    Metadata-Version: 2.1 / Name: onnxruntime / Version: <derived>
+INSTALLER   castwright-ort-marker
+RECORD      (empty — nothing to uninstall; see §The spike)
+```
 
-Wraps a venv-mutating operation: stop the sidecar, run, restart. Refuses with an actionable
-message when the sidecar cannot be stopped. Consumed by doors 3 and 4.
+**Cosmetic note for the implementer:** with the marker present, the swap's step 1 prints
+`Can't uninstall 'onnxruntime'. No files were found to uninstall.` and exits 0. That is
+expected output, not an error, and should not be "fixed."
 
-### Call sites
+**Which `site-packages`.** The marker is written relative to the venv `install-ort.mjs` was
+handed (`process.argv[2]`, the venv python), derived from that interpreter — not from a
+second convention. This repo has two conflicting ones (`SIDECAR_VENV_DIR` vs a hardcoded
+`repoRoot/server/tts-sidecar/.venv`), and they differ on exactly the versioned-dir install
+that reported this bug.
 
-| File | Change |
-|---|---|
-| `install-qwen3.mjs:399` | Chokepoint, `noDeps: true` (guarded by `overlayDeclares`) |
-| `install-whisper.mjs:96` | Chokepoint, `noDeps: true`, **drop `-U`**, **add `-c <constraints>`** |
-| `install-coqui.mjs:149` | Chokepoint **with** deps — Coqui is opt-in, in no overlay |
-| `install-coqui.mjs:154` | Already `--no-deps`; route for uniformity |
-| `install-coqui.mjs` step 3 (`:158-172`) | The CJK-phonemizer/`spacy` step — the file's largest dep-resolving install |
-| `upgrade/apply.ts:254-269` | Chokepoint **and** Layer 0 quiesce |
-| `bootstrap-venv.mjs` `runPip` | Chokepoint **and** Layer 0 quiesce |
-| `spawn-sidecar.ts` (in `spawnSidecar`, post-adopt) | `assertOrtInvariantBeforeSpawn` |
+### Changed: `server/tts-sidecar/scripts/install-whisper.mjs`
 
-The whisper fix is `-U` removal **plus** `-c <constraints>`. Dropping `-U` alone leaves the
-unconstrained half intact: on a box where `faster-whisper` is absent, pip still resolves to
-latest, so a 2.x release would install cleanly in violation of `base.txt:45`'s
-`>=1.0,<2.0` — with `--no-deps` guaranteeing it arrives dependency-less. Every sibling
-installer already passes `-c` (`install-qwen3.mjs:100`, `install-coqui.mjs:149`).
+Independent of the marker, and a real defect: `:96` runs `pip install -U faster-whisper`
+with **no constraints file**, against a package `base.txt:45` pins to `>=1.0,<2.0`. `-U`
+can walk it past its own pin, and on a box where it is absent pip resolves to whatever is
+latest — a 2.x release would install cleanly in violation of the pin. Every sibling passes
+`-c` (`install-qwen3.mjs:100`, `install-coqui.mjs:149`).
 
-**Explicitly out of scope:** the FlashAttention-2 wheel path in `install-qwen3.mjs`. Opt-in,
-hash-pinned, already non-fatal on every path.
+Fix: **drop `-U`, add `-c <sanitized base.txt>`.** This clears the fix-now bar (one
+defensible answer, coverable by a test here) and is declared in the PR body as an
+incidental fix.
+
+The pip args are currently inline in an unexported `main()` — `install-whisper.mjs` exports
+nothing — so **extracting an exported arg builder** (mirroring `qwenPipInstallArgs` at
+`install-qwen3.mjs:99-101`) is part of the work, not a test detail. Without it the
+regression test fails on import rather than on its assertion: a red phase by accident.
+
+### Changed: `server/src/spawn-windows-hide.test.ts`
+
+Its `EXTERNAL_FILES` array (`:55-63`) is a **hardcoded list** enforcing `windowsHide` on
+prod-reachable pip spawners outside `server/src`. It names three installers but omits
+`install-ort.mjs` (spawns pip at `:113`) and `bootstrap-venv.mjs` (`:104`) — both satisfy
+the array's own stated rule verbatim. This design makes `install-ort.mjs` materially more
+load-bearing, so both are added and the rule restated as "any file outside `server/src`
+that spawns pip" rather than re-enumerating installers.
+
+### Detection, not repair — a deliberate change from the earlier decision
+
+The agreed direction was "detect and self-heal on boot." **This revision detects and
+reports, and does not repair.** The reasoning, stated so it can be overruled:
+
+- Every Critical in both review rounds lived in the boot-time repair — the profile signal
+  that reads absence as an assertion, the adopted sidecar that defeats the stop primitive,
+  the uninstall-before-download ordering, the placement that would have run `pip uninstall`
+  inside the unit suite.
+- With the marker in place, **nothing new becomes broken**, so a repair mechanism only ever
+  serves the historical population.
+- That population is already healed by any path that re-runs the swap — an in-app upgrade
+  (`apply.ts:254-269`) or a venv rebuild — both of which now also write the marker.
+- The core sin of this bug is *silence*. A loud, accurate diagnosis plus a one-command fix
+  removes the silence at a fraction of the risk of an automatic destructive repair.
+
+So: a read-only check reports when the namespace owner disagrees with the active profile,
+and names the command that fixes it. It never uninstalls anything.
 
 ## Testing
 
-### The regression test
+### Regression tests (fail before, pass after)
 
-`install-whisper.mjs` **exports nothing** — its pip args are inline in an unexported
-`main()`, so revision 1's proposed assertion would have failed on *import* rather than on
-the assertion: a red phase by accident. Extracting an exported arg builder (mirroring
-`qwenPipInstallArgs` at `install-qwen3.mjs:99-101`) is therefore **part of the work**, not
-a test detail.
-
-With that in place, both assertions genuinely fail on today's tree and pass after:
-
-- `install-qwen3`'s args contain `--no-deps`
-- `install-whisper`'s args contain `--no-deps` and `-c`, and **not** `-U`
-
-### The guard that would otherwise go vacuously green
-
-`server/src/spawn-windows-hide.test.ts:54-62` enforces `windowsHide` by scanning a
-**hardcoded** `EXTERNAL_FILES` list that names the three installer scripts. Moving the pip
-spawns into `sidecar-pip.mjs` removes them from every file the guard scans — **the guard
-keeps passing while the actual spawn site goes unchecked.** `sidecar-pip.mjs` must be added
-to that array in the same PR. This is the "a guard test isn't wired until its file list
-moves" failure this repo has already recorded twice.
+- `install-whisper`'s args contain `-c` and **not** `-U` — fails on today's tree.
+- `planOrtMarker` returns `delete` for `cpu`, `amd`, **and** `apple`, and `write` only for
+  `nvidia` — the AMD/Apple cells are the ones that would silently break profile migration.
 
 ### Unit
 
-- `sidecar-pip-helpers.test.ts` — argv shapes; `overlayDeclares` returning false for
-  `qwen-tts` on `cpu`; `parsePipCheck` against real captured output; the filter asserting
-  the trio is expected on `nvidia` but **not** on `cpu`, where those lines would be genuine;
-  `translateVenvLockError`.
-- `ort-invariant.test.ts` — the matcher against the real `onnxruntime_gpu-…` underscore
-  form; and a matrix that **must** include the two cells revision 1 omitted:
-  **`{onnxruntime-gpu}` on a `cpu` profile → `ok`, never `repair`**, and
-  **no profile signal → `no-signal`, never `repair`**. Plus the gutted-namespace state.
-- Prefetch ordering — a failed download leaves both distributions installed.
-- Spawn wiring — the check runs on the spawning branch only, never on adopt, never from
-  `buildSidecarEnv`; a failed repair does not block the spawn; the function never throws.
-- Layer 0 — refusal path returns the actionable message rather than proceeding.
+- `readInstalledOrtVersion` parses the real `onnxruntime_gpu-1.27.0.dist-info` shape and
+  returns `null` (not a hardcoded fallback) when absent, so a missing dist can never
+  produce a confidently-wrong marker.
+- `writeOrtMarker` overwrites an existing stale marker rather than skipping it — the
+  spike proved pip leaves stale markers behind, so create-if-missing would preserve a lie.
+- `deleteOrtMarker` is a no-op when absent and removes only the marker directory.
+- The marker matcher targets the **raw** `.dist-info` directory name, and is
+  mutation-checked against `onnxruntime-1.28.0.dist-info` **and**
+  `onnxruntime_gpu-1.27.0.dist-info` in one assertion — pip normalises the GPU
+  distribution with an **underscore** (verified in the live venv), so a matcher that
+  catches both would delete the real GPU distribution.
 
-Every assertion is mutation-checked on its own line. The `cpu`-profile and no-signal cells
-specifically must fail if the profile input is dropped — they exist to catch the defect that
-killed revision 1.
+Every assertion is mutation-checked on its own line.
 
 ### Not applicable, stated rather than silently skipped
 
 - **pytest** — no Python behaviour changes.
 - **e2e** — no router/redux/layout seam.
 
-### On-box acceptance (owed, cannot be discharged in the PR)
+### On-box acceptance (owed; recording it is the merge gate, running it is not)
 
-1. **Windows + NVIDIA, app running.** In-app Qwen3 install completes; `pip check` after
-   shows only the expected trio; Kokoro still reports `CUDAExecutionProvider`.
-2. **Self-heal.** Deliberately clobber ORT, restart the server, confirm the pre-spawn repair
-   fires, logs, and restores `onnxruntime-gpu` within its pin.
-3. **No-signal safety.** Remove the venv stamp on a healthy NVIDIA box, restart, and confirm
-   the repair **does not** fire.
-4. **Upgrade path.** Run an in-app upgrade with the sidecar live; confirm quiesce, no
-   `WinError 5`, and GPU Kokoro afterwards.
+1. **Fresh NVIDIA bootstrap** → marker present at the installed GPU version; `pip check`
+   clean, exit 0; Kokoro reports `CUDAExecutionProvider`.
+2. **The reported bug** — Windows + NVIDIA, **app running**, in-app Qwen3 install completes
+   with no `WinError 5`; GPU Kokoro afterwards.
+3. **Profile migration `nvidia` → `cpu`** — the marker is deleted and real plain
+   `onnxruntime` installs. This is the case the second spike result created; it is the
+   most likely way this design breaks.
+4. **Pinokio update path** — `pinokio-scripts/update.js` on a real Pinokio install, the
+   deployment shape that reported the bug.
 
 Register row, run sheet, and live view all move in the shipping PR per checklist step 3.
 
 ## Before-shipping coverage
 
-Revision 1 omitted these rather than stating them. Step 1/4: this is substantial,
-cross-cutting work and **owes a plan under `docs/features/` plus an `INDEX.md` entry**.
-Step 5: it is user-visible (installs stop failing; a boot-time repair begins running; the
-upgrade path changes), so **both release-notes documents move in the PR**.
+Steps 1/4: substantial and cross-cutting — **owes a plan under `docs/features/` and an
+`INDEX.md` entry**. Step 5: user-visible (installs stop failing; upgrades stop breaking
+GPU Kokoro), so **both release-notes documents move in the PR**.
 
 ## Risks
 
-- **A repair firing in the destructive direction** would delete a working GPU runtime.
-  Mitigated by making the repair one-directional by construction, requiring a positive
-  profile signal, and by the two dedicated unit cells. This is the highest-severity failure
-  the design can produce and it is what killed revision 1.
-- **A prefetch that succeeds followed by an install that fails** still leaves the venv
-  without a runtime. Narrower than revision 1's window but not zero; the pre-spawn check
-  retries next boot, and the gutted-namespace probe detects it.
-- **`--no-deps` masking a new dependency** if an overlay drifts from the package's real
-  requirements. Mitigated by `overlayDeclares` plus Layer 3.
-- **Two servers.** This repo has a documented two-stacks-on-`:9000` history, guarded by
-  `enforceSingleSidecarOwner` (`index.ts:291-292`) — which only fires when
-  `getResolvedAutoStartSidecar()` is true. A second server with autostart off could run its pre-spawn repair against the other
-  stack's live sidecar. "Nothing holds the lock at pre-spawn time" is a single-process
-  assumption; the prefetch-first ordering and fail-open policy bound the damage to a failed
-  repair rather than a gutted venv.
+- **Marker version drift.** If `onnxruntime-gpu` is changed by something other than
+  `install-ort.mjs` (a manual `pip install -U onnxruntime-gpu`), the marker keeps the old
+  version. `faster-whisper`'s `onnxruntime<2,>=1.14` bound tolerates a wide range, so the
+  practical blast radius is small, but ORT-gpu changes should go through the swap.
+- **A stale marker suppressing a real install.** The failure mode the `delete` branch
+  exists to prevent; on-box case 3 is its acceptance.
+- **The marker is a metadata assertion.** It states that `onnxruntime-gpu` provides
+  `onnxruntime`, which is true at the package level but is not something pip derived
+  itself. A future pip that validates `RECORD` hashes could object; nothing in the pinned
+  toolchain does today.
+- **Pre-existing and untouched:** doors 1–3 resolve the venv as `SIDECAR_DIR/.venv`
+  (`install-qwen3.mjs:165-169`, `install-whisper.mjs:56-63`, `install-coqui.mjs:46`) while
+  doors 4–5 and the sidecar honour `SIDECAR_VENV_DIR` — on a versioned-dir install those
+  differ. This design does not fix that; it is called out because the marker lives in
+  whichever venv the swap ran against, and a split-venv install has a deeper problem than
+  this bug. **Files as its own issue.**
 
 ## Review findings
 
-Round 1, Premium tier, briefed to attack the world model rather than the prose. Nine
-findings; every one re-verified against the tree before folding.
+Two Premium-tier rounds against the per-site architecture. Round 1 found nine defects;
+round 2, briefed to attack round 1's fixes, found sixteen — including that those fixes had
+broken each other. Every finding was re-verified against the tree before being acted on.
 
-| # | Severity | Finding | Disposition |
-|---|---|---|---|
-| 1 | Critical | Repair fires in the destructive direction on an unstamped GPU box; `planOrtSwap` uninstalls both before downloading | Layer 2 rewritten: one-directional, positive-signal, prefetch-first |
-| 2 | Critical | `--no-deps` rule justified by false reasoning; breaks on the `--cpu` path | Rule restated; `overlayDeclares` precondition added |
-| 3 | Critical | Two unmodelled doors (`upgrade/apply.ts`, venv-bootstrap route) run pip against a live sidecar | Folded in; Layer 0 added |
-| 4 | Major | Line 530 is inside `buildSidecarEnv`, which unit tests call directly | Placement corrected to post-adopt inside `spawnSidecar` |
-| 5 | Major | `spawn-windows-hide.test.ts`'s hardcoded file list goes vacuously green | `sidecar-pip.mjs` added to the array in the same PR |
-| 6 | Major | `install-whisper.mjs` exports nothing; the regression test could not be written | Arg-builder extraction is now part of the work |
-| 7 | Major | Once-per-process guard is spent before the clobber it targets | Guard keyed on the detected owner-set |
-| 8 | Minor | `pip check` exits 1 in the expected state | Layer 3 parses stdout, ignores the exit code |
-| 9 | Minor | Dropping `-U` alone leaves whisper unconstrained | `-c <constraints>` added |
+**Dissolved by the pivot** (the mechanism they attacked no longer exists): the
+one-directional repair rule and its unreachable no-runtime states; the positive-profile-
+signal predicate; prefetch-first ordering; the `applyOrtSwap` signature change; quiesce and
+the adopted-sidecar `stop()` no-op; the repair's placement in `spawnSidecar`; the
+owner-set anti-storm guard; `overlayDeclares` and its `-r base.txt` include graph;
+`--no-deps` disabling `install-qwen3.mjs`'s documented repair purpose; the gutted-namespace
+probe; the `pip check` cry-wolf filter and its exit-1 handling.
 
-Also folded: the gutted-namespace detection gap, the explicit dist-info matcher, the
-`applyOrtSwap` signature change, the two-servers assumption, `install-coqui.mjs:165`, the
-totality/budget requirement, and the Before-shipping steps revision 1 omitted.
+**Carried into this revision as real fixes:**
+
+| Finding | Round | Disposition |
+|---|---|---|
+| `install-whisper.mjs` `-U` with no `-c` | 1 (#9), sharpened in 2 | Fixed here |
+| `install-whisper.mjs` exports nothing, so the test can't be written | 1 (#6) | Arg-builder extraction is part of the work |
+| `spawn-windows-hide.test.ts` list omits pip spawners | 1 (#5), widened in 2 (#9) | `install-ort.mjs` + `bootstrap-venv.mjs` added |
+| AMD/Apple are not "GPU profiles" | 2 (#7) | Drives the `write`/`delete` split |
+| Raw vs normalised `.dist-info` matcher | 2 (#12) | Matcher specified + mutation-checked |
+| Two venv-path conventions | 2 (#8, #14) | Marker follows the swap's venv; the split filed separately |
+| Out-of-process Pinokio doors | 2 (#3, #14) | Closed by construction — no server needed |

--- a/docs/superpowers/specs/2026-08-07-qwen-ort-namespace-chokepoint-design.md
+++ b/docs/superpowers/specs/2026-08-07-qwen-ort-namespace-chokepoint-design.md
@@ -17,8 +17,10 @@ Closes the design work behind **#2192**.
 > Revision 4 fixed the wiring and restored the self-heal; **round 4 then returned "not safe
 > to implement from"** — three Criticals in those fixes, including a venv state no revision
 > had ever named (the already-clobbered box, which #2192 says is the largest population) and
-> a version glob that would have failed every NVIDIA bootstrap. **Revision 5** folds all of
-> them. §Review findings records all four rounds.
+> a version glob that would have failed every NVIDIA bootstrap. **Round 5**, scoped to those
+> three, resolved one and rejected two — the ownership predicate could not tell a GPU build
+> from a CPU one, and would have deleted a correct marker on every boot. **Revision 6** folds
+> all of it. §Review findings records all five rounds.
 
 ## Problem
 
@@ -140,16 +142,22 @@ for "this profile swaps." **AMD and Apple both resolve to plain `onnxruntime`**
 (`accelerator-profile.mjs:178,189`) and take the `delete` branch — a "GPU profile"
 shorthand would wrongly group AMD with NVIDIA.
 
-**Critically, both consumers apply the marker OUTSIDE their `ort.action === 'swap'` gate.**
-Today each does `if (ort.action === 'swap') { …steps… }`, so the skip branch executes
-nothing. The delete side must still run on cpu/amd/apple.
+**The two halves sit on opposite sides of the existing `ort.action === 'swap'` gate.** Today
+each consumer does `if (ort.action === 'swap') { …steps… }`, so the skip branch executes
+nothing at all.
+
+- **`delete` goes OUTSIDE the gate**, at function entry — it must still run on
+  cpu/amd/apple, which never enter the block.
+- **`write` goes INSIDE the gate**, as its last statement — a write outside it would fire on
+  profiles that have no `ortPackage` to derive a version from (see below).
 
 **The two halves run at different points, and the order is load-bearing:**
 
 - **`delete` runs FIRST**, before any overlay `pip install` in that flow.
 - **`write` runs LAST**, after the swap steps succeed.
 
-A single call sited after the swap block would be too late. `cpu.txt:26` carries an
+A single combined call — of either half — sited after the swap block would be too late for
+the delete. `cpu.txt:26` carries an
 **explicit** `onnxruntime` line (the nvidia overlay only pulls it transitively), and
 `bootstrap-venv.mjs:181`'s AMD→ROCm-failure→CPU fallback runs
 `pip install -r <cpu overlay>`. With a stale marker still present at that moment, pip

--- a/docs/superpowers/specs/2026-08-07-qwen-ort-namespace-chokepoint-design.md
+++ b/docs/superpowers/specs/2026-08-07-qwen-ort-namespace-chokepoint-design.md
@@ -7,6 +7,16 @@ date: 2026-08-07
 
 Closes the design work behind **#2192**.
 
+> **Revision 2.** Revision 1 went through the mandatory adversarial review gate and did
+> not survive it. The gate found a **Critical defect in the fix itself**: revision 1's
+> boot-time self-heal would have silently converted healthy GPU boxes to CPU Kokoro —
+> the exact bug this spec exists to fix, fired on every boot, on machines that never had
+> the bug. It also found two more pip doors into the venv that revision 1 did not model,
+> a `--no-deps` rule justified by false reasoning, a placement citation that would have
+> run `pip uninstall` during the unit suite, and a guard that would have gone vacuously
+> green. Every finding was re-verified against the tree before folding. §Review findings
+> records the round in full.
+
 ## Problem
 
 An alpha tester on a Pinokio install could not install Qwen3:
@@ -19,18 +29,17 @@ Check the permissions.
 ```
 
 It is not a permissions problem. `WinError 5` on a `.dll` is Windows reporting a
-memory-mapped file held by a live process. The report is one visible symptom of a
-structural condition that has been present since the ORT swap was introduced.
+memory-mapped file held by a live process.
 
 ### The structural condition
 
-`install-ort.mjs` deliberately replaces plain `onnxruntime` with `onnxruntime-gpu` on
-GPU profiles — they share the `site-packages/onnxruntime/` namespace directory and
-cannot co-exist. pip does **not** accept `onnxruntime-gpu` as satisfying a requirement
-spelled `onnxruntime`: distributions match by name, not by the directory they own.
+`install-ort.mjs` deliberately replaces plain `onnxruntime` with `onnxruntime-gpu` on GPU
+profiles — they share the `site-packages/onnxruntime/` namespace directory and cannot
+co-exist. pip matches distributions by **name**, so `onnxruntime-gpu` never satisfies a
+requirement spelled `onnxruntime`.
 
-Three installed distributions require plain `onnxruntime` unconditionally. `pip check`
-on a **correctly bootstrapped** NVIDIA box therefore reports:
+Three installed distributions require plain `onnxruntime` unconditionally. `pip check` on
+a **correctly bootstrapped** NVIDIA box therefore reports (verified live, pip 25.0.1):
 
 ```
 faster-whisper 1.2.1 requires onnxruntime, which is not installed.
@@ -38,29 +47,25 @@ kokoro-onnx 0.5.0 requires onnxruntime, which is not installed.
 qwen-tts 0.1.1 requires onnxruntime, which is not installed.
 ```
 
-(`transformers` also lists `onnxruntime`, but only behind the `onnx` / `onnxruntime` /
-`dev-*` extras, so it never participates in resolution here.)
+…and **exits 1**. (`transformers` also lists `onnxruntime`, but only behind the `onnx` /
+`onnxruntime` / `dev-*` extras, so it never participates in resolution.)
 
-**The venv is permanently in a state pip considers broken, by design.** Any later pip
-invocation whose target package depends on `onnxruntime` will try to repair it by
-installing the CPU build.
+**The venv is permanently in a state pip considers broken, by design.** Any pip call whose
+target depends on `onnxruntime` will try to repair it by installing the CPU build.
 
 ### The two failure modes
 
-Both follow from that one condition; which one you get depends only on whether the
-sidecar is running.
+Both follow from that one condition; which you get depends only on whether the sidecar is
+running.
 
-**A — the reported crash.** The sidecar's `_run_device_probe()` (`main.py:9174`, wired
-into the startup handler sequence at `main.py:668`) runs `import onnxruntime` on **every
-boot**, unconditionally — it is not gated on Kokoro ever being loaded. That maps
-`onnxruntime_providers_shared.dll` and Windows holds the lock for the process lifetime.
-`POST /api/qwen/install` spawns the installer without stopping or unloading the sidecar
-(there is no stop/unload path in `routes/qwen-install.ts` or `tts/qwen-install-bootstrap.ts`),
-so pip tries to overwrite a locked DLL and exits 1.
+**A — the reported crash.** The sidecar's `_run_device_probe()` (`main.py:9174`, wired into
+the startup handler sequence at `main.py:668`) runs `import onnxruntime` on **every boot**,
+unconditionally. That maps `onnxruntime_providers_shared.dll` and Windows holds the lock
+for the process lifetime. Nothing stops or unloads the sidecar before the installers run.
 
-**B — the silent clobber, which is worse.** With the sidecar stopped, the same pip step
-succeeds and installs CPU `onnxruntime` over `onnxruntime-gpu`. Verified with `--dry-run`
-against a fully bootstrapped NVIDIA box:
+**B — the silent clobber, which is worse.** With the sidecar stopped the same step succeeds
+and installs CPU `onnxruntime` over `onnxruntime-gpu`. Verified with `--dry-run` on a fully
+bootstrapped NVIDIA box:
 
 ```
 Using cached onnxruntime-1.28.0-cp312-cp312-win_amd64.whl (13.8 MB)
@@ -68,161 +73,266 @@ Would install onnxruntime-1.28.0
 ```
 
 That is the 2026-06-16 silent-CPU-Kokoro regression re-entering through a different door,
-and it also drives past `install-ort.mjs`'s deliberate `ONNXRUNTIME_GPU_CONSTRAINT =
-'>=1.27,<1.28'` pin. No error, no log line. Anyone who installed Qwen3 after their initial
-bootstrap is likely running Kokoro on the CPU without knowing it. Failure mode A is the
-lucky one — it failed loudly.
+and it drives past `install-ort.mjs`'s deliberate `>=1.27,<1.28` pin. No error, no log line.
 
-### Why this is not a bug in `install-qwen3.mjs`
+### Four doors, not one
 
-`install-qwen3.mjs` is simply the first door someone walked through. `install-whisper.mjs:96`
-is a second and is more aggressive — `pip install -U faster-whisper`, with `-U` and no
-constraints file at all, against a package `base.txt:45` pins to `>=1.0,<2.0`. Any future
-installer that pip-installs a package depending on `onnxruntime` re-introduces both failure
-modes with nothing to catch it.
+`install-qwen3.mjs` is simply the first one someone walked through.
 
-`install-ort.mjs` describes itself as "the SINGLE enforcement point for GPU Kokoro." It is
-not one, and cannot be, while other installers pip-install into the same venv behind its
-back. This is the recurring shape recorded in the #2040 wave: a guard that holds at one
-door in a building with several.
+| # | Door | What it runs | Sidecar live? |
+|---|---|---|---|
+| 1 | `install-qwen3.mjs:399` | `pip install qwen-tts -c base.txt` | Yes — in-app installer |
+| 2 | `install-whisper.mjs:96` | `pip install -U faster-whisper`, **no constraints** | Yes — in-app installer |
+| 3 | `upgrade/apply.ts:254-269` | overlay install **plus** `pip uninstall -y onnxruntime onnxruntime-gpu` | **Yes** — in-app self-upgrade |
+| 4 | `POST /api/setup/venv/bootstrap` | `bootstrap-venv.mjs` — same overlay install + ORT swap | **Yes** — "Rebuild the voice engine runtime" |
+
+Doors 3 and 4 are the severe pair: they run `pip uninstall` on the ORT namespace **from
+inside the running server, against a live sidecar**. The upgrade gate refuses only on
+in-flight generation/analysis (`upgrade/busy-probe.ts`), not on "the sidecar is running,"
+and its teardown happens *after* the pip run (`apply.ts:155`). Door 3 can therefore break
+TTS during a routine upgrade, which is arguably more severe than the reported bug.
+
+`install-ort.mjs:11` calls itself "the SINGLE enforcement point for GPU Kokoro." It is not
+one, and cannot be, while four other paths pip-install into the same venv behind its back —
+the same one-door-in-a-many-door-building shape recorded in the #2040 wave.
 
 ## Approach
 
-Three layers. Layer 1 alone fixes both reported failure modes on both known paths; layers
-2 and 3 exist because layer 1 is a per-call decision that a future caller can forget.
+Four layers. The door table above determines which layer covers which door: doors 1–2 can
+be prevented outright, doors 3–4 genuinely need full dependency resolution and so must be
+made safe instead.
 
-| Layer | Mechanism | Kills |
+| Layer | Mechanism | Covers |
 |---|---|---|
-| 1. Prevention | `--no-deps` on overlay-declared packages | A and B, on the known paths |
-| 2. Repair | ORT invariant re-asserted after any dep-resolving pip call, and before the sidecar spawns | B, including already-broken boxes |
-| 3. Honesty | Filtered `pip check` after each install | A dependency `--no-deps` genuinely skipped |
+| 0. Quiesce | Venv-mutating operations stop the sidecar first, restart after; refuse with an actionable message if they can't | Doors 3–4 |
+| 1. Prevention | `--no-deps` where the active overlay installs the package | Doors 1–2 |
+| 2. Repair | One-directional, prefetch-first ORT invariant check before the sidecar spawns | Residual B, and already-broken boxes |
+| 3. Honesty | `pip check` parsed and filtered after each install | A dependency `--no-deps` genuinely skipped |
 
-### Layer 1 is per-call, not a blanket policy
+### Layer 0 — quiesce, and the acceptance criterion revision 1 dropped
 
-`--no-deps` is safe **only** when the package's dependencies are already declared in the
-requirements overlay, so nothing needs resolving:
+Revision 1 silently dropped #2192's option 3 (manage the sidecar around the install) and
+with it the issue's own acceptance criterion: *"either succeed, or fail with an actionable
+message — never a raw `WinError 5`."* With doors 3–4 in scope that criterion is
+unreachable any other way, because those doors must resolve dependencies.
 
-- `qwen-tts==0.1.1` — in `nvidia-cuda.txt:67` / `amd-rocm.txt:16`. Safe.
-- `faster-whisper>=1.0,<2.0` — in `base.txt:45`. Safe.
-- `coqui-tts` — **opt-in and deliberately not in any overlay.** `--no-deps` here would
-  install a broken Coqui. It must keep full resolution.
+A shared helper wraps any venv-mutating operation: stop the sidecar, run the operation,
+restart it. If the sidecar cannot be stopped — a generation is in flight — the operation
+**refuses with an actionable message** rather than proceeding into a `WinError 5`. Any
+lock error that still escapes is translated at the chokepoint into that same actionable
+message, so a raw `WinError 5` never reaches the UI.
 
-So the chokepoint takes `noDeps` as an explicit per-call flag that the caller justifies,
-never a default. A blanket policy would be a worse bug than the one being fixed.
+### Layer 1 — the rule, restated correctly
 
-### Layer 2 cannot live in the sidecar
+Revision 1 justified `--no-deps` as *"the package's dependencies are already declared in
+the requirements overlay."* **That reasoning is false.** `qwen-tts==0.1.1` declares nine
+requirements (`transformers`, `accelerate`, `gradio`, `librosa`, `torchaudio`, `soundfile`,
+`sox`, `onnxruntime`, `einops`); only `transformers` (`base.txt:50`) and `torchaudio`
+(`nvidia-cuda.txt:32`) appear in any overlay. The overlays declare the **package**, not its
+dependencies.
 
-Repairing the invariant means `pip uninstall onnxruntime`, and the sidecar holds that DLL
-open from boot. **A sidecar-side self-heal would hit the exact `WinError 5` it exists to
-fix.** The check therefore runs in the server, immediately before it spawns the sidecar
-child, when nothing holds the lock. `spawn-sidecar.ts:530` already resolves the accelerator
-profile and injects it into the child env, so the one input the check needs is in hand at
-the right moment.
+`--no-deps` works for a different reason: `bootstrap-venv.mjs:204` runs
+`pip install -r <overlay>` **with** full resolution, so the other seven arrive there. The
+correct rule follows from that, and carries a precondition revision 1 lacked:
 
-Detection needs no Python and no import: read `site-packages/` for a plain
-`onnxruntime-*.dist-info`. On a healthy NVIDIA box only `onnxruntime_gpu-*.dist-info`
-exists; a clobber leaves **both**, because pip never knew they collided.
+> `--no-deps` is safe only where the **active profile's overlay installs this exact
+> package**, so the bootstrap already resolved its tree. The chokepoint **refuses
+> `--no-deps` when the target is absent from the active overlay.**
 
-### Layer 3 must not cry wolf
+That precondition matters immediately: **`cpu.txt` has no `qwen-tts` line at all** (Qwen is
+GPU-only), yet `install-qwen3.mjs:67` still ships a `--cpu` flag that
+`qwen-install-bootstrap.ts:56` documents forwarding. Under revision 1's rule that path
+would install `qwen_tts` alone and then die at `from qwen_tts import Qwen3TTSModel`
+(`install-qwen3.mjs:419`) on a missing `einops`, reporting "Check network, disk space."
+Under the corrected rule it is a clean, explicit skip. The same precondition survives a
+future `qwen-tts` version bump that adds a dependency.
 
-`pip check` on a healthy GPU box always prints the three lines above. Reported unfiltered,
-it would fire on every install and be tuned out within a week. The chokepoint treats
-exactly that trio, and only on a GPU profile, as expected — and reports anything else.
+### Layer 2 — one-directional and prefetch-first
+
+Revision 1's repair was **the most dangerous thing in the spec**. Two independent defects:
+
+**It could fire in the destructive direction.** `spawn-sidecar.ts:526-529` resolves the
+profile as `envOverride → venv stamp → detected`, with `detected` hardcoded `'cpu'`, and
+`resolveProfile` falls through to `'cpu'` when nothing matches
+(`accelerator-profile.mjs:59-64`). A correctly-installed NVIDIA box with a missing or
+unreadable stamp — fresh worktree, partial Pinokio reset, `SIDECAR_VENV_DIR` pointing
+elsewhere — resolves to `cpu`. Revision 1's rule ("delegate to
+`installRecipe(profile).ortPackage`") would then see `onnxruntime-gpu` owning the namespace
+against an expected plain `onnxruntime`, call it broken, and repair it *away*. Revision 1's
+unit matrix never listed that cell.
+
+**And the repair is not recoverable.** `planOrtSwap`'s step 1 is
+`['uninstall','-y','onnxruntime', ortPackage]` — it removes **both** runtimes before step 2
+downloads the replacement (`install-ort.mjs:92-93`). A failed step 2 (offline, empty pip
+cache, disk full) leaves the venv with **no onnxruntime at all**. Revision 1 moved that
+sequence from install-time onto every boot and justified it as "degraded, not broken,"
+which was simply untrue.
+
+Three corrections, all required:
+
+1. **One-directional.** Repair **only** when plain `onnxruntime` is present on a GPU
+   profile. **Never** remove `onnxruntime-gpu` because the profile reads `cpu`. The
+   destructive direction is not a case to handle carefully; it is a case that must not
+   exist.
+2. **Positive profile signal required.** `resolveProfile`'s `'cpu'` fallthrough is an
+   absence of information, not an assertion that the box is CPU. The repair no-ops with a
+   log line unless there is a present, parseable venv stamp or an explicit `ACCELERATOR`.
+3. **Prefetch-first.** `applyOrtSwap(python, plan, { prefetch })` — with `prefetch: true`
+   the replacement is `pip download --no-deps`ed to a temp dir first, and the uninstall
+   only happens once the wheel is on disk. A network failure then aborts having touched
+   nothing. This mirrors the download-verify-install shape `install-qwen3.mjs` already uses
+   for the FA2 wheel. `install-ort.mjs`'s own CLI keeps today's ordering (`prefetch: false`)
+   — it runs at install time with the user watching and the network obviously up, where a
+   loud failure is the correct outcome.
+
+**Placement.** Revision 1 said "`spawn-sidecar.ts` (~530), before the child spawn." Line 530
+is inside **`buildSidecarEnv`** (459–534), a sync, side-effect-free function that unit tests
+call directly with a real `repoRoot` (`sidecar-env.test.ts:38,47,58,72,85`) — a pip-spawning
+repair there would fire `pip uninstall` against the developer's venv during
+`npm run test:server`. The correct site is inside `spawnSidecar` (from 540), **after** the
+adopt/probe decision and only on the branch that actually spawns; the adopt branch returns
+early when a fit sidecar already holds the port, and repairing there would run
+`pip uninstall` against a live adopted sidecar — the original bug. The resolved profile is
+passed in rather than re-derived.
+
+**Anti-storm guard.** Keyed on the detected owner-set, not once-per-process. A
+once-per-process guard is spent by the boot-time no-op check and would never fire for the
+canonical sequence: boot (nothing to fix) → in-app install clobbers ORT → sidecar restarts
+(`routes/sidecar-health.ts:636`) → repair already spent.
+
+**Totality and budget.** `assertOrtInvariantBeforeSpawn` never throws — its caller is
+fire-and-forget (`index.ts:309` `void`s `sidecarSupervisor.start()`), so a rejection would
+surface as an unhandled rejection. The repair carries an explicit time budget; its worst
+case is a ~250 MB download between server start and the sidecar existing, during which TTS
+is unavailable.
+
+**Scope honesty.** Layer 2 runs pre-spawn, so it is structurally blind to a clobber that
+happens while the server is up — which is every one of the four doors. It heals the
+already-broken population at next launch; it is not, and must not be described as, the
+thing that keeps the invariant during a session. Layers 0 and 1 do that.
+
+### Layer 3 — parse, don't trust the exit code
+
+`pip check` **exits 1** in the expected state on every GPU box (verified). The runner must
+therefore parse stdout and ignore the exit code for the classification; treating non-zero
+as failure would report failure on every install on every GPU box. The trio above, and only
+on a GPU profile, is expected; anything else is reported.
 
 ## Components
 
 ### New: `server/tts-sidecar/scripts/sidecar-pip.mjs`
 
 Pure planners plus a thin runner, matching the `install-torch.mjs` / `install-ort.mjs`
-house pattern (pure decision fn + guarded CLI, unit-testable without a venv).
+house pattern.
 
 | Export | Kind | Purpose |
 |---|---|---|
 | `sidecarPipInstallArgs(specs, { constraints, noDeps })` | pure | Build the pip argv |
+| `overlayDeclares(packageName, profile, platform)` | pure | The Layer-1 precondition |
 | `parsePipCheck(stdout)` | pure | → `{ dist, requirement }[]` |
 | `expectedOrtInconsistencies(profile)` | pure | The trio, **GPU profiles only** |
 | `unexpectedInconsistencies(output, profile)` | pure | The cry-wolf filter |
-| `runSidecarPip(python, specs, opts)` | I/O | install → re-assert ORT if deps resolved → filtered `pip check` |
+| `translateVenvLockError(stderr)` | pure | `WinError 5` on a venv path → actionable message |
+| `runSidecarPip(python, specs, opts)` | I/O | install → re-assert ORT if deps resolved → parse `pip check` |
 
 ### Changed: `server/tts-sidecar/scripts/install-ort.mjs`
 
-Export `applyOrtSwap(python, plan)`, extracted from the existing CLI block, so the CLI and
-the chokepoint run the same loop. `planOrtSwap` is unchanged. This avoids a second copy of
-the swap sequence — that file's own `#1844` note records that re-deriving the package name
-in a second place is exactly how the CLI drifted before.
+Export `applyOrtSwap(python, plan, { prefetch })`, extracted from the CLI block
+(`:98-121`). This is **a signature change, not pure motion**: the existing block is built
+around `process.exit(code)` and `stdio:'inherit'`, so the extracted function needs a return
+value and injectable I/O to be callable from the server and testable. `planOrtSwap` is
+unchanged.
 
 ### New: `server/src/tts/ort-invariant.ts`
 
 | Export | Kind | Purpose |
 |---|---|---|
 | `detectOrtNamespaceOwner(sitePackages)` | fs read | Which distributions claim the namespace |
-| `planOrtRepair({ profile, platform, owners })` | pure | `ok` / `repair` + reason |
-| `assertOrtInvariantBeforeSpawn(deps)` | I/O | Detect, repair via `install-ort.mjs`, log |
+| `planOrtRepair({ profileSignal, platform, owners })` | pure | `ok` / `repair` / `no-signal` |
+| `assertOrtInvariantBeforeSpawn(deps)` | I/O | Detect, repair, log. Never throws |
 
-`planOrtRepair` delegates "what *should* own the namespace" to
-`installRecipe(profile, platform).ortPackage` rather than re-deriving it — same
-single-source-of-truth rule as above.
+**The matcher is specified, not left to the implementer:** `/^onnxruntime-\d/` against the
+normalized dist-info name. pip 25.0.1 normalizes the GPU distribution to
+`onnxruntime_gpu-1.27.0.dist-info` with an **underscore** (verified in the live venv), so a
+naive `startsWith('onnxruntime')` matches it and would fire a destructive repair on every
+healthy GPU box, every boot.
 
-**The sharpest footgun in this design:** on `cpu` and `apple` profiles plain `onnxruntime`
-is *correct*. A check that repairs on "plain `onnxruntime` is present" without consulting
-the profile would rip the working runtime out of every CPU install. The profile is a
-required input, not an optimisation.
+**Detection also probes the namespace, not just the dist-infos.** `install-ort.mjs:86-90`
+documents a third state the dist-info rule alone cannot see: a *gutted namespace*, where a
+`pip uninstall onnxruntime` after a clobber strips shared files via the CPU build's RECORD,
+leaving `onnxruntime_gpu-*.dist-info` present over a hollow `onnxruntime/`. `import
+onnxruntime` breaks entirely and the dist-info rule returns `ok`. A cheap presence check on
+`capi/` and the provider DLLs covers it.
 
-**Failure policy — non-fatal, fail-open.** A failed repair logs loudly and lets the spawn
-proceed. CPU Kokoro is degraded, not broken; blocking TTS entirely would be a worse outcome
-than the bug. This also covers a previous child still dying and holding the DLL (the #2037
-shape): the repair fails, and retries on the next boot. Note this is the opposite polarity
-to `gpu/active-generation-gate.ts`'s fail-closed rule, and deliberately so — there the
-worst case of failing open is evicting a model out from under a live render; here the worst
-case of failing closed is no TTS at all.
+### New: `server/src/tts/venv-quiesce.ts` (Layer 0)
 
-The **repair action** gets a once-per-process guard so a recycle storm cannot become a pip
-storm. **Detection** stays unguarded — it is one `readdir`, and it must re-run after any
-repair to confirm the outcome.
+Wraps a venv-mutating operation: stop the sidecar, run, restart. Refuses with an actionable
+message when the sidecar cannot be stopped. Consumed by doors 3 and 4.
 
 ### Call sites
 
 | File | Change |
 |---|---|
-| `install-qwen3.mjs:399` | Chokepoint, `noDeps: true` |
-| `install-whisper.mjs:96` | Chokepoint, `noDeps: true`, **and drop `-U`** |
-| `install-coqui.mjs:149` | Chokepoint **with** deps — gains layers 2 and 3 only |
+| `install-qwen3.mjs:399` | Chokepoint, `noDeps: true` (guarded by `overlayDeclares`) |
+| `install-whisper.mjs:96` | Chokepoint, `noDeps: true`, **drop `-U`**, **add `-c <constraints>`** |
+| `install-coqui.mjs:149` | Chokepoint **with** deps — Coqui is opt-in, in no overlay |
 | `install-coqui.mjs:154` | Already `--no-deps`; route for uniformity |
-| `spawn-sidecar.ts` (~530) | Call `assertOrtInvariantBeforeSpawn` before the child spawn |
+| `install-coqui.mjs` step 3 (`:158-172`) | The CJK-phonemizer/`spacy` step — the file's largest dep-resolving install |
+| `upgrade/apply.ts:254-269` | Chokepoint **and** Layer 0 quiesce |
+| `bootstrap-venv.mjs` `runPip` | Chokepoint **and** Layer 0 quiesce |
+| `spawn-sidecar.ts` (in `spawnSidecar`, post-adopt) | `assertOrtInvariantBeforeSpawn` |
 
-The `-U` removal is a defect in code this branch already touches, with one defensible fix
-and a paired test, so it clears the fix-now bar and lands here rather than becoming a
-second ticket. It is declared in the PR body as an incidental fix.
+The whisper fix is `-U` removal **plus** `-c <constraints>`. Dropping `-U` alone leaves the
+unconstrained half intact: on a box where `faster-whisper` is absent, pip still resolves to
+latest, so a 2.x release would install cleanly in violation of `base.txt:45`'s
+`>=1.0,<2.0` — with `--no-deps` guaranteeing it arrives dependency-less. Every sibling
+installer already passes `-c` (`install-qwen3.mjs:100`, `install-coqui.mjs:149`).
 
-**Explicitly out of scope:** the FlashAttention-2 wheel path in `install-qwen3.mjs`. It is
-opt-in, hash-pinned, and already fully non-fatal on every failure path, so routing it buys
-nothing this issue is about.
+**Explicitly out of scope:** the FlashAttention-2 wheel path in `install-qwen3.mjs`. Opt-in,
+hash-pinned, already non-fatal on every path.
 
 ## Testing
 
 ### The regression test
 
-Fails before the fix, passes after — asserting the installers' pip argv directly, importing
-the `.mjs` the way `install-coqui-steps.test.ts` already does:
+`install-whisper.mjs` **exports nothing** — its pip args are inline in an unexported
+`main()`, so revision 1's proposed assertion would have failed on *import* rather than on
+the assertion: a red phase by accident. Extracting an exported arg builder (mirroring
+`qwenPipInstallArgs` at `install-qwen3.mjs:99-101`) is therefore **part of the work**, not
+a test detail.
+
+With that in place, both assertions genuinely fail on today's tree and pass after:
 
 - `install-qwen3`'s args contain `--no-deps`
-- `install-whisper`'s args contain neither `-U` nor a bare dep-resolving install
+- `install-whisper`'s args contain `--no-deps` and `-c`, and **not** `-U`
 
-Both assertions fail on today's tree.
+### The guard that would otherwise go vacuously green
+
+`server/src/spawn-windows-hide.test.ts:54-62` enforces `windowsHide` by scanning a
+**hardcoded** `EXTERNAL_FILES` list that names the three installer scripts. Moving the pip
+spawns into `sidecar-pip.mjs` removes them from every file the guard scans — **the guard
+keeps passing while the actual spawn site goes unchecked.** `sidecar-pip.mjs` must be added
+to that array in the same PR. This is the "a guard test isn't wired until its file list
+moves" failure this repo has already recorded twice.
 
 ### Unit
 
-- `sidecar-pip-helpers.test.ts` — argv shapes; `parsePipCheck` against real captured
-  output; and the filter asserting the trio is expected on `nvidia` but **not** on `cpu`,
-  where those same lines would be genuine breakage.
-- `ort-invariant.test.ts` — `detectOrtNamespaceOwner` against temp dirs holding fixture
-  `dist-info` directories: gpu-only → ok; gpu+plain → repair; plain-only on `cpu` → ok;
-  plain-only on `nvidia` → repair. Plus `planOrtRepair` across profile × platform.
-- Spawn wiring — the check runs before the spawn, and a failed repair does **not** block it.
+- `sidecar-pip-helpers.test.ts` — argv shapes; `overlayDeclares` returning false for
+  `qwen-tts` on `cpu`; `parsePipCheck` against real captured output; the filter asserting
+  the trio is expected on `nvidia` but **not** on `cpu`, where those lines would be genuine;
+  `translateVenvLockError`.
+- `ort-invariant.test.ts` — the matcher against the real `onnxruntime_gpu-…` underscore
+  form; and a matrix that **must** include the two cells revision 1 omitted:
+  **`{onnxruntime-gpu}` on a `cpu` profile → `ok`, never `repair`**, and
+  **no profile signal → `no-signal`, never `repair`**. Plus the gutted-namespace state.
+- Prefetch ordering — a failed download leaves both distributions installed.
+- Spawn wiring — the check runs on the spawning branch only, never on adopt, never from
+  `buildSidecarEnv`; a failed repair does not block the spawn; the function never throws.
+- Layer 0 — refusal path returns the actionable message rather than proceeding.
 
-Each assertion is mutation-checked on its own line: a test that passes with the fix reverted
-is not a test. In particular the `cpu`-profile cases must fail if the profile input is
-dropped, since that is the footgun they exist to catch.
+Every assertion is mutation-checked on its own line. The `cpu`-profile and no-signal cells
+specifically must fail if the profile input is dropped — they exist to catch the defect that
+killed revision 1.
 
 ### Not applicable, stated rather than silently skipped
 
@@ -231,24 +341,59 @@ dropped, since that is the footgun they exist to catch.
 
 ### On-box acceptance (owed, cannot be discharged in the PR)
 
-This is precisely "behaviour only real hardware can prove." Two rows:
+1. **Windows + NVIDIA, app running.** In-app Qwen3 install completes; `pip check` after
+   shows only the expected trio; Kokoro still reports `CUDAExecutionProvider`.
+2. **Self-heal.** Deliberately clobber ORT, restart the server, confirm the pre-spawn repair
+   fires, logs, and restores `onnxruntime-gpu` within its pin.
+3. **No-signal safety.** Remove the venv stamp on a healthy NVIDIA box, restart, and confirm
+   the repair **does not** fire.
+4. **Upgrade path.** Run an in-app upgrade with the sidecar live; confirm quiesce, no
+   `WinError 5`, and GPU Kokoro afterwards.
 
-1. **Windows + NVIDIA, app running.** In-app Qwen3 install completes. `pip check`
-   afterwards shows only the expected trio. Kokoro still reports `CUDAExecutionProvider`.
-2. **Self-heal.** Deliberately clobber ORT (`pip install --force-reinstall onnxruntime`),
-   restart the server, confirm the pre-spawn repair fires, logs, and restores
-   `onnxruntime-gpu` within its `>=1.27,<1.28` pin.
+Register row, run sheet, and live view all move in the shipping PR per checklist step 3.
 
-Register row, per-feature run sheet, and the live view all move in the shipping PR per
-Before-shipping checklist step 3.
+## Before-shipping coverage
+
+Revision 1 omitted these rather than stating them. Step 1/4: this is substantial,
+cross-cutting work and **owes a plan under `docs/features/` plus an `INDEX.md` entry**.
+Step 5: it is user-visible (installs stop failing; a boot-time repair begins running; the
+upgrade path changes), so **both release-notes documents move in the PR**.
 
 ## Risks
 
-- **A `cpu`/`apple` profile mis-detected as GPU would delete a working runtime.** Mitigated
-  by making the profile a required input to `planOrtRepair` and by the dedicated
-  `cpu`-profile unit cases. This is the highest-severity failure the design can produce.
-- **`--no-deps` masking a genuinely new dependency** if an overlay pin drifts out of sync
-  with the package's real requirements. Mitigated by layer 3 — which is why the filtered
-  `pip check` is part of the fix and not a nicety.
-- **Repair racing a dying sidecar child** holding the DLL. Mitigated by fail-open plus
-  retry-next-boot; the worst case is one more boot on CPU Kokoro.
+- **A repair firing in the destructive direction** would delete a working GPU runtime.
+  Mitigated by making the repair one-directional by construction, requiring a positive
+  profile signal, and by the two dedicated unit cells. This is the highest-severity failure
+  the design can produce and it is what killed revision 1.
+- **A prefetch that succeeds followed by an install that fails** still leaves the venv
+  without a runtime. Narrower than revision 1's window but not zero; the pre-spawn check
+  retries next boot, and the gutted-namespace probe detects it.
+- **`--no-deps` masking a new dependency** if an overlay drifts from the package's real
+  requirements. Mitigated by `overlayDeclares` plus Layer 3.
+- **Two servers.** This repo has a documented two-stacks-on-`:9000` history, guarded by
+  `enforceSingleSidecarOwner` (`index.ts:291-292`) — which only fires when
+  `getResolvedAutoStartSidecar()` is true. A second server with autostart off could run its pre-spawn repair against the other
+  stack's live sidecar. "Nothing holds the lock at pre-spawn time" is a single-process
+  assumption; the prefetch-first ordering and fail-open policy bound the damage to a failed
+  repair rather than a gutted venv.
+
+## Review findings
+
+Round 1, Premium tier, briefed to attack the world model rather than the prose. Nine
+findings; every one re-verified against the tree before folding.
+
+| # | Severity | Finding | Disposition |
+|---|---|---|---|
+| 1 | Critical | Repair fires in the destructive direction on an unstamped GPU box; `planOrtSwap` uninstalls both before downloading | Layer 2 rewritten: one-directional, positive-signal, prefetch-first |
+| 2 | Critical | `--no-deps` rule justified by false reasoning; breaks on the `--cpu` path | Rule restated; `overlayDeclares` precondition added |
+| 3 | Critical | Two unmodelled doors (`upgrade/apply.ts`, venv-bootstrap route) run pip against a live sidecar | Folded in; Layer 0 added |
+| 4 | Major | Line 530 is inside `buildSidecarEnv`, which unit tests call directly | Placement corrected to post-adopt inside `spawnSidecar` |
+| 5 | Major | `spawn-windows-hide.test.ts`'s hardcoded file list goes vacuously green | `sidecar-pip.mjs` added to the array in the same PR |
+| 6 | Major | `install-whisper.mjs` exports nothing; the regression test could not be written | Arg-builder extraction is now part of the work |
+| 7 | Major | Once-per-process guard is spent before the clobber it targets | Guard keyed on the detected owner-set |
+| 8 | Minor | `pip check` exits 1 in the expected state | Layer 3 parses stdout, ignores the exit code |
+| 9 | Minor | Dropping `-U` alone leaves whisper unconstrained | `-c <constraints>` added |
+
+Also folded: the gutted-namespace detection gap, the explicit dist-info matcher, the
+`applyOrtSwap` signature change, the two-servers assumption, `install-coqui.mjs:165`, the
+totality/budget requirement, and the Before-shipping steps revision 1 omitted.

--- a/docs/superpowers/specs/2026-08-07-qwen-ort-namespace-chokepoint-design.md
+++ b/docs/superpowers/specs/2026-08-07-qwen-ort-namespace-chokepoint-design.md
@@ -1,0 +1,254 @@
+---
+status: draft
+date: 2026-08-07
+---
+
+# The onnxruntime namespace chokepoint: one guarded pip path into the sidecar venv
+
+Closes the design work behind **#2192**.
+
+## Problem
+
+An alpha tester on a Pinokio install could not install Qwen3:
+
+```
+install-qwen3.mjs exited with code 1. ERROR: Could not install packages due to an
+OSError: [WinError 5] Accès refusé:
+'E:\pinokio\api\Castwright.git\server\tts-sidecar\.venv\Lib\site-packages\onnxruntime\capi\onnxruntime_providers_shared.dll'
+Check the permissions.
+```
+
+It is not a permissions problem. `WinError 5` on a `.dll` is Windows reporting a
+memory-mapped file held by a live process. The report is one visible symptom of a
+structural condition that has been present since the ORT swap was introduced.
+
+### The structural condition
+
+`install-ort.mjs` deliberately replaces plain `onnxruntime` with `onnxruntime-gpu` on
+GPU profiles — they share the `site-packages/onnxruntime/` namespace directory and
+cannot co-exist. pip does **not** accept `onnxruntime-gpu` as satisfying a requirement
+spelled `onnxruntime`: distributions match by name, not by the directory they own.
+
+Three installed distributions require plain `onnxruntime` unconditionally. `pip check`
+on a **correctly bootstrapped** NVIDIA box therefore reports:
+
+```
+faster-whisper 1.2.1 requires onnxruntime, which is not installed.
+kokoro-onnx 0.5.0 requires onnxruntime, which is not installed.
+qwen-tts 0.1.1 requires onnxruntime, which is not installed.
+```
+
+(`transformers` also lists `onnxruntime`, but only behind the `onnx` / `onnxruntime` /
+`dev-*` extras, so it never participates in resolution here.)
+
+**The venv is permanently in a state pip considers broken, by design.** Any later pip
+invocation whose target package depends on `onnxruntime` will try to repair it by
+installing the CPU build.
+
+### The two failure modes
+
+Both follow from that one condition; which one you get depends only on whether the
+sidecar is running.
+
+**A — the reported crash.** The sidecar's `_run_device_probe()` (`main.py:9174`, wired
+into the startup handler sequence at `main.py:668`) runs `import onnxruntime` on **every
+boot**, unconditionally — it is not gated on Kokoro ever being loaded. That maps
+`onnxruntime_providers_shared.dll` and Windows holds the lock for the process lifetime.
+`POST /api/qwen/install` spawns the installer without stopping or unloading the sidecar
+(there is no stop/unload path in `routes/qwen-install.ts` or `tts/qwen-install-bootstrap.ts`),
+so pip tries to overwrite a locked DLL and exits 1.
+
+**B — the silent clobber, which is worse.** With the sidecar stopped, the same pip step
+succeeds and installs CPU `onnxruntime` over `onnxruntime-gpu`. Verified with `--dry-run`
+against a fully bootstrapped NVIDIA box:
+
+```
+Using cached onnxruntime-1.28.0-cp312-cp312-win_amd64.whl (13.8 MB)
+Would install onnxruntime-1.28.0
+```
+
+That is the 2026-06-16 silent-CPU-Kokoro regression re-entering through a different door,
+and it also drives past `install-ort.mjs`'s deliberate `ONNXRUNTIME_GPU_CONSTRAINT =
+'>=1.27,<1.28'` pin. No error, no log line. Anyone who installed Qwen3 after their initial
+bootstrap is likely running Kokoro on the CPU without knowing it. Failure mode A is the
+lucky one — it failed loudly.
+
+### Why this is not a bug in `install-qwen3.mjs`
+
+`install-qwen3.mjs` is simply the first door someone walked through. `install-whisper.mjs:96`
+is a second and is more aggressive — `pip install -U faster-whisper`, with `-U` and no
+constraints file at all, against a package `base.txt:45` pins to `>=1.0,<2.0`. Any future
+installer that pip-installs a package depending on `onnxruntime` re-introduces both failure
+modes with nothing to catch it.
+
+`install-ort.mjs` describes itself as "the SINGLE enforcement point for GPU Kokoro." It is
+not one, and cannot be, while other installers pip-install into the same venv behind its
+back. This is the recurring shape recorded in the #2040 wave: a guard that holds at one
+door in a building with several.
+
+## Approach
+
+Three layers. Layer 1 alone fixes both reported failure modes on both known paths; layers
+2 and 3 exist because layer 1 is a per-call decision that a future caller can forget.
+
+| Layer | Mechanism | Kills |
+|---|---|---|
+| 1. Prevention | `--no-deps` on overlay-declared packages | A and B, on the known paths |
+| 2. Repair | ORT invariant re-asserted after any dep-resolving pip call, and before the sidecar spawns | B, including already-broken boxes |
+| 3. Honesty | Filtered `pip check` after each install | A dependency `--no-deps` genuinely skipped |
+
+### Layer 1 is per-call, not a blanket policy
+
+`--no-deps` is safe **only** when the package's dependencies are already declared in the
+requirements overlay, so nothing needs resolving:
+
+- `qwen-tts==0.1.1` — in `nvidia-cuda.txt:67` / `amd-rocm.txt:16`. Safe.
+- `faster-whisper>=1.0,<2.0` — in `base.txt:45`. Safe.
+- `coqui-tts` — **opt-in and deliberately not in any overlay.** `--no-deps` here would
+  install a broken Coqui. It must keep full resolution.
+
+So the chokepoint takes `noDeps` as an explicit per-call flag that the caller justifies,
+never a default. A blanket policy would be a worse bug than the one being fixed.
+
+### Layer 2 cannot live in the sidecar
+
+Repairing the invariant means `pip uninstall onnxruntime`, and the sidecar holds that DLL
+open from boot. **A sidecar-side self-heal would hit the exact `WinError 5` it exists to
+fix.** The check therefore runs in the server, immediately before it spawns the sidecar
+child, when nothing holds the lock. `spawn-sidecar.ts:530` already resolves the accelerator
+profile and injects it into the child env, so the one input the check needs is in hand at
+the right moment.
+
+Detection needs no Python and no import: read `site-packages/` for a plain
+`onnxruntime-*.dist-info`. On a healthy NVIDIA box only `onnxruntime_gpu-*.dist-info`
+exists; a clobber leaves **both**, because pip never knew they collided.
+
+### Layer 3 must not cry wolf
+
+`pip check` on a healthy GPU box always prints the three lines above. Reported unfiltered,
+it would fire on every install and be tuned out within a week. The chokepoint treats
+exactly that trio, and only on a GPU profile, as expected — and reports anything else.
+
+## Components
+
+### New: `server/tts-sidecar/scripts/sidecar-pip.mjs`
+
+Pure planners plus a thin runner, matching the `install-torch.mjs` / `install-ort.mjs`
+house pattern (pure decision fn + guarded CLI, unit-testable without a venv).
+
+| Export | Kind | Purpose |
+|---|---|---|
+| `sidecarPipInstallArgs(specs, { constraints, noDeps })` | pure | Build the pip argv |
+| `parsePipCheck(stdout)` | pure | → `{ dist, requirement }[]` |
+| `expectedOrtInconsistencies(profile)` | pure | The trio, **GPU profiles only** |
+| `unexpectedInconsistencies(output, profile)` | pure | The cry-wolf filter |
+| `runSidecarPip(python, specs, opts)` | I/O | install → re-assert ORT if deps resolved → filtered `pip check` |
+
+### Changed: `server/tts-sidecar/scripts/install-ort.mjs`
+
+Export `applyOrtSwap(python, plan)`, extracted from the existing CLI block, so the CLI and
+the chokepoint run the same loop. `planOrtSwap` is unchanged. This avoids a second copy of
+the swap sequence — that file's own `#1844` note records that re-deriving the package name
+in a second place is exactly how the CLI drifted before.
+
+### New: `server/src/tts/ort-invariant.ts`
+
+| Export | Kind | Purpose |
+|---|---|---|
+| `detectOrtNamespaceOwner(sitePackages)` | fs read | Which distributions claim the namespace |
+| `planOrtRepair({ profile, platform, owners })` | pure | `ok` / `repair` + reason |
+| `assertOrtInvariantBeforeSpawn(deps)` | I/O | Detect, repair via `install-ort.mjs`, log |
+
+`planOrtRepair` delegates "what *should* own the namespace" to
+`installRecipe(profile, platform).ortPackage` rather than re-deriving it — same
+single-source-of-truth rule as above.
+
+**The sharpest footgun in this design:** on `cpu` and `apple` profiles plain `onnxruntime`
+is *correct*. A check that repairs on "plain `onnxruntime` is present" without consulting
+the profile would rip the working runtime out of every CPU install. The profile is a
+required input, not an optimisation.
+
+**Failure policy — non-fatal, fail-open.** A failed repair logs loudly and lets the spawn
+proceed. CPU Kokoro is degraded, not broken; blocking TTS entirely would be a worse outcome
+than the bug. This also covers a previous child still dying and holding the DLL (the #2037
+shape): the repair fails, and retries on the next boot. Note this is the opposite polarity
+to `gpu/active-generation-gate.ts`'s fail-closed rule, and deliberately so — there the
+worst case of failing open is evicting a model out from under a live render; here the worst
+case of failing closed is no TTS at all.
+
+The **repair action** gets a once-per-process guard so a recycle storm cannot become a pip
+storm. **Detection** stays unguarded — it is one `readdir`, and it must re-run after any
+repair to confirm the outcome.
+
+### Call sites
+
+| File | Change |
+|---|---|
+| `install-qwen3.mjs:399` | Chokepoint, `noDeps: true` |
+| `install-whisper.mjs:96` | Chokepoint, `noDeps: true`, **and drop `-U`** |
+| `install-coqui.mjs:149` | Chokepoint **with** deps — gains layers 2 and 3 only |
+| `install-coqui.mjs:154` | Already `--no-deps`; route for uniformity |
+| `spawn-sidecar.ts` (~530) | Call `assertOrtInvariantBeforeSpawn` before the child spawn |
+
+The `-U` removal is a defect in code this branch already touches, with one defensible fix
+and a paired test, so it clears the fix-now bar and lands here rather than becoming a
+second ticket. It is declared in the PR body as an incidental fix.
+
+**Explicitly out of scope:** the FlashAttention-2 wheel path in `install-qwen3.mjs`. It is
+opt-in, hash-pinned, and already fully non-fatal on every failure path, so routing it buys
+nothing this issue is about.
+
+## Testing
+
+### The regression test
+
+Fails before the fix, passes after — asserting the installers' pip argv directly, importing
+the `.mjs` the way `install-coqui-steps.test.ts` already does:
+
+- `install-qwen3`'s args contain `--no-deps`
+- `install-whisper`'s args contain neither `-U` nor a bare dep-resolving install
+
+Both assertions fail on today's tree.
+
+### Unit
+
+- `sidecar-pip-helpers.test.ts` — argv shapes; `parsePipCheck` against real captured
+  output; and the filter asserting the trio is expected on `nvidia` but **not** on `cpu`,
+  where those same lines would be genuine breakage.
+- `ort-invariant.test.ts` — `detectOrtNamespaceOwner` against temp dirs holding fixture
+  `dist-info` directories: gpu-only → ok; gpu+plain → repair; plain-only on `cpu` → ok;
+  plain-only on `nvidia` → repair. Plus `planOrtRepair` across profile × platform.
+- Spawn wiring — the check runs before the spawn, and a failed repair does **not** block it.
+
+Each assertion is mutation-checked on its own line: a test that passes with the fix reverted
+is not a test. In particular the `cpu`-profile cases must fail if the profile input is
+dropped, since that is the footgun they exist to catch.
+
+### Not applicable, stated rather than silently skipped
+
+- **pytest** — no Python behaviour changes.
+- **e2e** — no router/redux/layout seam.
+
+### On-box acceptance (owed, cannot be discharged in the PR)
+
+This is precisely "behaviour only real hardware can prove." Two rows:
+
+1. **Windows + NVIDIA, app running.** In-app Qwen3 install completes. `pip check`
+   afterwards shows only the expected trio. Kokoro still reports `CUDAExecutionProvider`.
+2. **Self-heal.** Deliberately clobber ORT (`pip install --force-reinstall onnxruntime`),
+   restart the server, confirm the pre-spawn repair fires, logs, and restores
+   `onnxruntime-gpu` within its `>=1.27,<1.28` pin.
+
+Register row, per-feature run sheet, and the live view all move in the shipping PR per
+Before-shipping checklist step 3.
+
+## Risks
+
+- **A `cpu`/`apple` profile mis-detected as GPU would delete a working runtime.** Mitigated
+  by making the profile a required input to `planOrtRepair` and by the dedicated
+  `cpu`-profile unit cases. This is the highest-severity failure the design can produce.
+- **`--no-deps` masking a genuinely new dependency** if an overlay pin drifts out of sync
+  with the package's real requirements. Mitigated by layer 3 — which is why the filtered
+  `pip check` is part of the fix and not a nicety.
+- **Repair racing a dying sidecar child** holding the DLL. Mitigated by fail-open plus
+  retry-next-boot; the worst case is one more boot on CPU Kokoro.

--- a/docs/superpowers/specs/2026-08-07-qwen-ort-namespace-chokepoint-design.md
+++ b/docs/superpowers/specs/2026-08-07-qwen-ort-namespace-chokepoint-design.md
@@ -3,23 +3,19 @@ status: draft
 date: 2026-08-07
 ---
 
-# Make the sidecar venv pip-consistent: one marker, at one site
+# Make the sidecar venv pip-consistent: one marker, carried by the swap plan
 
 Closes the design work behind **#2192**.
 
-> **Revision 3 — architecture change.** Revisions 1 and 2 defended the symptom at every
-> pip call site. Both failed the adversarial review gate with Criticals, and round 2's
-> findings were largely round 1's *fixes* breaking: a repair rule that could no longer fire
-> on the states it existed to heal, a quiesce primitive that silently no-ops on an adopted
-> sidecar, a prefetch that still needed the network after uninstalling. The design had
-> grown to four layers over seven call sites and still could not reach the three
-> out-of-process Pinokio paths.
->
-> This revision attacks the root condition instead, and was **empirically validated before
-> being written** — see §The spike. It replaces the chokepoint, the quiesce layer, the
-> boot-time repair, `--no-deps`, and `overlayDeclares` with a marker written at one site.
-> §Review findings records what both rounds found and which findings the pivot dissolves
-> rather than fixes.
+> **Revision 4.** Three Premium adversarial rounds. Revisions 1–2 defended the symptom at
+> seven pip call sites and failed twice, with round 2 finding that round 1's fixes had
+> broken each other; revision 3 pivoted to attacking the root condition. **Round 3 cleared
+> the mechanism** — no runtime code reads onnxruntime distribution metadata, and no pip
+> mode in this repo defeats a marker — but found the *wiring* wrong in two Critical ways:
+> `install-ort.mjs` is never executed as a CLI in production, so the marker would have
+> fired on zero paths; and the claim that existing boxes self-heal via upgrade was false.
+> This revision fixes the wiring and restores the write-only self-heal. §Review findings
+> records all three rounds.
 
 ## Problem
 
@@ -35,13 +31,12 @@ OSError: [WinError 5] Accès refusé:
 
 ### The root condition
 
-`install-ort.mjs` replaces plain `onnxruntime` with `onnxruntime-gpu` on GPU profiles —
-they share the `site-packages/onnxruntime/` namespace and cannot co-exist. **pip matches
-distributions by name**, so `onnxruntime-gpu` never satisfies a requirement spelled
-`onnxruntime`.
+The nvidia profile replaces plain `onnxruntime` with `onnxruntime-gpu` — they share the
+`site-packages/onnxruntime/` namespace and cannot co-exist. **pip matches distributions by
+name**, so `onnxruntime-gpu` never satisfies a requirement spelled `onnxruntime`.
 
 Three installed distributions require plain `onnxruntime` unconditionally, so `pip check`
-on a **correctly bootstrapped** NVIDIA box reports (verified, pip 25.0.1) — and exits 1:
+on a **correctly bootstrapped** NVIDIA box reports — and exits 1:
 
 ```
 faster-whisper 1.2.1 requires onnxruntime, which is not installed.
@@ -53,56 +48,56 @@ qwen-tts 0.1.1 requires onnxruntime, which is not installed.
 depends on `onnxruntime` tries to repair it by installing the CPU build — which either
 crashes on the sidecar's DLL lock (`main.py:9174`'s `_run_device_probe` runs
 `import onnxruntime` on every boot, wired at `main.py:668`) or, with the sidecar stopped,
-silently replaces the GPU runtime. The latter is worse: no error, no log line, and it
-drives past `install-ort.mjs`'s deliberate `>=1.27,<1.28` pin.
+silently replaces the GPU runtime, driving past the deliberate `>=1.27,<1.28` pin.
 
-### Why per-site defence failed
+### Why per-site defence was abandoned
 
-At least seven pip sites reach this venv, across five entry points:
+Doors onto this bug — a door is a pip call whose target depends on `onnxruntime`:
 
 | Door | Runs | Server in the loop? |
 |---|---|---|
 | `install-qwen3.mjs:399` | `pip install qwen-tts` | Yes |
 | `install-whisper.mjs:96` | `pip install -U faster-whisper` | Yes |
-| `install-coqui.mjs` ×3 (`:149`, `:154`, `:158-172`) | opt-in Coqui + CJK phonemizers | Yes |
 | `upgrade/apply.ts:254-269` | overlay install **plus** `pip uninstall -y onnxruntime onnxruntime-gpu` | Yes |
-| `routes/venv-bootstrap.ts:38-41` → `bootstrap-venv.mjs` | overlay install + ORT swap | Yes |
+| `routes/venv-bootstrap.ts:38-41` → `bootstrap-venv.mjs` | overlay install + swap | Yes |
 | `pinokio-scripts/install.js:80`, `update.js:73` | `bootstrap-venv.mjs` | **No** |
-| `pinokio-scripts/reset.js:13` | `fs.rm` on the venv, no stop step | **No** |
 
-The last three run with no server process at all, so no server-side chokepoint, quiesce, or
-boot-time repair can ever reach them — and the Pinokio update path is the exact deployment
-shape that reported this bug.
+The last two run with no server process at all, so no server-side chokepoint, quiesce, or
+boot-time repair can reach them — and the Pinokio update path is the deployment shape that
+reported this bug. (`install-coqui.mjs`'s three pip steps are *not* doors: none of
+`coqui-tts`, `torchcodec`, or the CJK phonemizers declares `onnxruntime`.)
 
 ## Approach
 
-Record, once, the thing that is already true: **`onnxruntime-gpu` provides the
-`onnxruntime` package** — same import name, same API, same version line. A minimal
-`onnxruntime-<version>.dist-info` marker alongside the GPU distribution makes pip agree,
-and pip then stops trying to "repair" the venv from every door simultaneously.
+Record, once, what is already true: **`onnxruntime-gpu` provides the `onnxruntime`
+package** — same import name, same API, same version line. A minimal
+`onnxruntime-<version>.dist-info` marker beside the GPU distribution makes pip agree, and
+pip stops trying to repair the venv from every door simultaneously.
 
 Today's state is arguably the dishonest one: the venv asserts a requirement is unmet that
 is in fact met.
 
-### The spike
+### Spike 1 — the mechanism works
 
-Validated empirically on a bootstrapped NVIDIA box before this revision was written.
-Marker created, every path dry-run (writes nothing), marker removed, baseline confirmed
-restored.
+Validated on a bootstrapped NVIDIA box before this design was written. Marker created,
+every path dry-run (writes nothing), marker removed, baseline confirmed restored.
 
 | Path | Before | With the marker |
 |---|---|---|
-| `pip install qwen-tts` | `Would install onnxruntime-1.28.0` | `already satisfied: onnxruntime … (1.27.0)` |
-| `pip install faster-whisper` | same clobber | `already satisfied: onnxruntime<2,>=1.14 … (1.27.0)` |
+| `pip install qwen-tts` | `Would install onnxruntime-1.28.0` | `already satisfied … (1.27.0)` |
+| `pip install faster-whisper` | same clobber | `already satisfied … (1.27.0)` |
 | `pip install -r nvidia-cuda.txt` (upgrade / rebuild / Pinokio) | same clobber | `already satisfied` |
 | `pip check` | 3 errors, **exit 1** | `No broken requirements found.` **exit 0** |
 
-No `Would install onnxruntime` on any path. Every door closes at once, including the three
-out-of-process ones.
+Round 3 independently confirmed the two ways this could have been undermined and found
+neither: **no runtime code reads onnxruntime distribution metadata** (`main.py`'s only
+`importlib.metadata` use is `_coqui_installed_version`; every ORT probe is
+`import onnxruntime` + `get_available_providers()`), and **no pip mode in this repo
+defeats it** — no `--require-hashes`, no `--report`, no `uv`, no `pip freeze`.
 
-### The second spike result, which shapes the design
+### Spike 2 — the marker is sticky
 
-Tested separately in a throwaway venv, because `install-ort.mjs`'s swap **begins** with
+Tested in a throwaway venv, because the swap **begins** with
 `pip uninstall -y onnxruntime onnxruntime-gpu`:
 
 ```
@@ -112,136 +107,185 @@ uninstall exit=0                     ← the swap's step 1 does not break
 ```
 
 …**and the marker directory survived.** An empty `RECORD` means pip finds nothing to
-remove and leaves the `.dist-info` in place.
-
-Two consequences, both load-bearing:
-
-1. **Removal must be explicit.** pip will never delete the marker, so this design owns
-   both writing *and* deleting it. A `rm -rf` of the directory is the only mechanism.
-2. **A stale marker suppresses a legitimate install.** With the marker present,
-   `pip install onnxruntime` reports "already satisfied" and installs nothing. That is
-   exactly what a profile migration from `nvidia` to `cpu` needs to do — the CPU profile
-   requires real plain `onnxruntime`. **So the marker must be deleted whenever the swap is
-   not in effect**, not merely written when it is. `planOrtSwap`'s existing `skip` branch
-   (cpu / amd / apple) becomes an active *delete-if-present*, not an early return.
-
-Missing consequence 2 would convert this fix into a new silent-breakage bug on profile
-migration — the same class it exists to close.
+remove. So removal must be an explicit `rm` by our own code — pip will never do it — and
+the design owns both writing and deleting.
 
 ## Components
 
-### Changed: `server/tts-sidecar/scripts/install-ort.mjs`
+### The marker travels in the plan, not in a script nobody runs
 
-The single site. Both branches of `planOrtSwap` gain a marker action:
+**`install-ort.mjs` is not an execution site.** Nothing in the tree runs it as a CLI: its
+`planOrtSwap` export is imported by `bootstrap-venv.mjs:39` and `upgrade/apply.ts:28`, and
+both consumers execute the returned pip steps **in their own process**
+(`bootstrap-venv.mjs:212-220`, `apply.ts:263-266`). Its `import.meta.url === argv[1]` block
+(`:98-121`) is reachable only by a human running it by hand — which is exactly what
+#2192's manual workaround instructs, and why it reads like the site.
 
-| Branch | Profiles | Marker action |
+So the marker action rides the plan both consumers already loop over:
+
+```
+planOrtSwap(profile, platform) → { action, steps, ortPackage, marker: { action: 'write' | 'delete' } }
+```
+
+| Branch | Profiles | `marker.action` |
 |---|---|---|
-| `swap` | nvidia | **Write** (overwrite) after the force-reinstall succeeds |
-| `skip` | cpu, amd, apple | **Delete if present** — plain `onnxruntime` is correct there |
+| `swap` | nvidia | `write` — after the steps succeed |
+| `skip` | cpu, amd, apple | `delete` — plain `onnxruntime` is correct there |
 
 `installRecipe(profile, platform).ortPackage !== 'onnxruntime'` is the mechanical predicate
-for "this profile swaps." AMD and Apple both resolve to plain `onnxruntime`
-(`accelerator-profile.mjs:178,189`) and must therefore take the **delete** branch — a
-"GPU profile" shorthand would wrongly group AMD with NVIDIA.
+for "this profile swaps." **AMD and Apple both resolve to plain `onnxruntime`**
+(`accelerator-profile.mjs:178,189`) and take the `delete` branch — a "GPU profile"
+shorthand would wrongly group AMD with NVIDIA.
 
-New exports, pure planner plus thin writer, matching the file's existing shape:
+**Critically, both consumers apply the marker OUTSIDE their `ort.action === 'swap'` gate.**
+Today each does `if (ort.action === 'swap') { …steps… }`, so the skip branch executes
+nothing. The delete side must still run on cpu/amd/apple.
 
-| Export | Kind | Purpose |
-|---|---|---|
-| `planOrtMarker(profile, platform)` | pure | `{ action: 'write' \| 'delete' }` |
-| `readInstalledOrtVersion(sitePackages)` | fs read | Version from the installed `onnxruntime_gpu-*.dist-info` |
-| `writeOrtMarker(sitePackages, version)` | fs write | Create/overwrite the marker |
-| `deleteOrtMarker(sitePackages)` | fs write | Remove it if present |
+**The two halves run at different points, and the order is load-bearing:**
 
-**The version is derived, never hardcoded** — read from the `onnxruntime_gpu-*.dist-info`
-that the swap just installed. A hardcoded version silently starts lying the first time the
-`>=1.27,<1.28` pin is bumped, and `faster-whisper`'s `onnxruntime<2,>=1.14` bound means a
-sufficiently wrong version would make pip resolve *against* us.
+- **`delete` runs FIRST**, before any overlay `pip install` in that flow.
+- **`write` runs LAST**, after the swap steps succeed.
+
+A single call sited after the swap block would be too late. `cpu.txt:26` carries an
+**explicit** `onnxruntime` line (the nvidia overlay only pulls it transitively), and
+`bootstrap-venv.mjs:181`'s AMD→ROCm-failure→CPU fallback runs
+`pip install -r <cpu overlay>`. With a stale marker still present at that moment, pip
+reports `onnxruntime` satisfied and installs nothing — leaving the box with
+`onnxruntime-gpu` files, no CPU runtime, and a deleted marker afterwards: broken in both
+directions at once.
+
+The `rebuild` gate makes a marker on a non-nvidia venv unlikely (a profile change forces a
+full reinstall), but "unlikely" is the reasoning that failed the three previous rounds of
+this design. Deleting first costs nothing and removes the state entirely.
+
+### Changed files
+
+| File | Change |
+|---|---|
+| `install-ort.mjs` | `planOrtSwap` returns `marker`; add `applyOrtMarker`, `readInstalledOrtVersion`, `writeOrtMarker`, `deleteOrtMarker` |
+| `bootstrap-venv.mjs` | Call `applyOrtMarker` after the swap block, outside the gate. Needs its own injectable seam — `installForProfile` already injects `runPip` (`:151`), and an un-injected fs write there is untestable at that layer |
+| `upgrade/apply.ts` | Same call in `pipInstall`, outside the gate |
+| `index.ts` (server boot) | `ensureOrtMarker` — the write-only self-heal, below |
+| `install-whisper.mjs` | Drop `-U`, add `-c`; extract an exported arg builder |
+| `spawn-windows-hide.test.ts` | Widen the guard, below |
+
+**Version derivation.** Read from the dist-info the swap just installed, globbed from
+`plan.ortPackage` — **not** hardcoded, and **not** hardcoded to `onnxruntime_gpu-*` either:
+`planOrtSwap` already supports a non-GPU swap package (the documented
+`onnxruntime-directml` re-enable, `install-ort.mjs:9,21-23`), which would find no
+`onnxruntime_gpu-*` dist. A hardcoded version silently starts lying the first time the pin
+is bumped, and `faster-whisper`'s `onnxruntime<2,>=1.14` bound means a sufficiently wrong
+version makes pip resolve *against* us.
+
+**On `null`, fail the swap loudly.** If the version cannot be read, the swap fails —
+`bootstrap-venv.mjs:217` already treats a swap failure as fatal ("better to fail the
+install loudly than ship a GPU box that quietly synthesises on the CPU"). Silently skipping
+the write would re-open the bug with no signal, which is the exact silence class this
+design exists to close. Writing a version-less marker would produce invalid metadata.
 
 **Marker contents** — minimal and self-identifying, so it is greppable and obviously ours:
 
 ```
 METADATA    Metadata-Version: 2.1 / Name: onnxruntime / Version: <derived>
 INSTALLER   castwright-ort-marker
-RECORD      (empty — nothing to uninstall; see §The spike)
+RECORD      (empty — nothing to uninstall; see Spike 2)
 ```
 
-**Cosmetic note for the implementer:** with the marker present, the swap's step 1 prints
-`Can't uninstall 'onnxruntime'. No files were found to uninstall.` and exits 0. That is
-expected output, not an error, and should not be "fixed."
+**Which `site-packages`.** One resolver, named here so it is not re-derived: the
+`SIDECAR_VENV_DIR ?? <repoRoot>/server/tts-sidecar/.venv` convention already in
+`diagnostics/venv.ts:9-11`, extracted to a shared `resolveSidecarVenvDir(repoRoot)`. Within
+that venv, `Lib/site-packages` on Windows and `lib/python<maj>.<min>/site-packages` on
+posix — resolved by asking the venv interpreter, since the posix layout needs its minor
+version. This repo has a competing hardcoded convention in the `*-install-detect.ts` files;
+copying that one would make the marker land in a directory that does not exist on a
+versioned-dir install.
 
-**Which `site-packages`.** The marker is written relative to the venv `install-ort.mjs` was
-handed (`process.argv[2]`, the venv python), derived from that interpreter — not from a
-second convention. This repo has two conflicting ones (`SIDECAR_VENV_DIR` vs a hardcoded
-`repoRoot/server/tts-sidecar/.venv`), and they differ on exactly the versioned-dir install
-that reported this bug.
+**Cosmetic note:** with the marker present, the swap's step 1 prints `Can't uninstall
+'onnxruntime'. No files were found to uninstall.` and exits 0. Expected, not an error.
 
-### Changed: `server/tts-sidecar/scripts/install-whisper.mjs`
+### The self-heal, restored — and write-only
 
-Independent of the marker, and a real defect: `:96` runs `pip install -U faster-whisper`
-with **no constraints file**, against a package `base.txt:45` pins to `>=1.0,<2.0`. `-U`
-can walk it past its own pin, and on a box where it is absent pip resolves to whatever is
-latest — a 2.x release would install cleanly in violation of the pin. Every sibling passes
-`-c` (`install-qwen3.mjs:100`, `install-coqui.mjs:149`).
+Round 3 disproved the claim that existing boxes heal themselves. Both upgrade
+(`apply.ts:134`) and rebuild (`decideVenvAction` → `noop` when `stamp.reqHash ===
+required.reqHash`) gate on the requirements hash, and **this change touches no
+`requirements/*.txt`** — so nothing re-runs the swap and no existing box would ever get a
+marker.
 
-Fix: **drop `-U`, add `-c <sanitized base.txt>`.** This clears the fix-now bar (one
-defensible answer, coverable by a test here) and is declared in the PR body as an
-incidental fix.
+`ensureOrtMarker(venvDir)` runs once at server boot, before the supervisor starts
+(`index.ts:309`): if the namespace is owned by a swap distribution and no marker is
+present, write one. Otherwise do nothing.
 
-The pip args are currently inline in an unexported `main()` — `install-whisper.mjs` exports
-nothing — so **extracting an exported arg builder** (mirroring `qwenPipInstallArgs` at
-`install-qwen3.mjs:99-101`) is part of the work, not a test detail. Without it the
-regression test fails on import rather than on its assertion: a red phase by accident.
+**This is safe in a way the repair killed in rounds 1–2 was not.** It uninstalls nothing,
+downloads nothing, needs no network, touches no locked DLL, and needs no accelerator
+profile — it reads what is *installed*, not what *should* be. Every Critical from rounds
+1–2 lived in a destructive repair whose mechanism no longer exists here. Worst case is a
+directory with three small files.
 
-### Changed: `server/src/spawn-windows-hide.test.ts`
+It runs at server boot rather than per-spawn, so it is unaffected by the adopt/unfit-replace
+branching that round 2 showed makes `spawnSidecar` placement treacherous.
 
-Its `EXTERNAL_FILES` array (`:55-63`) is a **hardcoded list** enforcing `windowsHide` on
-prod-reachable pip spawners outside `server/src`. It names three installers but omits
-`install-ort.mjs` (spawns pip at `:113`) and `bootstrap-venv.mjs` (`:104`) — both satisfy
-the array's own stated rule verbatim. This design makes `install-ort.mjs` materially more
-load-bearing, so both are added and the rule restated as "any file outside `server/src`
-that spawns pip" rather than re-enumerating installers.
+### `install-whisper.mjs` — independent, and a real defect
 
-### Detection, not repair — a deliberate change from the earlier decision
+`:96` runs `pip install -U faster-whisper` with **no constraints file**, against a package
+`base.txt:45` pins to `>=1.0,<2.0`. `-U` can walk it past its own pin; where it is absent,
+pip resolves to whatever is latest, so a 2.x release would install cleanly in violation.
+Every sibling passes `-c` (`install-qwen3.mjs:100`, `install-coqui.mjs:149`).
 
-The agreed direction was "detect and self-heal on boot." **This revision detects and
-reports, and does not repair.** The reasoning, stated so it can be overruled:
+Fix: **drop `-U`, add `-c <sanitized base.txt>`.** Round 3 confirmed this safe: `base.txt`
+carries no `onnxruntime` line (enforced by `requirements-layout.test.ts:21`), so the
+constraints file cannot conflict with the marker's version, and it has no `-r` includes,
+satisfying `pip-constraints.mjs`'s documented assumption.
 
-- Every Critical in both review rounds lived in the boot-time repair — the profile signal
-  that reads absence as an assertion, the adopted sidecar that defeats the stop primitive,
-  the uninstall-before-download ordering, the placement that would have run `pip uninstall`
-  inside the unit suite.
-- With the marker in place, **nothing new becomes broken**, so a repair mechanism only ever
-  serves the historical population.
-- That population is already healed by any path that re-runs the swap — an in-app upgrade
-  (`apply.ts:254-269`) or a venv rebuild — both of which now also write the marker.
-- The core sin of this bug is *silence*. A loud, accurate diagnosis plus a one-command fix
-  removes the silence at a fraction of the risk of an automatic destructive repair.
+Because the pip args are inline in an unexported `main()` — `install-whisper.mjs` exports
+nothing — **extracting an exported arg builder is part of the work**, not a test detail;
+without it the regression test fails on import rather than on its assertion. The step also
+becomes a no-op on every normal box, so its header (`:12-13`) and log line (`:95`), which
+still say "pulls ctranslate2 + av", are updated in the same diff.
 
-So: a read-only check reports when the namespace owner disagrees with the active profile,
-and names the command that fixes it. It never uninstalls anything.
+### `spawn-windows-hide.test.ts`
+
+Its `EXTERNAL_FILES` array (`:54-62`) enforces `windowsHide` on prod-reachable pip spawners
+outside `server/src` via a **hardcoded list** that names three installers. It omits
+`install-ort.mjs` (`:113`), `bootstrap-venv.mjs` (`:104`), and `install-torch.mjs` (`:59`,
+prod-reachable on the AMD path via `installForProfile`). Adding names keeps the list and the
+stated rule out of step. **Replace the enumeration with a glob** over
+`server/tts-sidecar/scripts/*.mjs` + `scripts/*.mjs`, selecting files that spawn pip.
 
 ## Testing
 
-### Regression tests (fail before, pass after)
+### The test that would have caught round 3's Critical
+
+At the seam where the marker is actually applied — `installForProfile` and `pipInstall` —
+with the fs writer injected alongside the existing `runPip`: assert the marker action is
+**emitted** for nvidia and the delete for cpu/amd/apple. Revision 3's plan tested only
+isolated planners and writers, so it would have been fully green while the shipped change
+did nothing.
+
+### Regression (fail before, pass after)
 
 - `install-whisper`'s args contain `-c` and **not** `-U` — fails on today's tree.
-- `planOrtMarker` returns `delete` for `cpu`, `amd`, **and** `apple`, and `write` only for
-  `nvidia` — the AMD/Apple cells are the ones that would silently break profile migration.
+- `planOrtSwap` returns `marker.action === 'delete'` for `cpu`, `amd`, **and** `apple`, and
+  `'write'` for `nvidia`. Note this is a *new* return field, so its red phase is an import
+  failure, not an assertion failure — it is listed here for completeness, and the
+  seam test above is the one that carries the regression weight.
 
 ### Unit
 
-- `readInstalledOrtVersion` parses the real `onnxruntime_gpu-1.27.0.dist-info` shape and
-  returns `null` (not a hardcoded fallback) when absent, so a missing dist can never
-  produce a confidently-wrong marker.
-- `writeOrtMarker` overwrites an existing stale marker rather than skipping it — the
-  spike proved pip leaves stale markers behind, so create-if-missing would preserve a lie.
+- `readInstalledOrtVersion` globs from `plan.ortPackage`, parses the real
+  `onnxruntime_gpu-1.27.0.dist-info` shape, and returns `null` when absent — with a paired
+  test that `null` **aborts the swap** rather than skipping the write.
+- `writeOrtMarker` overwrites a stale marker rather than skipping it — Spike 2 proved pip
+  leaves stale markers behind, so create-if-missing would preserve a lie.
 - `deleteOrtMarker` is a no-op when absent and removes only the marker directory.
-- The marker matcher targets the **raw** `.dist-info` directory name, and is
-  mutation-checked against `onnxruntime-1.28.0.dist-info` **and**
-  `onnxruntime_gpu-1.27.0.dist-info` in one assertion — pip normalises the GPU
-  distribution with an **underscore** (verified in the live venv), so a matcher that
-  catches both would delete the real GPU distribution.
+- **Ordering**: on a non-swapping profile the delete is emitted **before** the overlay
+  install, not after — asserted at the seam, with the AMD→CPU fallback as the case. A test
+  that only checks "delete was called" passes under the broken ordering.
+- `ensureOrtMarker` is a no-op when a marker exists, when the namespace is unowned, and on
+  a cpu-profile venv; and never calls uninstall or network code.
+- The marker matcher targets the **raw** `.dist-info` directory name, mutation-checked
+  against `onnxruntime-1.28.0.dist-info` **and** `onnxruntime_gpu-1.27.0.dist-info` in one
+  assertion — pip normalises the GPU distribution with an **underscore** (verified live), so
+  a matcher catching both would delete the real GPU distribution.
 
 Every assertion is mutation-checked on its own line.
 
@@ -256,61 +300,72 @@ Every assertion is mutation-checked on its own line.
    clean, exit 0; Kokoro reports `CUDAExecutionProvider`.
 2. **The reported bug** — Windows + NVIDIA, **app running**, in-app Qwen3 install completes
    with no `WinError 5`; GPU Kokoro afterwards.
-3. **Profile migration `nvidia` → `cpu`** — the marker is deleted and real plain
-   `onnxruntime` installs. This is the case the second spike result created; it is the
-   most likely way this design breaks.
+3. **Self-heal on an existing box** — a venv bootstrapped *before* this change (no marker,
+   `pip check` failing) gains one on next server start with no reinstall. This is the case
+   round 3 proved nothing else covers.
 4. **Pinokio update path** — `pinokio-scripts/update.js` on a real Pinokio install, the
    deployment shape that reported the bug.
+5. **AMD box** — no marker is written, and one left over from a prior nvidia profile is
+   deleted.
 
 Register row, run sheet, and live view all move in the shipping PR per checklist step 3.
+
+## What this does not deliver
+
+#2192 asks that the in-app install "either succeed, or fail with an actionable message —
+**never a raw `WinError 5`**." This design delivers prevention, not translation: there is no
+`WinError`/errno handling in `routes/qwen-install.ts` or `tts/qwen-install-bootstrap.ts`,
+so a lock on any *other* venv DLL (ctranslate2, torch) would still surface a raw pip
+traceback. Prevention is the better fix for the reported case; the translation half is
+**explicitly not shipped here** and is filed separately rather than left implied.
 
 ## Before-shipping coverage
 
 Steps 1/4: substantial and cross-cutting — **owes a plan under `docs/features/` and an
-`INDEX.md` entry**. Step 5: user-visible (installs stop failing; upgrades stop breaking
-GPU Kokoro), so **both release-notes documents move in the PR**.
+`INDEX.md` entry**. Step 5: user-visible (installs stop failing; upgrades stop breaking GPU
+Kokoro), so **both release-notes documents move in the PR**.
 
 ## Risks
 
-- **Marker version drift.** If `onnxruntime-gpu` is changed by something other than
-  `install-ort.mjs` (a manual `pip install -U onnxruntime-gpu`), the marker keeps the old
-  version. `faster-whisper`'s `onnxruntime<2,>=1.14` bound tolerates a wide range, so the
-  practical blast radius is small, but ORT-gpu changes should go through the swap.
-- **A stale marker suppressing a real install.** The failure mode the `delete` branch
-  exists to prevent; on-box case 3 is its acceptance.
-- **The marker is a metadata assertion.** It states that `onnxruntime-gpu` provides
-  `onnxruntime`, which is true at the package level but is not something pip derived
-  itself. A future pip that validates `RECORD` hashes could object; nothing in the pinned
-  toolchain does today.
-- **Pre-existing and untouched:** doors 1–3 resolve the venv as `SIDECAR_DIR/.venv`
-  (`install-qwen3.mjs:165-169`, `install-whisper.mjs:56-63`, `install-coqui.mjs:46`) while
-  doors 4–5 and the sidecar honour `SIDECAR_VENV_DIR` — on a versioned-dir install those
-  differ. This design does not fix that; it is called out because the marker lives in
-  whichever venv the swap ran against, and a split-venv install has a deeper problem than
-  this bug. **Files as its own issue.**
+- **Wiring, not mechanism, is where this design has failed before.** The marker rides the
+  plan and is applied by both consumers outside their swap gate; the seam test exists
+  specifically because revision 3 was green while shipping nothing.
+- **Marker version drift** if `onnxruntime-gpu` is changed outside the swap (a manual
+  `pip install -U onnxruntime-gpu`). `faster-whisper`'s `<2,>=1.14` bound tolerates a wide
+  range, so blast radius is small.
+- **`pip freeze` now lists both** `onnxruntime==<v>` and `onnxruntime-gpu==<v>`. Nothing in
+  the tree runs it, but a future support-bundle `pip install -r frozen.txt` would clobber.
+- **The marker is a metadata assertion** — true at the package level, but not something pip
+  derived itself. A future pip that validates `RECORD` hashes could object; nothing in the
+  pinned toolchain does today.
+- **`cpu.txt:26` carries an explicit `onnxruntime` line.** The AMD→CPU fallback
+  (`bootstrap-venv.mjs:181`) is the one live path where a marker would suppress a real,
+  explicitly-requested install — reachable only on an AMD box, which takes the `delete`
+  branch and so never carries one. This is why `delete` is active rather than a no-op.
+- **Pre-existing and untouched:** doors 1–2 resolve the venv as `SIDECAR_DIR/.venv` while
+  the rest honour `SIDECAR_VENV_DIR` — on a versioned-dir install those differ. **Filed as
+  its own issue**; a split-venv install has a deeper problem than this bug.
 
 ## Review findings
 
-Two Premium-tier rounds against the per-site architecture. Round 1 found nine defects;
-round 2, briefed to attack round 1's fixes, found sixteen — including that those fixes had
-broken each other. Every finding was re-verified against the tree before being acted on.
+Three Premium-tier rounds. Rounds 1 and 2 attacked a per-site architecture (chokepoint,
+`--no-deps`, quiesce, destructive boot repair) and found nine and sixteen defects
+respectively — round 2 briefed to attack round 1's fixes, which it found had broken each
+other. That architecture was abandoned rather than patched a third time; §Approach is what
+replaced it.
 
-**Dissolved by the pivot** (the mechanism they attacked no longer exists): the
-one-directional repair rule and its unreachable no-runtime states; the positive-profile-
-signal predicate; prefetch-first ordering; the `applyOrtSwap` signature change; quiesce and
-the adopted-sidecar `stop()` no-op; the repair's placement in `spawnSidecar`; the
-owner-set anti-storm guard; `overlayDeclares` and its `-r base.txt` include graph;
-`--no-deps` disabling `install-qwen3.mjs`'s documented repair purpose; the gutted-namespace
-probe; the `pip check` cry-wolf filter and its exit-1 handling.
+Round 3 attacked the replacement. **It cleared the mechanism** (no runtime metadata reader;
+no pip mode defeats a marker; the `install-whisper` fix is safe) and found the wiring wrong:
 
-**Carried into this revision as real fixes:**
-
-| Finding | Round | Disposition |
+| Finding | Severity | Disposition |
 |---|---|---|
-| `install-whisper.mjs` `-U` with no `-c` | 1 (#9), sharpened in 2 | Fixed here |
-| `install-whisper.mjs` exports nothing, so the test can't be written | 1 (#6) | Arg-builder extraction is part of the work |
-| `spawn-windows-hide.test.ts` list omits pip spawners | 1 (#5), widened in 2 (#9) | `install-ort.mjs` + `bootstrap-venv.mjs` added |
-| AMD/Apple are not "GPU profiles" | 2 (#7) | Drives the `write`/`delete` split |
-| Raw vs normalised `.dist-info` matcher | 2 (#12) | Matcher specified + mutation-checked |
-| Two venv-path conventions | 2 (#8, #14) | Marker follows the swap's venv; the split filed separately |
-| Out-of-process Pinokio doors | 2 (#3, #14) | Closed by construction — no server needed |
+| `install-ort.mjs` is never run as a CLI — the marker would fire on zero paths | Critical | Marker rides the plan; both consumers apply it; both now Changed files |
+| Existing boxes are *not* healed by upgrade/rebuild — both gate on an unchanged reqHash | Critical | Write-only `ensureOrtMarker` at server boot, restored |
+| Profile migration returns `rebuild` → refuses, so the marker dies with the venv | Major | Risk model corrected; `delete` kept as insurance for the AMD→CPU fallback |
+| Test plan could not detect the fix not working | Major | Seam test at `installForProfile` / `pipInstall` |
+| The read-only detector was never specified | Major | Superseded — the write-only self-heal replaces it |
+| `null` version handling unspecified; glob hardcoded to `onnxruntime_gpu-*` | Major | Fails the swap loudly; glob derived from `plan.ortPackage` |
+| `site-packages` resolution ambiguous | Major | One named resolver + interpreter-derived layout |
+| Widened `windowsHide` rule still omits `install-torch.mjs` | Minor | Glob instead of enumeration |
+| `install-coqui.mjs` rows were padding — none of those packages needs `onnxruntime` | Minor | Removed from the doors table |
+| The "actionable message" half of the acceptance criterion is not delivered | Minor | Stated explicitly in §What this does not deliver |


### PR DESCRIPTION
## Summary

Design of record for **#2192** — Qwen3 install failing with `WinError 5` on a locked
`onnxruntime` DLL, and silently replacing `onnxruntime-gpu` with the CPU build when it
succeeds. Docs only: a spec and an implementation plan, no runtime code.

**The root condition.** The nvidia profile swaps plain `onnxruntime` for `onnxruntime-gpu`,
and pip matches distributions by *name* — so `pip check` on a correctly bootstrapped NVIDIA
box reports three unmet requirements and exits 1. The venv is permanently in a state pip
considers broken, so **any** pip call whose target depends on `onnxruntime` tries to repair
it: crashing on the sidecar's DLL lock if the app is running, silently destroying the GPU
runtime if it isn't. Verified empirically (`--dry-run`, nothing written):
`Would install onnxruntime-1.28.0`.

**The fix.** Record, once, what is already true — `onnxruntime-gpu` provides the
`onnxruntime` package. A minimal marker `.dist-info` makes pip agree, and every door closes
at once, including the three out-of-process Pinokio paths (`install.js`, `update.js`,
`reset.js`) that no server-side guard could ever reach. Spike-validated before the design was
written: every install path goes `already satisfied`, `pip check` → clean, exit 0.

## What's here

- `docs/superpowers/specs/2026-08-07-qwen-ort-namespace-chokepoint-design.md` — the spec,
  revision 6.
- `docs/superpowers/plans/2026-08-07-ort-pip-consistency-marker.md` — 12 TDD tasks with real
  test code and mutation checks.

## Review history

**Five Premium adversarial rounds.** Worth reading the spec's §Review findings — the design
changed substantially under them:

- **Rounds 1–2** attacked a per-site architecture (chokepoint / `--no-deps` / quiesce /
  boot repair). Round 2, briefed to attack round 1's fixes, found they had broken each other.
  Abandoned rather than patched a third time.
- **Round 3** cleared the replacement *mechanism* — no runtime code reads onnxruntime
  distribution metadata, no pip mode in this repo defeats a marker — but found the wiring
  fired on **zero** production paths (`install-ort.mjs` is never run as a CLI).
- **Round 4** returned "not safe to implement from": a venv state no revision had named (the
  already-clobbered box), and a version glob that would have failed every NVIDIA bootstrap.
- **Round 5** found the ownership predicate could not distinguish a GPU build from a CPU one
  and would have deleted a correct marker on every boot, and surfaced a fifth state
  (interrupted swap). It also found the better oracle now used:
  `capi/build_and_package_info.py`, which is pure filesystem.

## Test plan

Docs-only — no tests to run. The plan's Task 9 Step 5 is the first end-to-end proof
(`npm run dev` on this box should log the marker being recorded, and `pip check` should go
clean); Tasks 1–11 each carry unit tests with explicit mutation checks.

`npm run verify:fast:branch` passes (all legs correctly scope-skipped for a docs-only diff).

Per CONTRIBUTING.md's doc-only fast path, this PR is exempt from the `code-review` gate.

Refs #2192
