### PR TITLE
docs(docs): record #2288 M1 as shipped, and that it did not unblock #2286

### DIFF
--- a/docs/superpowers/plans/2026-08-12-quote-delimiter-validity.md
+++ b/docs/superpowers/plans/2026-08-12-quote-delimiter-validity.md
@@ -1,5 +1,9 @@
 # Quote-delimiter validity in `findQuoteRuns` — Implementation Plan
 
+> **SHIPPED as M1** — PR [#2300](https://github.com/dudarenok-maker/Castwright/pull/2300), merged `e839a939`, 2026-08-13, after five review rounds (Rounds 2–4 below record what each changed). All six tasks are complete; the plan is kept for the reasoning, not as work to pick up.
+>
+> [#2288](https://github.com/dudarenok-maker/Castwright/issues/2288) stays open for **M2**, the general gap-seeded straddle. M1 did **not** unblock [#2286](https://github.com/dudarenok-maker/Castwright/pull/2286) / [#2279](https://github.com/dudarenok-maker/Castwright/issues/2279) — re-measured, not assumed: the widening sweep reads 437 of 51,608 corrupted shapes both before and after, with all nine added pairs individually disqualified. M2's executable acceptance criteria are in [#2288#issuecomment-5275015405](https://github.com/dudarenok-maker/Castwright/issues/2288#issuecomment-5275015405).
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Stop an apostrophe being read as a closing quote, which today truncates every single-quoted English dialogue turn at its first contraction.
@@ -8,7 +12,7 @@
 
 **Tech Stack:** TypeScript (Node, ESM), Vitest. Server suite only.
 
-**Design of record:** `docs/superpowers/specs/2026-08-12-quote-delimiter-validity-design.md` (revision 3 — see the "Round 2" section at the end of this plan for what changed after Tasks 1–6 below were implemented). Read it before Task 2 — the "Rejected" section explains why two other clauses are deliberately absent, and the metric section explains why the never-delete invariant exists.
+**Design of record:** `docs/superpowers/specs/2026-08-12-quote-delimiter-validity-design.md` (revision 4 as shipped — see the "Round 2", "Round 3" and "Round 4" sections at the end of this plan for what each changed after Tasks 1–6 below were implemented). Read it before Task 2 — the "Rejected" section explains why two other clauses are deliberately absent, and the metric section explains why the never-delete invariant exists.
 
 ## Global Constraints
 

--- a/docs/superpowers/specs/2026-08-12-quote-delimiter-validity-design.md
+++ b/docs/superpowers/specs/2026-08-12-quote-delimiter-validity-design.md
@@ -1,6 +1,24 @@
 # Quote-delimiter validity in `findQuoteRuns` — design
 
-Status: proposed · Issue: [#2288](https://github.com/dudarenok-maker/Castwright/issues/2288) · Blocks: [#2286](https://github.com/dudarenok-maker/Castwright/pull/2286) / [#2279](https://github.com/dudarenok-maker/Castwright/issues/2279)
+Status: **shipped as M1** (PR [#2300](https://github.com/dudarenok-maker/Castwright/pull/2300), merged `e839a939`, 2026-08-13) · Issue: [#2288](https://github.com/dudarenok-maker/Castwright/issues/2288), still open for M2 · Related: [#2286](https://github.com/dudarenok-maker/Castwright/pull/2286) / [#2279](https://github.com/dudarenok-maker/Castwright/issues/2279), **still blocked**
+
+> **Shipped, and what it did not do.** This design covers M1 only — the
+> apostrophe-shaped closer, the rejection-anchored skip bound, and the
+> never-delete fallback. It landed with 938 clean repairs / 0 merged / 0 lost
+> over 140 English books.
+>
+> It does **not** unblock the quote-pair widening, and that was re-measured
+> against the shipped fix rather than assumed: the six-language widening sweep
+> reads **437 of 51,608 corrupted shapes both before and after M1 — zero
+> movement**. Partitioned, **0 of 2,456 well-formed shapes corrupt; all 437
+> need drifted delimiters** (a turn pairing an opener with a closer from
+> another pair), and scored one added pair at a time, **all nine are
+> individually disqualified**, so no subset of the widening is shippable
+> either. M2 — the general gap-seeded straddle, where nothing is rejected so
+> M1's bound never engages — remains owed, with executable acceptance criteria
+> in [#2288#issuecomment-5275015405](https://github.com/dudarenok-maker/Castwright/issues/2288#issuecomment-5275015405).
+> The header below said `Blocks: #2286 / #2279` while this was in design; that
+> is now `Related`, because shipping it did not lift the block.
 
 > **Revision 4.** Revision 3 (below) specified the resumed-skip bound as
 > **computed once per accepted opener occurrence, anchored at the opening


### PR DESCRIPTION
## Summary

Two design documents went stale the moment #2288's M1 merged, and both would mislead the next agent to pick the ticket up.

- The spec still read `Status: proposed` for work that shipped as PR #2300 (`e839a939`), and its header claimed `Blocks: #2286 / #2279`. Shipping it did **not** lift that block, so the relationship is now recorded as `Related: … still blocked`.
- The plan cited the spec at **revision 3**; the version that shipped is revision 4 (Round 3 moved the bound's anchor, Round 4 closed the multi-closer hole). That is the same stale-citation class the review gate caught four separate times on the original branch — a sentence gets edited around a figure and the figure is left behind.

Both now carry a shipped banner naming the PR, the merge SHA, and — stated once, in both places — what M1 did not do.

## The measurement the banners cite

Whether M1 unblocks the quote-pair widening was **re-measured against the shipped fix, not assumed**. Same six-language sweep, both sides on the M1 parser so only the table differs:

| | pre-M1 | post-M1 |
|---|---:|---:|
| shapes | 51,608 | 51,608 |
| corrupted | 437 | **437** |

Zero movement — M1 fixed a different seeding mode. Partitioned, **0 of 2,456 well-formed shapes corrupt and all 437 need drifted delimiters** (that zero is control-proven reachable: forcing every shape into the well-formed bucket moves all 437 into it). Scored one added pair at a time, **all nine are individually disqualified**, so no subset of the widening can be carved out early either.

Full figures, the per-candidate table, and M2's executable acceptance criteria are recorded on #2288, #2286 and #2279.

## Test plan

Documentation only — no runtime code, config, test or CI surface, so no paired test is owed and no test can regress. The factual claims above are the measurements recorded on the linked tickets.

No on-box acceptance owed or discharged; no register row moves.

No release-notes entry: no shippable delta — this records a ship that already had its entry in PR #2300.

Refs #2288, #2286, #2279
