### PR TITLE
docs(docs): plan 277 Round 4 drain plan and its driving board

### DIFF
--- a/docs/features/277-v115-bug-chore-sweep-board.html
+++ b/docs/features/277-v115-bug-chore-sweep-board.html
@@ -1,0 +1,967 @@
+<!--
+  DRIVING BOARD for docs/features/277-v115-bug-chore-sweep.md, Round 4.
+
+  Hand-authored. NOT generated from the markdown, and the markdown must never be
+  published in its place — passing the correct `url` while pointing at the `.md`
+  keeps the URL and silently replaces this page with default markdown rendering.
+  (That failure mode cost the onbox register four republishes on 2026-07-31/08-01,
+  which is why that page — and this one — are tracked files rather than scratchpad
+  output. See docs/testing/onbox-acceptance-register-live-view.html.)
+
+  Canonical URL (server-assigned; it cannot be renamed or re-slugged):
+  https://claude.ai/code/artifact/f3608d3e-0e02-4eaa-9af3-3322b9ce0bb3
+
+  To update: edit THIS file, then publish it with that URL passed as `url`.
+  Publishing without the url mints a second, competing board.
+
+  Item state (the checkboxes) lives in the reader's localStorage, not in this
+  file — so a redeploy never wipes progress, and this file stays the plan of
+  record rather than a status snapshot that drifts from the board.
+
+  Deliberately NOT a complete HTML document: the publisher wraps the file in its
+  own <!doctype html><head></head><body> skeleton, so a doctype/<html>/<head>/
+  <body> here would nest. Browsers still render it standalone for local preview.
+-->
+
+<title>v1.15 bug &amp; chore sweep — Round 4 board</title>
+
+<style>
+  :root {
+    --ground:#f7f5f6; --surface:#ffffff; --surface-2:#efecee; --surface-3:#e7e2e6;
+    --ink:#171316; --ink-2:#4a424a; --muted:#7b727a; --rule:#e3dee1;
+    --accent:#a43c6c; --accent-wash:#f9e8f0; --accent-ink:#ffffff;
+    --ready:#1c7a58;  --ready-wash:#e2f1eb;
+    --design:#4a56a6; --design-wash:#e8eaf7;
+    --onbox:#a9640b;  --onbox-wash:#f8eeda;
+    --blocked:#7b727a;--blocked-wash:#eeebed;
+    --gated:#98351d;  --gated-wash:#fae9e3;
+    --shadow:0 1px 2px rgba(23,19,22,.05), 0 6px 18px rgba(23,19,22,.05);
+    --font-display:"Lora",Georgia,"Times New Roman",serif;
+    --font-ui:"General Sans",system-ui,-apple-system,"Segoe UI",sans-serif;
+    --font-data:"JetBrains Mono",ui-monospace,"Cascadia Mono","Consolas",monospace;
+    --maxw:78rem;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --ground:#131015; --surface:#1b171d; --surface-2:#231e26; --surface-3:#2c2630;
+      --ink:#ece7ea; --ink-2:#bcb2ba; --muted:#8d8390; --rule:#2f2833;
+      --accent:#e58cb4; --accent-wash:#2e1a25; --accent-ink:#1b171d;
+      --ready:#5cc8a0;  --ready-wash:#152820;
+      --design:#98a3e8; --design-wash:#1a1d33;
+      --onbox:#e0a34a;  --onbox-wash:#2c2113;
+      --blocked:#8d8390;--blocked-wash:#241f27;
+      --gated:#e08a6c;  --gated-wash:#2f1b14;
+      --shadow:0 1px 2px rgba(0,0,0,.35), 0 6px 20px rgba(0,0,0,.28);
+    }
+  }
+  :root[data-theme="dark"] {
+    --ground:#131015; --surface:#1b171d; --surface-2:#231e26; --surface-3:#2c2630;
+    --ink:#ece7ea; --ink-2:#bcb2ba; --muted:#8d8390; --rule:#2f2833;
+    --accent:#e58cb4; --accent-wash:#2e1a25; --accent-ink:#1b171d;
+    --ready:#5cc8a0;  --ready-wash:#152820;
+    --design:#98a3e8; --design-wash:#1a1d33;
+    --onbox:#e0a34a;  --onbox-wash:#2c2113;
+    --blocked:#8d8390;--blocked-wash:#241f27;
+    --gated:#e08a6c;  --gated-wash:#2f1b14;
+    --shadow:0 1px 2px rgba(0,0,0,.35), 0 6px 20px rgba(0,0,0,.28);
+  }
+
+  * { box-sizing:border-box; }
+  body {
+    margin:0; background:var(--ground); color:var(--ink);
+    font-family:var(--font-ui); font-size:16px; line-height:1.55;
+    -webkit-font-smoothing:antialiased;
+  }
+  .wrap { max-width:var(--maxw); margin:0 auto; padding:2.5rem 1.25rem 5rem; }
+  a { color:var(--accent); text-decoration-thickness:1px; text-underline-offset:2px; }
+  :focus-visible { outline:2px solid var(--accent); outline-offset:2px; border-radius:3px; }
+  .mono { font-family:var(--font-data); font-variant-numeric:tabular-nums; }
+
+  /* ---------- masthead ---------- */
+  header.masthead { display:flex; gap:1.5rem; align-items:flex-start; flex-wrap:wrap;
+    border-bottom:1px solid var(--rule); padding-bottom:1.75rem; margin-bottom:2rem; }
+  .masthead .lead { flex:1 1 26rem; min-width:0; }
+  .eyebrow { font-family:var(--font-data); font-size:.7rem; letter-spacing:.13em;
+    text-transform:uppercase; color:var(--muted); margin:0 0 .6rem; }
+  h1 { font-family:var(--font-display); font-weight:600; font-size:clamp(1.9rem,4vw,2.7rem);
+    line-height:1.14; margin:0 0 .6rem; text-wrap:balance; letter-spacing:-.01em; }
+  .standfirst { margin:0; color:var(--ink-2); font-size:1.02rem; max-width:46ch; }
+  .stamp { font-family:var(--font-data); font-size:.74rem; color:var(--muted);
+    display:flex; flex-direction:column; gap:.3rem; text-align:right; }
+  .stamp b { color:var(--ink-2); font-weight:600; }
+  .toggle { font-family:var(--font-ui); font-size:.78rem; cursor:pointer; align-self:flex-end;
+    background:var(--surface); color:var(--ink-2); border:1px solid var(--rule);
+    border-radius:999px; padding:.3rem .8rem; }
+  .toggle:hover { border-color:var(--accent); color:var(--accent); }
+
+  /* ---------- the drain bar ---------- */
+  .drain { background:var(--surface); border:1px solid var(--rule); border-radius:12px;
+    box-shadow:var(--shadow); padding:1.4rem 1.5rem 1.25rem; margin-bottom:1.25rem; }
+  .drain h2 { font-family:var(--font-ui); font-size:.72rem; letter-spacing:.13em;
+    text-transform:uppercase; color:var(--muted); margin:0 0 .1rem; font-weight:600; }
+  .drain .claim { font-family:var(--font-display); font-size:1.15rem; margin:0 0 1rem;
+    color:var(--ink); text-wrap:balance; }
+  .bar { display:flex; width:100%; height:2.9rem; border-radius:7px; overflow:hidden;
+    gap:2px; background:var(--rule); }
+  .seg { border:0; padding:0; cursor:pointer; position:relative; color:var(--accent-ink);
+    font-family:var(--font-data); font-size:.82rem; font-weight:600;
+    display:flex; align-items:center; justify-content:center;
+    transition:filter .15s ease, opacity .15s ease; }
+  .seg:hover { filter:brightness(1.08); }
+  .seg[aria-pressed="false"] { opacity:.34; }
+  .seg.ready{background:var(--ready)} .seg.design{background:var(--design)}
+  .seg.onbox{background:var(--onbox)} .seg.blocked{background:var(--blocked)}
+  .seg.gated{background:var(--gated)}
+  .seg span { color:#fff; text-shadow:0 1px 2px rgba(0,0,0,.35); }
+  .legend { display:flex; flex-wrap:wrap; gap:.35rem 1.4rem; margin-top:.85rem;
+    font-size:.82rem; color:var(--ink-2); }
+  .legend div { display:flex; gap:.5rem; align-items:baseline; }
+  .legend i { width:.6rem; height:.6rem; border-radius:2px; display:inline-block;
+    flex:none; transform:translateY(-1px); }
+  .legend b { font-weight:600; color:var(--ink); }
+  .legend span { color:var(--muted); }
+  .hint { margin:.9rem 0 0; font-size:.8rem; color:var(--muted); }
+
+  /* ---------- kpi ---------- */
+  .kpis { display:grid; grid-template-columns:repeat(auto-fit,minmax(9.5rem,1fr));
+    gap:.75rem; margin-bottom:2.25rem; }
+  .kpi { background:var(--surface); border:1px solid var(--rule); border-radius:10px;
+    padding:.9rem 1rem; }
+  .kpi .v { font-family:var(--font-data); font-size:1.75rem; font-weight:600;
+    line-height:1.1; font-variant-numeric:tabular-nums; }
+  .kpi .l { font-size:.76rem; color:var(--muted); margin-top:.2rem; }
+  .kpi.is-accent .v { color:var(--accent); }
+
+  /* ---------- controls ---------- */
+  .controls { display:flex; flex-wrap:wrap; gap:.5rem; align-items:center;
+    margin-bottom:1.5rem; }
+  .chip { font-family:var(--font-ui); font-size:.79rem; cursor:pointer;
+    background:var(--surface); color:var(--ink-2); border:1px solid var(--rule);
+    border-radius:999px; padding:.32rem .8rem; }
+  .chip[aria-pressed="true"] { background:var(--accent); border-color:var(--accent);
+    color:var(--accent-ink); font-weight:600; }
+  .chip:hover:not([aria-pressed="true"]) { border-color:var(--accent); color:var(--accent); }
+  .controls .spacer { flex:1 1 auto; }
+  .controls .count { font-family:var(--font-data); font-size:.78rem; color:var(--muted); }
+
+  /* ---------- callout ---------- */
+  .callout { border-left:3px solid var(--accent); background:var(--accent-wash);
+    border-radius:0 9px 9px 0; padding:1.1rem 1.3rem; margin:0 0 2.25rem; }
+  .callout h3 { font-family:var(--font-display); font-size:1.12rem; margin:0 0 .45rem; }
+  .callout p { margin:0 0 .6rem; color:var(--ink-2); font-size:.93rem; }
+  .callout p:last-child { margin-bottom:0; }
+  .callout .nums { font-family:var(--font-data); font-size:.85rem; color:var(--ink);
+    line-height:1.9; }
+  .callout .nums b { background:var(--surface); border:1px solid var(--rule);
+    border-radius:5px; padding:.1rem .38rem; font-weight:600; }
+
+  /* ---------- groups ---------- */
+  .group { background:var(--surface); border:1px solid var(--rule); border-radius:12px;
+    box-shadow:var(--shadow); margin-bottom:1.1rem; overflow:hidden; }
+  .group > header { display:flex; gap:.9rem; align-items:baseline; flex-wrap:wrap;
+    padding:1.05rem 1.3rem; border-bottom:1px solid var(--rule); background:var(--surface-2); }
+  .group h3 { font-family:var(--font-display); font-size:1.14rem; margin:0; flex:0 1 auto; }
+  .group .meta { font-family:var(--font-data); font-size:.75rem; color:var(--muted); }
+  .group .why { flex:1 1 100%; margin:.15rem 0 0; font-size:.87rem; color:var(--ink-2); }
+  .group .why em { color:var(--ink); font-style:normal; font-weight:600; }
+  .group .acts { margin-left:auto; display:flex; gap:.4rem; }
+  .btn { font-family:var(--font-ui); font-size:.74rem; cursor:pointer;
+    background:var(--surface); color:var(--ink-2); border:1px solid var(--rule);
+    border-radius:6px; padding:.26rem .6rem; white-space:nowrap; }
+  .btn:hover { border-color:var(--accent); color:var(--accent); }
+
+  .disp { font-family:var(--font-data); font-size:.66rem; letter-spacing:.09em;
+    text-transform:uppercase; font-weight:600; border-radius:4px; padding:.16rem .45rem;
+    white-space:nowrap; }
+  .disp.ready{background:var(--ready-wash);color:var(--ready)}
+  .disp.design{background:var(--design-wash);color:var(--design)}
+  .disp.onbox{background:var(--onbox-wash);color:var(--onbox)}
+  .disp.blocked{background:var(--blocked-wash);color:var(--blocked)}
+  .disp.gated{background:var(--gated-wash);color:var(--gated)}
+
+  ul.items { list-style:none; margin:0; padding:0; }
+  li.item { display:grid; grid-template-columns:auto 4.6rem 1fr auto;
+    gap:.35rem .85rem; padding:.8rem 1.3rem; border-bottom:1px solid var(--rule);
+    align-items:start; }
+  li.item:last-child { border-bottom:0; }
+  li.item.done { background:var(--surface-2); }
+  li.item.done .t { text-decoration:line-through; color:var(--muted); }
+  li.item input[type=checkbox] { width:1.05rem; height:1.05rem; margin:.2rem 0 0;
+    accent-color:var(--accent); cursor:pointer; flex:none; }
+  li.item .num { font-family:var(--font-data); font-size:.86rem; font-weight:600;
+    padding-top:.05rem; }
+  li.item .num a { text-decoration:none; }
+  li.item .num a:hover { text-decoration:underline; }
+  li.item .body { min-width:0; }
+  li.item .t { font-size:.94rem; line-height:1.4; }
+  li.item .n { font-size:.83rem; color:var(--ink-2); margin-top:.22rem; }
+  li.item .n b { color:var(--ink); font-weight:600; }
+  li.item .tags { display:flex; gap:.35rem; align-items:center; flex-wrap:wrap;
+    justify-content:flex-end; padding-top:.1rem; }
+  .tag { font-family:var(--font-data); font-size:.68rem; color:var(--muted);
+    border:1px solid var(--rule); border-radius:4px; padding:.1rem .4rem; white-space:nowrap; }
+  .tag.age { color:var(--gated); border-color:var(--gated); }
+  .tag.bug { color:var(--accent); border-color:var(--accent); }
+
+  /* ---------- closing blocks ---------- */
+  .cols { display:grid; grid-template-columns:repeat(auto-fit,minmax(19rem,1fr));
+    gap:1.1rem; margin-top:2.5rem; }
+  .panel { background:var(--surface); border:1px solid var(--rule); border-radius:12px;
+    padding:1.2rem 1.35rem; box-shadow:var(--shadow); }
+  .panel h3 { font-family:var(--font-display); font-size:1.1rem; margin:0 0 .8rem; }
+  ol.seq { margin:0; padding-left:1.2rem; font-size:.92rem; color:var(--ink-2); }
+  ol.seq li { margin-bottom:.45rem; }
+  ol.seq li b { color:var(--ink); }
+  ol.decisions { list-style:none; margin:0; padding:0; counter-reset:d; }
+  ol.decisions li { counter-increment:d; display:grid; grid-template-columns:auto 1fr;
+    gap:.7rem; padding:.6rem 0; border-bottom:1px solid var(--rule); font-size:.92rem; }
+  ol.decisions li:last-child { border-bottom:0; padding-bottom:0; }
+  ol.decisions li::before { content:counter(d); font-family:var(--font-data);
+    font-size:.75rem; font-weight:600; color:var(--accent-ink); background:var(--accent);
+    width:1.35rem; height:1.35rem; border-radius:50%; display:flex;
+    align-items:center; justify-content:center; margin-top:.12rem; }
+  ol.decisions b { display:block; }
+  ol.decisions span { color:var(--ink-2); font-size:.88rem; }
+
+  footer.foot { margin-top:2.75rem; padding-top:1.25rem; border-top:1px solid var(--rule);
+    font-size:.8rem; color:var(--muted); display:flex; gap:1rem; flex-wrap:wrap;
+    justify-content:space-between; }
+
+  .toast { position:fixed; bottom:1.25rem; left:50%; transform:translateX(-50%) translateY(1rem);
+    background:var(--ink); color:var(--ground); font-size:.84rem; padding:.55rem 1.1rem;
+    border-radius:999px; opacity:0; pointer-events:none; transition:opacity .2s, transform .2s; }
+  .toast.show { opacity:1; transform:translateX(-50%) translateY(0); }
+
+  .is-hidden { display:none !important; }
+
+  @media (max-width:640px) {
+    .wrap { padding:1.75rem 1rem 4rem; }
+    .stamp { text-align:left; }
+    li.item { grid-template-columns:auto 4.4rem 1fr; }
+    li.item .tags { grid-column:2 / -1; justify-content:flex-start; }
+    .bar { height:3.4rem; }
+    .seg { font-size:.75rem; }
+  }
+  @media (prefers-reduced-motion:reduce) { * { transition:none !important; } }
+</style>
+
+<div class="wrap">
+
+  <header class="masthead">
+    <div class="lead">
+      <p class="eyebrow">Plan 277 · Round 4 · driving board</p>
+      <h1>Draining the bug &amp; chore queue</h1>
+      <p class="standfirst">49 open items. Four different actions, not one backlog —
+        and a fifth of the queue that no amount of effort will ever clear.</p>
+    </div>
+    <div class="stamp">
+      <span>baseline <b>main @ f2b2e866</b></span>
+      <span>taken <b>2026-08-11</b></span>
+      <span><b>14</b> bug · <b>35</b> chore</span>
+      <button class="toggle" id="themeBtn" type="button" aria-label="Switch colour theme">◐ theme</button>
+    </div>
+  </header>
+
+  <section class="drain" aria-labelledby="drainH">
+    <h2 id="drainH">The queue is not one pile</h2>
+    <p class="claim">Treating all 49 as a single backlog is why it looks immovable.
+      They split five ways — and only 20 of them are work you can dispatch tomorrow.</p>
+
+    <div class="bar" role="group" aria-label="Filter items by disposition">
+      <button class="seg ready"   type="button" data-disp="ready"   aria-pressed="true" style="flex:20" title="20 diff-shaped items"><span>20</span></button>
+      <button class="seg design"  type="button" data-disp="design"  aria-pressed="true" style="flex:8"  title="8 design-first items"><span>8</span></button>
+      <button class="seg onbox"   type="button" data-disp="onbox"   aria-pressed="true" style="flex:6"  title="6 on-box items"><span>6</span></button>
+      <button class="seg blocked" type="button" data-disp="blocked" aria-pressed="true" style="flex:10" title="10 blocked items"><span>10</span></button>
+      <button class="seg gated"   type="button" data-disp="gated"   aria-pressed="true" style="flex:5"  title="5 gated items"><span>5</span></button>
+    </div>
+
+    <div class="legend">
+      <div><i style="background:var(--ready)"></i><span><b>Ready</b> — dispatch now, in file-disjoint lanes</span></div>
+      <div><i style="background:var(--design)"></i><span><b>Design-first</b> — phase 1 only, closes in Round 5</span></div>
+      <div><i style="background:var(--onbox)"></i><span><b>On-box</b> — the deliverable is a measurement</span></div>
+      <div><i style="background:var(--blocked)"></i><span><b>Blocked</b> — a disposition decision, not work</span></div>
+      <div><i style="background:var(--gated)"></i><span><b>Gated</b> — live worktree or paused wave</span></div>
+    </div>
+    <p class="hint">Click a segment to filter the board. Tick an item to mark it cleared —
+      progress is stored in this browser, so a redeploy of the page never wipes it.</p>
+  </section>
+
+  <div class="kpis">
+    <div class="kpi"><div class="v" id="kpiOpen">49</div><div class="l">open today</div></div>
+    <div class="kpi"><div class="v" style="color:var(--ready)">20</div><div class="l">dispatchable now</div></div>
+    <div class="kpi"><div class="v" style="color:var(--onbox)">6</div><div class="l">one GPU sitting</div></div>
+    <div class="kpi"><div class="v" style="color:var(--blocked)">10</div><div class="l">never, by effort</div></div>
+    <div class="kpi is-accent"><div class="v">~13</div><div class="l">honest end state</div></div>
+    <div class="kpi"><div class="v" id="kpiDone">0</div><div class="l">ticked here</div></div>
+  </div>
+
+  <div class="controls" role="group" aria-label="Filter items by area">
+    <span class="count">Area</span>
+    <button class="chip" type="button" data-area="srv"  aria-pressed="false">server</button>
+    <button class="chip" type="button" data-area="side" aria-pressed="false">sidecar</button>
+    <button class="chip" type="button" data-area="ops"  aria-pressed="false">ops</button>
+    <button class="chip" type="button" data-area="fe"   aria-pressed="false">frontend</button>
+    <button class="chip" type="button" data-area="fs"   aria-pressed="false">full-stack</button>
+    <span class="spacer"></span>
+    <button class="chip" type="button" id="hideDone" aria-pressed="false">hide ticked</button>
+    <span class="count" id="showing">49 of 49 shown</span>
+  </div>
+
+  <div class="callout">
+    <h3>Round 0 — the premise pass, before a single lane is briefed</h3>
+    <p><b>20 of the 49 were filed 14 or more days ago.</b> Round 3 ran this check and found
+      <b>4 of 10 premises dead in twenty minutes</b>; two plan docs were nearly written against
+      defects that do not exist. The trap here is larger.</p>
+    <p class="nums">
+      <b>#1826</b> <b>#1691</b> <b>#1393</b> <b>#1309</b> <b>#898</b> <b>#485</b>
+      <b>#1685</b> <b>#1600</b> <b>#1527</b> <b>#1084</b>
+      &nbsp;+ duplicate check on <b>#2056</b> vs <b>#2026</b>
+    </p>
+    <p>Two mechanics are non-negotiable. Fetch with <code>--comments</code> —
+      <code>gh issue view --json body</code> omits them, and comments are where owner decisions
+      land. And <b>a claim that something isn't there needs a command, not a reading</b>; the
+      command's pattern is the thing to doubt.</p>
+    <p><b>Already reclassified by this pass:</b> #2187's fix shipped (alignment 67.7 → 96.0%) and
+      is open only on on-box row C2 · #1976 is a bookkeeping shell that closes with #1996 ·
+      #2015's capture half is solved, only the rebuild is open.</p>
+  </div>
+
+  <main id="board">
+
+    <!-- G1 -->
+    <section class="group" data-group="g1">
+      <header>
+        <h3>Bookkeeping closures</h3>
+        <span class="disp ready">ready</span>
+        <span class="meta">4 items · one docs PR</span>
+        <span class="acts"><button class="btn" type="button" data-brief="g1">copy brief</button></span>
+        <p class="why">The cheapest reduction in the whole plan. <em>No code.</em> Bundle the
+          outstanding register-publish debts into the same PR.</p>
+      </header>
+      <ul class="items">
+        <li class="item" data-id="2057" data-disp="ready" data-area="ops">
+          <input type="checkbox" aria-label="Mark 2057 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/2057">#2057</a></div>
+          <div class="body"><div class="t">Reconcile the onbox register's owed #2026 row and republish the HTML twin</div>
+          <div class="n"><b>Unblocked since 2026-08-01</b>, when PR #2039 merged — actionable for ten days. The register gates every on-box PR; a stale row makes that gate lie.</div></div>
+          <div class="tags"><span class="tag">ops</span><span class="tag">01 Aug</span></div>
+        </li>
+        <li class="item" data-id="1976" data-disp="ready" data-area="side">
+          <input type="checkbox" aria-label="Mark 1976 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/1976">#1976</a></div>
+          <div class="body"><div class="t">A finished render strands ~3.9 GB of reclaimable VRAM</div>
+          <div class="n"><b>Annotate as a shell, don't schedule it.</b> Four of five criteria shipped; it closes when #1996 does. It reads like a live independent bug and is not one.</div></div>
+          <div class="tags"><span class="tag bug">bug</span><span class="tag">sidecar</span><span class="tag">31 Jul</span></div>
+        </li>
+        <li class="item" data-id="2056" data-disp="ready" data-area="side">
+          <input type="checkbox" aria-label="Mark 2056 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/2056">#2056</a></div>
+          <div class="body"><div class="t">Russian neuter <span class="mono">-ее</span> mispronounced by Coqui XTTS v2</div>
+          <div class="n">Resolve against #2026 — duplicate, or split the upstream-blocked half cleanly. One honest ticket beats two half-descriptions.</div></div>
+          <div class="tags"><span class="tag bug">bug</span><span class="tag">sidecar</span><span class="tag">01 Aug</span></div>
+        </li>
+        <li class="item" data-id="2042" data-disp="ready" data-area="ops">
+          <input type="checkbox" aria-label="Mark 2042 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/2042">#2042</a></div>
+          <div class="body"><div class="t">The sweep's own tracking issue</div>
+          <div class="n">Closes last, carrying the round's final numbers.</div></div>
+          <div class="tags"><span class="tag">ops</span><span class="tag">01 Aug</span></div>
+        </li>
+      </ul>
+    </section>
+
+    <!-- G2 -->
+    <section class="group" data-group="g2">
+      <header>
+        <h3>Lane A · server: <span class="mono">analysis.ts</span> + cast store</h3>
+        <span class="disp ready">ready</span>
+        <span class="meta">4 items · sequential</span>
+        <span class="acts"><button class="btn" type="button" data-brief="g2">copy brief</button></span>
+        <p class="why">All four touch the same files, so this is <em>one worktree run in order</em>
+          — not four parallel agents. Plan 277's invariant 1 is a constraint, not a suggestion.</p>
+      </header>
+      <ul class="items">
+        <li class="item" data-id="2239" data-disp="ready" data-area="srv">
+          <input type="checkbox" aria-label="Mark 2239 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/2239">#2239</a></div>
+          <div class="body"><div class="t">Move <span class="mono">clearNotLinkedEdgesForDroppedRejections</span> out of <span class="mono">analysis.ts</span> into <span class="mono">store/</span></div>
+          <div class="n"><span class="mono">analysis.ts</span> is the file every cast-lock incident has run through; shrinking it is how the next one gets cheaper.</div></div>
+          <div class="tags"><span class="tag">server</span><span class="tag">10 Aug</span></div>
+        </li>
+        <li class="item" data-id="2161" data-disp="ready" data-area="srv">
+          <input type="checkbox" aria-label="Mark 2161 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/2161">#2161</a></div>
+          <div class="body"><div class="t"><span class="mono">rejectedPairs.forgotSupersededTo</span> can dangle the way <span class="mono">supersededBy</span> did before #2110</div>
+          <div class="n">A known-shape defect with a shipped precedent to copy.</div></div>
+          <div class="tags"><span class="tag">server</span><span class="tag">06 Aug</span></div>
+        </li>
+        <li class="item" data-id="2228" data-disp="ready" data-area="srv">
+          <input type="checkbox" aria-label="Mark 2228 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/2228">#2228</a></div>
+          <div class="body"><div class="t">srv-89 — no test stands up either analyzer persist block; three wiring facts are source-scan only</div>
+          <div class="n">Source-scan-only facts are exactly the <b>green-checking-nothing</b> class Round 2 catalogued seven times.</div></div>
+          <div class="tags"><span class="tag">server</span><span class="tag">07 Aug</span></div>
+        </li>
+        <li class="item" data-id="2006" data-disp="ready" data-area="srv">
+          <input type="checkbox" aria-label="Mark 2006 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/2006">#2006</a></div>
+          <div class="body"><div class="t">srv-81 — the last open half of the three clone-consent TOCTOU gates</div>
+          <div class="n">Consent validated in one scope and written in another is a real correctness hole on a privacy-sensitive path.</div></div>
+          <div class="tags"><span class="tag">server</span><span class="tag">31 Jul</span></div>
+        </li>
+      </ul>
+    </section>
+
+    <!-- G3 -->
+    <section class="group" data-group="g3">
+      <header>
+        <h3>Lane B · server: process, routes, voice scoring</h3>
+        <span class="disp ready">ready</span>
+        <span class="meta">5 items</span>
+        <span class="acts"><button class="btn" type="button" data-brief="g3">copy brief</button></span>
+        <p class="why">File-disjoint from Lane A. Two of these are <em>stale enough to premise-check
+          before briefing.</em></p>
+      </header>
+      <ul class="items">
+        <li class="item" data-id="2196" data-disp="ready" data-area="srv">
+          <input type="checkbox" aria-label="Mark 2196 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/2196">#2196</a></div>
+          <div class="body"><div class="t">An out-of-process book folder move leaves a stale record that resurrects the old directory</div>
+          <div class="n"><b>Data-loss-adjacent</b> — the user's own filesystem action gets silently undone.</div></div>
+          <div class="tags"><span class="tag bug">bug</span><span class="tag">server</span><span class="tag">06 Aug</span></div>
+        </li>
+        <li class="item" data-id="1969" data-disp="ready" data-area="srv">
+          <input type="checkbox" aria-label="Mark 1969 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/1969">#1969</a></div>
+          <div class="body"><div class="t">Reassigning a character's voice keeps scoring it against the old voice's persisted audition centroid</div>
+          <div class="n">Voice-match scores are wrong after any reassignment — a routine action.</div></div>
+          <div class="tags"><span class="tag bug">bug</span><span class="tag">server</span><span class="tag">30 Jul</span></div>
+        </li>
+        <li class="item" data-id="2106" data-disp="ready" data-area="srv">
+          <input type="checkbox" aria-label="Mark 2106 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/2106">#2106</a></div>
+          <div class="body"><div class="t"><span class="mono">findListenerPid</span> has no timeout, so a slow refusal resets the respawn budget forever</div>
+          <div class="n">Carries <span class="mono">needs-plan</span> — confirm it needs one rather than just a timeout. An unbounded respawn budget is an infinite-loop class, not a slowdown.</div></div>
+          <div class="tags"><span class="tag bug">bug</span><span class="tag">server</span><span class="tag">05 Aug</span></div>
+        </li>
+        <li class="item" data-id="1826" data-disp="ready" data-area="srv">
+          <input type="checkbox" aria-label="Mark 1826 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/1826">#1826</a></div>
+          <div class="body"><div class="t">Serialize voice-library entry writes (per-uuid lock or <span class="mono">updatedAt</span> CAS)</div>
+          <div class="n"><b>Premise-check first</b> — the cast-lock sweep added a <span class="mono">voice-library-usage.ts</span> detector and may already cover this.</div></div>
+          <div class="tags"><span class="tag">server</span><span class="tag age">26 Jul</span></div>
+        </li>
+        <li class="item" data-id="1691" data-disp="ready" data-area="srv">
+          <input type="checkbox" aria-label="Mark 1691 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/1691">#1691</a></div>
+          <div class="body"><div class="t">Make stage-1 cloud TPM reservation roster-aware (&gt;130-char-cast ceiling)</div>
+          <div class="n">A large cast blows the reservation ceiling silently. <b>Check against #1685</b> before dispatching.</div></div>
+          <div class="tags"><span class="tag">server</span><span class="tag age">17 Jul</span></div>
+        </li>
+      </ul>
+    </section>
+
+    <!-- G4 -->
+    <section class="group" data-group="g4">
+      <header>
+        <h3>Lane C · frontend + test hygiene</h3>
+        <span class="disp ready">ready</span>
+        <span class="meta">2 items</span>
+        <span class="acts"><button class="btn" type="button" data-brief="g4">copy brief</button></span>
+        <p class="why">Small lane, but <em>#2235 goes first in the round</em> — a flake in the gate
+          corrupts every red-phase verification downstream of it.</p>
+      </header>
+      <ul class="items">
+        <li class="item" data-id="2230" data-disp="ready" data-area="fe">
+          <input type="checkbox" aria-label="Mark 2230 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/2230">#2230</a></div>
+          <div class="body"><div class="t">A 409 from the Listen-view book-meta editor is swallowed silently</div>
+          <div class="n">The edit vanishes with no error; the user retypes it and it vanishes again.</div></div>
+          <div class="tags"><span class="tag bug">bug</span><span class="tag">frontend</span><span class="tag">07 Aug</span></div>
+        </li>
+        <li class="item" data-id="2235" data-disp="ready" data-area="srv">
+          <input type="checkbox" aria-label="Mark 2235 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/2235">#2235</a></div>
+          <div class="body"><div class="t">Flaky <span class="mono">export.test.ts</span> dies with an uncaught ENOENT in its staging dir</div>
+          <div class="n">~1-in-2 standalone on a contended box. Round 1 put this class first for exactly this reason.</div></div>
+          <div class="tags"><span class="tag bug">bug</span><span class="tag">test</span><span class="tag">07 Aug</span></div>
+        </li>
+      </ul>
+    </section>
+
+    <!-- G5 -->
+    <section class="group" data-group="g5">
+      <header>
+        <h3>Lane D · ops, config, CI</h3>
+        <span class="disp ready">ready</span>
+        <span class="meta">4 items</span>
+        <span class="acts"><button class="btn" type="button" data-brief="g5">copy brief</button></span>
+        <p class="why">Independent of the server lanes. <em>#1966's date gate expires 2026-08-14</em>,
+          so it lands naturally inside this round.</p>
+      </header>
+      <ul class="items">
+        <li class="item" data-id="2194" data-disp="ready" data-area="ops">
+          <input type="checkbox" aria-label="Mark 2194 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/2194">#2194</a></div>
+          <div class="body"><div class="t">An existing <span class="mono">server/.env</span> keeps every knob locked after #2179, because upgrades never rewrite it</div>
+          <div class="n"><b>Every existing install silently ignores the new defaults</b> — an upgrade that does nothing.</div></div>
+          <div class="tags"><span class="tag">ops</span><span class="tag">06 Aug</span></div>
+        </li>
+        <li class="item" data-id="1994" data-disp="ready" data-area="ops">
+          <input type="checkbox" aria-label="Mark 1994 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/1994">#1994</a></div>
+          <div class="body"><div class="t">Qwen has no golden duration baseline, so a speech-rate regression on the default engine is invisible</div>
+          <div class="n">The golden tier covers the fallback engine and not the hot path.</div></div>
+          <div class="tags"><span class="tag">ops</span><span class="tag">31 Jul</span></div>
+        </li>
+        <li class="item" data-id="2243" data-disp="ready" data-area="ops">
+          <input type="checkbox" aria-label="Mark 2243 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/2243">#2243</a></div>
+          <div class="body"><div class="t">ops-56 — decide whether <span class="mono">docs/superpowers/plans/**</span> is a record or live instructions, then finish the review-gate sweep</div>
+          <div class="n"><b>Stale docs read as conformance</b> — the #2144 failure shape exactly.</div></div>
+          <div class="tags"><span class="tag">ops</span><span class="tag">10 Aug</span></div>
+        </li>
+        <li class="item" data-id="1966" data-disp="ready" data-area="ops">
+          <input type="checkbox" aria-label="Mark 1966 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/1966">#1966</a></div>
+          <div class="body"><div class="t">ops-48 — evaluate <span class="mono">@nanonets/graft</span></div>
+          <div class="n">Date-gated to <b>2026-08-14</b>. Retires a standing "revisit later" with a yes/no.</div></div>
+          <div class="tags"><span class="tag">ops</span><span class="tag">30 Jul</span></div>
+        </li>
+      </ul>
+    </section>
+
+    <!-- G6 -->
+    <section class="group" data-group="g6">
+      <header>
+        <h3>#898 phase 2 — execute-only</h3>
+        <span class="disp ready">ready</span>
+        <span class="meta">1 item · own thread</span>
+        <span class="acts"><button class="btn" type="button" data-brief="g6">copy brief</button></span>
+        <p class="why"><em>The highest expected value single item in the plan — and it should not
+          wait behind the lanes.</em></p>
+      </header>
+      <ul class="items">
+        <li class="item" data-id="898" data-disp="ready" data-area="srv">
+          <input type="checkbox" aria-label="Mark 898 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/898">#898</a></div>
+          <div class="body"><div class="t">srv-41 — pairing device-token hardening: TTL + scoped access</div>
+          <div class="n">Spec merged (#2147), plan merged (#2151 — 10 tasks, 65 steps, 28 mutations, two PRs in a load-bearing order), handover brief posted. <b>Phase 1 is complete; brief a fresh implementation thread from the ticket and nothing else.</b> Its design phase already produced one live auth bypass (#2144) as a side effect.</div></div>
+          <div class="tags"><span class="tag">server</span><span class="tag">security</span><span class="tag age">18 Jun</span></div>
+        </li>
+      </ul>
+    </section>
+
+    <!-- G7 -->
+    <section class="group" data-group="g7">
+      <header>
+        <h3>Design-first — phase 1 only</h3>
+        <span class="disp design">design</span>
+        <span class="meta">8 items · closes in Round 5</span>
+        <span class="acts"><button class="btn" type="button" data-brief="g7">copy brief</button></span>
+        <p class="why">Each has more than one defensible answer, so the deliverable is a ticket +
+          plan doc. Use the <em>cold-brief handoff</em> — a fresh agent reads the brief with no
+          access to the drafts. <em>Take the first four; defer the rest.</em></p>
+      </header>
+      <ul class="items">
+        <li class="item" data-id="1996" data-disp="design" data-area="side">
+          <input type="checkbox" aria-label="Mark 1996 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/1996">#1996</a></div>
+          <div class="body"><div class="t">Reclaim a stranded VRAM pool at render completion, not just on a later admission failure</div>
+          <div class="n"><b>Take this round.</b> Attempt 1 (PR #2029) was killed by review. Traps are recorded: call <span class="mono">PlacementController._reclaim_stranded_cache</span>, not <span class="mono">_placement.reclaim</span>; tests must assert <b>ordering</b>, not that the hook was called; the idle watchdogs are the likely home. Closing it also closes #1976.</div></div>
+          <div class="tags"><span class="tag bug">bug</span><span class="tag">sidecar</span><span class="tag">31 Jul</span></div>
+        </li>
+        <li class="item" data-id="2015" data-disp="design" data-area="srv">
+          <input type="checkbox" aria-label="Mark 2015 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/2015">#2015</a></div>
+          <div class="body"><div class="t">srv-82 — <span class="mono">analysis.ts</span>'s five cast.json writes replay a merge base read at the start of the run</div>
+          <div class="n"><b>Take this round — the rebuild half only.</b> Four prior designs died on the capture problem, which PR #2185 solved. Do not re-solve capture.</div></div>
+          <div class="tags"><span class="tag">server</span><span class="tag">31 Jul</span></div>
+        </li>
+        <li class="item" data-id="1932" data-disp="design" data-area="side">
+          <input type="checkbox" aria-label="Mark 1932 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/1932">#1932</a></div>
+          <div class="body"><div class="t">side-18 — consolidate the two Coqui VRAM eviction mechanisms</div>
+          <div class="n"><b>Take this round.</b> Premise verified as holding in Round 3. Either consolidate, or document the split as deliberate and scope each in code — two mechanisms for one job is how the next OOM gets misdiagnosed.</div></div>
+          <div class="tags"><span class="tag">sidecar</span><span class="tag age">28 Jul</span></div>
+        </li>
+        <li class="item" data-id="2131" data-disp="design" data-area="srv">
+          <input type="checkbox" aria-label="Mark 2131 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/2131">#2131</a></div>
+          <div class="body"><div class="t">Decide whether an unresolvable <span class="mono">qa.asr.model</span> should fail early, not just non-fatally at first transcribe</div>
+          <div class="n"><b>Take this round.</b> Today a whole book renders before the QA gate discovers it cannot run.</div></div>
+          <div class="tags"><span class="tag">server</span><span class="tag">05 Aug</span></div>
+        </li>
+        <li class="item" data-id="2059" data-disp="design" data-area="srv">
+          <input type="checkbox" aria-label="Mark 2059 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/2059">#2059</a></div>
+          <div class="body"><div class="t">Attribution-dialogue leading + interior dash produces a doubled comma</div>
+          <div class="n">Defer. Genuinely a question — "should it collapse?" — so it needs a decision, not a fix. A visible text artifact in Russian dialogue.</div></div>
+          <div class="tags"><span class="tag bug">bug</span><span class="tag">server</span><span class="tag">01 Aug</span></div>
+        </li>
+        <li class="item" data-id="1309" data-disp="design" data-area="ops">
+          <input type="checkbox" aria-label="Mark 1309 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/1309">#1309</a></div>
+          <div class="body"><div class="t">ops-24 — the LAN port-443 forwarder collapses per-client identity, weakening rate limits</div>
+          <div class="n">Defer. Verified byte-for-byte in Round 3. Rate limits that cannot distinguish clients are not rate limits.</div></div>
+          <div class="tags"><span class="tag">ops</span><span class="tag age">04 Jul</span></div>
+        </li>
+        <li class="item" data-id="485" data-disp="design" data-area="side">
+          <input type="checkbox" aria-label="Mark 485 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/485">#485</a></div>
+          <div class="body"><div class="t">side-13 — import safety + provenance for shared voice artifacts</div>
+          <div class="n">Defer. Size M; gates fs-28 … fs-31, so it is holding up more than itself.</div></div>
+          <div class="tags"><span class="tag">sidecar</span><span class="tag age">02 Jun</span></div>
+        </li>
+        <li class="item" data-id="1393" data-disp="design" data-area="srv">
+          <input type="checkbox" aria-label="Mark 1393 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/1393">#1393</a></div>
+          <div class="body"><div class="t">srv-58 — <span class="mono">reconcileResidentQwenTiers</span> can evict a Qwen tier a concurrent book is mid-render on</div>
+          <div class="n"><b>Paused after three rejected designs.</b> Its own verified facts — no per-segment tier stamp, and <span class="mono">inFlightByBook</span> cannot see splice or QA-repair renders — rule out the shape it was filed as. Restart needs a fresh thread from the <span class="mono">synthesiseChapter</span> publishing question, not a fourth revision.</div></div>
+          <div class="tags"><span class="tag">server</span><span class="tag age">06 Jul</span></div>
+        </li>
+      </ul>
+    </section>
+
+    <!-- G8 -->
+    <section class="group" data-group="g8">
+      <header>
+        <h3>On-box — one GPU sitting clears six</h3>
+        <span class="disp onbox">on-box</span>
+        <span class="meta">6 items · one session</span>
+        <span class="acts"><button class="btn" type="button" data-brief="g8">copy brief</button></span>
+        <p class="why">The deliverable is a <em>measurement</em>, not a diff — dispatching a coding
+          agent at these accomplishes nothing. <em>Nothing else in the plan has this ratio.</em></p>
+      </header>
+      <ul class="items">
+        <li class="item" data-id="2187" data-disp="onbox" data-area="srv">
+          <input type="checkbox" aria-label="Mark 2187 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/2187">#2187</a></div>
+          <div class="body"><div class="t">srv-59 follow-up — dialogue-structure aligner under-aligns on Russian dash dialogue</div>
+          <div class="n"><b>The fix already shipped</b> (<span class="mono">b2be5b7b</span>; book alignment 67.7 → 96.0%). Discharge register row C2 — force <span class="mono">fresh: true</span>, and do <b>not</b> re-measure alignment, that is already done from cache — then close.</div></div>
+          <div class="tags"><span class="tag bug">bug</span><span class="tag">server</span><span class="tag">06 Aug</span></div>
+        </li>
+        <li class="item" data-id="2026" data-disp="onbox" data-area="side">
+          <input type="checkbox" aria-label="Mark 2026 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/2026">#2026</a></div>
+          <div class="body"><div class="t">XTTS Russian quality: neuter <span class="mono">-ее</span>, no pause on a leading em-dash, rare language collapse</div>
+          <div class="n">Reproduces on a stock catalogue voice, so it is engine-level, not clone-related.</div></div>
+          <div class="tags"><span class="tag bug">bug</span><span class="tag">sidecar</span><span class="tag">01 Aug</span></div>
+        </li>
+        <li class="item" data-id="1998" data-disp="onbox" data-area="side">
+          <input type="checkbox" aria-label="Mark 1998 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/1998">#1998</a></div>
+          <div class="body"><div class="t">A cloned voice on XTTS loses most of its speaker identity in a language other than the source clip's</div>
+          <div class="n">Measured 0.600 → 0.229.</div></div>
+          <div class="tags"><span class="tag bug">bug</span><span class="tag">sidecar</span><span class="tag">31 Jul</span></div>
+        </li>
+        <li class="item" data-id="1084" data-disp="onbox" data-area="srv">
+          <input type="checkbox" aria-label="Mark 1084 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/1084">#1084</a></div>
+          <div class="body"><div class="t">ASR content-QA never tuned or validated for non-English</div>
+          <div class="n">The gate went live on non-EN at <span class="mono">3a56bf74</span> with an English-tuned <span class="mono">maxWer: 0.4</span> cap. Pairs with #1527.</div></div>
+          <div class="tags"><span class="tag">server</span><span class="tag age">24 Jun</span></div>
+        </li>
+        <li class="item" data-id="1527" data-disp="onbox" data-area="srv">
+          <input type="checkbox" aria-label="Mark 1527 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/1527">#1527</a></div>
+          <div class="body"><div class="t">On-box <span class="mono">maxWer</span> calibration for es / fr / de / ru</div>
+          <div class="n">The #1084 follow-up — same sitting, same corpus.</div></div>
+          <div class="tags"><span class="tag">server</span><span class="tag age">11 Jul</span></div>
+        </li>
+        <li class="item" data-id="1685" data-disp="onbox" data-area="srv">
+          <input type="checkbox" aria-label="Mark 1685 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/1685">#1685</a></div>
+          <div class="body"><div class="t">Verify #1682 cloud request sizing on-box, and calibrate the stage-2 local input fraction</div>
+          <div class="n">Settle this before dispatching #1691 — they touch the same ceiling.</div></div>
+          <div class="tags"><span class="tag">server</span><span class="tag age">17 Jul</span></div>
+        </li>
+      </ul>
+    </section>
+
+    <!-- G9 -->
+    <section class="group" data-group="g9">
+      <header>
+        <h3>Blocked — a disposition decision, not work</h3>
+        <span class="disp blocked">blocked</span>
+        <span class="meta">10 items · a fifth of the queue</span>
+        <span class="acts"><button class="btn" type="button" data-brief="g9">copy brief</button></span>
+        <p class="why"><em>No amount of effort clears these.</em> They wait on other people's
+          releases or on hardware that is not owned — and they distort every triage pass that
+          walks the queue. <em>Recommended: park with a <span class="mono">blocked</span> label
+          and a review date</em>, rather than closing, which loses the per-item context.</p>
+      </header>
+      <ul class="items">
+        <li class="item" data-id="1228" data-disp="blocked" data-area="side">
+          <input type="checkbox" aria-label="Mark 1228 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/1228">#1228</a></div>
+          <div class="body"><div class="t">side-23 — bump transformers to ≥5.3.0 (CVE-2026-4372)</div>
+          <div class="n">Waits on <b>qwen-tts</b> upstream support.</div></div>
+          <div class="tags"><span class="tag">sidecar</span><span class="tag age">03 Jul</span></div>
+        </li>
+        <li class="item" data-id="893" data-disp="blocked" data-area="side">
+          <input type="checkbox" aria-label="Mark 893 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/893">#893</a></div>
+          <div class="body"><div class="t">side-17 — sidecar engine-dep major bump (torch / transformers / huggingface_hub)</div>
+          <div class="n">Waits on <b>torchaudio EOL at 2.11</b>.</div></div>
+          <div class="tags"><span class="tag">sidecar</span><span class="tag age">18 Jun</span></div>
+        </li>
+        <li class="item" data-id="711" data-disp="blocked" data-area="ops">
+          <input type="checkbox" aria-label="Mark 711 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/711">#711</a></div>
+          <div class="body"><div class="t">ops-14 — eslint 9→10 (+ <span class="mono">@eslint/js</span>)</div>
+          <div class="n">Waits on upstream <span class="mono">@eslint/js</span>.</div></div>
+          <div class="tags"><span class="tag">ops</span><span class="tag age">10 Jun</span></div>
+        </li>
+        <li class="item" data-id="431" data-disp="blocked" data-area="srv">
+          <input type="checkbox" aria-label="Mark 431 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/431">#431</a></div>
+          <div class="body"><div class="t">srv-4 — track upstream-blocked deprecation chains (jsdom · archiver · @google/genai)</div>
+          <div class="n">A standing tracker; nothing to do until one of the three moves.</div></div>
+          <div class="tags"><span class="tag">server</span><span class="tag age">01 Jun</span></div>
+        </li>
+        <li class="item" data-id="790" data-disp="blocked" data-area="ops">
+          <input type="checkbox" aria-label="Mark 790 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/790">#790</a></div>
+          <div class="body"><div class="t">ops-17 — migrate the companion off KGP-applying plugins</div>
+          <div class="n">Waits on <b>Flutter built-in Kotlin / AGP 9</b>.</div></div>
+          <div class="tags"><span class="tag">ops</span><span class="tag age">13 Jun</span></div>
+        </li>
+        <li class="item" data-id="1477" data-disp="blocked" data-area="ops">
+          <input type="checkbox" aria-label="Mark 1477 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/1477">#1477</a></div>
+          <div class="body"><div class="t">ops-27 — migrate to TypeScript 7.0 (native Go compiler)</div>
+          <div class="n">"Once the ecosystem catches up." It has not.</div></div>
+          <div class="tags"><span class="tag">ops</span><span class="tag age">09 Jul</span></div>
+        </li>
+        <li class="item" data-id="1335" data-disp="blocked" data-area="side">
+          <input type="checkbox" aria-label="Mark 1335 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/1335">#1335</a></div>
+          <div class="body"><div class="t">AMD GPU support phase 2 — on-box acceptance</div>
+          <div class="n">Needs <b>ROCm hardware that is not owned</b>.</div></div>
+          <div class="tags"><span class="tag">sidecar</span><span class="tag age">05 Jul</span></div>
+        </li>
+        <li class="item" data-id="822" data-disp="blocked" data-area="ops">
+          <input type="checkbox" aria-label="Mark 822 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/822">#822</a></div>
+          <div class="body"><div class="t">ops-16 — Pinokio installer on-box acceptance (Windows + macOS)</div>
+          <div class="n">Needs a <b>macOS box</b>. The Windows half could split out if that helps.</div></div>
+          <div class="tags"><span class="tag">ops</span><span class="tag age">15 Jun</span></div>
+        </li>
+        <li class="item" data-id="1001" data-disp="blocked" data-area="side">
+          <input type="checkbox" aria-label="Mark 1001 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/1001">#1001</a></div>
+          <div class="body"><div class="t">side-22 — explore building FlashAttention-2 from source for Windows cp312 / torch 2.11 / cu128</div>
+          <div class="n">No wheel path exists.</div></div>
+          <div class="tags"><span class="tag">sidecar</span><span class="tag age">22 Jun</span></div>
+        </li>
+        <li class="item" data-id="947" data-disp="blocked" data-area="ops">
+          <input type="checkbox" aria-label="Mark 947 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/947">#947</a></div>
+          <div class="body"><div class="t">ops-18 — catch any large-region visual change, not just the top-bar</div>
+          <div class="n">Deferred <b>by its own issue text</b> until a real regression is observed.</div></div>
+          <div class="tags"><span class="tag">ops</span><span class="tag age">20 Jun</span></div>
+        </li>
+      </ul>
+    </section>
+
+    <!-- G10 -->
+    <section class="group" data-group="g10">
+      <header>
+        <h3>Gated — not scheduled by this sweep</h3>
+        <span class="disp gated">gated</span>
+        <span class="meta">5 items</span>
+        <span class="acts"><button class="btn" type="button" data-brief="g10">copy brief</button></span>
+        <p class="why">Two sit in <em>live worktrees as of 2026-08-11</em>; three belong to a
+          <em>paused wave</em>. Dispatching into either is how two sessions steal each other's HEAD.</p>
+      </header>
+      <ul class="items">
+        <li class="item" data-id="1984" data-disp="gated" data-area="fs">
+          <input type="checkbox" aria-label="Mark 1984 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/1984">#1984</a></div>
+          <div class="body"><div class="t">Attribution collapse is invisible — the dropped-quotes panel shows the last batch only</div>
+          <div class="n"><b>Live in <span class="mono">wt-1984-spec</span>, revision 7</b>, with rounds 5, 6 and 7 all failing their gates. Its scope growth is stalled awaiting owner sign-off. A real book lost 103 of 144 quoted sentences and sat that way for 17 days.</div></div>
+          <div class="tags"><span class="tag bug">bug</span><span class="tag">full-stack</span><span class="tag">31 Jul</span></div>
+        </li>
+        <li class="item" data-id="2128" data-disp="gated" data-area="ops">
+          <input type="checkbox" aria-label="Mark 2128 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/2128">#2128</a></div>
+          <div class="body"><div class="t">The repair pass's re-render list never clears — a re-rendered chapter reappears on every later run</div>
+          <div class="n"><b>Live in <span class="mono">wt-2128-audio-currency</span></b>, committed 2026-08-11.</div></div>
+          <div class="tags"><span class="tag bug">bug</span><span class="tag">ops</span><span class="tag">05 Aug</span></div>
+        </li>
+        <li class="item" data-id="2068" data-disp="gated" data-area="fs">
+          <input type="checkbox" aria-label="Mark 2068 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/2068">#2068</a></div>
+          <div class="body"><div class="t">fs-38 — four residual gaps in the cast-time clone-readiness gate</div>
+          <div class="n">fs-38 Wave 3 is <b>paused</b> with E-04 failing and on-box at 16/60.</div></div>
+          <div class="tags"><span class="tag">full-stack</span><span class="tag">01 Aug</span></div>
+        </li>
+        <li class="item" data-id="2054" data-disp="gated" data-area="fs">
+          <input type="checkbox" aria-label="Mark 2054 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/2054">#2054</a></div>
+          <div class="body"><div class="t">fs-38 — cast-time clone gate is silent when a cloned slot has no resolvable <span class="mono">libraryUuid</span></div>
+          <div class="n">The render hard-fails <span class="mono">misconfigured</span>. Same paused wave.</div></div>
+          <div class="tags"><span class="tag">full-stack</span><span class="tag">01 Aug</span></div>
+        </li>
+        <li class="item" data-id="1600" data-disp="gated" data-area="fs">
+          <input type="checkbox" aria-label="Mark 1600 cleared"><div class="num"><a href="https://github.com/dudarenok-maker/Castwright/issues/1600">#1600</a></div>
+          <div class="body"><div class="t">fs-61 — backfill designed voices + covers onto the zh / ja Coalfall placeholder samples</div>
+          <div class="n">Needs the Qwen VoiceDesign pipeline on a GPU box, and the wave unpaused.</div></div>
+          <div class="tags"><span class="tag">full-stack</span><span class="tag age">14 Jul</span></div>
+        </li>
+      </ul>
+    </section>
+
+  </main>
+
+  <div class="cols">
+    <section class="panel">
+      <h3>Sequencing</h3>
+      <ol class="seq">
+        <li><b>Round 0</b> — premise pass. Read-only, no branch.</li>
+        <li><b>Group 1</b> — bookkeeping, one docs PR.</li>
+        <li><b>#898 phase 2</b> in its own thread, <b>in parallel with Lanes A–D</b>: four worktrees, file-disjoint, Lane A internally sequential.</li>
+        <li><b>Group 7</b> — phase-1 threads for #1996, #2015, #1932, #2131.</li>
+        <li><b>Group 8</b> — at the next GPU sitting.</li>
+        <li><b>Group 9</b> — on the owner's call.</li>
+      </ol>
+    </section>
+
+    <section class="panel">
+      <h3>Decisions this round is waiting on</h3>
+      <ol class="decisions">
+        <li><span><b>The blocked ten</b>Park with a label, or collapse into one upstream-watch tracker? Parking is recommended.</span></li>
+        <li><span><b>A GPU sitting</b>Six items and a large slice of the owed acceptance debt clear in one session.</span></li>
+        <li><span><b>fs-38 Wave 3</b>Stay paused, or unpause — which adds 3 items and unblocks four stale worktrees.</span></li>
+        <li><span><b>#1984 scope growth</b>Stalled on sign-off, independently of this sweep.</span></li>
+      </ol>
+    </section>
+  </div>
+
+  <footer class="foot">
+    <span>Plan of record: <span class="mono">docs/features/277-v115-bug-chore-sweep.md</span> · tracker <a href="https://github.com/dudarenok-maker/Castwright/issues/2042">#2042</a></span>
+    <span class="mono">Rounds 1–3 closed ~31 items · queue held flat as new findings replaced them</span>
+  </footer>
+</div>
+
+<div class="toast" id="toast" role="status" aria-live="polite"></div>
+
+<script>
+(function () {
+  "use strict";
+  var KEY = "castwright-sweep-r4-cleared";
+  var THEME = "castwright-sweep-r4-theme";
+  var root = document.documentElement;
+
+  /* ---- theme ---- */
+  try {
+    var saved = localStorage.getItem(THEME);
+    if (saved === "dark" || saved === "light") root.setAttribute("data-theme", saved);
+  } catch (e) {}
+  document.getElementById("themeBtn").addEventListener("click", function () {
+    var cur = root.getAttribute("data-theme");
+    if (!cur) {
+      cur = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    }
+    var next = cur === "dark" ? "light" : "dark";
+    root.setAttribute("data-theme", next);
+    try { localStorage.setItem(THEME, next); } catch (e) {}
+  });
+
+  /* ---- toast ---- */
+  var toastEl = document.getElementById("toast"), toastTimer;
+  function toast(msg) {
+    toastEl.textContent = msg;
+    toastEl.classList.add("show");
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(function () { toastEl.classList.remove("show"); }, 2200);
+  }
+
+  /* ---- cleared state ---- */
+  var cleared = {};
+  try { cleared = JSON.parse(localStorage.getItem(KEY) || "{}") || {}; } catch (e) { cleared = {}; }
+  function persist() { try { localStorage.setItem(KEY, JSON.stringify(cleared)); } catch (e) {} }
+
+  var items = Array.prototype.slice.call(document.querySelectorAll("li.item"));
+  items.forEach(function (li) {
+    var id = li.getAttribute("data-id");
+    var box = li.querySelector("input[type=checkbox]");
+    if (cleared[id]) { box.checked = true; li.classList.add("done"); }
+    box.addEventListener("change", function () {
+      if (box.checked) { cleared[id] = 1; li.classList.add("done"); }
+      else { delete cleared[id]; li.classList.remove("done"); }
+      persist(); render();
+    });
+  });
+
+  /* ---- filters ---- */
+  var dispOff = {};   /* disposition -> true when switched off */
+  var areaOn = {};    /* area -> true when explicitly selected */
+  var hideDone = false;
+
+  function anyAreaSelected() {
+    for (var k in areaOn) { if (areaOn[k]) return true; }
+    return false;
+  }
+
+  function render() {
+    var shown = 0, done = 0;
+    items.forEach(function (li) {
+      var d = li.getAttribute("data-disp");
+      var a = li.getAttribute("data-area");
+      var isDone = !!cleared[li.getAttribute("data-id")];
+      if (isDone) done++;
+      var ok = !dispOff[d]
+        && (!anyAreaSelected() || areaOn[a])
+        && !(hideDone && isDone);
+      li.classList.toggle("is-hidden", !ok);
+      if (ok) shown++;
+    });
+    /* a group with nothing left visible hides itself */
+    Array.prototype.forEach.call(document.querySelectorAll("section.group"), function (g) {
+      var vis = g.querySelectorAll("li.item:not(.is-hidden)").length;
+      g.classList.toggle("is-hidden", vis === 0);
+    });
+    document.getElementById("showing").textContent = shown + " of " + items.length + " shown";
+    document.getElementById("kpiDone").textContent = String(done);
+    document.getElementById("kpiOpen").textContent = String(items.length - done);
+  }
+
+  Array.prototype.forEach.call(document.querySelectorAll(".seg"), function (btn) {
+    btn.addEventListener("click", function () {
+      var d = btn.getAttribute("data-disp");
+      dispOff[d] = !dispOff[d];
+      btn.setAttribute("aria-pressed", dispOff[d] ? "false" : "true");
+      render();
+    });
+  });
+
+  Array.prototype.forEach.call(document.querySelectorAll(".chip[data-area]"), function (btn) {
+    btn.addEventListener("click", function () {
+      var a = btn.getAttribute("data-area");
+      areaOn[a] = !areaOn[a];
+      btn.setAttribute("aria-pressed", areaOn[a] ? "true" : "false");
+      render();
+    });
+  });
+
+  var hd = document.getElementById("hideDone");
+  hd.addEventListener("click", function () {
+    hideDone = !hideDone;
+    hd.setAttribute("aria-pressed", hideDone ? "true" : "false");
+    render();
+  });
+
+  /* ---- dispatch briefs ---- */
+  var BRIEFS = {
+    g1: { branch: "docs/docs-sweep-r4-bookkeeping",
+          note: "Docs-only PR — exempt from the pr-review-gate. Bundle the outstanding register-publish debts. Republish the register live view with its recorded url, never the .md." },
+    g2: { branch: "chore/server-sweep-r4-cast-store",
+          note: "SEQUENTIAL — all four touch analysis.ts / the cast store. One worktree, one item at a time. cast.json writes go through withCastLock; the guard test fails the build on a new unlocked site." },
+    g3: { branch: "fix/server-sweep-r4-process-and-voice",
+          note: "Premise-check #1826 and #1691 before briefing — both are 14+ days old. #1685 settles the same ceiling as #1691." },
+    g4: { branch: "fix/frontend-sweep-r4-409-and-flake",
+          note: "Do #2235 first: a flake in the gate corrupts every red-phase verification after it. #2230 crosses a redux/router seam, so it wants a Playwright spec." },
+    g5: { branch: "chore/ops-sweep-r4-config-and-ci",
+          note: "#1966's date gate expires 2026-08-14. Any new knob needs a config:sync run and a Settings row." },
+    g6: { branch: "feat/server-898-device-token-scope",
+          note: "EXECUTE ONLY — phase 1 is complete. Brief a fresh implementation thread from issue #898 plus plan #2151 and nothing else; do NOT fork this session. Two PRs, load-bearing order. Serves a LAN browser running the full desktop UI, so scoping every token to `companion` would 403 the web app." },
+    g7: { branch: "(design threads — no code branch)",
+          note: "Phase 1 only: spec + plan doc + handover brief. Mandatory Premium-tier assumption-checker pass before approval, then a cold-brief handoff. Take #1996, #2015, #1932, #2131 this round; defer #2059, #1309, #485, #1393." },
+    g8: { branch: "(on-box session — measurement, not a diff)",
+          note: "Record every outcome in docs/testing/onbox-acceptance-register.md, the per-feature run sheet, AND the live view HTML. For #2187 force fresh:true and do NOT re-measure alignment." },
+    g9: { branch: "(disposition decision — no code)",
+          note: "Recommended: park each with a `blocked` label plus a review date, rather than closing — closing loses the per-item context and several already carry `tracking`." },
+    g10:{ branch: "(do not dispatch)",
+          note: "#1984 and #2128 are live worktrees; #2068/#2054/#1600 belong to the paused fs-38 Wave 3." }
+  };
+
+  Array.prototype.forEach.call(document.querySelectorAll("button[data-brief]"), function (btn) {
+    btn.addEventListener("click", function () {
+      var g = btn.getAttribute("data-brief");
+      var sec = document.querySelector('section.group[data-group="' + g + '"]');
+      var title = sec.querySelector("h3").textContent.trim();
+      var meta = BRIEFS[g] || { branch: "", note: "" };
+      var lines = [];
+      lines.push("Round 4 — " + title);
+      lines.push("Plan of record: docs/features/277-v115-bug-chore-sweep.md (Round 4 section)");
+      if (meta.branch) lines.push("Branch: " + meta.branch);
+      lines.push("");
+      lines.push("Issues:");
+      Array.prototype.forEach.call(sec.querySelectorAll("li.item"), function (li) {
+        lines.push("  #" + li.getAttribute("data-id") + " — " + li.querySelector(".t").textContent.trim());
+      });
+      lines.push("");
+      lines.push("Constraints: " + meta.note);
+      lines.push("");
+      lines.push("Standing rules: fresh worktree + branch (node scripts/wt-new.mjs), verify .husky/_ exists,");
+      lines.push("paired mutation-verified tests per change, premise-check any issue filed 14+ days ago");
+      lines.push("with `gh issue view --comments`, report incidental findings rather than widening the diff.");
+      var text = lines.join("\n");
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(
+          function () { toast("Dispatch brief copied"); },
+          function () { toast("Copy blocked — select the text manually"); }
+        );
+      } else {
+        toast("Clipboard unavailable in this context");
+      }
+    });
+  });
+
+  render();
+})();
+</script>

--- a/docs/features/277-v115-bug-chore-sweep.md
+++ b/docs/features/277-v115-bug-chore-sweep.md
@@ -627,6 +627,302 @@ on on-box measurement), #1932, #1309, #485, #1393 (paused), and #898's phase 2 �
 which is fully briefed and needs only execution. #1950's work merged with
 someone else's PR and the issue is open only for want of a linkage.
 
+## Round 4 — the drain plan (planned 2026-08-11)
+
+Rounds 1–3 dispatched at whatever was actionable that morning. Round 4 is
+scoped differently: the goal is **to take the queue as close to empty as it can
+honestly go**, which means admitting up front that a fifth of it will never be
+cleared by effort at all.
+
+### Baseline, re-taken on `main` @ `f2b2e866` (2026-08-11)
+
+**49 open items — 14 `bug` + 35 `type:chore`** (board total open: 102; the
+balance is `type:feature`). Three rounds have closed ~31 items since the
+2026-08-01 baseline of 54, and the queue has held roughly flat because new
+findings replaced them at about the same rate.
+
+The items are **not one pile**, and treating them as one is why the queue looks
+immovable. They take four different actions:
+
+| Disposition | Count | The action |
+|---|---|---|
+| Diff-shaped — dispatchable now | 20 | Lanes A–D + #898 phase 2 + bookkeeping |
+| Design-first — phase-1 only | 8 | Ticket + plan doc, closes in Round 5 |
+| On-box — the deliverable is a measurement | 6 | One GPU sitting |
+| Blocked upstream / hardware | 10 | A disposition decision, not work |
+| Gated — live worktree or paused wave | 5 | Not scheduled by this sweep |
+
+20 + 8 + 6 + 10 + 5 = 49.
+
+**Realistic end state: 49 → ~13**, of which most are the design-first set
+awaiting Round 5 and the parked-blocked set.
+
+### Two live worktrees — do not dispatch into these
+
+`wt-1984-spec` (#1984, revision 7) and `wt-2128-audio-currency` (#2128), both
+committed 2026-08-11. Four others — `feat+fs38-wave3c-fe`, `fs38-followups-c`,
+`feat+fs-35-per-chapter-detect-emotions`, `feat+server-fs59-cjk-w5` — last moved
+in July and belong to the paused fs-38 Wave 3.
+
+### Round 0 — the premise pass, before any lane is briefed
+
+**20 of the 49 were filed 14+ days ago.** Round 3 found 4 of 10 premises dead in
+about twenty minutes, and two plan docs were nearly written against defects that
+do not exist. The same trap is loaded here, and it is larger.
+
+Scope: the ten stale non-blocked items — **#1826, #1691, #1393, #1309, #898,
+#485, #1685, #1600, #1527, #1084** — plus a duplicate check on **#2056 vs
+#2026** (both describe the Russian neuter `-ее` mispronunciation on XTTS; one is
+probably redundant).
+
+Two mechanics are non-negotiable, both from the Round 3 outcome above:
+
+- Fetch with `--comments`. `gh issue view --json body` omits them, and comments
+  are where scope gets broadened and owner decisions land.
+- **A claim that something isn't there needs a command, not a reading** — and
+  the command's pattern is the thing to doubt. Every false statement in Round 3
+  was an absence inferred from a grep nobody questioned.
+
+*Benefit (technical):* the cheapest step in the round and historically the
+highest-yield. It closes items outright and stops lanes being briefed against
+fiction.
+
+**Three reclassifications already found by this pass, from the durable record:**
+
+| # | Filed as | What is actually true |
+|---|---|---|
+| #2187 | Aligner under-aligns Russian dash dialogue | **The fix shipped** (`b2be5b7b`; book alignment 67.7% → 96.0%). Open only until on-box row C2 is discharged. Not code work. |
+| #1976 | A finished render strands ~3.9 GB | **A bookkeeping shell.** Four of its five criteria shipped; it closes when #1996 does. Not independent work. |
+| #2015 | analysis.ts's five writes replay a merge base | **Capture is solved** (PR #2185). Only the *rebuild* half is open — do not re-solve capture. |
+
+### Group 1 — bookkeeping closures (4, no code)
+
+One docs PR. The cheapest reduction available in the whole plan.
+
+- **#2057** — reconcile the onbox register's owed #2026 row and republish the
+  HTML twin. **Unblocked since 2026-08-01**, when PR #2039 merged.
+  *Benefit (technical):* the register is the merge gate for every on-box-gated
+  PR; a stale row makes that gate lie.
+- **#1976** — annotate as a shell that closes with #1996, so it stops being
+  scheduled. *Benefit (technical):* it reads like a live independent bug on the
+  board and is not one.
+- **#2056** — resolve against #2026: duplicate, or split the upstream-blocked
+  half cleanly. *Benefit (user):* one honest ticket for the XTTS Russian problem
+  instead of two half-descriptions of it.
+- **#2042** — this tracking issue; closes last, carrying the round's numbers.
+
+Bundle the outstanding register-publish debts into the same PR.
+
+### Group 2 — Lane A · server: `analysis.ts` + cast store (4, **sequential**)
+
+All four touch the same files, so this is **one worktree run in order**, not
+four parallel agents — invariant 1 below is the constraint, not a suggestion.
+
+- **#2239** — move `clearNotLinkedEdgesForDroppedRejections` out of
+  `analysis.ts` into `store/`.
+  *Benefit (architectural):* `analysis.ts` is the file every cast-lock incident
+  has run through; shrinking it is how the next one gets cheaper.
+- **#2161** — `rejectedPairs.forgotSupersededTo` can dangle the same way
+  `supersededBy` did before #2110.
+  *Benefit (technical):* a known-shape defect with a shipped precedent to copy.
+- **#2228** — srv-89: no test stands up either analyzer persist block; three
+  wiring facts are source-scan-only.
+  *Benefit (technical):* source-scan-only facts are exactly the
+  green-checking-nothing class Round 2 catalogued seven times.
+- **#2006** — the last open half of the three clone-consent TOCTOU gates.
+  *Benefit (user):* consent validated in one scope and written in another is a
+  real correctness hole on a privacy-sensitive path.
+
+### Group 3 — Lane B · server: process, routes, voice scoring (5)
+
+- **#2196** — an out-of-process book folder move leaves a stale record that
+  resurrects the old directory.
+  *Benefit (user):* data-loss-adjacent — the user's own filesystem action gets
+  silently undone.
+- **#1969** — reassigning a character's voice keeps scoring it against the old
+  voice's persisted audition centroid.
+  *Benefit (user):* voice-match scores are wrong after any reassignment, which
+  is a routine action.
+- **#2106** — `findListenerPid` has no timeout, so a slow refusal resets the
+  respawn budget forever. Carries `needs-plan`; confirm it needs one rather than
+  just a timeout.
+  *Benefit (technical):* an unbounded respawn budget is an infinite-loop class,
+  not a slowdown.
+- **#1826** — serialize voice-library entry writes (per-uuid lock or `updatedAt`
+  CAS). **Premise-check first** — the cast-lock sweep added a
+  `voice-library-usage.ts` detector and may already cover this.
+  *Benefit (technical):* the last unserialised writer in the family that sweep
+  otherwise closed.
+- **#1691** — make stage-1 cloud TPM reservation roster-aware (>130-char-cast
+  ceiling). Stale (07-17); check against #1685 before dispatching.
+  *Benefit (technical):* a large cast blows the reservation ceiling silently.
+
+### Group 4 — Lane C · frontend + test hygiene (2)
+
+- **#2230** — a 409 from the Listen-view book-meta editor is swallowed silently.
+  *Benefit (user):* the edit vanishes with no error; the user retypes it and it
+  vanishes again.
+- **#2235** — flaky `export.test.ts` uncaught ENOENT in its staging dir,
+  ~1-in-2 standalone on a contended box.
+  *Benefit (technical):* a flake in the gate corrupts every red-phase
+  verification downstream of it — Round 1 put this class first for this reason.
+
+### Group 5 — Lane D · ops, config, CI (4)
+
+- **#2194** — an existing `server/.env` keeps every knob locked after #2179,
+  because upgrades never rewrite it.
+  *Benefit (user):* every existing install silently ignores the new defaults —
+  an upgrade that does nothing.
+- **#1994** — Qwen has no golden duration baseline, so a speech-rate regression
+  on the **default** engine is invisible.
+  *Benefit (technical):* the golden tier covers the fallback engine and not the
+  hot path.
+- **#2243** — ops-56: decide whether `docs/superpowers/plans/**` is a record or
+  live instructions, then finish the review-gate sweep.
+  *Benefit (architectural):* stale docs read as conformance — the #2144 failure
+  shape exactly.
+- **#1966** — ops-48: evaluate `@nanonets/graft`. Date-gated to **2026-08-14**,
+  so it lands naturally inside this round.
+  *Benefit (technical):* retires a standing "revisit later" with a yes/no.
+
+### Group 6 — #898 phase 2 (1, execute-only)
+
+**The highest expected value single item in the plan, and it should not wait
+behind the lanes.**
+
+- **#898** — srv-41 pairing device-token scoping. Spec merged (#2147), plan
+  merged (#2151: 10 tasks, 65 steps, 28 mutations, two PRs in a load-bearing
+  order), handover brief posted. Phase 1 is complete; this needs a **fresh
+  implementation thread briefed from the ticket and nothing else.**
+  *Benefit (user):* the only fully-briefed security item in the queue, and its
+  design phase already produced one live auth bypass (#2144) as a side effect.
+
+### Group 7 — design-first: phase-1 only, no diffs (8)
+
+Each has more than one defensible answer, so the deliverable is a ticket + plan
+doc and closure happens in Round 5. Use the **cold-brief handoff** — a fresh
+agent reads the brief with no access to the drafts. It is what rescued #898
+after two rejected specs.
+
+**Take the first four this round; defer the rest.** Eight concurrent phase-1
+threads is more design than one round should carry.
+
+- **#1996** — VRAM reclaim hook location. Attempt 1 (PR #2029) was killed by
+  review; the traps are recorded — call
+  `PlacementController._reclaim_stranded_cache`, not `_placement.reclaim`; tests
+  must assert **ordering**, not that the hook was called; the idle watchdogs are
+  the likely home. Closing this also closes #1976.
+  *Benefit (user):* ~3.9 GB stranded after every render on an 8 GB card.
+- **#2015** — the cast.json **rebuild** half only.
+  *Benefit (technical):* four prior designs died on the capture problem, which
+  is now solved — this restart is much cheaper than it looks.
+- **#1932** — side-18: consolidate the two Coqui VRAM eviction mechanisms, or
+  document the split as deliberate and scope each in code. Premise verified as
+  holding in Round 3.
+  *Benefit (architectural):* two mechanisms for one job is how the next OOM gets
+  misdiagnosed.
+- **#2131** — decide whether an unresolvable `qa.asr.model` should fail early.
+  *Benefit (user):* today a whole book renders before the QA gate discovers it
+  cannot run.
+- **#2059** — attribution leading+interior dash produces a doubled comma.
+  Genuinely a question ("should it collapse?"), so it needs a decision, not a
+  fix. *Benefit (user):* a visible text artifact in Russian dialogue.
+- **#1309** — ops-24: the LAN port-443 forwarder collapses per-client identity,
+  weakening rate limits. Verified byte-for-byte in Round 3.
+  *Benefit (technical):* rate limits that cannot distinguish clients are not
+  rate limits.
+- **#485** — side-13: import safety + provenance for shared voice artifacts.
+  Size M; gates fs-28 … fs-31.
+  *Benefit (architectural):* it blocks four downstream features, so it is
+  holding up more than itself.
+- **#1393** — srv-58 Qwen tier eviction race. **Paused after three rejected
+  designs** — its own verified facts (no per-segment tier stamp;
+  `inFlightByBook` cannot see splice or QA-repair renders) rule out the shape it
+  was filed as. Restarting it needs a fresh thread from the `synthesiseChapter`
+  publishing question, not a fourth revision.
+  *Benefit (technical):* real cross-book corruption risk — but restarting it
+  wrongly has already cost three attempts.
+
+### Group 8 — on-box: one GPU sitting clears 6
+
+The deliverable is a **measurement**, not a diff. Dispatching a coding agent at
+these accomplishes nothing. **Nothing else in this plan has this ratio.**
+
+- **#2187** — discharge register row C2. Force `fresh: true`, and do **not**
+  re-measure alignment — that is already done from cache. Then close.
+- **#2026** — XTTS Russian quality on a stock catalogue voice (engine-level, not
+  clone-related).
+- **#1998** — cloned-voice identity loss across languages (0.600 → 0.229).
+- **#1084** + **#1527** — ASR content-QA `maxWer` never tuned or validated for
+  es/fr/de/ru; the 0.4 cap is English-tuned.
+- **#1685** — verify #1682 cloud request sizing; calibrate the stage-2 local
+  input fraction.
+
+Plus #1996's confirmation measurement, once its design lands.
+
+### Group 9 — blocked: a disposition decision, not work (10)
+
+#1228 (transformers CVE, upstream), #893 (sidecar dep bump, torchaudio EOL
+@2.11), #711 (eslint 9→10), #431 (jsdom · archiver · @google/genai), #790
+(ops-17 KGP / AGP 9), #1477 (TypeScript 7.0), #1335 (AMD / ROCm hardware not
+owned), #822 (Pinokio macOS box), #1001 (FlashAttention-2 wheels), #947 (ops-18,
+deferred by its own issue text).
+
+**No amount of effort clears these.** They wait on other people's releases or on
+hardware that is not owned. They are a fifth of the queue and they distort every
+triage pass that walks it.
+
+- **Option A — park.** Add a `blocked` label plus a review date; exclude them
+  from sweep counts.
+- **Option B — collapse.** Close all ten into one standing "upstream watch"
+  tracking issue that lists them.
+
+**Recommended: A.** Closing loses the per-item context, and several already
+carry `tracking`.
+
+*Benefit (technical):* either way, the queue starts reflecting work that can
+actually be done.
+
+### Group 10 — gated, not scheduled (5)
+
+- **#1984**, **#2128** — live worktrees as of 2026-08-11. #1984 is at revision 7
+  with rounds 5/6/7 all failing their gates and **scope growth awaiting owner
+  sign-off**. Neither is touched by this sweep.
+- **#2068**, **#2054**, **#1600** — fs-38 Wave 3, which is **paused** with E-04
+  failing and on-box at 16/60. They unpause with the wave or not at all.
+
+### Sequencing
+
+1. **Round 0** premise pass — read-only, no branch.
+2. **Group 1** bookkeeping — one docs PR.
+3. **#898 phase 2** in its own thread, **in parallel with Lanes A–D** (four
+   worktrees, file-disjoint; Lane A internally sequential).
+4. **Group 7** phase-1 threads for #1996 / #2015 / #1932 / #2131.
+5. **Group 8** at the next GPU sitting.
+6. **Group 9** on the owner's call.
+
+### Decisions this round needs from the repo owner
+
+1. **Group 9** — park with a label, or collapse into one tracking issue?
+2. **Group 8** — is a GPU sitting available? It is the best ratio in the plan.
+3. **fs-38 Wave 3** — stays paused, or unpauses (adds 3 items and unblocks four
+   stale worktrees)?
+4. **#1984** — the scope growth is stalled on sign-off, independently of this
+   sweep.
+
+### Driving view
+
+`docs/features/277-v115-bug-chore-sweep-board.html` is the hand-authored board
+for this round — every one of the 49 items, grouped as above, filterable by
+disposition and area, with per-item state kept in the reader's `localStorage` so
+a redeploy never wipes progress. It is a **tracked file**, edited here and
+republished from here; treat it the way the onbox register's live view is
+treated, and never publish a rendering of this markdown over its URL.
+
+Canonical URL:
+<https://claude.ai/code/artifact/f3608d3e-0e02-4eaa-9af3-3322b9ce0bb3> — pass it
+as `url` on every republish, or a second competing board is minted.
+
 ## Invariants to preserve
 
 1. **Lane files must not overlap.** The Round 1 grouping above is the constraint,
@@ -713,6 +1009,13 @@ ten filed premises did not survive verification and a fifth was already solved
 by a concurrent session. Two plan docs would otherwise have been written against
 defects that do not exist. Full detail in "Round 3 outcome" above, including the
 `gh issue view` comment-blindness trap and the cold-brief handoff.
+
+**Round 4 — planned 2026-08-11, not yet dispatched.** Baseline re-taken at 49
+open items (14 bug + 35 chore) on `main` @ `f2b2e866`. Scoped as a *drain*
+rather than a dispatch: the full plan, the four-way disposition split, the
+Round 0 premise pass, and the four owner decisions it is waiting on are in
+"Round 4 — the drain plan" above. Driving board:
+`docs/features/277-v115-bug-chore-sweep-board.html`.
 
 **Still open from this sweep:** #1984, #1996, #1932, #1309, #485, #1393 (paused
 after three rejected designs — its own verified facts rule out the shape it was


### PR DESCRIPTION
## Summary

Adds the **Round 4** section to `docs/features/277-v115-bug-chore-sweep.md` and a hand-authored HTML board to drive it.

Baseline re-taken on `main` @ `f2b2e866`: **49 open items — 14 `bug` + 35 `type:chore`** (down from the 54 taken 2026-08-01; rounds 1–3 closed ~31 and the queue held roughly flat as new findings replaced them).

The framing change is that **the queue is not one backlog**. It splits four ways, and only the first group is dispatchable:

| Disposition | Count | Action |
|---|---|---|
| Diff-shaped | 20 | Lanes A–D + #898 phase 2 + bookkeeping |
| Design-first | 8 | Phase 1 only; closes in Round 5 |
| On-box | 6 | One GPU sitting — the deliverable is a measurement |
| Blocked upstream / hardware | 10 | A disposition decision, not work |
| Gated (live worktree / paused wave) | 5 | Not scheduled |

Realistic end state: **49 → ~13**.

**Round 0 is a premise pass** over the ten stale non-blocked items before any lane is briefed. 20 of the 49 were filed 14+ days ago, and Round 3 found 4 of 10 premises dead in twenty minutes. Three reclassifications are already folded in:

- **#2187** — the fix shipped (`b2be5b7b`, alignment 67.7 → 96.0%); open only on on-box row C2.
- **#1976** — a bookkeeping shell that closes when #1996 does.
- **#2015** — the capture half is solved by #2185; only the rebuild is open.

The board (`277-v115-bug-chore-sweep-board.html`) follows the **onbox-register live-view pattern**: a tracked, hand-authored file published with its recorded `url`, never a rendering of the markdown. Per-item state lives in the reader's `localStorage`, so the file stays the plan of record rather than a status snapshot that drifts from the page.

Published at <https://claude.ai/code/artifact/f3608d3e-0e02-4eaa-9af3-3322b9ce0bb3>.

## Test plan

Docs-only — no runtime surface, so no automated coverage applies and the `pr-review-gate` doc-only exemption holds.

The board was rendered and exercised in chromium rather than eyeballed as source:

- 1280px and 375px — no console messages, no horizontal overflow (`scrollWidth == clientWidth == 375`).
- Both themes via the toggle, plus token-level `prefers-color-scheme` and `[data-theme]` coverage; `body` paints an explicit token background.
- Interactions: disposition filter (49 → 39 with `blocked` off, and the now-empty group self-hides), area chips, hide-ticked, per-item checkbox with `localStorage` round-trip, and the live KPI recount.
- Rendered DOM confirms the arithmetic: **49 items across 10 groups**.

Release notes: skipped — process/docs only, no shippable delta.

Refs #2042

🤖 Generated with [Claude Code](https://claude.com/claude-code)
