### PR TITLE
chore(scripts): scrub git env vars in run-golden-audio's spawn wrapper

### DIFF
--- a/scripts/run-golden-audio.mjs
+++ b/scripts/run-golden-audio.mjs
@@ -63,6 +63,7 @@ import { spawnSync } from 'node:child_process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { maxNvidiaSmiUtil, GPU_BUSY_THRESHOLD } from './verify-cache.mjs';
+import { scrubGitEnv } from './git-env.mjs';
 
 // Re-exported for backward compatibility: scripts/tests/run-golden-audio.test.mjs
 // imports maxNvidiaSmiUtil from this module. The implementation itself moved to
@@ -153,12 +154,24 @@ function warnIfGpuBusyForBless() {
 
 const results = [];
 
-function run(label, cmd, cmdArgs, { env, shell } = {}) {
+// #2193 — scrub git repo-discovery env vars before every spawn here, even
+// though this wrapper launches npm/pytest rather than git directly: an npm
+// script is free to shell out to git at any time without ever touching this
+// file, so the scrub is unconditional rather than a per-callee judgement
+// call. `scrubGitEnv()` returns a plain object copy of `process.env`, so
+// spreading `env` over it clears an ambient key exactly like spreading over
+// `process.env` did (see the two call sites' own GOLDEN_BLESS comments).
+//
+// Exported solely so scripts/tests/run-golden-audio.test.mjs can call it
+// directly and observe the scrub at a real spawned child, without triggering
+// a full golden-audio run (#2193) — not part of the module's documented CLI
+// surface.
+export function run(label, cmd, cmdArgs, { env, shell } = {}) {
   console.log(`\n=== golden-audio: ${label} ===`);
   const r = spawnSync(cmd, cmdArgs, {
     stdio: 'inherit',
     cwd: ROOT,
-    env: { ...process.env, ...env },
+    env: { ...scrubGitEnv(), ...env },
     // npm is a `.cmd` shim on Windows; Node refuses to spawn `.cmd` directly
     // (EINVAL) unless routed through a shell.
     shell: shell ?? false,
@@ -227,7 +240,7 @@ if (isDirectInvocation) {
       // Explicit `undefined` (not `{}`) so an ambient GOLDEN_BLESS=1 exported in
       // the shell can't leak through on the non-bless path and silently turn an
       // ordinary assert run into a bless that overwrites committed fixtures —
-      // `run()`'s `{ ...process.env, ...env }` spread only clears an inherited
+      // `run()`'s `{ ...scrubGitEnv(), ...env }` spread only clears an inherited
       // key when this object explicitly sets it to `undefined`.
       env: { GOLDEN_BLESS: bless ? '1' : undefined },
     });

--- a/scripts/tests/run-golden-audio.test.mjs
+++ b/scripts/tests/run-golden-audio.test.mjs
@@ -10,6 +10,7 @@ import {
   maxNvidiaSmiUtil,
   gpuBusyWarningFor,
   CONTENTION_UNKNOWN_MESSAGE,
+  run,
 } from '../run-golden-audio.mjs';
 
 // Resolve relative to THIS file, not the process cwd — `node --test` can be
@@ -22,7 +23,7 @@ const REPO_ROOT = join(HERE, '..', '..');
 const src = readFileSync(SRC_PATH, 'utf8');
 
 // The exact non-leaking shape both Suite calls must use: `undefined` (not
-// `{}`) on the non-bless arm, so `run()`'s `{ ...process.env, ...env }`
+// `{}`) on the non-bless arm, so `run()`'s `{ ...scrubGitEnv(), ...env }`
 // spread actually clears an ambient GOLDEN_BLESS instead of leaving it to
 // leak through. Anchored on the `'1'` / `undefined` ORDER, so an inverted
 // ternary (`bless ? undefined : '1'`) fails this regex — it would silently
@@ -56,6 +57,133 @@ test('GOLDEN_BLESS is cleared (not left ambient) on the non-bless path for BOTH 
         '`undefined` (which clears an ambient value) otherwise — an inverted ternary, ' +
         'or a bare `env: {}`, must fail this test',
     );
+  }
+});
+
+// #2193 — run()'s spawned children used to inherit `process.env` verbatim,
+// so an ambient GIT_DIR/GIT_WORK_TREE (e.g. exported by a parent git hook,
+// or left behind in an operator's shell) would pass straight through to the
+// `npm`/pytest child. This calls the real exported `run()` and observes the
+// child's OWN view of GIT_DIR — not the options object `run()` built — so a
+// regression that reverts the `scrubGitEnv()` spread fails this test.
+// `stdio: 'inherit'` (run()'s own default) forwards the child's stdout
+// straight to this test process's stdout rather than back through
+// spawnSync's return value, so the probe child writes what it saw to a temp
+// file instead, which this test then reads back.
+//
+// #2217 review, F2 — asserting only GIT_DIR's absence is equally satisfied
+// by `scrubGitEnv({})` (an empty base, dropping the REST of the parent
+// environment too) as by the real fix (`scrubGitEnv()`, which scrubs the
+// real `process.env`) — both leave GIT_DIR absent. `GOLDEN_COQUI`,
+// `GOLDEN_QWEN_VOICE`, `CUDA_VISIBLE_DEVICES`, etc. all ride the same spread
+// as an ordinary ambient var, so this also asserts a decoy non-git ambient
+// variable DOES reach the child, ruling out the empty-base regression.
+test('run() scrubs an inherited GIT_DIR from the spawned child env, while an unrelated ambient var survives', () => {
+  const probeFile = join(
+    tmpdir(),
+    `run-golden-audio-gitdir-probe-${process.pid}-${Date.now()}.txt`,
+  );
+  const SENTINEL_KEY = 'RUN_GOLDEN_AUDIO_TEST_SENTINEL';
+  const savedGitDir = process.env.GIT_DIR;
+  const savedSentinel = process.env[SENTINEL_KEY];
+  process.env.GIT_DIR = '/decoy/.git';
+  process.env[SENTINEL_KEY] = 'sentinel-value';
+  try {
+    const code = run('gitdir-probe', process.execPath, [
+      '-e',
+      `require('fs').writeFileSync(${JSON.stringify(probeFile)}, ` +
+        `String(process.env.GIT_DIR) + '\\n' + String(process.env.${SENTINEL_KEY}))`,
+    ]);
+    assert.equal(code, 0);
+    const [gitDirSeen, sentinelSeen] = readFileSync(probeFile, 'utf8').split('\n');
+    assert.equal(
+      gitDirSeen,
+      'undefined',
+      `expected the spawned child to see no GIT_DIR at all; it saw ${JSON.stringify(gitDirSeen)}`,
+    );
+    assert.equal(
+      sentinelSeen,
+      'sentinel-value',
+      'expected an unrelated ambient var to survive the scrub and reach the child; saw ' +
+        JSON.stringify(sentinelSeen),
+    );
+  } finally {
+    if (savedGitDir === undefined) delete process.env.GIT_DIR;
+    else process.env.GIT_DIR = savedGitDir;
+    if (savedSentinel === undefined) delete process.env[SENTINEL_KEY];
+    else process.env[SENTINEL_KEY] = savedSentinel;
+    rmSync(probeFile, { force: true });
+  }
+});
+
+// #2193 — the regex test above (line 51) only proves the two call sites
+// still WRITE `env: { GOLDEN_BLESS: bless ? '1' : undefined }`; it does not
+// prove that shape actually clears an ambient GOLDEN_BLESS at the spawned
+// child now that run()'s spread base changed from `process.env` to
+// `scrubGitEnv()`. Same probe-file pattern as the GIT_DIR test above.
+//
+// #2217 review, F1 — the positive control below must NOT set the ambient
+// GOLDEN_BLESS to the SAME value ('1') it then asserts the child saw: with
+// the ambient also '1', the assertion can't tell "the caller's explicit '1'
+// reached the child" from "the ambient '1' leaked through uncleared" — those
+// are two different bugs and the control was blind to the first. Fixed by
+// deleting the ambient entirely before the control run, so a '1' at the
+// child can only have come from the caller-supplied `env`. What this now
+// catches: a `run()` that honours a caller key only when its value is
+// `undefined` (i.e. only ever clears, never sets) and silently drops any
+// caller key carrying a real value — which in production would make
+// `npm run test:golden-audio -- --bless` silently degrade to an ordinary
+// assert run that never blesses.
+test('run() clears an ambient GOLDEN_BLESS via an explicit undefined, and honours an explicit "1" with no ambient present', () => {
+  const probeFile = join(
+    tmpdir(),
+    `run-golden-audio-bless-probe-${process.pid}-${Date.now()}.txt`,
+  );
+  const savedBless = process.env.GOLDEN_BLESS;
+  try {
+    // Non-bless shape: an ambient '1' must be cleared by an explicit `undefined`.
+    process.env.GOLDEN_BLESS = '1';
+    run(
+      'bless-probe-clear',
+      process.execPath,
+      [
+        '-e',
+        `require('fs').writeFileSync(${JSON.stringify(probeFile)}, String(process.env.GOLDEN_BLESS))`,
+      ],
+      { env: { GOLDEN_BLESS: undefined } },
+    );
+    const seenWhileClearing = readFileSync(probeFile, 'utf8');
+    assert.equal(
+      seenWhileClearing,
+      'undefined',
+      'an explicit `undefined` must clear the ambient GOLDEN_BLESS at the spawned child; saw ' +
+        JSON.stringify(seenWhileClearing),
+    );
+
+    // Positive control: bless shape, with NO ambient GOLDEN_BLESS at all —
+    // the child can only see '1' if run() actually forwarded the caller's
+    // explicit value, not because it happened to match a leaked ambient one.
+    delete process.env.GOLDEN_BLESS;
+    run(
+      'bless-probe-set',
+      process.execPath,
+      [
+        '-e',
+        `require('fs').writeFileSync(${JSON.stringify(probeFile)}, String(process.env.GOLDEN_BLESS))`,
+      ],
+      { env: { GOLDEN_BLESS: '1' } },
+    );
+    const seenWhileSetting = readFileSync(probeFile, 'utf8');
+    assert.equal(
+      seenWhileSetting,
+      '1',
+      'an explicit GOLDEN_BLESS: "1" must still reach the spawned child even with no ambient ' +
+        `value present; saw ${JSON.stringify(seenWhileSetting)}`,
+    );
+  } finally {
+    if (savedBless === undefined) delete process.env.GOLDEN_BLESS;
+    else process.env.GOLDEN_BLESS = savedBless;
+    rmSync(probeFile, { force: true });
   }
 });
 


### PR DESCRIPTION
## Summary

`scripts/run-golden-audio.mjs`'s local `run()` was the last spawn wrapper in `scripts/` that did not scrub git repo-discovery env vars — `env: { ...process.env, ...env }` passed an inherited `GIT_DIR` / `GIT_WORK_TREE` straight to the child. It now spreads `scrubGitEnv()` instead.

#2193 was filed rather than folded into #2184 because it needed a decision: this wrapper launches `npm` and `pytest`, never `git` or `gh`, so there is no known live defect. The decision (recorded on the issue with its rejected alternatives) is to scrub anyway. The wrapper's callees are not a fixed target — an npm script is free to shell out to git at any time without ever touching this file — so the scrub is unconditional rather than a per-callee judgement the next reader has to re-derive. The rationale is in the file, not only in the issue.

Rejected: leaving it documented as not-needing-the-scrub, and the larger option of retiring every per-file `run()` helper behind one shared spawn helper. The latter was the option the issue itself flagged as "the only version where a fourth wrapper cannot appear" — see below for why that framing turned out to be wrong.

## Test plan

- `scripts/tests/run-golden-audio.test.mjs` — two new behavioural tests, both observing the **child's own view** of its environment via a probe file. `run()` uses `stdio: 'inherit'`, so `spawnSync`'s return value cannot capture the child's stdout; the probe child writes what it saw to a temp file which the test reads back. Assertions are on what the child received, never on the options object `run()` built.
  - `GIT_DIR` set ambiently does not reach the child. Mutation-verified: reverting to `...process.env` fails it with `expected the spawned child to see no GIT_DIR at all; it saw "/decoy/.git"`.
  - An explicit `undefined` still clears an ambient `GOLDEN_BLESS`, **and** an explicit `'1'` still reaches the child. Both call sites depend on the first half — it is what stops an ambient `GOLDEN_BLESS=1` turning an ordinary assert run into a bless that overwrites committed golden fixtures. Mutation-verified against `{ ...scrubGitEnv() }` (dropping the caller's env entirely): `an explicit \`undefined\` must clear the ambient GOLDEN_BLESS at the spawned child; saw "1"`.
### Corrections after independent review

Two of the tests above did not prove what an earlier version of this PR body claimed, and the claim was mine — I wrote it from the implementer's report without checking the reasoning. Both are fixed here; both fixes are mutation-verified.

**The positive control could not discriminate.** It set an ambient `GOLDEN_BLESS='1'` and then asserted that passing `env: { GOLDEN_BLESS: '1' }` made the child see `'1'` — the expected value was identical to the ambient it was supposed to be tested against, so it could not tell a caller-supplied value from a leak. The justifying comment (and this PR body) claimed the clearing assertion "would also pass" under `{ ...scrubGitEnv() }` and that the control ruled that out. **Both halves were false**: under that mutation the *clearing* assertion is what goes red, and the control passes and rules out nothing. The control now deletes the ambient before asserting, so its expected value cannot be supplied by the environment. Mutation-verified against a `run()` that forwards only `undefined`-valued caller keys — the shape that in production would make `--bless` silently degrade to an ordinary assert run.

**Neither test noticed the parent environment disappearing.** `env: { ...scrubGitEnv({}), ...env }` — passing no parent environment at all — passed all 11 tests and linted clean, because both tests only asserted an *absence*, and absence is equally satisfied by sending nothing. In production that silently stops `GOLDEN_COQUI`, `GOLDEN_QWEN_VOICE`, `GOLDEN_ASR`, `GOLDEN_REBLESS_*`, `CUDA_VISIBLE_DEVICES` and `ASR_MODEL` reaching the suites; on Linux and macOS, where `verify.yml` runs, `PATH` goes too (it survives on Windows only because libuv force-injects required vars). The GIT_DIR test now sets a decoy non-git ambient variable alongside the decoy `GIT_DIR` and asserts the child **does** receive it. Mutation-verified.

A stale comment at the Suite A call site still described the old `{ ...process.env, ...env }` spread — and the new block comment points a future reader at those call-site comments as its authority. Corrected.

Not changed, deliberately: only one of the five scrub keys is exercised through this wrapper. The other four are unit-tested key-by-key against `scrubGitEnv` itself, and the mutation that would exploit the gap leaves the import unused and so fails `eslint --max-warnings 0`. Reasonable layering rather than a hole.
- The pre-existing source-text test at `:43` is kept. It catches a different regression (a call site losing its env object entirely) and the new test's comment says so.
- `run` is now exported solely so the test can call it without triggering a full golden-audio run. Documented as such at the definition; it is not part of the module's CLI surface.
- `npm run test:hooks` → **1208 pass, 0 fail**, 25 suites. `npm run lint` → clean.

## Release notes

**Deliberately skipped**, per CLAUDE.md's "internal chore with no user- or operator-visible effect" carve-out — the same one PR #2203 used. This touches a maintainer-only opt-in test runner; nothing in the shipped app changes.

## What deciding this turned up — filed as #2216

The issue's premise, that this is "the last unscrubbed spawn wrapper in `scripts/`", is accurate and beside the point. Enumerating the population properly finds roughly **24 direct `git` invocations under `scripts/` and `pinokio-scripts/` that do not scrub** — none of them a wrapper, which is why every previous wrapper-shaped search missed them. Four sit inside git hooks, four in worktree tooling, three in the Pinokio installer including `git checkout <tag>`.

No live defect is claimed for those. The point is narrower: the scrub has been applied three times by incident (#2169, #2184, #2193) and the set it ought to cover was never listed. Deciding which sites need it is a judgement per site, widens the blast radius well past this issue, and does not clear CLAUDE.md's fix-now bar — so it is **#2216**, with its own decision recorded.

Closes #2193
