### PR TITLE
test(server): poll for the retry's analyzer call, not 20ms of wall clock

### DIFF
--- a/docs/testing/flaky-register.md
+++ b/docs/testing/flaky-register.md
@@ -26,9 +26,32 @@ it never gates a merge.
 |------|------|-------|---------|----------------|-------------|
 | #1981 — a stale cast PUT does not erase a concurrently /assign-planted voice | `server/src/routes/book-state-preserve-voices.test.ts` | intermittent under full-suite box contention | Fails intermittently in a full `test:server` run under box contention; passes 7/7 in isolation. Observed 2026-08-07: `1 failed / 6741 passed`, `[fail] test:server (exit 1, took 746.6s)`. | #2226 | Not quarantined — still gates |
 | #2235 — revokes the older same-format manifest when a re-export of the same format finishes | `server/src/routes/export.test.ts` | intermittent under full-suite box contention | Fails on its first attempt and passes on retry inside a full `npm run test:server` run; surfaced only as a `[retry-hazard]` warning because vitest's `retry:1` absorbs it. Observed 2026-08-11 in the `dbcf36c5` pre-commit run (506 files / 7079 tests passed). | #2235 | Not quarantined — still gates |
-| #2262 — cancel immediately removes the job from the registry, so a same-scope retry starts fresh instead of joining the doomed job | `server/src/routes/script-review.test.ts` | UNDETERMINED — not yet distinguished from ordinary box contention (same class as #2226/#2235) vs. a real cancel-then-retry ordering bug masked by `retry:1` | Two independent sightings on 2026-08-11, both absorbed by vitest's `retry:1`, both stopping at "passes in isolation" — inconclusive, since the test asserts on the job **registry** (module-level mutable state), the exact shape #2028 (ops-46, the retry-hazard reporter) warns `retry:1` can turn from a genuine red-phase failure into a green. Resolving requires a `--retry=0` run under deliberate contention to establish a failure rate. | #2262 | Not quarantined — still gates |
 
 _Otherwise empty — no other tests are currently quarantined or tracked here._
+
+<!-- Graduated 2026-08-12: `server/src/routes/script-review.test.ts` ::
+"cancel immediately removes the job from the registry, so a same-scope retry
+starts fresh instead of joining the doomed job" (#2262). Its row recorded the
+class as UNDETERMINED — box contention vs. a real cancel-then-retry ordering
+bug masked by `retry:1` — and that is why this note exists rather than a bare
+deletion: the row carried an open question, and the next investigator should
+find the answer, not the question again.
+
+It was contention, established by MECHANISM rather than by a failure rate. The
+synchronisation point was a bare 20ms wall-clock sleep before
+`expect(runReview).toHaveBeenCalledTimes(2)` — the whole budget for the second
+request to reach the analyzer. Positive control: shrinking 20ms -> 0ms on an
+idle box reproduces the reported symptom verbatim. The feared reading is
+structurally incapable of producing it: "the retry joins the doomed job" is a
+PERMANENT absence of the second call, which fails at every budget and in
+isolation, not a race a retry re-rolls — and `firstCall.release()` sits after
+the assertion, so under the unfixed code the doomed job could never be cleaned
+up in time for a late second call. Corroborated by 5 isolated `--retry=0` runs
+and one full `src/routes` `--retry=0` run (128 files / 2092 tests), all green.
+
+Fixed by polling the condition (`vi.waitFor`, 2000ms) instead of sleeping at
+it, so the test is no longer timing-dependent. #2028's retry-hazard concern was
+right to flag this test; it did not apply to this failure. -->
 
 <!-- Graduated 2026-07-27: the two sleep-prevention wake-lock tests in
 `server/src/routes/generation.test.ts` (#1854). They were never flaky. They

--- a/server/src/routes/script-review.test.ts
+++ b/server/src/routes/script-review.test.ts
@@ -1599,18 +1599,21 @@ describe('cancellation (fs-58 follow-up #1481)', () => {
       Promise.resolve({ ops: [{ id: 1, op: 'strip_tag', newText: 'Hello', rationale: 'r' }] }),
     );
     const second = firePost(`/api/books/${bookId}/script-review`, { chapterId: 1 });
-    // Stays wall-clock, like the rejoin test above: the retry either starts a
-    // genuinely new analyzer call or (in the buggy case) JOINS the doomed
-    // first job and never calls runReview a second time at all — which of
-    // those happens is exactly what this test is checking, so there is no
-    // single mocked-call-entered condition to gate on here; a regression
-    // would make that signal dead by construction, turning a red assertion
-    // into a 15s timeout instead of a crisp failure.
-    await new Promise((r) => setTimeout(r, 20));
+    /* #2262 — this was a bare 20ms sleep, which is the whole budget for the
+       second request to travel supertest -> handler -> fs writes -> runReview,
+       and not enough under contention. Wait for the condition instead of at it.
+       vi.waitFor rejects with the CALLBACK's own error, so a genuine regression
+       still fails on `expected 2, got 1` rather than a polling message — no
+       swallow-and-reassert needed. Same idiom as gemini.test.ts:696.
 
-    // A genuinely new analyzer call was made — the second request did NOT
-    // join the doomed first job.
-    expect(runReview).toHaveBeenCalledTimes(2);
+       Asserting the PRESENCE of the second call is what makes this pollable;
+       the sibling rejoin test above asserts its ABSENCE and stays wall-clock
+       for that reason — the two are not interchangeable.
+
+       Note both causes print the same text: a genuine rejoin regression and a
+       box slow enough to blow 2000ms are indistinguishable here. If this ever
+       reddens, re-run it in isolation before hunting a registry bug. */
+    await vi.waitFor(() => expect(runReview).toHaveBeenCalledTimes(2), { timeout: 2000, interval: 5 });
 
     firstCall.release({ ops: [] });
     const secondRes = await second.done;


### PR DESCRIPTION
## Summary

`script-review.test.ts`'s cancellation test — *"cancel immediately removes the job from the registry, so a same-scope retry starts fresh instead of joining the doomed job"* — failed on its first attempt and passed on retry under full-suite contention. `retry:1` absorbed it, so it surfaced only as a `[retry-hazard]` warning.

**The synchronisation point was a bare 20ms wall-clock sleep** (`script-review.test.ts:1609`), which is the entire budget for the second request to travel supertest → route handler → fs writes → `runReview`, before asserting the call count. On a loaded box that isn't enough.

## Why this is contention and not a masked correctness bug

#2262 was filed because two readings were live and undistinguished: box contention, or a real cancel-then-retry ordering bug that `retry:1` was hiding. The issue's acceptance asked for a failure *rate* under deliberate contention.

**A rate turned out to be the wrong instrument — the question is settled by mechanism.**

- **Positive control:** shrinking the budget 20ms → 0ms, in isolation on an idle box, reproduces the reported symptom verbatim — `AssertionError: expected "vi.fn()" to be called 2 times, but got 1 times`. Load and a smaller budget are the same variable.
- **The feared reading is structurally incapable of producing the observed symptom.** "The retry joins the doomed job" means the second call *never* arrives — a permanent absence that fails at every budget and in isolation, not a race a retry re-rolls. The symptom on record is fails-once-then-passes, which requires the call to arrive late.
- **Corroboration that it does arrive:** 5 isolated runs at `--retry=0` green (82/82), and one full `src/routes` run at `--retry=0` green (128 files / 2092 tests) under real fork-sharing parallelism.

So `retry:1` is not masking a correctness bug here. #2028's retry-hazard concern is well-founded in general and was right to flag this test; it does not apply to this failure. Full diagnosis on the issue: [#2262 comment](https://github.com/dudarenok-maker/Castwright/issues/2262#issuecomment-5260212820).

## The fix

`vi.waitFor` against the condition actually being asserted, on an **explicit 2s budget** rather than vitest's default:

```js
await vi.waitFor(() => expect(runReview).toHaveBeenCalledTimes(2), { timeout: 2000, interval: 5 });
```

The old sleep's comment argued that polling would turn a crisp red assertion into a timeout. That objection is answered by `vi.waitFor` itself: it rejects with the **callback's own error**, so a genuine regression still fails on `expected 2, got 1`, 2s later instead of 20ms later. Same idiom as `gemini.test.ts:696`.

**Two earlier cuts of this fix were wrong and were corrected before merge**, both recorded here rather than buried. The first let `waitFor` throw a sentinel, so the assertion was never reached and the regression diagnostic became *worse* than the bug being fixed. The second wrapped it in `.catch(() => {})` to force fall-through — which worked, but rested on a **false premise** about `vi.waitFor` that was written into the commit message as the design rationale. The review caught it; I verified by experiment (mutate the route, observe the failure text) that no swallow is needed, and simplified. Asserting the *presence* of the second call is what makes this pollable at all — the sibling rejoin test asserts its *absence* and stays wall-clock, so the deleted comment was wrong to equate them.

## Test plan

**Mutation-proved against the real regression, not against the assertion.** Deleting the cancel handler's `subsetScriptReviewJobByChapter.delete(key)` (`script-review.ts:600`) — which is precisely "a same-scope retry rejoins the doomed job" — fails the test with:

```
AssertionError: expected "vi.fn()" to be called 2 times, but got 1 times
```

On the assertion, as required — **not** on a `waitFor` throw and not on a vitest timeout. Reverted; route file confirmed byte-identical to `HEAD`.

| Leg | Result |
|---|---|
| `vitest run src/routes/script-review.test.ts --retry=0` | pass — 82/82 |
| `vitest run src/routes --retry=0` | pass — 128 files / 2092 tests |
| pre-push `verify:fast:branch` | pass |

Note the pre-commit hook reported `test:server` as `[cached]`, i.e. it did not execute; the suites above were run directly and the push battery ran it for real.

## Flaky register

The row #2274 added for this test recorded its class as **undetermined**. It is **removed** — the test is no longer timing-dependent, so it no longer belongs in a register of tests that fail as a function of machine load — but replaced by a `<!-- Graduated 2026-08-12: … -->` note, matching the file's own 2/2 precedent. That row carried an *open question*, and a bare deletion would send the next investigator to re-run the whole distinguish-contention-from-correctness investigation this issue already finished.

## Process note, recorded rather than buried

**The amend was committed with `--no-verify`, by explicit repo-owner decision.** The battery was bypassed; the verification was not.

Run green first: this file at 82/82 (`--retry=0`), and the hook's own `test:server` leg at **507 files / 7175 tests passed** before it died on a `Worker exited unexpectedly` fork-pool teardown crash — which the runner itself classifies as *"not a test failure"* and auto-retries. At the time, **three concurrent pre-commit batteries from three different worktrees** had this box at 0 CPU across a 5-second sample.

Note `--no-verify` also skips `commit-msg`. The subject was shortened to 63 characters deliberately, because the equivalent bypass on #2274 let an over-length subject through and blocked a push three commits later.

Cloud `verify.yml` is unaffected and remains the authoritative required gate on this PR.

## Release notes

Deliberately none — test-only, with no user- or operator-visible effect. Stated rather than silently omitted, per before-shipping step 5.

## Reported in passing, not fixed

Other tests in this file use the same wall-clock idiom, including the sibling "rejoin" test the old comment cross-referenced. Left alone: sweeping them is a separate change, and none has been observed failing. Say the word and I'll file it.

Closes #2262
