### PR TITLE
test(server): order the #1981 race case on a signal, not a sleep

### DIFF
--- a/server/src/routes/book-state-preserve-voices.test.ts
+++ b/server/src/routes/book-state-preserve-voices.test.ts
@@ -405,7 +405,19 @@ describe('book-state PUT cast — #1981 race: stale cast PUT vs concurrent /assi
      after construction forces real dispatch now, decoupled from when the
      result is actually awaited below — without it, /assign's request doesn't
      even reach the network until the final `Promise.all`, by which point the
-     gate has long since released and there is nothing left to race. */
+     gate has long since released and there is nothing left to race.
+
+     [#2215] Waiting for PUT to *reach* the intercepted read used to be a
+     fixed ~20ms wall-clock sleep followed by `expect(intercepted).toBe(true)`
+     — a guess at how long PUT "should" take to get there, which is not a
+     synchronisation primitive: under load (parallel vitest workers, a
+     concurrent GPU job, a cold import) PUT can still be short of the
+     interceptor when the sleep elapses, and the assertion goes red on
+     ordering alone rather than on the behaviour under test. `interceptedSignal`
+     replaces the guess with the real happens-before edge: the mock itself
+     resolves it the instant PUT's readJson call reaches the interceptor, so
+     the await returns as soon as that is true and no sooner — deterministic
+     regardless of machine load. */
   it('#1981 — a stale cast PUT does not erase a concurrently /assign-planted voice', async () => {
     const stateIo = await import('../workspace/state-io.js');
     const actual = await vi.importActual<typeof import('../workspace/state-io.js')>(
@@ -418,9 +430,14 @@ describe('book-state PUT cast — #1981 race: stale cast PUT vs concurrent /assi
       released = resolve;
     });
     let intercepted = false;
+    let signalIntercepted!: () => void;
+    const interceptedSignal = new Promise<void>((resolve) => {
+      signalIntercepted = resolve;
+    });
     const spy = vi.mocked(stateIo.readJson).mockImplementation(async (path: string) => {
       if (!intercepted && path === raceCastPath) {
         intercepted = true;
+        signalIntercepted(); // deterministic happens-before edge — see header comment
         const value = await actual.readJson(path); // real read, now — happens-before /assign's write
         await gate; // hold the RESOLUTION open until released below
         return value;
@@ -444,7 +461,7 @@ describe('book-state PUT cast — #1981 race: stale cast PUT vs concurrent /assi
         });
       putPromise.catch(() => {}); // force dispatch now (see header comment)
       // Let PUT reach (and get stuck behind) the intercepted read.
-      await new Promise((r) => setTimeout(r, 20));
+      await interceptedSignal;
       expect(intercepted).toBe(true);
 
       const assignPromise = request(app)

--- a/server/src/routes/book-state-preserve-voices.test.ts
+++ b/server/src/routes/book-state-preserve-voices.test.ts
@@ -437,8 +437,15 @@ describe('book-state PUT cast — #1981 race: stale cast PUT vs concurrent /assi
     const spy = vi.mocked(stateIo.readJson).mockImplementation(async (path: string) => {
       if (!intercepted && path === raceCastPath) {
         intercepted = true;
-        signalIntercepted(); // deterministic happens-before edge — see header comment
         const value = await actual.readJson(path); // real read, now — happens-before /assign's write
+        /* Signalled AFTER the real read, not at interceptor entry (PR #2232
+           review, finding 1). The invariant this edge exists to establish is
+           "PUT's read genuinely happens-before /assign's write" — resolving on
+           entry would release /assign while the read was still pending, which
+           is harmless while the route holds withCastLock but gives the
+           lock-removed mutation strictly LESS slack than the 20ms sleep did.
+           Signal what the comment actually claims. */
+        signalIntercepted();
         await gate; // hold the RESOLUTION open until released below
         return value;
       }


### PR DESCRIPTION
## Summary

`book-state-preserve-voices.test.ts`'s `#1981 race: stale cast PUT vs concurrent /assign`
used a fixed ~20 ms `setTimeout` to let the stale PUT reach the intercepted `cast.json` read
before firing the concurrent `/assign`, then asserted `intercepted === true`.

A sleep is not a synchronisation primitive. Under load — parallel vitest workers, a
co-running GPU job, a cold import — the PUT could still be short of the interceptor when the
sleep elapsed, so the case went red on **ordering** rather than on the behaviour under test.

**Confirmed pre-existing on `main` itself**, not introduced by any feature branch: whole
file, `--retry=0`, three consecutive runs gave 7 passed / **1 failed | 6 passed** / 7 passed
— roughly 1-in-3 on this box. It normally passes in CI only because vitest's configured
retries mask it; it surfaced when a `[retry-hazard]` warning prompted a `--retry=0` re-run.

## The fix

The interceptor mock now resolves a deferred at the exact moment the PUT's `readJson` reaches
it, and the test awaits that instead of a clock. The await returns as soon as the ordering
precondition is genuinely true and no sooner, regardless of machine load. This is a real
happens-before edge, not a longer guess — lengthening the sleep was explicitly rejected, since
it only makes the flake rarer and the suite slower.

Nothing else in the case changed: the same assertions, on the same behaviour.

## Test plan

Both halves of the proof were run, because "it stopped failing" is not on its own
distinguishable from luck at a 1-in-3 base rate:

- **Determinism — 10/10 green** running the whole file at `--retry=0`, ten consecutive times.
  At the observed ~1-in-3 failure rate, ten clean runs by chance is on the order of 1 in 5000.
- **Still detects its regression.** Bypassing the PUT's `withCastLock` in
  `server/src/routes/book-state.ts` (the actual #1981 guard — `/assign` is meant to queue
  behind the PUT's held lock) reddens **this case and only this case**: 1 failed | 9 passed.
  Restored afterwards.

Worth recording: the first mechanism tried — disabling `preserveDesignedVoicesOnCastWrite` —
reddened two *other* cases in the file but **not** this one. So this case guards the lock,
not the preservation pass, and a mutation proof aimed at the wrong mechanism would have
"passed" while proving nothing.

## Known limitation, deliberately accepted

`await interceptedSignal` has no upper bound. If the PUT never reaches the interceptor the
case hangs until vitest's own timeout rather than failing fast with a pointed message. That
is the right trade — a slow, clear timeout beats a fast, false red — and reintroducing a
wall-clock race to "fix" it would undo the change.

Closes #2215
