### PR TITLE
docs(docs): mark the mid-run rename plan shipped, not awaiting a PR

### DIFF
--- a/docs/superpowers/plans/2026-08-07-rename-midrun-bookdir-pinning.md
+++ b/docs/superpowers/plans/2026-08-07-rename-midrun-bookdir-pinning.md
@@ -37,8 +37,8 @@ frontend, `openapi-typescript` for the generated client types.
 **Issue:** `Closes #2165`
 **Design source:** issue #2165's body plus its design-investigation comment
 (the comment corrects the body twice and is the authoritative version).
-**Status:** implemented — all 5 tasks complete on
-`fix/server-2165-rename-midrun-pinning` (2026-08-07); PR not yet opened.
+**Status:** shipped — merged 2026-08-07 as PR #2229 (merge commit `f430b3be`),
+closing #2165. See Ship notes.
 
 ---
 


### PR DESCRIPTION
## Summary

The plan's `**Status:**` line still read "PR not yet opened" after PR #2229 merged — it was written by the plan's own ship task, before the PR existed. Now reads shipped, with the PR number and merge commit.

Docs-only: no runtime, config, test, CI, or dependency change.

## Test plan

None applicable — a single status line in a plan document. Docs-only PR, so exempt from the `code-review` gate per CLAUDE.md.

Refs #2165