### PR TITLE
fix(server): make a multi-pair reject undo atomic

### DIFF
--- a/server/src/routes/analysis-reject-edge-reconcile.test.ts
+++ b/server/src/routes/analysis-reject-edge-reconcile.test.ts
@@ -8,10 +8,11 @@ import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, statSync }
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { reconcileRejectEdgesOnDisk } from './analysis.js';
+import { reconcileRejectEdgesOnDisk, DEGRADED_CAST_ID_HISTORY_LOG_MESSAGE } from './analysis.js';
 import {
   loadCastIdHistoryWithStatus,
   dropSupersededIdsReclaimedByLiveCast,
+  CastIdHistoryUnreadableError,
 } from '../store/cast-id-history.js';
 
 const BOOK_ID = 'book-hollow-tide';
@@ -172,8 +173,12 @@ describe('reconcileRejectEdgesOnDisk', () => {
           ]);
           // No write at all.
           expect(statSync(join(bookDir, '.audiobook', 'cast.json')).mtimeMs).toBe(before);
-          // And nothing claims otherwise in the run log.
-          expect(lines).toEqual([]);
+          // #2201 — the run log gets ONE line naming the skip, distinguishable
+          // from the `Cleared N …` / `Restored N …` lines that fire only when
+          // a write actually happened.
+          expect(lines).toHaveLength(1);
+          expect(lines[0]).toMatch(/could not be read/);
+          expect(lines[0]).not.toMatch(/Cleared|Restored/);
 
           // Operator-visible: one warning naming the book and the skip.
           const warnings = warnSpy.mock.calls.map((c) => String(c[0]));
@@ -188,28 +193,50 @@ describe('reconcileRejectEdgesOnDisk', () => {
     }
   });
 
-  /* PR #2202 gate review (Critical). The `degraded` guard above is defeated by
-     the production ORDERING: `recordRetirements` and both `dropSuperseded*`
-     helpers run earlier in the same persist block, read through the collapsing
-     `loadCastIdHistory`, and write back UNCONDITIONALLY — so by the time the
-     reconciliation reads, the damaged file has been replaced by a valid, empty
-     one and its own read says `ok`. Both records of a real user decision then
-     go: the `rejectedPairs` half was already unreadable, and the removal pass
-     deletes the `notLinkedTo` half that was still enforcing it.
+  /* #2201 — the sibling half of [C8]/[C9]: a healthy run (this is [C1]'s own
+     fixture, replayed here to pin the log-line side specifically) must NOT
+     emit the degraded-skip line — it would be a false "this book needs
+     attention" report on a book that needed nothing of the sort. */
+  it('[C12] a healthy run does not emit the degraded-skip log line', async () => {
+    seed({ characters: [{ id: 'mairin', notLinkedTo: [{ bookId: BOOK_ID, characterId: 'm2' }] }] }, null);
+    const { lines, log } = collectLog();
+
+    await reconcileRejectEdgesOnDisk(bookDir, BOOK_ID, log);
+
+    expect(lines.some((l) => l.includes('could not be read'))).toBe(false);
+  });
+
+  /* #2214 — the ROOT fix. PR #2202's `degraded` guard above only protected
+     THIS function's own consequence; the always-writing history step run
+     earlier in the same persist block (`recordRetirements`, both
+     `dropSuperseded*` helpers) read through the collapsing `loadCastIdHistory`
+     and wrote back UNCONDITIONALLY — so by the time the reconciliation used
+     to read, the damaged file had already been replaced by a valid, empty one.
+     #2214 hardens the step itself: it now reads through
+     `loadCastIdHistoryWithStatus` and THROWS `CastIdHistoryUnreadableError`
+     on a degraded verdict, before inspecting or mutating anything — so the
+     laundering this test used to have to defend against (via
+     `statusBeforePersist`) can no longer happen in the first place. The
+     `statusBeforePersist` plumbing stays wired (exercised below) as defence
+     in depth, not because it is still the only thing standing between a
+     degraded read and a deletion.
 
      Driven here as the two real functions in the real order against one book
      dir, rather than through the persist block itself — no unit test stands
      that block up (which is exactly why [C7] below is a source scan), and this
-     interleaving IS the defeat. [C7] pins that analysis.ts orders it this way;
-     this pins that ordering it this way actually saves the edge. */
-  it('[C10] an always-writing history step cannot launder a degraded read into a deletion', async () => {
+     interleaving is what a regression here would defeat. [C7] pins that
+     analysis.ts orders it this way; this pins that the ordering, plus the
+     root fix, actually saves the edge. */
+  it('[C10] a degraded read refuses to write — the damaged file is never laundered into a valid empty one', async () => {
     /* A genuine reject: the edge on cast.json, its `rejectedPairs` backing in
        a history file that has been truncated mid-write. No `rejectedPairs`
        survives the damage — the exact shape [C1] deletes. */
+    const rawHistory = '{"schema":1,"supersededBy":{},"rejectedPairs":[{"from":"m2","to":"mai';
     seedRawHistory(
       { characters: [{ id: 'mairin', notLinkedTo: [{ bookId: BOOK_ID, characterId: 'm2' }] }] },
-      '{"schema":1,"supersededBy":{},"rejectedPairs":[{"from":"m2","to":"mai',
+      rawHistory,
     );
+    const historyPath = join(bookDir, '.audiobook', 'cast-id-history.json');
     const { lines, log } = collectLog();
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
@@ -218,24 +245,34 @@ describe('reconcileRejectEdgesOnDisk', () => {
       const { status } = await loadCastIdHistoryWithStatus(bookDir);
       expect(status).toBe('degraded');
 
-      // 2. An always-writing step runs, exactly as the persist block runs it.
-      await dropSupersededIdsReclaimedByLiveCast(bookDir, ['mairin']);
+      /* 2. An always-writing step runs, exactly as the persist block runs it —
+            it now REFUSES, throwing instead of silently laundering the file.
+            This is the root fix under test: production wraps this call in a
+            try/catch (analysis.ts's persist blocks), so the throw itself is
+            non-fatal to the run — what matters here is that it happens at
+            all, before any write. */
+      await expect(dropSupersededIdsReclaimedByLiveCast(bookDir, ['mairin'])).rejects.toThrow(
+        CastIdHistoryUnreadableError,
+      );
 
-      /* 3. The damage is now UNOBSERVABLE from disk — the file is valid and
-            empty. This is the assertion that makes the rest meaningful: the
-            reconciliation's own read can no longer defend the edge, so only
-            the verdict carried from step 1 can. */
-      expect((await loadCastIdHistoryWithStatus(bookDir)).status).toBe('ok');
+      /* 3. The damage is still fully OBSERVABLE from disk — byte-identical to
+            what was seeded. Before #2214 this step replaced it with a valid,
+            empty file; now it never touches it. */
+      expect(readFileSync(historyPath, 'utf8')).toBe(rawHistory);
+      expect((await loadCastIdHistoryWithStatus(bookDir)).status).toBe('degraded');
 
-      // 4. The reconciliation, handed the pre-rewrite verdict.
+      // 4. The reconciliation, handed the pre-rewrite verdict — #2202's
+      //    downstream defence, still exercised as belt-and-braces.
       await reconcileRejectEdgesOnDisk(bookDir, BOOK_ID, log, status);
 
       // The user's decision survives — the whole point.
       expect(readCast().characters[0].notLinkedTo).toEqual([
         { bookId: BOOK_ID, characterId: 'm2' },
       ]);
-      // And nothing claims to have cleared a stranded link.
-      expect(lines).toEqual([]);
+      // And nothing claims to have cleared a stranded link — #2201's log
+      // line reports the skip, never a clear/restore.
+      expect(lines.some((l) => l.includes('Cleared') || l.includes('Restored'))).toBe(false);
+      expect(lines.some((l) => l.includes('could not be read'))).toBe(true);
 
       const skip = warnSpy.mock.calls
         .map((c) => String(c[0]))
@@ -306,5 +343,60 @@ describe('reconcileRejectEdgesOnDisk', () => {
       ).toBeLessThan(firstRewriteIdx);
       expect(captureIdx).toBeLessThan(reconcileIdx);
     }
+  });
+
+  /* #2214/#2201 — the #2214 hardening (every id-history mutating helper now
+     THROWS CastIdHistoryUnreadableError on a degraded read instead of
+     laundering the file) made #2201's user-facing log line unreachable on
+     the real path: the unconditional `dropSupersededIdsReclaimedByLiveCast`
+     call inside each persist block's try now throws BEFORE
+     `reconcileRejectEdgesOnDisk` — the only place that line used to live —
+     is ever reached, jumping straight to `catch (historyErr)`. Neither
+     persist block is standable-up in a unit test (see [C7]/[C11]'s own
+     comments for why — no test in this file, or `book-state-preserve-
+     voices.test.ts`'s only other reference to `reconcileRejectEdgesOnDisk`,
+     exercises `runMainAnalyzerJob`/`runSubsetAnalyzerJob` end to end), so
+     this pins the fix at the same source-scan seam [C7]/[C11] already use,
+     rather than calling `reconcileRejectEdgesOnDisk` directly — which is
+     exactly the blind spot (#2214's own PR description) that let the
+     original defect through undetected. */
+  it('[C13] both persist-block catch handlers emit the shared degraded-history log line on CastIdHistoryUnreadableError', () => {
+    const src = readFileSync(fileURLToPath(new URL('./analysis.ts', import.meta.url)), 'utf8');
+
+    const catchHandlerWarnLines = [
+      "console.warn('[analysis] failed to record character-id retirement(s)', historyErr);",
+      "console.warn('[analysis-subset] failed to record character-id retirement(s)', historyErr);",
+    ];
+
+    for (const warnLine of catchHandlerWarnLines) {
+      const warnIdx = src.indexOf(warnLine);
+      expect(warnIdx, `catch handler not found: ${warnLine}`).toBeGreaterThan(-1);
+
+      // Scope the search to THIS catch block only — bounded by the start of
+      // the next `catch (historyErr) {` (or EOF for the last one) — so a fix
+      // present in one handler but missing from the other cannot pass by
+      // matching the sibling's copy further down the file.
+      const nextCatchStart = src.indexOf('} catch (historyErr) {', warnIdx + 1);
+      const block = src.slice(warnIdx, nextCatchStart === -1 ? src.length : nextCatchStart);
+
+      expect(
+        block,
+        `catch handler after "${warnLine}" does not check instanceof CastIdHistoryUnreadableError`,
+      ).toContain('if (historyErr instanceof CastIdHistoryUnreadableError) {');
+      expect(
+        block,
+        `catch handler after "${warnLine}" does not emit the shared degraded-history log line`,
+      ).toContain('log(1, DEGRADED_CAST_ID_HISTORY_LOG_MESSAGE);');
+    }
+
+    // Reused, not copy-pasted, per #2214's brief: the exact same constant
+    // backs reconcileRejectEdgesOnDisk's own degraded branch AND both catch
+    // handlers — three call sites, one wording.
+    expect(src.match(/log\(1, DEGRADED_CAST_ID_HISTORY_LOG_MESSAGE\);/g) ?? []).toHaveLength(3);
+
+    // The shared constant itself carries the user-facing wording a reader of
+    // reconcileRejectEdgesOnDisk's own degraded branch already recognises.
+    expect(DEGRADED_CAST_ID_HISTORY_LOG_MESSAGE).toMatch(/could not be read/);
+    expect(DEGRADED_CAST_ID_HISTORY_LOG_MESSAGE).toMatch(/No links were changed/);
   });
 });

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -127,6 +127,7 @@ import {
   dropSupersededTargetsNoLongerLive,
   refuseRetirementsOfLiveIds,
   loadCastIdHistoryWithStatus,
+  CastIdHistoryUnreadableError,
   type CastIdHistoryStatus,
 } from '../store/cast-id-history.js';
 import { reconcileRejectEdges } from '../store/reject-edge-reconcile.js';
@@ -371,6 +372,18 @@ async function clearNotLinkedEdgesForDroppedRejections(
 
    Exported only so analysis-reject-edge-reconcile.test.ts can drive it
    without standing up a full analysis run. */
+
+/* #2214/#2201 — shared user-facing wording for "cast-id-history.json could
+   not be read, nothing changed" so it reads identically no matter which of
+   the three call sites emits it: this function's own degraded-read branch
+   below, and the two persist blocks' `catch (historyErr)` handlers, which
+   need the same line because a degraded read now makes
+   `dropSupersededIdsReclaimedByLiveCast` throw before this function is ever
+   reached (see those handlers' own comments). */
+export const DEGRADED_CAST_ID_HISTORY_LOG_MESSAGE =
+  `Skipped "not the same character" link check — cast-id-history.json for this book could not ` +
+  `be read. No links were changed; the file needs attention (see the server log for the cause).`;
+
 export async function reconcileRejectEdgesOnDisk(
   bookDir: string,
   bookId: string | undefined,
@@ -410,6 +423,13 @@ export async function reconcileRejectEdgesOnDisk(
             `stranded "not the same character" link cannot be told from one whose recorded rejection ` +
             `is merely unreadable right now. No links were changed; the next persist will try again.`,
         );
+        /* #2201 — the console.warn above is operator-visible only; a user
+           watching the in-app run log saw nothing and read a clean run as
+           proof the book was healthy. Distinguishable from the `Cleared N
+           stranded …` / `Restored N …` lines below (those fire only when a
+           write actually happened): this one fires only when nothing changed
+           because the file could not be trusted. */
+        log(1, DEGRADED_CAST_ID_HISTORY_LOG_MESSAGE);
         return;
       }
       const { adds, removes, next } = reconcileRejectEdges(bookId, cast.characters, history);
@@ -5299,6 +5319,16 @@ export async function runMainAnalyzerJob(
             await reconcileRejectEdgesOnDisk(record.bookDir, retirementBookId, log, historyStatusBeforePersist);
           } catch (historyErr) {
             console.warn('[analysis] failed to record character-id retirement(s)', historyErr);
+            /* #2214/#2201 — a degraded cast-id-history.json now makes the
+               unconditional `dropSupersededIdsReclaimedByLiveCast` call above
+               throw before `reconcileRejectEdgesOnDisk` is ever reached, so
+               its own degraded-read log line never fires on this path. Emit
+               the same user-facing wording here so a run against a damaged
+               file still shows something in the in-app log instead of
+               reading as clean. */
+            if (historyErr instanceof CastIdHistoryUnreadableError) {
+              log(1, DEGRADED_CAST_ID_HISTORY_LOG_MESSAGE);
+            }
           }
           await logCarriedForwardCharacters(
             record.bookDir,
@@ -6608,6 +6638,10 @@ export async function runSubsetAnalyzerJob(
             await reconcileRejectEdgesOnDisk(record.bookDir, subsetBookId, log, historyStatusBeforePersist);
           } catch (historyErr) {
             console.warn('[analysis-subset] failed to record character-id retirement(s)', historyErr);
+            // #2214/#2201 — mirrors the main path's same-named handler above.
+            if (historyErr instanceof CastIdHistoryUnreadableError) {
+              log(1, DEGRADED_CAST_ID_HISTORY_LOG_MESSAGE);
+            }
           }
           await logCarriedForwardCharacters(
             record.bookDir,

--- a/server/src/routes/cast-reject-orphan-atomicity.test.ts
+++ b/server/src/routes/cast-reject-orphan-atomicity.test.ts
@@ -25,6 +25,13 @@ const faults = vi.hoisted(() => ({
      binding — the route imports `writeJsonAtomic` from this module — so it is
      a real ordering observation, not a spy attached to a copy. */
   calls: [] as string[],
+  /* #2198 — fails the Nth cast-id-history.json write, COUNTED CUMULATIVELY
+     across every call in the test (not reset per HTTP request), so the same
+     mechanism naturally distinguishes the pre-fix two-loop shape (several
+     history writes per DELETE call) from the post-#2198 batched shape (one).
+     `null` disables it. */
+  historyWriteFailAtCount: null as number | null,
+  historyWriteCallCount: 0,
 }));
 
 vi.mock('../workspace/state-io.js', async (importOriginal) => {
@@ -43,6 +50,12 @@ vi.mock('../workspace/state-io.js', async (importOriginal) => {
       }
       if (faults.failCastWrite && which === 'cast') {
         throw new Error('simulated ENOSPC on cast.json');
+      }
+      if (which === 'history') {
+        faults.historyWriteCallCount += 1;
+        if (faults.historyWriteFailAtCount === faults.historyWriteCallCount) {
+          throw new Error(`simulated failure on cast-id-history.json write #${faults.historyWriteCallCount}`);
+        }
       }
       return actual.writeJsonAtomic(path, data);
     },
@@ -95,10 +108,19 @@ function castBytes(): string {
   return readFileSync(join(bookDir, '.audiobook', 'cast.json'), 'utf8');
 }
 
+function historyPath(): string {
+  return join(bookDir, '.audiobook', 'cast-id-history.json');
+}
+
+/** Raw bytes, not parsed — byte-identity is the whole point of the #2198
+    atomicity tests below ("it threw" does not prove the file survived). */
+function historyBytes(): string | null {
+  return existsSync(historyPath()) ? readFileSync(historyPath(), 'utf8') : null;
+}
+
 function readHistory(): Record<string, unknown> | null {
-  const path = join(bookDir, '.audiobook', 'cast-id-history.json');
-  if (!existsSync(path)) return null;
-  return JSON.parse(readFileSync(path, 'utf8'));
+  if (!existsSync(historyPath())) return null;
+  return JSON.parse(readFileSync(historyPath(), 'utf8'));
 }
 
 beforeAll(async () => {
@@ -121,6 +143,8 @@ beforeEach(() => {
   faults.failHistoryWrite = false;
   faults.failCastWrite = false;
   faults.calls.length = 0;
+  faults.historyWriteFailAtCount = null;
+  faults.historyWriteCallCount = 0;
   writeBookOnDisk();
 });
 
@@ -251,5 +275,139 @@ describe('#2166 — the two verbs are deliberately asymmetric', () => {
       JSON.parse(castBytes()).characters.find((c: { id: string }) => c.id === 'mairin').notLinkedTo,
     ).toEqual([]);
     expect(readHistory()?.rejectedPairs).toEqual([{ from: 'mairin_2', to: 'mairin' }]);
+  });
+});
+
+describe('#2198 — a multi-pair reject Undo is atomic (one batched write, not two loops)', () => {
+  /* Live cast target for the normalised-sibling shape below: 'the_torment'
+     (the row's own raw id, no supersededBy entry of its own) and
+     'The-Torment' (a differently-spelled sibling that normalises to the same
+     key) both govern the SAME live character, 'the-torment' — the repo's own
+     real drift shape (see cast-reject-orphan.test.ts's M-6/M-7). */
+  function seedTormentBook() {
+    writeFileSync(
+      join(bookDir, '.audiobook', 'cast.json'),
+      JSON.stringify({
+        characters: [
+          { id: 'narrator', name: 'Narrator', role: 'narrator', color: 'unset' },
+          {
+            id: 'the-torment',
+            name: 'The Torment',
+            role: 'character',
+            color: 'unset',
+            notLinkedTo: [
+              { bookId, characterId: 'the_torment' },
+              { bookId, characterId: 'The-Torment' },
+            ],
+          },
+        ],
+      }),
+    );
+    writeFileSync(
+      historyPath(),
+      JSON.stringify({
+        schema: 1,
+        supersededBy: {},
+        rejectedPairs: [
+          // The row's OWN raw id — carries the stash that, once restored,
+          // is what blinds the retry (see the test body for the mechanism).
+          { from: 'the_torment', to: 'the-torment', forgotSupersededTo: 'the-torment' },
+          // A differently-spelled sibling that normalises to the same key,
+          // with NO supersededBy entry of its own — it governs this row only
+          // via the normalised-id tier, which is exactly what's at stake.
+          { from: 'The-Torment', to: 'the-torment' },
+        ],
+      }),
+    );
+  }
+
+  it('[B1] #2198 repro — a mid-batch failure must not blind a retry to a normalised-spelling sibling pair', async () => {
+    seedTormentBook();
+
+    /* Fails the SECOND cast-id-history.json write across the whole test
+       (cumulative, not per-request — see the mock's own comment). Under the
+       pre-#2198 two-loop shape this lands exactly between "pair 1's restore
+       lands" (write #1, succeeds — moves supersededBy['the_torment'] to
+       'the-torment') and "pair 1's removal from rejectedPairs" (write #2,
+       fails) — the failure mode #2198 exists to close. Under the fixed
+       batched shape there is only ONE history write per DELETE call, so this
+       merely fails the whole first attempt outright, leaving the file
+       untouched for a clean retry — no blinding is possible either way. */
+    faults.historyWriteFailAtCount = 2;
+
+    await request(app)
+      .delete(`/api/books/${bookId}/cast/the-torment/reject-orphan-match`)
+      .send({ orphanedId: 'the_torment' });
+
+    // Retry — no further fault injected (the counter only ever hits 2 once).
+    // Under the FIXED (batched) shape the first call already completes the
+    // whole undo in its one write (count never reaches 2), so this retry is
+    // a confirmatory no-op. Under the PRE-FIX (two-loop) shape the first
+    // call 500s partway through, having already moved `supersededBy` for the
+    // raw pair — that's what's asserted below via the FINAL state, since the
+    // pre-fix bug is specifically that a retry's response silently omits the
+    // stuck sibling rather than reporting an error.
+    const retry = await request(app)
+      .delete(`/api/books/${bookId}/cast/the-torment/reject-orphan-match`)
+      .send({ orphanedId: 'the_torment' });
+    expect(retry.status).toBe(200);
+
+    // THE ASSERTION THIS TEST EXISTS FOR: after the retry, BOTH pairs must be
+    // gone — not just the raw self-pair. Pre-#2198, the sibling pair drops
+    // out of `rejectedPairsGoverning` on the retry (the restored alias makes
+    // `the_torment` resolve via the `history` tier instead of
+    // `normalised-id`, so `normalisedTierRelevant` goes false) and is
+    // permanently stuck on disk — this fails on the pre-fix code.
+    const history = readHistory();
+    expect(history?.rejectedPairs).toEqual([]);
+    expect(history?.supersededBy).toEqual({ the_torment: 'the-torment' });
+  });
+
+  it('[B3] a failure at the SECOND history write discriminates a truly batched write from a per-pair one', async () => {
+    /* [B2] below kills the FIRST history write — that fails identically
+       before ANY mutation lands whether the primitive writes once for the
+       whole batch or once per pair, so it cannot tell the two shapes apart.
+       This case can: under the FIXED (batched) shape there is only ONE
+       history write for this whole 2-pair batch, so failing the SECOND one
+       never fires — the request must succeed outright, in one shot, with
+       the whole batch landed. Under a per-pair-write shape (one write per
+       loop iteration, in ADDITION to the final write), write #1 (pair 1)
+       lands and write #2 (pair 2) fails — a 500 with a file that reflects
+       pair 1 done and pair 2 still pending. */
+    seedTormentBook();
+    faults.historyWriteFailAtCount = 2;
+
+    const res = await request(app)
+      .delete(`/api/books/${bookId}/cast/the-torment/reject-orphan-match`)
+      .send({ orphanedId: 'the_torment' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.removedFrom).toEqual(['the_torment', 'The-Torment']);
+
+    const history = readHistory();
+    expect(history?.rejectedPairs).toEqual([]);
+    expect(history?.supersededBy).toEqual({ the_torment: 'the-torment' });
+  });
+
+  it('[B2] a failure at the FIRST history write leaves cast-id-history.json byte-identical — writeJsonAtomic\'s own atomicity, plus no mutation lands before the write fires. Does NOT by itself distinguish a batched write from a per-pair one (see [B3])', async () => {
+    seedTormentBook();
+    const before = historyBytes();
+
+    // Fails the very first (and, in the fixed shape, only) history write.
+    faults.historyWriteFailAtCount = 1;
+
+    const res = await request(app)
+      .delete(`/api/books/${bookId}/cast/the-torment/reject-orphan-match`)
+      .send({ orphanedId: 'the_torment' });
+
+    expect(res.status).toBe(500);
+    // Byte-identical — not merely "still parses the same" — proving the
+    // temp-file-plus-rename write never landed at all.
+    expect(historyBytes()).toBe(before);
+
+    // The cast.json edge removal is unconditional and runs BEFORE the
+    // id-history write (I5), so it's unaffected by this failure.
+    const cast = JSON.parse(castBytes());
+    expect(cast.characters.find((c: { id: string }) => c.id === 'the-torment').notLinkedTo).toEqual([]);
   });
 });

--- a/server/src/routes/cast-reject-orphan.failure-modes.test.ts
+++ b/server/src/routes/cast-reject-orphan.failure-modes.test.ts
@@ -55,7 +55,7 @@ let bookId: string;
 
 const rejectOrphanedPairMock = vi.fn();
 const forgetSupersededIdMock = vi.fn();
-const restoreSupersededIdMock = vi.fn();
+const undoRejectedPairsMock = vi.fn();
 
 vi.mock('../store/cast-id-history.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../store/cast-id-history.js')>();
@@ -65,8 +65,11 @@ vi.mock('../store/cast-id-history.js', async (importOriginal) => {
       rejectOrphanedPairMock(...args) ?? actual.rejectOrphanedPair(...args),
     forgetSupersededId: (...args: Parameters<typeof actual.forgetSupersededId>) =>
       forgetSupersededIdMock(...args) ?? actual.forgetSupersededId(...args),
-    restoreSupersededId: (...args: Parameters<typeof actual.restoreSupersededId>) =>
-      restoreSupersededIdMock(...args) ?? actual.restoreSupersededId(...args),
+    // #2198 — the DELETE route now undoes a whole batch through this single
+    // primitive instead of calling restoreSupersededId directly, so this is
+    // the seam a failure-mode test on the id-history side must mock.
+    undoRejectedPairs: (...args: Parameters<typeof actual.undoRejectedPairs>) =>
+      undoRejectedPairsMock(...args) ?? actual.undoRejectedPairs(...args),
   };
 });
 
@@ -143,13 +146,13 @@ beforeEach(() => {
   writeBookOnDisk(initialCast);
   rejectOrphanedPairMock.mockReset();
   forgetSupersededIdMock.mockReset();
-  restoreSupersededIdMock.mockReset();
+  undoRejectedPairsMock.mockReset();
   // Default: all three no-op and fall through to the real implementation
   // (`?? actual...` in the mock factory above), so a test only needs to
   // override the ONE primitive it's exercising.
   rejectOrphanedPairMock.mockReturnValue(undefined);
   forgetSupersededIdMock.mockReturnValue(undefined);
-  restoreSupersededIdMock.mockReturnValue(undefined);
+  undoRejectedPairsMock.mockReturnValue(undefined);
 });
 
 afterAll(() => {
@@ -288,7 +291,7 @@ describe('POST reject-orphan-match — id-history write failure modes (#2040 Tas
 });
 
 describe('DELETE reject-orphan-match (undo) — I5 (review round 1): the notLinkedTo removal already landed before any fatal id-history step can fail', () => {
-  it('a restoreSupersededId failure 500s with a message that does NOT claim "nothing else was changed" — the notLinkedTo edge is already gone', async () => {
+  it('#2198 — an undoRejectedPairs failure 500s with a message that does NOT claim "nothing else was changed" — the notLinkedTo edge is already gone', async () => {
     // Seed a state matching what a genuine prior POST reject leaves behind:
     // the notLinkedTo edge on cast.json, and a pair with a stash to restore
     // on cast-id-history.json.
@@ -311,7 +314,10 @@ describe('DELETE reject-orphan-match (undo) — I5 (review round 1): the notLink
       }),
     );
 
-    restoreSupersededIdMock.mockImplementation(() => {
+    // #2198 — the route now calls the single batched `undoRejectedPairs`
+    // instead of `restoreSupersededId` directly, so that's the primitive a
+    // DELETE id-history failure-mode test mocks.
+    undoRejectedPairsMock.mockImplementation(() => {
       throw new Error('disk full');
     });
     const res = await callUndoReject(bookId, 'mairin', { orphanedId: 'mayrin' });

--- a/server/src/routes/cast-reject-orphan.ts
+++ b/server/src/routes/cast-reject-orphan.ts
@@ -151,34 +151,41 @@
    never gets past the fatal step re-reads the stash fresh from disk every
    time, since nothing has been forgotten yet on that attempt.
 
-   DELETE's write order mirrors POST's: restore (fatal) runs before pair
-   removal (fatal), same ordering rationale as before — but the restore
-   itself no longer reuses `retireCharacterId` (C1, fix round 1): see
-   `restoreSupersededId`'s own doc comment in `cast-id-history.ts` for why
-   `retireCharacterId`'s unconditional-write-plus-repoint semantics can
+   DELETE's id-history side is now (#2198) a SINGLE batched write via
+   `undoRejectedPairs` — restore-then-pair-removal is applied to every
+   governing pair against one in-memory `history`, then written once. This
+   replaces the pre-#2198 shape of two separate loops, each primitive taking
+   its own lock/read/write: pair 1's restore fully landing already moved
+   `supersededBy[pair1.from]`, and a LATER pair's write throwing then left
+   that move in place while `rejectedPairs` still held every pair — a retry's
+   own `rejectedPairsGoverning` computed against the now-moved `supersededBy`
+   could stop seeing pairs it had not gotten to yet, going permanently blind
+   to work still owed (the bug #2198 fixes). A single `writeJsonAtomic` makes
+   the whole batch all-or-nothing instead: a mid-batch failure leaves
+   cast-id-history.json byte-identical to before this call, so a retry sees
+   exactly the same governing pairs it saw the first time.
+
+   The restore itself still doesn't reuse `retireCharacterId` (C1, fix round
+   1): see `restoreSupersededId`'s own doc comment in `cast-id-history.ts` for
+   why `retireCharacterId`'s unconditional-write-plus-repoint semantics can
    themselves reproduce #2040's own failure mode when a LATER, unrelated
    re-analysis has since recorded the CORRECT alias for `orphanedId` —
-   exactly the overwrite-and-repoint `restoreSupersededId` refuses to
-   perform. When the restore is skipped for that reason, the pair is still
-   removed (the user asked to undo the REJECTION, which succeeds
+   exactly the overwrite-and-repoint `restoreSupersededId` (and
+   `undoRejectedPairs`, sharing its applier) refuses to perform. When a
+   restore is skipped for that reason, the pair is still removed within the
+   same batched write (the user asked to undo the REJECTION, which succeeds
    regardless — the alias restore is a best-effort bonus on top, not the
    primary consequence of Undo) and the response says so via
    `supersededByOther`, so the client can tell the user the alias moved on
-   rather than silently doing nothing. The two id-history writes stay BOTH
-   fatal on a genuine I/O failure (unlike POST's non-fatal forget): losing
-   EITHER one breaks the #2089 lossless-undo bar (`resolve(orphanedId)`
-   after DELETE must equal what it returned before the original POST,
-   MODULO a since-superseded alias, which is the one case DELETE is no
-   longer trying to reproduce exactly — see C1). Skipping the restore
-   attempt entirely would leave the alias tier unresolvable even though the
-   reject that blocked it is gone; skipping the pair removal leaves the
-   reject blocking resolution even though the caller asked to undo it. The
-   restore attempt runs BEFORE the pair removal specifically so a mid-way
-   500 stays retry-safe: the pair (and its `forgotSupersededTo`) is only
-   actually consumed by `unrejectOrphanedPair` once the restore attempt has
-   already run — a restore-then-fail retry just re-reads the still-present
-   pair; a remove-then-fail-restore retry would have nothing left to read
-   `forgotSupersededTo` from.
+   rather than silently doing nothing. The batched write stays fatal on a
+   genuine I/O failure (unlike POST's non-fatal forget): losing it breaks the
+   #2089 lossless-undo bar (`resolve(orphanedId)` after DELETE must equal what
+   it returned before the original POST, MODULO a since-superseded alias,
+   which is the one case DELETE is no longer trying to reproduce exactly —
+   see C1). The cast.json edge removal above it is unconditional and already
+   landed by the time this write is attempted (I5, below), so a failure here
+   is retry-safe: the pair (and its `forgotSupersededTo`) is untouched on
+   disk, and a retry re-reads it fresh.
 
    Important 1/2 (review round 2): DELETE used to find "the" pair by a raw
    `p.from === orphanedId && p.to === characterId` match. Round 1 made the
@@ -211,8 +218,7 @@ import { withCastLock } from '../workspace/cast-lock.js';
 import {
   forgetSupersededId,
   rejectOrphanedPair,
-  unrejectOrphanedPair,
-  restoreSupersededId,
+  undoRejectedPairs,
   loadCastIdHistory,
 } from '../store/cast-id-history.js';
 import { buildCastResolver, rejectedPairsGoverning } from '../store/cast-resolve.js';
@@ -550,65 +556,63 @@ castRejectOrphanRouter.delete(
         await writeJsonAtomic(castJsonPath(bookDir), { characters: cast.characters });
       }
 
-      /* C1 (fix round 1, Critical) — restoreSupersededId, NOT
-         retireCharacterId. retireCharacterId writes supersededBy[from]
-         UNCONDITIONALLY and repoints every entry whose VALUE is `from` — both
-         sound only when `from` is genuinely dead, which an Undo cannot
-         assume: a re-analysis may have recorded a DIFFERENT, correct alias
-         for `orphanedId` since the original reject. Using retireCharacterId
-         here would silently overwrite that correct alias back to the stale
-         rejected one and repoint anything targeting `orphanedId` — #2040's
-         own failure mode, produced by the button labelled "Undo". See
-         `restoreSupersededId`'s own doc comment in `cast-id-history.ts`.
-         Looped over `matchingPairs` (ordinarily just one) rather than a
-         single pair, for the same reason the notLinkedTo removal above is:
-         whichever pair(s) the shared helper says govern this row. Round 3
-         (M-7) — accumulates into an ARRAY rather than overwriting a single
-         local: round 1 only ever kept the LAST skipped restore's target, so a
-         row governing two pairs that both skipped silently dropped the first
-         one from the response, the log, and the toast. */
-      const supersededByOthers: string[] = [];
-      for (const pair of matchingPairs) {
-        if (pair.forgotSupersededTo === undefined) continue;
-        try {
-          const restoreResult = await restoreSupersededId(bookDir, pair.from, pair.forgotSupersededTo);
-          if (!restoreResult.restored && restoreResult.supersededByOther !== undefined) {
-            supersededByOthers.push(restoreResult.supersededByOther);
-            console.log(
-              `[cast-reject-orphan] (undo) book=${bookId} skipped restoring "${pair.from}" -> ` +
-                `"${pair.forgotSupersededTo}" — a newer alias to "${restoreResult.supersededByOther}" already exists`,
-            );
-          }
-        } catch (restoreErr) {
-          console.error(
-            '[cast-reject-orphan] failed to restore the forgotten supersededBy entry during undo — surfacing as a failure',
-            restoreErr,
-          );
-          return res.status(500).json({
-            /* I5 (fix round 1) — the notLinkedTo removal above is
-               UNCONDITIONAL and already landed by this point (see the module
-               doc's cast.json paragraph); this message used to claim
-               "nothing else was changed", which was false. */
-            error:
-              'Failed to restore the forgotten alias entry. Retry — the character link removal, if any, was already saved.',
-          });
-        }
+      /* #2198 — a single BATCHED call, not two separate loops each taking
+         their own lock/read/write. The pre-fix shape (loop 1: restore every
+         pair's alias; loop 2: remove every pair) was four-plus independent
+         writes with no transaction across them: pair 1's restore fully
+         landing already moves `supersededBy[pair1.from]`, and a LATER pair's
+         write throwing left that move in place while `rejectedPairs` still
+         held every pair — so a retry's own `rejectedPairsGoverning` computed
+         against the now-moved `supersededBy` could stop seeing pairs it had
+         not gotten to yet, going permanently blind to work still owed. A
+         single `writeJsonAtomic` (temp-file-plus-rename) makes the whole
+         batch all-or-nothing, so a mid-batch failure leaves the file
+         byte-identical to before this call and a retry sees exactly what it
+         saw the first time. See `undoRejectedPairs`'s own doc comment in
+         `cast-id-history.ts`.
+
+         C1 (fix round 1, Critical), preserved exactly: the batched restore
+         is `restoreSupersededId`'s semantics, never `retireCharacterId`'s —
+         it does NOT overwrite a NEWER alias a later re-analysis recorded
+         since the original reject. When a restore is skipped for that
+         reason, the pair's removal still happens (the user asked to undo the
+         REJECTION, which succeeds regardless) and the result says so via
+         `supersededByOther`.
+
+         Round 3 (M-7), preserved exactly: accumulated into an ARRAY — a row
+         governing two pairs that both skip reports BOTH skipped targets, not
+         just the last one. */
+      let undoResults;
+      try {
+        undoResults = await undoRejectedPairs(bookDir, matchingPairs);
+      } catch (undoErr) {
+        console.error(
+          '[cast-reject-orphan] failed to undo the rejection in cast-id-history.json — surfacing as a failure',
+          undoErr,
+        );
+        return res.status(500).json({
+          /* Collapses the two prior 500 branches (restore-fatal,
+             pair-removal-fatal) into one — both described a partial write
+             that the batched primitive can no longer produce. Accurate for
+             the new behaviour: nothing in cast-id-history.json changed (the
+             batch is all-or-nothing), and the cast.json edge removal above
+             it already landed (I5, unconditional and first). */
+          error:
+            'Failed to durably undo the rejection. Nothing in cast-id-history.json changed — retry. The character link removal, if any, was already saved.',
+        });
       }
 
-      for (const pair of matchingPairs) {
-        try {
-          await unrejectOrphanedPair(bookDir, pair.from, pair.to);
-        } catch (unrejectErr) {
-          console.error(
-            '[cast-reject-orphan] failed to remove the rejected pair from cast-id-history.json — surfacing as a failure',
-            unrejectErr,
+      const supersededByOthers: string[] = [];
+      matchingPairs.forEach((pair, i) => {
+        const result = undoResults[i];
+        if (!result.restored && result.supersededByOther !== undefined) {
+          supersededByOthers.push(result.supersededByOther);
+          console.log(
+            `[cast-reject-orphan] (undo) book=${bookId} skipped restoring "${pair.from}" -> ` +
+              `"${pair.forgotSupersededTo}" — a newer alias to "${result.supersededByOther}" already exists`,
           );
-          return res.status(500).json({
-            error:
-              'Failed to durably remove the rejection. Retry — the character link update and alias restore, if any, were already saved.',
-          });
         }
-      }
+      });
 
       const resolution = await resolveOrphanedId(bookDir, cast.characters, orphanedId);
 

--- a/server/src/store/cast-id-history.test.ts
+++ b/server/src/store/cast-id-history.test.ts
@@ -950,7 +950,14 @@ describe('cast id history', () => {
       expect(existsSync(castIdHistoryPath(dir))).toBe(false);
     });
 
-    it('a batch that changes nothing leaves an EXISTING file byte-identical (no rewrite, not even a reformat)', async () => {
+    /* NOTE (PR #2236 review, M1): this case does NOT prove "no write happened".
+       `writeJsonAtomic` reproduces byte-identical output for an unmutated
+       object, so it stays green even with the `if (changed)` guard forced to
+       always-write — verified. What actually pins the guard is its sibling
+       above, which asserts an ABSENT file is not created. Kept because
+       byte-identity on an existing file is still worth asserting; the title no
+       longer claims it detects a redundant rewrite. */
+    it('a batch that changes nothing leaves an EXISTING file byte-identical', async () => {
       await rejectOrphanedPair(dir, 'unrelated-from', 'unrelated-to');
       const before = readFileSync(castIdHistoryPath(dir), 'utf8');
       // Neither pair below matches anything present, and neither carries a

--- a/server/src/store/cast-id-history.test.ts
+++ b/server/src/store/cast-id-history.test.ts
@@ -15,6 +15,7 @@ import {
   rejectOrphanedId,
   rejectOrphanedPair,
   unrejectOrphanedPair,
+  undoRejectedPairs,
   CastIdHistoryUnreadableError,
 } from './cast-id-history.js';
 
@@ -415,6 +416,19 @@ describe('cast id history', () => {
             await expect(unrejectOrphanedPair(dir, 'mayrin', 'mairin')).rejects.toThrow(
               CastIdHistoryUnreadableError,
             );
+            expect(readFileSync(castIdHistoryPath(dir), 'utf8')).toBe(historyText);
+          } finally {
+            warnSpy.mockRestore();
+          }
+        });
+
+        it('undoRejectedPairs throws and leaves the file byte-identical — even on what would have been a no-op (#2198)', async () => {
+          writeTestHistoryFile(historyText);
+          const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+          try {
+            await expect(
+              undoRejectedPairs(dir, [{ from: 'mayrin', to: 'mairin', forgotSupersededTo: 'wren' }]),
+            ).rejects.toThrow(CastIdHistoryUnreadableError);
             expect(readFileSync(castIdHistoryPath(dir), 'utf8')).toBe(historyText);
           } finally {
             warnSpy.mockRestore();
@@ -873,6 +887,92 @@ describe('cast id history', () => {
       expect((await loadCastIdHistory(dir)).rejectedPairs).toEqual([
         { from: 'mayrin', to: 'wren' },
       ]);
+    });
+  });
+
+  /* #2198 — the transactional batch primitive the DELETE undo route now
+     calls instead of looping `restoreSupersededId` + `unrejectOrphanedPair`
+     per pair. These pin the primitive's own contract directly, independent
+     of the route: restore semantics identical to `restoreSupersededId`'s
+     (never overwrite a newer alias), removal always happens regardless of
+     whether the restore ran or was skipped, and the whole batch writes
+     ONCE (or not at all, when nothing changes). */
+  describe('undoRejectedPairs (#2198 — batched multi-pair undo)', () => {
+    it('restores the alias and removes the pair in one call', async () => {
+      await rejectOrphanedPair(dir, 'mayrin', 'mairin', 'wren');
+      const results = await undoRejectedPairs(dir, [
+        { from: 'mayrin', to: 'mairin', forgotSupersededTo: 'wren' },
+      ]);
+      expect(results).toEqual([{ from: 'mayrin', to: 'mairin', restored: true }]);
+      const history = await loadCastIdHistory(dir);
+      expect(history.supersededBy).toEqual({ mayrin: 'wren' });
+      expect(history.rejectedPairs).toEqual([]);
+    });
+
+    it('does NOT overwrite a NEWER alias — restored: false + supersededByOther, original entry untouched, but the pair is still removed', async () => {
+      // A later, unrelated re-analysis recorded the CORRECT alias since the
+      // original reject stashed 'wren' — seeded directly, mirroring C1's own
+      // scenario (`restoreSupersededId`'s doc comment).
+      writeTestHistoryFile(
+        JSON.stringify({
+          schema: 1,
+          supersededBy: { mayrin: 'newer-target' },
+          rejectedPairs: [{ from: 'mayrin', to: 'mairin', forgotSupersededTo: 'wren' }],
+        }),
+      );
+
+      const results = await undoRejectedPairs(dir, [
+        { from: 'mayrin', to: 'mairin', forgotSupersededTo: 'wren' },
+      ]);
+      expect(results).toEqual([
+        { from: 'mayrin', to: 'mairin', restored: false, supersededByOther: 'newer-target' },
+      ]);
+      const history = await loadCastIdHistory(dir);
+      // The newer alias survives untouched — the failure mode C1 exists to prevent.
+      expect(history.supersededBy.mayrin).toBe('newer-target');
+      // The rejection is still undone regardless — Undo's primary consequence.
+      expect(history.rejectedPairs).toEqual([]);
+    });
+
+    it('a pair with no forgotSupersededTo contributes no alias restore, only pair removal', async () => {
+      await rejectOrphanedPair(dir, 'mayrin', 'mairin');
+      const results = await undoRejectedPairs(dir, [{ from: 'mayrin', to: 'mairin' }]);
+      expect(results).toEqual([{ from: 'mayrin', to: 'mairin', restored: true }]);
+      const history = await loadCastIdHistory(dir);
+      expect(history.supersededBy).toEqual({});
+      expect(history.rejectedPairs).toEqual([]);
+    });
+
+    it('an absent pair is a no-op for that entry, and a batch that changes nothing writes no file at all', async () => {
+      expect(existsSync(castIdHistoryPath(dir))).toBe(false);
+      const results = await undoRejectedPairs(dir, [{ from: 'ghost', to: 'nobody' }]);
+      expect(results).toEqual([{ from: 'ghost', to: 'nobody', restored: true }]);
+      expect(existsSync(castIdHistoryPath(dir))).toBe(false);
+    });
+
+    it('a batch that changes nothing leaves an EXISTING file byte-identical (no rewrite, not even a reformat)', async () => {
+      await rejectOrphanedPair(dir, 'unrelated-from', 'unrelated-to');
+      const before = readFileSync(castIdHistoryPath(dir), 'utf8');
+      // Neither pair below matches anything present, and neither carries a
+      // forgotSupersededTo — nothing for the batch to change.
+      await undoRejectedPairs(dir, [{ from: 'ghost-1', to: 'nobody-1' }, { from: 'ghost-2', to: 'nobody-2' }]);
+      expect(readFileSync(castIdHistoryPath(dir), 'utf8')).toBe(before);
+    });
+
+    it('two pairs in one batch: both restored and both removed, independent of each other', async () => {
+      await rejectOrphanedPair(dir, 'a', 'target', 'alias-a');
+      await rejectOrphanedPair(dir, 'b', 'target', 'alias-b');
+      const results = await undoRejectedPairs(dir, [
+        { from: 'a', to: 'target', forgotSupersededTo: 'alias-a' },
+        { from: 'b', to: 'target', forgotSupersededTo: 'alias-b' },
+      ]);
+      expect(results).toEqual([
+        { from: 'a', to: 'target', restored: true },
+        { from: 'b', to: 'target', restored: true },
+      ]);
+      const history = await loadCastIdHistory(dir);
+      expect(history.supersededBy).toEqual({ a: 'alias-a', b: 'alias-b' });
+      expect(history.rejectedPairs).toEqual([]);
     });
   });
 

--- a/server/src/store/cast-id-history.test.ts
+++ b/server/src/store/cast-id-history.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { mkdtempSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, readFileSync, mkdirSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import {
@@ -11,9 +11,11 @@ import {
   dropSupersededTargetsNoLongerLive,
   refuseRetirementsOfLiveIds,
   forgetSupersededId,
+  restoreSupersededId,
   rejectOrphanedId,
   rejectOrphanedPair,
   unrejectOrphanedPair,
+  CastIdHistoryUnreadableError,
 } from './cast-id-history.js';
 
 let dir: string;
@@ -290,6 +292,157 @@ describe('cast id history', () => {
       } finally {
         warnSpy.mockRestore();
       }
+    });
+  });
+
+  /* #2214 — every mutating helper in this module used to read through the
+     COLLAPSING `loadCastIdHistory` and write back unconditionally, so a
+     `degraded` file (exists but unreadable or the wrong shape) was silently
+     REPLACED with a valid, empty one — losing every retirement, displacement
+     and rejection ever recorded for the book. Each helper now reads through
+     `loadCastIdHistoryWithStatus` and throws `CastIdHistoryUnreadableError`
+     before inspecting or mutating anything on a `degraded` verdict — even on
+     a path that would otherwise have been a no-op, since a degraded read
+     can't be told apart from a needed write. These pin that guarantee
+     per-helper: the call throws, AND the file on disk is byte-identical
+     afterward (proof the write never happened, not just that something threw). */
+  describe('a degraded read refuses to write, for every mutating helper (#2214)', () => {
+    const DEGRADED_FIXTURES = [
+      ['unparseable', '{invalid json'],
+      ['wrong shape', JSON.stringify({ schema: 2, supersededBy: {} })],
+    ] as const;
+
+    for (const [label, historyText] of DEGRADED_FIXTURES) {
+      describe(`file is ${label}`, () => {
+        it('retireCharacterId throws and leaves the file byte-identical', async () => {
+          writeTestHistoryFile(historyText);
+          const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+          try {
+            await expect(retireCharacterId(dir, 'mayrin', 'mairin')).rejects.toThrow(
+              CastIdHistoryUnreadableError,
+            );
+            expect(readFileSync(castIdHistoryPath(dir), 'utf8')).toBe(historyText);
+          } finally {
+            warnSpy.mockRestore();
+          }
+        });
+
+        it('dropSupersededIdsReclaimedByLiveCast throws and leaves the file byte-identical', async () => {
+          writeTestHistoryFile(historyText);
+          const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+          try {
+            await expect(
+              dropSupersededIdsReclaimedByLiveCast(dir, ['mairin']),
+            ).rejects.toThrow(CastIdHistoryUnreadableError);
+            expect(readFileSync(castIdHistoryPath(dir), 'utf8')).toBe(historyText);
+          } finally {
+            warnSpy.mockRestore();
+          }
+        });
+
+        it('dropSupersededTargetsNoLongerLive throws and leaves the file byte-identical', async () => {
+          writeTestHistoryFile(historyText);
+          const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+          try {
+            await expect(
+              dropSupersededTargetsNoLongerLive(dir, ['mairin']),
+            ).rejects.toThrow(CastIdHistoryUnreadableError);
+            expect(readFileSync(castIdHistoryPath(dir), 'utf8')).toBe(historyText);
+          } finally {
+            warnSpy.mockRestore();
+          }
+        });
+
+        it('forgetSupersededId throws and leaves the file byte-identical', async () => {
+          writeTestHistoryFile(historyText);
+          const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+          try {
+            await expect(forgetSupersededId(dir, 'mayrin')).rejects.toThrow(
+              CastIdHistoryUnreadableError,
+            );
+            expect(readFileSync(castIdHistoryPath(dir), 'utf8')).toBe(historyText);
+          } finally {
+            warnSpy.mockRestore();
+          }
+        });
+
+        it('restoreSupersededId throws and leaves the file byte-identical — even on what would have been a no-op', async () => {
+          writeTestHistoryFile(historyText);
+          const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+          try {
+            // 'mayrin' -> 'mairin' would be idempotent (`existing === target`)
+            // if the real supersededBy already held it — a degraded read can't
+            // tell that from a needed write, so it must throw regardless.
+            await expect(restoreSupersededId(dir, 'mayrin', 'mairin')).rejects.toThrow(
+              CastIdHistoryUnreadableError,
+            );
+            expect(readFileSync(castIdHistoryPath(dir), 'utf8')).toBe(historyText);
+          } finally {
+            warnSpy.mockRestore();
+          }
+        });
+
+        it('rejectOrphanedId throws and leaves the file byte-identical', async () => {
+          writeTestHistoryFile(historyText);
+          const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+          try {
+            await expect(rejectOrphanedId(dir, 'mayrin')).rejects.toThrow(
+              CastIdHistoryUnreadableError,
+            );
+            expect(readFileSync(castIdHistoryPath(dir), 'utf8')).toBe(historyText);
+          } finally {
+            warnSpy.mockRestore();
+          }
+        });
+
+        it('rejectOrphanedPair throws and leaves the file byte-identical — even on what would have been an idempotent no-op', async () => {
+          writeTestHistoryFile(historyText);
+          const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+          try {
+            await expect(rejectOrphanedPair(dir, 'mayrin', 'mairin')).rejects.toThrow(
+              CastIdHistoryUnreadableError,
+            );
+            expect(readFileSync(castIdHistoryPath(dir), 'utf8')).toBe(historyText);
+          } finally {
+            warnSpy.mockRestore();
+          }
+        });
+
+        it('unrejectOrphanedPair throws and leaves the file byte-identical — even on what would have been a no-op', async () => {
+          writeTestHistoryFile(historyText);
+          const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+          try {
+            await expect(unrejectOrphanedPair(dir, 'mayrin', 'mairin')).rejects.toThrow(
+              CastIdHistoryUnreadableError,
+            );
+            expect(readFileSync(castIdHistoryPath(dir), 'utf8')).toBe(historyText);
+          } finally {
+            warnSpy.mockRestore();
+          }
+        });
+      });
+    }
+
+    describe('absent stays unchanged — silently writable, exactly as before', () => {
+      it('retireCharacterId still writes normally on an absent file', async () => {
+        expect(existsSync(castIdHistoryPath(dir))).toBe(false);
+        await retireCharacterId(dir, 'mayrin', 'mairin');
+        expect((await loadCastIdHistory(dir)).supersededBy).toEqual({ mayrin: 'mairin' });
+      });
+
+      it('rejectOrphanedPair still writes normally on an absent file', async () => {
+        expect(existsSync(castIdHistoryPath(dir))).toBe(false);
+        await rejectOrphanedPair(dir, 'mayrin', 'mairin');
+        expect((await loadCastIdHistory(dir)).rejectedPairs).toEqual([
+          { from: 'mayrin', to: 'mairin' },
+        ]);
+      });
+
+      it('rejectOrphanedId still writes normally on an absent file', async () => {
+        expect(existsSync(castIdHistoryPath(dir))).toBe(false);
+        await rejectOrphanedId(dir, 'mayrin');
+        expect((await loadCastIdHistory(dir)).rejected).toEqual(['mayrin']);
+      });
     });
   });
 

--- a/server/src/store/cast-id-history.ts
+++ b/server/src/store/cast-id-history.ts
@@ -224,6 +224,55 @@ export async function loadCastIdHistoryWithStatus(
   return { status: 'degraded', history: { schema: 1, supersededBy: {} } };
 }
 
+/** Thrown by every mutating helper below when the read that would decide
+ *  what to preserve came back `degraded` (#2214) — the file exists but is
+ *  unreadable or the wrong shape. Every helper here used to read through the
+ *  COLLAPSING `loadCastIdHistory` and write back unconditionally, which
+ *  REPLACED the damaged file with a valid, empty one — silently destroying
+ *  every retirement, displacement and rejection ever recorded for the book,
+ *  with every later read then reporting `ok`. Throwing here instead, before
+ *  any inspection or mutation, is the fix: a caller cannot tell a
+ *  degraded-read no-op from a genuinely needed write (e.g.
+ *  `restoreSupersededId`'s `existing === target` early return, or
+ *  `rejectOrphanedPair`'s idempotent-pair return), so nothing below may run
+ *  at all once the verdict is `degraded`.
+ *
+ *  `absent` and `ok` are unaffected — a missing file is the common, expected
+ *  case (most books never retire an id) and stays silently writable, exactly
+ *  as before. Callers already tolerate a throw from these helpers (the write
+ *  itself could always fail — EPERM/ENOSPC — see `loadCastIdHistory`'s own
+ *  doc comment above); this is the same contract extended to a degraded
+ *  READ. Same spirit as `cast-merge-base.ts`'s `UNREADABLE` sentinel
+ *  (#2185): a transient read blip must never be mistaken for evidence. */
+export class CastIdHistoryUnreadableError extends Error {
+  readonly bookDir: string;
+  readonly path: string;
+
+  constructor(bookDir: string) {
+    const path = castIdHistoryPath(bookDir);
+    super(
+      `[cast-id-history] refusing to write ${path} — it exists but could not be read or did not ` +
+        `pass the shape check (see the [cast-id-history] warning just above for the cause). Writing ` +
+        `through this read would replace it with a valid, empty history, silently losing every ` +
+        `recorded retirement, displacement and rejection for this book. Fix or remove the file, then retry.`,
+    );
+    this.name = 'CastIdHistoryUnreadableError';
+    this.bookDir = bookDir;
+    this.path = path;
+  }
+}
+
+/** Read the history for a mutating helper below, refusing to proceed on a
+ *  `degraded` verdict (#2214) — see `CastIdHistoryUnreadableError`'s own doc
+ *  comment for why. `absent` and `ok` return their history unchanged. */
+async function loadHistoryOrThrow(bookDir: string): Promise<CastIdHistory> {
+  const { status, history } = await loadCastIdHistoryWithStatus(bookDir);
+  if (status === 'degraded') {
+    throw new CastIdHistoryUnreadableError(bookDir);
+  }
+  return history;
+}
+
 /** Record that characterId `from` has been retired and replaced by `to`.
  *  Updates transitive mappings: whether a→b then b→c is recorded, or b→c
  *  then a→b, both a and b end up pointing to c in the final map (O(1)
@@ -334,7 +383,9 @@ export async function retireCharacterId(
   // Serialize writes per-book
   const bookId = bookDir; // Use bookDir as the lock key
   return withKeyLock(`cast-id-history:${bookId}`, async () => {
-    const history = await loadCastIdHistory(bookDir);
+    // #2214 — throws CastIdHistoryUnreadableError on a degraded read, refusing to
+    // launder a damaged file into a valid, empty one.
+    const history = await loadHistoryOrThrow(bookDir);
 
     /* Direct reversal (#2040 Task 8 fix round 1, item 3): `to` is itself
        recorded as having been retired in favour of `from` — an earlier call
@@ -472,7 +523,9 @@ export async function dropSupersededIdsReclaimedByLiveCast(
 ): Promise<DisplacedHistoryEntry[]> {
   const live = new Set(liveIds);
   return withKeyLock(`cast-id-history:${bookDir}`, async () => {
-    const history = await loadCastIdHistory(bookDir);
+    // #2214 — throws CastIdHistoryUnreadableError on a degraded read, refusing to
+    // launder a damaged file into a valid, empty one.
+    const history = await loadHistoryOrThrow(bookDir);
     const dropped: DisplacedHistoryEntry[] = [];
     for (const [key, target] of Object.entries(history.supersededBy)) {
       if (live.has(key)) {
@@ -562,7 +615,9 @@ export async function dropSupersededTargetsNoLongerLive(
 ): Promise<DisplacedHistoryEntry[]> {
   const live = new Set(liveIds);
   return withKeyLock(`cast-id-history:${bookDir}`, async () => {
-    const history = await loadCastIdHistory(bookDir);
+    // #2214 — throws CastIdHistoryUnreadableError on a degraded read, refusing to
+    // launder a damaged file into a valid, empty one.
+    const history = await loadHistoryOrThrow(bookDir);
     const dropped: DisplacedHistoryEntry[] = [];
     for (const [key, target] of Object.entries(history.supersededBy)) {
       if (!live.has(target)) {
@@ -624,7 +679,9 @@ export async function forgetSupersededId(
   expectedTarget?: string,
 ): Promise<string | undefined> {
   return withKeyLock(`cast-id-history:${bookDir}`, async () => {
-    const history = await loadCastIdHistory(bookDir);
+    // #2214 — throws CastIdHistoryUnreadableError on a degraded read, refusing to
+    // launder a damaged file into a valid, empty one.
+    const history = await loadHistoryOrThrow(bookDir);
     const removed = history.supersededBy[id];
     if (removed === undefined) return undefined;
     if (expectedTarget !== undefined && removed !== expectedTarget) {
@@ -682,7 +739,9 @@ export async function restoreSupersededId(
   target: string,
 ): Promise<{ restored: boolean; supersededByOther?: string }> {
   return withKeyLock(`cast-id-history:${bookDir}`, async () => {
-    const history = await loadCastIdHistory(bookDir);
+    // #2214 — throws CastIdHistoryUnreadableError on a degraded read, refusing to
+    // launder a damaged file into a valid, empty one.
+    const history = await loadHistoryOrThrow(bookDir);
     const existing = history.supersededBy[id];
     if (existing === target) {
       return { restored: true };
@@ -715,7 +774,9 @@ export async function restoreSupersededId(
  *  `supersededBy` itself. */
 export async function rejectOrphanedId(bookDir: string, id: string): Promise<void> {
   return withKeyLock(`cast-id-history:${bookDir}`, async () => {
-    const history = await loadCastIdHistory(bookDir);
+    // #2214 — throws CastIdHistoryUnreadableError on a degraded read, refusing to
+    // launder a damaged file into a valid, empty one.
+    const history = await loadHistoryOrThrow(bookDir);
     const rejected = history.rejected ?? [];
     if (rejected.includes(id)) return;
     history.rejected = [...rejected, id];
@@ -751,7 +812,9 @@ export async function rejectOrphanedPair(
   forgotSupersededTo?: string,
 ): Promise<void> {
   return withKeyLock(`cast-id-history:${bookDir}`, async () => {
-    const history = await loadCastIdHistory(bookDir);
+    // #2214 — throws CastIdHistoryUnreadableError on a degraded read, refusing to
+    // launder a damaged file into a valid, empty one.
+    const history = await loadHistoryOrThrow(bookDir);
     const pairs = history.rejectedPairs ?? [];
     if (pairs.some((p) => p.from === from && p.to === to)) return;
     const entry: RejectedPair =
@@ -779,7 +842,9 @@ export async function unrejectOrphanedPair(
   to: string,
 ): Promise<string | undefined> {
   return withKeyLock(`cast-id-history:${bookDir}`, async () => {
-    const history = await loadCastIdHistory(bookDir);
+    // #2214 — throws CastIdHistoryUnreadableError on a degraded read, refusing to
+    // launder a damaged file into a valid, empty one.
+    const history = await loadHistoryOrThrow(bookDir);
     const pairs = history.rejectedPairs ?? [];
     const idx = pairs.findIndex((p) => p.from === from && p.to === to);
     if (idx < 0) return undefined;

--- a/server/src/store/cast-id-history.ts
+++ b/server/src/store/cast-id-history.ts
@@ -742,17 +742,35 @@ export async function restoreSupersededId(
     // #2214 — throws CastIdHistoryUnreadableError on a degraded read, refusing to
     // launder a damaged file into a valid, empty one.
     const history = await loadHistoryOrThrow(bookDir);
-    const existing = history.supersededBy[id];
-    if (existing === target) {
-      return { restored: true };
+    const { result, changed } = applyRestoreSupersededId(history, id, target);
+    if (changed) {
+      await writeJsonAtomic(castIdHistoryPath(bookDir), history);
     }
-    if (existing !== undefined) {
-      return { restored: false, supersededByOther: existing };
-    }
-    history.supersededBy[id] = target;
-    await writeJsonAtomic(castIdHistoryPath(bookDir), history);
-    return { restored: true };
+    return result;
   });
+}
+
+/** In-memory-only applier shared by `restoreSupersededId` and the batched
+ *  `undoRejectedPairs` below (#2198) — mutates `history` and reports the same
+ *  `{ restored, supersededByOther }` shape `restoreSupersededId` returns,
+ *  plus whether a mutation actually happened, so a caller batching several of
+ *  these under one write knows whether it needs to write at all. Never reads,
+ *  never locks, never writes — see this module's `undoRejectedPairs` doc
+ *  comment for why sharing the LOCKED wrapper instead would deadlock. */
+function applyRestoreSupersededId(
+  history: CastIdHistory,
+  id: string,
+  target: string,
+): { result: { restored: boolean; supersededByOther?: string }; changed: boolean } {
+  const existing = history.supersededBy[id];
+  if (existing === target) {
+    return { result: { restored: true }, changed: false };
+  }
+  if (existing !== undefined) {
+    return { result: { restored: false, supersededByOther: existing }, changed: false };
+  }
+  history.supersededBy[id] = target;
+  return { result: { restored: true }, changed: true };
 }
 
 /** LEGACY (#2040 Task 17) — id-wide reject. Superseded by `rejectOrphanedPair`
@@ -845,12 +863,110 @@ export async function unrejectOrphanedPair(
     // #2214 — throws CastIdHistoryUnreadableError on a degraded read, refusing to
     // launder a damaged file into a valid, empty one.
     const history = await loadHistoryOrThrow(bookDir);
-    const pairs = history.rejectedPairs ?? [];
-    const idx = pairs.findIndex((p) => p.from === from && p.to === to);
-    if (idx < 0) return undefined;
-    const removed = pairs[idx];
-    history.rejectedPairs = [...pairs.slice(0, idx), ...pairs.slice(idx + 1)];
-    await writeJsonAtomic(castIdHistoryPath(bookDir), history);
-    return removed.forgotSupersededTo;
+    const { removed, changed } = applyUnrejectOrphanedPair(history, from, to);
+    if (changed) {
+      await writeJsonAtomic(castIdHistoryPath(bookDir), history);
+    }
+    return removed?.forgotSupersededTo;
+  });
+}
+
+/** In-memory-only applier shared by `unrejectOrphanedPair` and the batched
+ *  `undoRejectedPairs` below (#2198) — same split as `applyRestoreSupersededId`
+ *  above: mutates `history`, reports the removed pair (if any) and whether a
+ *  mutation happened, never reads/locks/writes itself. */
+function applyUnrejectOrphanedPair(
+  history: CastIdHistory,
+  from: string,
+  to: string,
+): { removed: RejectedPair | undefined; changed: boolean } {
+  const pairs = history.rejectedPairs ?? [];
+  const idx = pairs.findIndex((p) => p.from === from && p.to === to);
+  if (idx < 0) return { removed: undefined, changed: false };
+  const removed = pairs[idx];
+  history.rejectedPairs = [...pairs.slice(0, idx), ...pairs.slice(idx + 1)];
+  return { removed, changed: true };
+}
+
+/** Undo a whole BATCH of `rejectOrphanedPair` entries atomically (#2198) —
+ *  the transactional replacement for a caller looping `restoreSupersededId`
+ *  + `unrejectOrphanedPair` per pair. One `withKeyLock`, one read, one
+ *  `writeJsonAtomic` for the WHOLE batch: `writeJsonAtomic` is a
+ *  temp-file-plus-rename, so a single write is all-or-nothing for free, and a
+ *  batch that fails partway through leaves the file byte-identical to before
+ *  the call — no half-restored alias, no half-removed pair.
+ *
+ *  This closes #2198: the pre-fix DELETE handler ran two SEPARATE loops over
+ *  a governing-pairs batch, each primitive taking its own lock/read/write.
+ *  Pair 1 fully completing already moves `supersededBy[pair1.from]`, which is
+ *  exactly what makes `rejectedPairsGoverning`'s resolution SEE fewer
+ *  governing pairs on a retry after pair 2's loop throws — the retry goes
+ *  blind to work it hasn't done yet. Per-pair atomicity doesn't fix this
+ *  (pair 1 alone still moves `supersededBy`); only batch-scope atomicity
+ *  does, which is why this shares appliers with, rather than calls, the two
+ *  single-pair primitives above.
+ *
+ *  MUST NOT call `restoreSupersededId`/`unrejectOrphanedPair` — both take
+ *  `withKeyLock('cast-id-history:' + bookDir)` themselves, and this function
+ *  already holds that same lock for the whole batch. Re-entering it would
+ *  hang forever, with no timeout and no diagnostic. `applyRestoreSupersededId`
+ *  / `applyUnrejectOrphanedPair` are the shared, lock-free appliers this
+ *  function and the two single-pair primitives both mutate `history` through.
+ *
+ *  Order within `pairs` does not affect the result: each pair's restore (if
+ *  any) and pair-removal are applied to the in-memory `history` in the order
+ *  given, but every pair's restore reads/writes only its OWN `from` key, and
+ *  every pair's removal only removes its OWN `(from, to)` entry, so two
+ *  pairs can never observe or clobber each other's effect.
+ *
+ *  A pair with `forgotSupersededTo === undefined` contributes no alias
+ *  restore (mirrors the pre-#2198 loop's `continue`) — only its
+ *  `rejectedPairs` removal happens. `restored` on that pair's result is
+ *  `true` (nothing blocked it): the field's only `false` case is a NEWER
+ *  alias occupying `supersededBy[from]`, which cannot happen when no restore
+ *  was attempted at all.
+ *
+ *  If nothing in the batch changes anything (every pair already absent, no
+ *  alias needed restoring), no write happens at all — same idempotent-write
+ *  discipline as every other primitive in this module. */
+export interface UndoRejectedPairResult {
+  from: string;
+  to: string;
+  /** false only when a NEWER alias already occupies supersededBy[from]. */
+  restored: boolean;
+  supersededByOther?: string;
+}
+
+export async function undoRejectedPairs(
+  bookDir: string,
+  pairs: ReadonlyArray<{ from: string; to: string; forgotSupersededTo?: string }>,
+): Promise<UndoRejectedPairResult[]> {
+  return withKeyLock(`cast-id-history:${bookDir}`, async () => {
+    // #2214 — throws CastIdHistoryUnreadableError on a degraded read, refusing to
+    // launder a damaged file into a valid, empty one.
+    const history = await loadHistoryOrThrow(bookDir);
+    const results: UndoRejectedPairResult[] = [];
+    let changed = false;
+    for (const pair of pairs) {
+      let restored = true;
+      let supersededByOther: string | undefined;
+      if (pair.forgotSupersededTo !== undefined) {
+        const applied = applyRestoreSupersededId(history, pair.from, pair.forgotSupersededTo);
+        restored = applied.result.restored;
+        supersededByOther = applied.result.supersededByOther;
+        if (applied.changed) changed = true;
+      }
+      const { changed: unrejectChanged } = applyUnrejectOrphanedPair(history, pair.from, pair.to);
+      if (unrejectChanged) changed = true;
+      results.push(
+        supersededByOther === undefined
+          ? { from: pair.from, to: pair.to, restored }
+          : { from: pair.from, to: pair.to, restored, supersededByOther },
+      );
+    }
+    if (changed) {
+      await writeJsonAtomic(castIdHistoryPath(bookDir), history);
+    }
+    return results;
   });
 }

--- a/server/src/store/cast-id-history.ts
+++ b/server/src/store/cast-id-history.ts
@@ -733,6 +733,14 @@ export async function forgetSupersededId(
  *  DELETE after a prior successful restore), no write happens and
  *  `restored: true` is still returned — the desired end state already
  *  holds. */
+/** NOTE (#2198): this single-pair primitive has no production caller — the
+ *  reject Undo batches through `undoRejectedPairs` instead. It is kept
+ *  (exported and tested) as the primitive the batch's applier is shared with.
+ *  **Do not reach for it to undo several pairs in a loop**: that is precisely
+ *  the split-write shape #2198 removed — each call takes its own lock, read and
+ *  write, so a mid-loop failure leaves a half-completed state that blinds the
+ *  retry. Batch callers use `undoRejectedPairs`.
+ */
 export async function restoreSupersededId(
   bookDir: string,
   id: string,
@@ -854,6 +862,14 @@ export async function rejectOrphanedPair(
  *  No-op (and no write) when the pair isn't present, mirroring this module's
  *  idempotent-write discipline — a repeat undo of an already-undone pair is
  *  safe. */
+/** NOTE (#2198): this single-pair primitive has no production caller — the
+ *  reject Undo batches through `undoRejectedPairs` instead. It is kept
+ *  (exported and tested) as the primitive the batch's applier is shared with.
+ *  **Do not reach for it to undo several pairs in a loop**: that is precisely
+ *  the split-write shape #2198 removed — each call takes its own lock, read and
+ *  write, so a mid-loop failure leaves a half-completed state that blinds the
+ *  retry. Batch callers use `undoRejectedPairs`.
+ */
 export async function unrejectOrphanedPair(
   bookDir: string,
   from: string,


### PR DESCRIPTION
> **Stacked on #2233** (`fix/server-2214-degraded-history-writes`). Its commit is in this
> branch's history because the new primitive must inherit #2214's degraded-read guard rather
> than invent a second convention. Once #2233 merges this diff collapses to its own commit.

## Summary

The reject **Undo** did its per-pair work in two sequential loops over `matchingPairs` —
`restoreSupersededId` for every pair, then `unrejectOrphanedPair` for every pair. Each
primitive takes its own lock, its own read and its own `writeJsonAtomic`, so the two loops were
four-plus independent writes with no transaction across them.

A failure between them left `supersededBy[from]` restored while the `rejectedPairs` entry
survived. That restored alias changes what the **retry** computes:
`resolveIgnoringPairRejects` returns the `history` tier instead of a normalised one,
`normalisedTierRelevant` goes false, and the normalised-spelling sibling pairs drop out of
`governingPairs`. The retry can no longer see them, so it never removes them — and #2166's
reconciliation then writes their `notLinkedTo` edges back. **The Undo is permanently stuck.**

## Why this shape, and not the two obvious alternatives

- **Reordering (unreject first) was rejected**: the `rejectedPairs` entry is where
  `forgotSupersededTo` is *stored*. Removing it first means a later restore failure loses the
  alias unrecoverably — trading a blind retry for silent data loss.
- **Per-pair atomicity is insufficient**: pair 1 completing still moves `supersededBy`, which
  is exactly what blinds the retry for pair 2.

`undoRejectedPairs(bookDir, pairs)` does the whole batch under **one `withKeyLock`, one read,
one `writeJsonAtomic`**. `writeJsonAtomic` is temp-file-plus-rename, so a single write gives
all-or-nothing for free. With no half-completed state, the retry can never be blinded.

`restoreSupersededId` and `unrejectOrphanedPair` keep their exact semantics and their own
locks, sharing **lock-free appliers** with the batch rather than being called from it — calling
them would re-enter the same key lock and hang forever with no timeout and no diagnostic.
Reads via `loadHistoryOrThrow`, like every other mutating helper (#2214). Writes nothing when
nothing changed.

The DELETE's two 500 branches collapse into one, with a message accurate for the new shape:
nothing in `cast-id-history.json` changed, and the `cast.json` edge removal above it already
landed. **#2166's ordering invariant is untouched** — the edge is still destroyed before the
pair entry; the DELETE was already correct there and must not be reordered.

## Test plan

- **`[B1]`** reproduces the bug: two pairs governing one row (`the_torment` raw +
  `The-Torment` normalised sibling), a mid-batch failure, then a retry. Verified **red against
  the pre-fix code**.
- **`[B3]`** is the discriminating atomicity case: it fails the **second** history write, which
  only exists in the per-pair shape. Green on the fix, red when the write is moved into the
  loop.
- **`[B2]`** kills the *first* write and is green under both the atomic and per-pair shapes —
  it pins `writeJsonAtomic`'s own atomicity and "no mutation before the write", **not** this
  PR's guarantee. Its title now says so rather than overclaiming. (It was initially presented
  as the atomicity proof; it isn't, and that was caught by aiming a mutation at the precise
  mechanism instead of doing a coarse revert.)
- Store-level cases: restore+remove, newer-alias-blocks-restore (original entry untouched),
  no `forgotSupersededTo`, absent pair (no write), two-pair batch, degraded read throws and
  leaves the file byte-identical.
- One existing failure-modes test **updated and flagged**: it mocked `restoreSupersededId`,
  which the route no longer calls; retargeted to the new seam. Its assertions are unchanged
  and still hold.
- 169 passed across the four affected files; `npm run typecheck` clean.

**Mutation proofs**, each run alone: restore-when-`forgotSupersededTo` (3 red), never-overwrite-newer-alias (1 red), pair-removal-always-happens (7 red), degraded-read-throws (2 red), route-surfaces-500 (1 red), and the atomicity mutation above (`[B1]` + `[A7]` red, nothing else).

Closes #2198
