### PR TITLE
test(frontend): give main.test.tsx an explicit timeout

### DIFF
--- a/src/main.test.tsx
+++ b/src/main.test.tsx
@@ -47,14 +47,20 @@ function stubMatchMedia() {
 }
 
 describe('main.tsx router wiring (fe-56)', () => {
-  it("mounts with react-router/dom's RouterProvider, not the bare react-router export", async () => {
-    document.body.innerHTML = '<div id="root"></div>';
-    stubMatchMedia();
+  it(
+    "mounts with react-router/dom's RouterProvider, not the bare react-router export",
+    async () => {
+      document.body.innerHTML = '<div id="root"></div>';
+      stubMatchMedia();
 
-    await import('./main');
-    await new Promise((resolve) => setTimeout(resolve, 0));
+      await import('./main');
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(domRouterProviderMock).toHaveBeenCalled();
-    expect(bareRouterProviderMock).not.toHaveBeenCalled();
-  });
+      expect(domRouterProviderMock).toHaveBeenCalled();
+      expect(bareRouterProviderMock).not.toHaveBeenCalled();
+    },
+    // Importing main.tsx pulls the entire application dependency graph into jsdom (~5s on an idle box).
+    // This is genuine work required to verify the real RouterProvider import, not a bug to optimize away.
+    30_000
+  );
 });


### PR DESCRIPTION
## Summary

`src/main.test.tsx` ran for **5.00s against vitest's default 5000ms timeout** — zero margin. It gives the test an explicit 30s timeout and a comment saying why it is slow.

This is not a conventional flake. There is no race and no ordering dependency: line 54 is `await import('./main')`, so the test imports the app's real entry point and pulls the entire dependency graph into jsdom. **The five seconds is genuine work**, and whether it passes is a function of machine load rather than luck.

It cost a blocked **commit**, not just a CI leg — `verify:fast:scoped` gates pre-commit for any staged `src/**` change, so it fired while another worktree ran its battery during #2270, forcing a ~145s battery re-run.

## Why this shape of fix

Two alternatives were rejected:

- **Mocking the heavy imports** would make the test vacuous. Its only purpose is to pin `main.tsx`'s real `RouterProvider` import — the file's header explains that `react-router` and `react-router/dom` both export a component of that name, so importing the wrong one still compiles *and* typechecks. Mocking the graph away removes exactly what it guards.
- **Raising `testTimeout` globally** in `vitest.config.ts` would relax the deadline for all 4,712 tests and hide genuinely hung ones. The relief belongs on the one test that needs it.

The 30s value is a ~6x margin over the idle-box cost, and the inline comment exists so the next reader does not read the number as arbitrary and "optimise" it back down.

## Test plan

- `npx vitest run src/main.test.tsx` — 1/1 passed; reported `tests 2.93s` on an idle box (the 5.00s observation was already load-inflated, which is the point).
- Pre-commit hook ran the full frontend suite: 333 files, 4,712 tests, all passed.

No release-notes entry: internal test-infrastructure change with no user- or operator-visible delta.

Closes #2276
