### PR TITLE
docs(docs): design pass on #2310 — which layer decodes an HTML entity

### DIFF
--- a/docs/superpowers/plans/2026-08-13-entity-decode-layer.md
+++ b/docs/superpowers/plans/2026-08-13-entity-decode-layer.md
@@ -1,0 +1,669 @@
+# Entity decode layer — implementation plan (#2310)
+
+> **⚠️ CONTINGENT ON AN OWNER DECISION.** This plan implements **Option 1** of
+> `docs/superpowers/specs/2026-08-13-entity-decode-layer-design.md` — widen the
+> named-entity decode in `stripHtml`. Options 2 and 3 are refuted in the spec,
+> but the choice is the owner's and it has **not been approved yet**. Do not
+> start Task 1 until the owner has approved Option 1. If they pick another
+> option, this plan is void, not adaptable.
+>
+> The decision also carries a **new production dependency** on `entities`
+> (spec, "Why a library rather than a curated table") — approving the plan
+> approves that dependency.
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use
+> `superpowers:subagent-driven-development` to implement this plan task-by-task.
+
+**Goal:** An `&ndash;`- or `&mdash;`-opened dialogue line in `es`, `fr` and `ru`
+reaches the TTS engine with the **same normalised text** a literal `—`-opened
+line produces — the leading marker becomes a pause, not spoken characters. And
+the whole rest of the surviving-entity class (`&eacute;`, `&rsquo;`, `&laquo;`,
+`&hellip;`, `&apos;` …) stops being read aloud with it.
+
+**Architecture:** Replace the **three** hand-rolled copies of the five-entity
+list (`stripHtml`, `extractFirstHeading`, `epub.ts`'s `decodeEntities`) with
+**one shared helper** doing a complete HTML5 named-entity decode, scoped by regex
+to *named* references only so the existing numeric-reference contract is
+untouched. Nothing downstream changes: the dash pipeline is already correct for a
+real dash character, proved by `&#8211;` producing correct audio today.
+
+**Two facts that shape the tasks, both established late in the design pass —
+read spec Finding 0 before Task 1:**
+
+1. **TTS does not read the parsed body.** It reads the stage-2 model's returned
+   `SentenceOutput.text` (`synthesise-chapter.ts:2514,2570` ←
+   `analysis.ts:5077-5080`). So the body-line symptom is conditional on the model
+   echoing the entity, which was **not** verified and is not assumed here.
+2. **Chapter titles bypass the model entirely** (`generation.ts:1548` →
+   `synthesise-chapter.ts:1562,2248`) and their text comes from
+   `extractFirstHeading` — which has its **own** copy of the narrow entity list.
+   **The title path is the unconditional instance of this bug**, and it is the
+   acceptance evidence to lead with. Fixing `stripHtml` alone would leave it
+   unfixed.
+
+**Tech Stack:** TypeScript, Node, Vitest, `entities@^8.0.0`.
+
+**Spec:** `docs/superpowers/specs/2026-08-13-entity-decode-layer-design.md` —
+the design of record. **Read it before Task 1.** Finding 1 is why the fix is at
+this layer; Finding 6 is the three edge cases a naive swap gets wrong.
+
+## Global Constraints
+
+- **`decodeHTMLStrict`, never `decodeHTML`.** `decodeHTML` implements HTML5's
+  legacy semicolon-less rule and corrupts ordinary prose: `Fish &notice this` →
+  `Fish ¬ice this`, `Copyright &copy 2026` → `Copyright © 2026`. Task 2 pins
+  this with a test. Measured in spec Finding 6.
+- **Scope the library call to NAMED references only** — via
+  `/&[a-zA-Z][a-zA-Z0-9]*;/g`. Do **not** call `decodeHTMLStrict` on the whole
+  string. `decodeHTMLStrict` maps out-of-range numeric references to U+FFFD,
+  which **violates `decodeNumericEntities`'s documented contract**
+  (`html-utils.ts:15-16`: "Invalid or out-of-range references are left untouched
+  rather than dropped") and would send U+FFFD to the engine — it is not stripped
+  by `stripUnsafeForTts`. Note the contract is narrower than its own wording:
+  `&#0;` and `&#xD800;` **do** decode today (probed), so only `&#99999999;` /
+  `&#x110000;` / malformed refs are actually left literal.
+- **Leave `decodeNumericEntities` completely untouched**, and keep it running
+  **after** the named pass. It stays the only owner of numeric references.
+- **Fold U+00A0 to a plain space between the two passes**, not before. Today
+  `&nbsp;` → `' '` (U+0020); `decodeHTMLStrict` yields U+00A0. Folding the
+  *character* (not the spelling `&nbsp;`) also catches HTML5 aliases —
+  `&NonBreakingSpace;` decodes to U+00A0 too. Placed **before**
+  `decodeNumericEntities`, it leaves `&#160;` → U+00A0 exactly as today. **Do
+  not** "simplify" by folding after the numeric pass — that silently changes
+  `&#160;`.
+- **The `&nbsp;` special-case line is redundant once the fold exists.** Remove
+  it; do not keep both. (`&nbsp;` → U+00A0 → `' '`.)
+- **All three copies of the entity list get the same fix, via one shared
+  helper** — `stripHtml` (`html-utils.ts:52-56`), `extractFirstHeading`
+  (`html-utils.ts:72-79`), and `epub.ts`'s `decodeEntities` (`:499-510`, which
+  also decodes NCX chapter labels at `:430`). Three copies drifting apart is the
+  documented failure mode here: `decodeEntities`' comment already claims to
+  "match stripHtml" and does not. **Do not fix one and leave the others.**
+- **Do NOT remove the dash shims** — `dialogueOpen` in
+  `server/src/analyzer/dialogue-structure/lang/{es,fr,ru}.ts`, the `DASH`
+  constant in `dialogue-structure/parser.ts:10` and `legibility.ts:3`, and
+  `aligner.ts:92-94`'s 7-char entity atom (six files, one shim shape). They stop
+  firing on freshly-parsed body text, but they normalise **LLM-returned** text,
+  which can echo an entity whatever the parser did, and entity-laden sentence
+  text persists in `manuscript-edits.json` and the analysis cache. Removing them
+  would regress dialogue *attribution* — strictly worse than the
+  mispronunciation being fixed.
+  **Note: `state.json` carries no chapter body** (`workspace/scan.ts:63-100`) —
+  an earlier draft justified the shims that way and was wrong. Do not restore
+  that reasoning.
+- **Every existing test must stay green unchanged.** Verified by probe: the two
+  `epub.test.ts` double-unescape cases (`&amp;lt;` → `&lt;`, `&amp;amp;lt;` →
+  `&amp;lt;`) and `html-utils.test.ts:53` all produce identical output under the
+  new implementation. If one goes red, the implementation diverged from this
+  plan — do not edit the test.
+- **The vacuous-fixture trap.** `&nbsp;` is decoded by `stripHtml`, so it can
+  never represent "an entity that survives" — that mistake shipped in #2289.
+  After this change no *known* entity survives either. **The one fixture shape
+  that still genuinely survives is an UNKNOWN named reference** (`&zzz;`,
+  `&notanentity;`) — probed: `decodeHTMLStrict` leaves them literal. Use that,
+  not `&hellip;` (which stops surviving) and never `&nbsp;`.
+- **Do not assert the body-line symptom against a live model.** Per spec
+  Finding 0, TTS reads model-returned text. Every test here fixes its input
+  string explicitly; none round-trips an analyzer. A test that did would pass or
+  fail by model version.
+- **Worktree hazard:** this plan adds a dependency. `node_modules` is
+  **junctioned** from the primary checkout — a plain `npm install` in the
+  worktree **replaces the junction with a real directory** and changes teardown.
+  See Task 1 for the required sequence.
+
+---
+
+### Task 1: Add the `entities` dependency
+
+**Files:**
+- Modify: `server/package.json`
+- Modify: `package-lock.json` (generated)
+
+- [ ] **Step 1: Add the dependency.**
+
+Add to `server/package.json` `dependencies` (alphabetical, between `epub2` and
+`express`):
+
+```json
+"entities": "^8.0.0",
+```
+
+- [ ] **Step 2: Install without destroying the junction.**
+
+`entities@8.0.0` is already in the root lockfile as a **dev** transitive of
+`parse5` ← `jsdom`; this promotes it to a **server production** dep. It has zero
+dependencies and zero peer dependencies, so resolution is trivial.
+
+Run the install **in the primary checkout** (`C:\Claude\Projects\Audiobook-Generator`),
+not the worktree, then re-verify the worktree's junctions still point at real
+directories per CLAUDE.md's worktree checklist (`(Get-Item $p -Force).Target` —
+**not** `.LinkTarget`, which reads empty on Windows PowerShell 5.1).
+
+- [ ] **Step 3: Verify it resolves from the server.**
+
+```bash
+cd server && node -e "import('entities').then(m => console.log(typeof m.decodeHTMLStrict))"
+# expect: function
+```
+
+**Verify:** `npm run typecheck` passes.
+
+---
+
+### Task 2: Widen the named-entity decode in `stripHtml`
+
+**Files:**
+- Modify: `server/src/parsers/html-utils.ts`
+- Modify: `server/src/parsers/html-utils.test.ts`
+
+**Interfaces:** `stripHtml(html: string): string` — signature unchanged.
+
+- [ ] **Step 1: Write the failing tests.**
+
+Append to `server/src/parsers/html-utils.test.ts`:
+
+```ts
+describe('stripHtml — named character references (#2310)', () => {
+  /* Why the complete HTML5 set and not a curated list: the curated list is
+     what this repo already tried twice and was bitten by both times — the
+     original five-entry set (XML-predefined + &nbsp;, copied wholesale in the
+     first server commit), and es/fr `dialogueOpen` carrying &mdash; but not
+     &ndash; (#2289). An enumeration of spellings loses a spelling per round. */
+  it('#2310: decodes the dash entities that opened this bug', () => {
+    expect(stripHtml('<p>&ndash; Un momento &mdash; dijo él.</p>')).toBe(
+      '– Un momento — dijo él.',
+    );
+  });
+
+  it('#2310: decodes accented letters — the case that corrupts whole words', () => {
+    expect(stripHtml('<p>&eacute;t&eacute; &agrave; la fen&ecirc;tre</p>')).toBe(
+      'été à la fenêtre',
+    );
+  });
+
+  it('#2310: decodes typographic punctuation and guillemets', () => {
+    expect(stripHtml('<p>&laquo;Привет&raquo;&hellip; &rsquo;tis</p>')).toBe(
+      '«Привет»… ’tis',
+    );
+  });
+
+  it('#2310: decodes &apos; — an XML-predefined entity the hand-rolled set dropped', () => {
+    expect(stripHtml('<p>&apos;tis</p>')).toBe("'tis");
+  });
+
+  /* decodeHTMLStrict vs decodeHTML. decodeHTML implements HTML5's legacy
+     semicolon-less rule and would render these `Fish ¬ice this` /
+     `Copyright © 2026`. This test is the ONLY thing pinning that choice —
+     swapping to decodeHTML turns it red. */
+  it('#2310: a bare ampersand in prose is never decoded (decodeHTMLStrict, not decodeHTML)', () => {
+    expect(stripHtml('<p>Fish &notice this</p>')).toBe('Fish &notice this');
+    expect(stripHtml('<p>Copyright &copy 2026</p>')).toBe('Copyright &copy 2026');
+    expect(stripHtml('<p>Smith & Sons, AT&T and R&D</p>')).toBe('Smith & Sons, AT&T and R&D');
+  });
+
+  it('#2310: an unknown entity is left literal', () => {
+    expect(stripHtml('<p>&unknownentity; stays</p>')).toBe('&unknownentity; stays');
+  });
+
+  it('#2310: &amp;ndash; single-passes to &ndash;, never to a dash', () => {
+    expect(stripHtml('<p>&amp;ndash;</p>')).toBe('&ndash;');
+  });
+
+  it('#2310: &nbsp; still yields U+0020, not U+00A0 — and so do its aliases', () => {
+    expect(stripHtml('<p>A&nbsp;B</p>')).toBe('A B');
+    expect(stripHtml('<p>A&nbsp;B</p>')).not.toContain('\u00a0');
+    expect(stripHtml('<p>A&NonBreakingSpace;B</p>')).not.toContain('\u00a0');
+  });
+
+  /* The contract at html-utils.ts:15-16 — documented since the Coalfall fix
+     but never pinned by a test until now. decodeHTMLStrict maps these to
+     U+FFFD, which stripUnsafeForTts does NOT remove, so a whole-string
+     decodeHTMLStrict call would send a replacement char to the TTS engine.
+
+     ONLY these two, and this is measured, not assumed: `codePointOr` guards
+     `!Number.isFinite`, `< 0` and `> 0x10ffff`, so `&#0;` and `&#xD800;` DO
+     decode today (to NUL and a lone surrogate, both removed later by
+     `stripUnsafeForTts`). Adding those two here ships a RED test — an earlier
+     draft of this plan did exactly that, and probing is how it was caught. */
+  it('#2310: out-of-range numeric references are still left literal', () => {
+    for (const ref of ['&#99999999;', '&#x110000;']) {
+      const out = stripHtml(`<p>A${ref}B</p>`);
+      expect(out).toBe(`A${ref}B`);
+      expect(out).not.toContain('\ufffd');
+    }
+  });
+
+  /* Found by adversarial review: these decode BEFORE the `[ \t]+\n` and
+     `\n{3,}` collapses at html-utils.ts:58-59, and the parsers emit one
+     paragraph per line \u2014 so they can change chapter STRUCTURE, not just
+     wording. Vanishingly rare in real ebook output; pinned anyway, because
+     "rare" is not "handled". */
+  it('#2310: &NewLine; / &Tab; decode without corrupting paragraph structure', () => {
+    expect(stripHtml('<p>A&Tab;B</p>')).toBe('A\tB');
+    expect(stripHtml('<p>One&NewLine;Two</p>').split('\n').filter(Boolean)).toEqual(['One', 'Two']);
+  });
+});
+```
+
+Run them — all fail except the last (which passes today and must keep passing:
+it is a **characterisation** test guarding Task 2's regression risk, not a
+red-then-green one). Note that distinction in the run log.
+
+- [ ] **Step 2: Implement — as ONE exported helper, used by all three copies.**
+
+In `server/src/parsers/html-utils.ts`, add the import and the shared helper.
+**This is the deliverable, not an optional refactor**: three hand-rolled copies
+of this list exist today and two have already drifted apart (`decodeEntities`
+claims to "match stripHtml" and has no numeric support at all). Tasks 2, 2b and
+7 all call this one function.
+
+```ts
+import { decodeHTMLStrict } from 'entities';
+
+/* Decode the COMPLETE HTML5 named-entity set. #2310.
+
+   The previous five (`&nbsp; &lt; &gt; &quot; &amp;`) were the XML predefined
+   set plus `&nbsp;`, introduced whole in the first server commit (a922c075) as
+   the standard "unescape XML" idiom — never a curated judgement about which
+   entities are safe to decode in prose, and never widened on purpose.
+   Everything it missed (`&ndash;` `&mdash;` `&eacute;` `&rsquo;` `&laquo;`
+   `&hellip;` `&apos;` …) survived into body text AND chapter titles and was
+   READ ALOUD VERBATIM by the TTS engine.
+
+   Three deliberate constraints, all load-bearing — see
+   docs/superpowers/specs/2026-08-13-entity-decode-layer-design.md:
+
+   1. `decodeHTMLStrict`, not `decodeHTML`. The latter honours HTML5's legacy
+      semicolon-less references and would turn `Fish &notice this` into
+      `Fish ¬ice this` and `Copyright &copy 2026` into `Copyright © 2026`.
+      Requiring the semicolon leaves `AT&T` / `Smith & Sons` alone.
+   2. Scoped to NAMED references by regex. Called on a whole string,
+      `decodeHTMLStrict` would also take the numeric ones — and it maps
+      out-of-range references to U+FFFD, breaking `decodeNumericEntities`'s
+      contract above (and U+FFFD is not stripped before synthesis). Numerics
+      stay that function's job, and callers run it afterwards.
+   3. U+00A0 folds to a plain space. `&nbsp;` yielded U+0020 before #2310 and
+      must keep doing so; folding the CHARACTER rather than the spelling also
+      covers aliases such as `&NonBreakingSpace;`. Callers must run this
+      BEFORE `decodeNumericEntities` so `&#160;` still yields U+00A0 as it did.
+
+   A leftmost `replace` does not rescan its own output, so `&amp;lt;` yields
+   `&lt;` rather than double-unescaping to `<`. */
+export function decodeNamedEntities(s: string): string {
+  return s.replace(/&[a-zA-Z][a-zA-Z0-9]*;/g, (m) => decodeHTMLStrict(m)).replace(/ /g, ' ');
+}
+```
+
+Then replace the five `.replace()` calls at `:52-56` and the return at `:57`:
+
+```ts
+  s = decodeNamedEntities(s);
+  return decodeNumericEntities(s)
+```
+
+**Verify:** `cd server && npx vitest run src/parsers/html-utils.test.ts` — all
+green, including the pre-existing 22 tests, **unedited**.
+
+---
+
+### Task 2b: The chapter-title path — `extractFirstHeading`
+
+**The model-independent instance of this bug.** `extractFirstHeading`
+(`html-utils.ts:72-79`) carries its **own** copy of the five-entity list, and its
+output becomes the chapter title `synthesise-chapter.ts:2248` synthesises with
+**no model in the path** (spec Finding 0). Fixing `stripHtml` alone leaves a
+chapter titled `L&rsquo;&Eacute;t&eacute;` read aloud verbatim.
+
+**Files:**
+- Modify: `server/src/parsers/html-utils.ts:72-80`
+- Modify: `server/src/parsers/html-utils.test.ts`
+
+- [ ] **Step 1: Write the failing test.**
+
+```ts
+describe('extractFirstHeading — named entities (#2310)', () => {
+  /* The chapter title is spoken as its own title beat and — unlike body text —
+     never passes through the stage-2 model, so this path reproduces #2310
+     unconditionally, whatever the model does with dashes. */
+  it('#2310: decodes named entities in a heading', () => {
+    expect(extractFirstHeading('<h1>L&rsquo;&Eacute;t&eacute; &mdash; Tome I</h1>')).toBe(
+      'L’Été — Tome I',
+    );
+  });
+  it('#2310: still leaves a bare ampersand alone', () => {
+    expect(extractFirstHeading('<h1>Smith &amp; Sons, AT&T</h1>')).toBe('Smith & Sons, AT&T');
+  });
+});
+```
+
+- [ ] **Step 2: Implement.** Replace the five inline `.replace()` calls at
+`:75-79` with the shared helper:
+
+```ts
+  const raw = decodeNumericEntities(decodeNamedEntities(m[1].replace(/<[^>]+>/g, ' ')))
+    .replace(/\s+/g, ' ')
+    .trim();
+```
+
+**Verify:** `cd server && npx vitest run src/parsers/html-utils.test.ts`
+
+---
+
+### Task 3: Pin the end-to-end text handed to the engine
+
+This is the acceptance criterion the issue states, and the test that stops a
+future change at a *different* layer from silently reopening the bug.
+
+**Files:**
+- Create: `server/src/tts/entity-dialogue-e2e.test.ts`
+
+- [ ] **Step 1: Write the failing test.**
+
+```ts
+/* #2310 — the end-to-end guard. `stripHtml` decodes the entity (Task 2) and
+   the dash pipeline (`dialogueOpen`, LEADING_DASH, softenDashes) then treats it
+   exactly like a literal dash. This test spans BOTH layers on purpose: a future
+   change to either one that reopens the bug turns it red, which a unit test at
+   one layer alone would not catch.
+
+   Asserted as EQUALITY AGAINST THE GLYPH FORM, never against a hardcoded
+   string — the point is that the two forms agree, whatever `softenDashes`
+   renders a leading dash as. A hardcoded expectation would drift. */
+import { describe, expect, it } from 'vitest';
+import { extractFirstHeading, stripHtml } from '../parsers/html-utils.js';
+import { normaliseForTts } from './text-normalize.js';
+
+describe('#2310 — an entity-opened dialogue line reaches the engine as the glyph does', () => {
+  const cases = [
+    { lang: 'es', entity: '&ndash; Un momento &mdash; dijo él.', glyph: '– Un momento — dijo él.' },
+    { lang: 'es', entity: '&mdash; Un momento.', glyph: '— Un momento.' },
+    { lang: 'fr', entity: '&ndash; Un instant &mdash; dit-il.', glyph: '– Un instant — dit-il.' },
+    { lang: 'ru', entity: '&mdash; Кто там?', glyph: '— Кто там?' },
+    { lang: 'ru', entity: '&ndash; Стой.', glyph: '– Стой.' },
+  ];
+
+  for (const { lang, entity, glyph } of cases) {
+    it(`${lang}: ${entity.slice(0, 12)}… normalises identically to the glyph form`, () => {
+      const fromEntity = normaliseForTts(stripHtml(`<p>${entity}</p>`), lang);
+      const fromGlyph = normaliseForTts(stripHtml(`<p>${glyph}</p>`), lang);
+      expect(fromEntity).toBe(fromGlyph);
+      /* Non-vacuity: equality alone would hold if BOTH sides were broken (e.g.
+         if stripHtml stopped decoding and softenDashes stopped firing). Pin
+         that the marker actually became a pause and no entity text survives. */
+      expect(fromEntity).not.toMatch(/&[a-zA-Z]+;/);
+      expect(fromEntity.startsWith('... ')).toBe(true);
+    });
+  }
+
+  it('the accented-letter case — the one that corrupts whole words, not just openers', () => {
+    const out = normaliseForTts(stripHtml('<p>&ndash; C&rsquo;est l&rsquo;&eacute;t&eacute;.</p>'), 'fr');
+    expect(out).not.toMatch(/&[a-zA-Z]+;/);
+    expect(out).toContain('été');
+  });
+
+  /* Closes the vacuity hole review found: LEADING_DASH (/^\s*[–—]\s*/) collapses
+     en AND em dash to the same '... ', so the equality assertions above pass
+     even if the decode produced the WRONG dash. Assert on the pre-normalisation
+     stripHtml output, where the two are still distinguishable. */
+  it('the decoded dash is the RIGHT codepoint, not merely dash-like', () => {
+    expect(stripHtml('<p>&ndash; x</p>')).toBe('– x'); // U+2013 en
+    expect(stripHtml('<p>&mdash; x</p>')).toBe('— x'); // U+2014 em
+  });
+
+  /* The model-independent path (spec Finding 0). Chapter titles never reach
+     stage-2, so this reproduces regardless of what the model does — it is the
+     assertion to trust when the body-path symptom is model-conditional. */
+  it('the chapter-title beat: an entity-laden heading is spoken clean', () => {
+    const title = extractFirstHeading('<h1>L&rsquo;&Eacute;t&eacute; &mdash; Tome I</h1>')!;
+    const spoken = normaliseForTts(title, 'fr');
+    expect(spoken).not.toMatch(/&[a-zA-Z]+;/);
+    expect(spoken).toContain('L’Été');
+  });
+});
+```
+
+**The non-vacuity assertions are not optional.** A bare
+`expect(fromEntity).toBe(fromGlyph)` passes if both sides are equally broken —
+which is exactly the state before Task 2 for a *pair* of entity inputs. The
+`startsWith('... ')` and no-surviving-entity checks are what make it a real gate.
+
+- [ ] **Step 2: Confirm red before Task 2, green after.**
+
+Stash Task 2's change, run, confirm red **and read the failure** — it must fail
+on the entity/glyph *inequality*, not on an import error or a thrown exception.
+Restore, run, confirm green.
+
+**Verify:** `cd server && npx vitest run src/tts/entity-dialogue-e2e.test.ts`
+
+---
+
+### Task 4: Attribution still works once the entity branch stops firing
+
+**Files:**
+- Modify: `server/src/analyzer/dialogue-structure/parser.test.ts`
+
+- [ ] **Step 1: Add the test.**
+
+Append to the `#2289` describe block:
+
+```ts
+  /* #2310 — once stripHtml decodes the entity, `dialogueOpen`'s entity branch
+     stops firing on freshly-parsed text and the `[-–—]` character-class branch
+     carries the load instead. Pin that the handover is real, so the shims can
+     be retained as pure back-compat rather than silently doing the work. */
+  it('#2310: the DECODED dash still opens dialogue in es and fr', () => {
+    expect(parseChapterStructure(stripHtml('<p>&ndash; Un momento.</p>'), esIdx)[0].kind)
+      .toBe('dialogue');
+    expect(parseChapterStructure(stripHtml('<p>&mdash; Un instant.</p>'), frIdx)[0].kind)
+      .toBe('dialogue');
+  });
+```
+
+Add `import { stripHtml } from '../../parsers/html-utils.js';` to the file's
+imports.
+
+**Verify:** `cd server && npx vitest run src/analyzer/dialogue-structure/parser.test.ts`
+
+---
+
+### Task 5: Correct the comment this change makes false
+
+**Files:**
+- Modify: `server/src/analyzer/dialogue-structure/parser.test.ts` (`:709-713`)
+- Modify: `server/src/analyzer/dialogue-structure/lang/{es,fr,ru}.ts`
+
+Not optional tidying — a stale comment here **re-arms the exact trap** that
+shipped in #2289 and had to be corrected once already.
+
+- [ ] **Step 1: Swap the `&hellip;` negative control's fixture.**
+
+Its current comment claims *"`&hellip;` survives stripHtml so this control is
+realistic end-to-end"*. After Task 2 that is **false** — `&hellip;` decodes.
+
+**Swap the fixture, don't just relabel the test.** `decodeHTMLStrict` leaves
+**unknown** named references literal (probed: `&zzz;` → `&zzz;`), so an unknown
+entity restores the end-to-end realism that `&hellip;` loses:
+
+```ts
+  it('#2289: negative control — an unrelated entity (&zzz;) does not open dialogue', () => {
+    /* Guards against an over-broad fix such as /^\s*(?:&\w+;|[-–—])\s*/iu,
+       which would match any entity.
+
+       #2310 swapped this fixture from `&hellip;` to `&zzz;`. `&hellip;` used to
+       survive `stripHtml`, which is what made this control realistic body text;
+       since #2310 the full named set decodes, so it no longer would. An
+       UNKNOWN reference is left literal by `decodeHTMLStrict`, so `&zzz;` keeps
+       the control realistic end-to-end rather than demoting it to a unit-level
+       mutation guard. (`&nbsp;` was never a candidate — it was decoded even
+       before #2310, which is the vacuous-fixture bug #2289 shipped and had to
+       correct.) */
+    const paras = parseChapterStructure('&zzz; Un momento — dijo él.', esIdx);
+    expect(paras[0].kind).toBe('narration');
+  });
+```
+
+- [ ] **Step 2: Record why the `dialogueOpen` entity alternatives are retained.**
+
+In each of `lang/es.ts`, `lang/fr.ts`, `lang/ru.ts`, replace the `#2289` comment
+above `dialogueOpen` (`ru.ts` has none — add one):
+
+```ts
+  /* #2289 / #2310 — the entity alternatives are RETAINED, not redundant.
+     Since #2310 `stripHtml` decodes the full named set, so freshly-parsed text
+     reaches here with a real dash and the `[-–—]` branch does the work. But
+     `state.json` bodies persisted BEFORE #2310 still carry the literal entity
+     and are not always re-parsed, and dropping these alternatives would regress
+     dialogue ATTRIBUTION for those books — strictly worse than the
+     mispronunciation #2310 fixed. Removing them needs a persisted-body
+     migration audit first. Same reasoning covers the `DASH` constants in
+     dialogue-structure/{parser,legibility}.ts and aligner.ts's 7-char atom. */
+```
+
+**Verify:** `cd server && npx vitest run src/analyzer/` — green.
+
+---
+
+### Task 6: Strip U+00AD, newly reachable from EPUB
+
+A chore **this change makes owed** (spec Finding 6c), not a pre-existing one.
+
+**Files:**
+- Modify: `server/src/tts/text-normalize.ts:76`
+- Modify: `server/src/tts/text-normalize.test.ts`
+
+`&shy;` now decodes to U+00AD SOFT HYPHEN. Measured: U+00AD matches **neither**
+`ZERO_WIDTH_AND_BIDI` (U+200B–U+200F, U+202A–U+202E, U+2060, U+FEFF) **nor**
+`CONTROL_CHARS` (U+0000–U+001F, U+007F–U+009F), and **is not matched by `\s`**,
+so it survives `stripAudioTags`' whitespace collapse and reaches the engine.
+(`&thinsp;` → U+2009 needs nothing — `\s` matches it and it collapses.)
+
+Decoding is still a clear improvement over the status quo, where `&shy;` was
+spoken as "ampersand s h y semicolon". This closes the remaining gap.
+
+- [ ] **Step 1: Write the failing test.**
+
+```ts
+it('#2310: strips U+00AD soft hyphen (reachable from EPUB &shy; since #2310)', () => {
+  expect(stripUnsafeForTts('soft\u00adhyphen')).toBe('softhyphen');
+});
+```
+
+- [ ] **Step 2: Add `\u00AD` to `ZERO_WIDTH_AND_BIDI`.**
+
+```ts
+/* … existing codepoint list …
+   - U+00AD SOFT HYPHEN — invisible in HTML, no audio mapping. Reachable from
+     EPUB since #2310 taught stripHtml to decode `&shy;`; it matches neither
+     CONTROL_CHARS nor `\s`, so nothing else would remove it. */
+const ZERO_WIDTH_AND_BIDI = new RegExp(
+  '[\\u00AD\\u200B-\\u200F\\u202A-\\u202E\\u2060\\uFEFF]',
+  'g',
+);
+```
+
+**Verify:** `cd server && npx vitest run src/tts/text-normalize.test.ts`
+
+---
+
+### Task 7: The third entity decoder — `epub.ts` metadata and NCX labels
+
+Spec Finding 4. `epub.ts:499`'s `decodeEntities` claims **"matches stripHtml"**
+and does not: it has no general numeric decoding, so `&#x27;` — the exact hex
+apostrophe the Coalfall regression (`a4a9877b`) fixed in `stripHtml` — is still
+literal here. It decodes OPF **book title, author and series** *and* — a detail
+an earlier draft of this plan missed — the **NCX chapter labels at `:430`**,
+which become chapter titles and are therefore on the spoken, model-independent
+path alongside Task 2b. The comment is already false today.
+
+**Files:**
+- Modify: `server/src/parsers/epub.ts:499-510`
+- Modify: `server/src/parsers/epub.test.ts`
+
+- [ ] **Step 1: Write the failing tests.**
+
+```ts
+it('#2310: decodeEntities decodes the full named set (titles carry them too)', () => {
+  expect(decodeEntities('L&rsquo;&Eacute;t&eacute; &mdash; Tome I')).toBe('L’Été — Tome I');
+});
+it('#2310: decodeEntities decodes hex numeric refs (the Coalfall gap, never fixed here)', () => {
+  expect(decodeEntities('Oduvan&#x27;s Forge')).toBe("Oduvan's Forge");
+});
+it('#2310: decodeEntities leaves a bare ampersand alone', () => {
+  expect(decodeEntities('Smith &amp; Sons, AT&T')).toBe('Smith & Sons, AT&T');
+});
+```
+- [ ] **Step 2: Implement** with the **same shared helper** Task 2 created — do
+not write a third copy of the decode:
+
+```ts
+/** Decode entities in OPF metadata (title / author / series) and NCX chapter
+    labels. Shares `stripHtml`'s decode rules BY CONSTRUCTION, via
+    `decodeNamedEntities` — the previous hand-rolled copy claimed to "match
+    stripHtml" and had already drifted (no numeric support at all, so the hex
+    apostrophe from the Coalfall regression stayed literal in titles long after
+    `stripHtml` was fixed). Three copies of one list is what produced #2310;
+    there is now one. */
+export function decodeEntities(s: string): string {
+  return decodeNumericEntities(decodeNamedEntities(s)).trim();
+}
+```
+
+Import `decodeNamedEntities` and `decodeNumericEntities` from `./html-utils.js`.
+**The two existing double-unescape tests must stay green unedited** — verified
+by probe: `&amp;lt;` → `&lt;` and `&amp;amp;lt;` → `&amp;lt;` both hold.
+
+**Verify:** `cd server && npx vitest run src/parsers/`
+
+---
+
+### Task 8: Regression plan, register, notes
+
+- [ ] **Step 1: Release notes** — append to `docs/release-notes-next.md`
+  (technical, PR-refed) and a brand-voice line to the in-progress section of
+  `RELEASE_NOTES.md`. This is user-visible: dialogue in EPUBs that used named
+  entities stops being read as gibberish.
+
+- [ ] **Step 2: On-box acceptance.** The *text* change is fully proved by Tasks
+  2–7 in CI. What is **not** provable there is that a real EPUB with named
+  entities produces clean audio end-to-end. Add a row to
+  `docs/testing/onbox-acceptance-register.md` and update **all three surfaces**
+  per CLAUDE.md's before-shipping step 3, including
+  `onbox-acceptance-register-live-view.html` published to the URL already
+  recorded in the register header. Run
+  `npm run check:onbox-register -- --against-published <saved copy>` immediately
+  before publishing.
+
+  **Lead with the chapter-title beat — it is the only criterion that cannot be
+  masked by model behaviour** (spec Finding 0). Observe, on an EPUB whose
+  headings carry named entities (`<h1>L&rsquo;&Eacute;t&eacute;</h1>`): the
+  spoken title beat says "L'Été" and contains **no** "ampersand … semicolon".
+
+  Then, secondarily: a Spanish or French EPUB using `&mdash;`/`&ndash;`/accented
+  entities in body text renders dialogue openers as a **pause**, with no spoken
+  "ampersand" and no corrupted accented words, and the manuscript view shows
+  real glyphs rather than entity text. **Record whether the body-line symptom
+  reproduced at all before the fix** — if stage-2 strips leading dashes on the
+  current model it may not have, which is a finding about the chain, not a
+  failure of the fix.
+
+- [ ] **Step 3:** PR body carries `Closes #2310`, and declares the incidental
+  fixes (Tasks 5, 6, 7) under "Also fixed, found in passing".
+
+**Verify:** `npm run verify:fast:branch`
+
+---
+
+## Task ordering
+
+Task 1 → 2 → **2b** → 3 gets the acceptance criteria green. **2b is not
+optional and not a follow-up**: it is the model-independent half of the same
+defect, and without it the fix is unverifiable on the one path that reproduces
+unconditionally.
+
+4 and 5 protect the attribution seam and the fixture/comment that would
+otherwise mislead the next reader. 6 and 7 are incidental findings this work
+made owed — fixed in the same round per CLAUDE.md, not filed. 8 is the shipping
+bookkeeping.
+
+Tasks 6 and 7 are independent of 3–5 and may be dispatched in parallel. Task 7
+depends on Task 2's shared helper existing.

--- a/docs/superpowers/specs/2026-08-13-entity-decode-layer-design.md
+++ b/docs/superpowers/specs/2026-08-13-entity-decode-layer-design.md
@@ -1,0 +1,683 @@
+# Which layer decodes an HTML entity — design
+
+- **Issue:** #2310
+- **Status:** proposed (design), **v2** — awaiting owner approval of the recommended option.
+  v2 folded in the mandatory `assumption-checker` pass ([Appendix B](#appendix-b--assumption-checker-findings))
+  and a mid-flight correction from the coordinating thread ([Finding 0](#finding-0--the-ticket-omits-a-model-shaped-link-in-its-own-chain)).
+  The recommendation is unchanged from v1; the *reasoning* for two decisions changed materially.
+- **Date:** 2026-08-13
+- **Scope:** server (`parsers/html-utils.ts` entity decode + one new `server/` dependency); no frontend, no OpenAPI, no schema change
+- **Provenance:** found by the review gate on PR #2309 (#2289). Previously recorded, unfixed, at
+  `docs/superpowers/plans/2026-06-16-russian-attribution-narrator-heuristic.md:480`.
+
+## Problem
+
+An HTML entity that survives `stripHtml` is correctly recognised as a **dialogue
+opener** — the paragraph is classified as dialogue and the speaker attributed —
+but the entity then reaches the TTS engine **verbatim** and is read aloud. An
+`&ndash;`-opened Spanish line gets the right speaker and a corrupted first few
+syllables, where a literal `—` would have produced a clean pause.
+
+## The chain — verified, not inherited
+
+Every link below was re-verified against the code in this worktree
+(`6b60f632`). The probes are reproduced in
+[Appendix A](#appendix-a--probe-transcripts); nothing here is asserted from the
+ticket.
+
+1. **`stripHtml` decodes five named entities plus numeric references**
+   (`server/src/parsers/html-utils.ts:52-57`): `&nbsp; &lt; &gt; &quot; &amp;`,
+   then `decodeNumericEntities` for `&#NNN;` / `&#xHH;`. **Verified.**
+2. **`&ndash;` / `&mdash;` survive into the body text.** **Verified** — and the
+   surviving class is much larger than the ticket states (see
+   [Finding 2](#finding-2--the-defect-class-is-far-larger-than-two-dash-entities)).
+3. **`dialogueOpen` matches the entity** and the paragraph is classified as
+   dialogue (`lang/{es,fr,ru}.ts`). **Verified** — this part works and is not
+   the defect.
+4. **`LEADING_DASH = /^\s*[–—]\s*/`** (`server/src/tts/text-normalize.ts:57`)
+   matches literal glyphs only, so the entity never becomes the `'... '` pause.
+   **Verified.**
+5. **The `&` expansion rule** (`server/src/tts/normalize/index.ts:88`) is
+   `s.replace(/ & /g, …)` — space-delimited standalone token only, so `AT&T`
+   survives and `&ndash;` passes through untouched. **Verified.**
+
+6. **The body text does NOT go straight to the engine — a model sits in the
+   middle.** See [Finding 0](#finding-0--the-ticket-omits-a-model-shaped-link-in-its-own-chain),
+   which corrects the ticket's chain and an earlier revision of this spec.
+
+**End-to-end, measured** (`normaliseForTts` output, the exact string handed to
+the engine — for the *title* path unconditionally, and for the *body* path
+whenever the model echoes the sentence verbatim):
+
+| Input body text | Reaches the engine as |
+|---|---|
+| `— Un momento — dijo él.` (glyphs) | `"... Un momento, dijo él."` ✅ |
+| `&ndash; Un momento &mdash; dijo &eacute;l.` | `"&ndash; Un momento &mdash; dijo &eacute;l."` ❌ |
+| `&#8211; Un momento.` (**numeric**) | `"... Un momento."` ✅ |
+
+The language argument (`es`/`fr`/`ru`/absent) changes nothing — all four produce
+the identical untouched entity string.
+
+## Finding 0 — the ticket omits a model-shaped link in its own chain
+
+The ticket's chain implies parsed body text flows to the TTS engine. **It does
+not.** Verified:
+
+- `synthesise-chapter.ts:2514`, `:2570` (and the empty-text filter at `:921`)
+  synthesise `normaliseForTts(group.text, langCode)`, where `group.text` traces
+  to `SentenceOutput.text` — the **stage-2 model's returned sentence text**,
+  stitched into narrative order at `routes/analysis.ts:5077-5080`. Nothing
+  re-derives it from the source prose.
+
+So `stripHtml`'s output reaches the **analyzer**; what reaches TTS is the
+model's echo of it. `dialogueOpen` matching the entity proves the entity reaches
+the analyzer — a *different string* from the one the engine reads.
+
+**This adds a conditional the ticket does not state:** the entity is spoken only
+if stage-2 echoes it into its returned text. A second thread has observed, on a
+live run, that today's model does **not** echo verbatim — it returns sentences
+with the leading dash **stripped** (`— сказал Егор.` → `сказал Егор.`). That was
+measured, not hypothesised.
+
+**What I verified and what I did not:** I verified the code path (the three call
+sites and the stitch) by reading it. I did **not** verify the model's echo
+behaviour for entity-opened lines — that needs a live analyzer run, which this
+design pass did not do. I am not claiming the body-path symptom currently
+reproduces, and I am not claiming it doesn't.
+
+### The model-independent route: chapter titles
+
+**Chapter titles bypass stage-2 entirely**, and that route reproduces
+unconditionally. Traced end to end:
+
+`epub.ts:142,252` → `mergeChapterTitle(ncxTitle, extractFirstHeading(html), n)`
+→ `ChapterHint.title` → `generation.ts:1548` `buildChapterTitleNarration({id,
+title})` → `chapterTitleNarration` → `synthesise-chapter.ts:1562` `titleText` →
+**`:2248` `normaliseForTts(titleText, langCode)` → `provider.synthesize`.**
+
+No model anywhere in that path. And `extractFirstHeading`
+(`html-utils.ts:72-79`) carries **its own third copy of the same five-entity
+list**, so `<h1>L&rsquo;&Eacute;t&eacute;</h1>` yields the chapter title
+`L&rsquo;&Eacute;t&eacute;`, which is spoken verbatim.
+
+**Consequences, all of which the design must carry:**
+
+1. **The unconditional instance of this bug is a chapter title, not a dialogue
+   line.** It is strictly better repro and acceptance evidence, because no model
+   behaviour can mask it.
+2. **This is decisive against option 3.** A fix at `normaliseForTts` only ever
+   sees post-model text for bodies, so it inherits the whole conditional; a fix
+   at `stripHtml`/`extractFirstHeading` runs *before* the model, so the model
+   never sees an entity and cannot echo, strip, or mangle one. Options 1 and 2
+   are immune to model behaviour; option 3 is defined by it.
+3. **There are three copies of the entity set, not two** — `stripHtml`,
+   `extractFirstHeading`, and `epub.ts`'s `decodeEntities` — which makes
+   extracting one shared helper mandatory rather than optional.
+4. **The end-to-end test must fix the sentence text explicitly** rather than
+   round-tripping a real model, or it passes or fails by model version.
+
+## Finding 1 — the numeric row above is the fact that decides this
+
+**The same dash, expressed as `&#8211;`, already produces the correct output
+today.** `decodeNumericEntities` decodes it at the parser, and everything
+downstream — `dialogueOpen` (via its `[-–—]` character-class branch),
+`LEADING_DASH`, `softenDashes` — then works with no change whatsoever.
+
+This is a **positive control that already ships in production**. It proves:
+
+- the desired end state is reachable by decoding alone;
+- **no downstream layer needs to change** once decoding happens — the entire
+  dash pipeline is already correct for a real dash character;
+- the defect is precisely and only that **named** references are decoded from a
+  five-entry hand-rolled list while **numeric** references are decoded
+  completely.
+
+The fix is therefore to make named references behave the way numeric references
+already do. That is a statement about one function, not about the pipeline.
+
+## Finding 2 — the defect class is far larger than two dash entities
+
+The ticket frames this as `&ndash;`/`&mdash;` in three languages. Measured, the
+surviving set is open-ended. Every one of these reaches the TTS engine verbatim
+today:
+
+| Entity | Survives `stripHtml`? | Consequence when spoken |
+|---|---|---|
+| `&ndash;` `&mdash;` | **survives** | the filed bug — corrupted dialogue opener |
+| `&eacute;` `&egrave;` `&agrave;` `&ccedil;` … | **survives** | **corrupts words, not just openers** — accented letters are pervasive in `fr`/`es` prose |
+| `&rsquo;` `&lsquo;` `&ldquo;` `&rdquo;` | **survives** | every apostrophe and quote mark in the chapter |
+| `&laquo;` `&raquo;` | **survives** | the `ru`/`fr` guillemet — also a `quotePairs` marker |
+| `&hellip;` | **survives** | ellipsis, a pause marker |
+| `&apos;` | **survives** | **an XML-predefined entity** — see Finding 3 |
+| `&shy;` `&thinsp;` | **survives** | invisible in HTML, spoken as gibberish |
+| `&nbsp;` `&lt;` `&gt;` `&quot;` `&amp;` | decoded | — |
+
+`&eacute;` is the one that reframes the severity. A French EPUB whose serializer
+emitted named accent entities does not have a dialogue-opener problem — it has
+**every accented word in the book** read as `"ampersand e acute semicolon"`.
+That is not a cosmetic first-syllable defect.
+
+**This finding is what disqualifies option 3** (soften on the TTS side). A
+widened `LEADING_DASH` fixes exactly one entity in exactly one position and
+leaves the whole rest of this table spoken.
+
+## Finding 3 — why the entity set is exactly those five: it is incidental
+
+This was the highest-value question in the brief, and it has a clean answer.
+
+`git log -S'&nbsp;' --follow` traces the set to **`a922c075`, 2026-05-12 — the
+very first server commit** ("Add local analysis server + Gemini analyzer"). It
+was introduced whole, in its final form:
+
+```js
+.replace(/&nbsp;/g, ' ').replace(/&amp;/g, '&').replace(/&lt;/g, '<')
+.replace(/&gt;/g, '>').replace(/&quot;/g, '"').replace(/&#39;/g, "'")
+```
+
+That is **the XML predefined entity set** (`&amp; &lt; &gt; &quot; &apos;`,
+with `&apos;` written as `&#39;`) **plus `&nbsp;`** — i.e. the standard
+"hand-rolled XML unescape" idiom, copied in wholesale. It is what you write
+when you are unescaping XML, not a curated decision about which entities are
+safe to decode in prose.
+
+**Conclusions, load-bearing for the recommendation:**
+
+- **The narrowness is incidental, not deliberate.** No commit ever narrowed it;
+  no commit ever considered and rejected widening. There is no load-bearing
+  reason to preserve it.
+- Every subsequent change to entity handling has been a **reactive widening**
+  after a production regression: `a4a9877b` added hex numeric refs after the
+  Coalfall / Master Oduvan incident (an evidence-quote failure that cost a
+  speaker his entire cast); `#2289` added `&ndash;` to `es`/`fr` after this
+  same class bit again.
+- **`&apos;` — one of the five XML entities the idiom is meant to cover — is
+  not decoded at all.** The hand-rolled list dropped it in translation (it
+  became `&#39;`, which only covers the numeric spelling). A latent, unfiled
+  instance of this same bug has been shipping since day one.
+
+**The set is not small because small is safe. It is small because nobody ever
+widened it on purpose.** That removes the only stated reason to prefer a
+narrow fix.
+
+## Finding 4 — THREE divergent copies of the entity set
+
+**Corrected from "two" after review.** The third is in the file being edited,
+and it is the one on the model-independent path.
+
+**Copy 2 — `extractFirstHeading` (`html-utils.ts:72-79`).** Its own verbatim
+five-entity list. It feeds `mergeChapterTitle` (`epub.ts:142`, `:252`;
+`mobi.ts`) → `ChapterHint.title` → **the spoken chapter-title beat**
+(Finding 0). `<h1>L&rsquo;&Eacute;t&eacute;</h1>` yields a title read aloud as
+`"L ampersand rsquo semicolon..."`. This is the filed defect, on the one surface
+no model behaviour can mask — **in scope, not adjacent**.
+
+**Copy 4 — `epub.ts:430` NCX chapter labels**, decoded via `decodeEntities`. The
+first revision described `decodeEntities` as metadata-only (`readCalibreMeta`);
+it also decodes the chapter labels that become titles. Same surface, same fix.
+
+### Copy 3 — `decodeEntities` itself
+
+`server/src/parsers/epub.ts:499` carries `decodeEntities`, commented **"Decode
+the small entity set the parsers care about (matches stripHtml)"**. It does
+**not** match: it decodes `&#39;` explicitly but has no general numeric decoding
+at all, so `&#x27;` — the exact hex apostrophe that caused the Coalfall
+regression `a4a9877b` fixed in `stripHtml` — is still literal here.
+
+`decodeEntities` decodes **OPF/NCX metadata**: book title, author, series
+(`readCalibreMeta`). So an entity-laden book *title* is a live instance of the
+same defect on a different surface, and the comment claiming parity with
+`stripHtml` is already false. Both are chores this work makes owed.
+
+## Finding 5 — blast radius, measured
+
+### Who consumes `stripHtml` output
+
+`epub.ts:150` (epub2 path), `epub.ts:256` (raw-zip fallback), `mobi.ts:166`.
+Each wraps it in the `tagShoutingDialog`/`tagExcitedDialog`/`tagHesitantDialog`
+audio-tag inserters, which only add `[...]` spans and never touch entities. The
+result becomes `ChapterHint.body` → `ParsedManuscript` → `ManuscriptRecord`
+(`sourceText` = the bodies joined) → the analyzer, the evidence verifier, the
+manuscript UI, and TTS.
+
+### Does anything depend on entities *surviving*?
+
+Grepped across `server/src/`. Everything that pattern-matches a literal entity
+spelling is a **dash-detection compatibility shim carrying the entity as an
+alternative alongside the real glyph**:
+
+| Site | Shape |
+|---|---|
+| `lang/{ru,es,fr}.ts` `dialogueOpen` | `/^\s*(?:&mdash;\|&ndash;\|[-–—])\s*/iu` |
+| `dialogue-structure/parser.ts:10` | `DASH = (?:&mdash;\|&ndash;\|[-–—])` |
+| `dialogue-structure/legibility.ts:3` | same `DASH` constant |
+| `dialogue-structure/aligner.ts:92-94` | `buildNormalizedMap` folds a 7-char `&mdash;`/`&ndash;` run to `-` with an offset map |
+
+**Every one degrades gracefully**: each already carries the real dash character
+in the same alternation, so once the entity is decoded to `–`/`—` the
+character-class branch matches instead. **Nothing breaks; the entity branches
+simply stop firing on freshly-parsed text.** Verified by reading each site, not
+inferred.
+
+`verifyEvidenceAgainstSource` (`routes/analysis.ts:612-671`) is the one exact
+substring matcher, via `normaliseForMatch` (`util/text-match.ts:18-28`), which
+folds typographic variants but **does not decode entities**. Both sides of that
+comparison — the LLM's echoed quote and the source — are drawn from the *same*
+post-`stripHtml` text, so they shift together. Self-consistent under widening.
+
+### Does the fix reach already-imported books?
+
+**Yes** — and this corrects a natural assumption worth stating because it is
+wrong. `getOrHydrateManuscript` (`store/manuscripts.ts:71-90`) **re-parses the
+original manuscript file from the workspace** on any cache miss (server restart,
+`removeManuscript`), carrying forward only the user-set `excluded` flag. The
+source `.epub`/`.mobi` is preserved on disk, so an existing book re-parsed after
+this ships gets decoded text. The `state.json` `chapters[].body` snapshot still
+holds the old entity-laden text until rewritten.
+
+So the fix reaches existing books **on re-analysis**, exactly as the ru
+attribution plan's cached-analysis scope note describes — not only new uploads.
+It does **not** retroactively rewrite persisted `state.json` bodies.
+
+### Blast radius the first revision missed (found by adversarial review)
+
+Two real effects, neither hypothetical:
+
+**`&NewLine;` → U+000A and `&Tab;` → U+0009 can change paragraph structure.**
+The named decode runs at `html-utils.ts:52-56`, i.e. **before** the `[ \t]+\n`
+and `\n{3,}` → `\n\n` collapses at `:58-59`. A serializer emitting `&NewLine;`
+would therefore newly create line breaks, and the parsers emit **one paragraph
+per line**. This is structural, not cosmetic. It is also vanishingly rare in
+real EPUB body text — `&NewLine;` and `&Tab;` are HTML5 additions almost never
+produced by ebook toolchains — but "rare" is not "handled", so the plan carries
+a test pinning that both are decoded *and* that the collapse still yields the
+expected paragraph count.
+
+**Decoded quotes and ellipses newly fire the audio-tag inserters.** `stripHtml`'s
+output is wrapped in `tagShoutingDialog`/`tagExcitedDialog`/`tagHesitantDialog`
+(`epub.ts:149-150`, `:255-257`, `mobi.ts:165-167`). Those match on real
+characters: `QUOTE_OPENS`/`QUOTE_CLOSES` (`audio-tags.ts:31-32`) and the
+hesitation patterns at `:117-118`. Today `&ldquo;`/`&raquo;`/`&hellip;` survive,
+so **`rewriteQuoteSpans` finds no spans at all** in an entity-encoded chapter and
+no `[shouting]`/`[excited]`/`[hesitant]` tag is ever emitted. After decoding they
+fire normally.
+
+**This is the fix working, not a regression** — an entity-encoded book was
+silently getting *no* audio-tag enrichment, which is the same defect class one
+layer over. But it is a behaviour change that belongs in a section titled "blast
+radius, measured", and the first revision omitted it. `stripAudioTags` removes
+the bracket vocabulary before synthesis, so audio is unaffected; the tags reach
+the analyzer and the UI, which is where they are meant to go.
+
+### Other formats
+
+`parsers/` holds `epub.ts`, `mobi.ts` (both via `stripHtml`), `pdf.ts`
+(`pdf-parse` → plain Unicode), `text.ts` (`.txt`/`.md`, raw). **There is no
+`.docx` parser** and — decisive for option 2 — **there is no universal
+post-parse normalisation seam.** Each parser builds `ChapterHint.body`
+independently and `assembleManuscript` merely joins them.
+
+## The options, with measured blast radii
+
+### Option 1 — widen the decode in `stripHtml` ✅ **recommended**
+
+Fixes every downstream consumer at once, at the one place that already owns
+entity decoding.
+
+- **Blast radius, measured:** the four dash shims keep matching via their glyph
+  branch (Finding 5). The evidence verifier is self-consistent. Nothing
+  downstream depends on entities surviving. The *hypothesised* risk — "the small
+  set may be load-bearing" — is **disproved** by Finding 3.
+- **Cost:** one new `server/` dependency (see below), and two genuine edge cases
+  that must be handled deliberately rather than absorbed (Finding 6).
+
+### Option 2 — decode at import-time normalisation ✗
+
+- **There is no import-time normalisation layer to put it in** (Finding 5). This
+  option's premise does not exist in the codebase; choosing it means *creating*
+  a new cross-parser seam.
+- It would add a second place that knows about entities — and Finding 4 shows
+  the codebase already has two, one of which has silently drifted out of sync
+  with the other. Adding a third is the failure mode already in evidence.
+- The only thing it buys over option 1 — sparing `pdf.ts`/`text.ts` — is worth
+  nothing: those formats carry no entities.
+
+### Option 3 — soften on the TTS side only ✗
+
+- **Fixes one entity in one position and leaves the whole of Finding 2's table
+  spoken**, including `&eacute;` corrupting every accented word.
+- **The UI keeps displaying the raw entity.** `chapterHints[].body` is the same
+  server-computed field the manuscript view renders, so today users see
+  `&mdash;` in the manuscript too. Option 3 leaves the UI and the analyzer
+  agreeing with each other and disagreeing with the audio — the ticket's own
+  stated objection, confirmed against the render path.
+- It is the only option that makes the `dialogueOpen` entity alternatives
+  permanently necessary rather than merely retained.
+
+## Recommendation
+
+**Option 1** — widen `stripHtml`'s named-entity decode to the full HTML5 named
+set, via `entities`' **`decodeHTMLStrict`**, scoped to named references only.
+
+The single strongest fact behind it: **`&#8211;` already produces the correct
+audio today through the unmodified pipeline.** The desired behaviour is not a
+new capability to be built at some layer — it is behaviour the codebase already
+has for one spelling of the character and lacks for the other, because a
+five-entry list copied from an XML-unescape idiom on day one was never revisited.
+
+### Why a library rather than a curated table
+
+A hand-written table of "the ~40 entities that matter" is the option the repo
+has already tried, twice, and been bitten by both times: the original five-entry
+set (Finding 3), and `es`/`fr` `dialogueOpen` carrying `&mdash;` but not
+`&ndash;` (#2289 — same dash, other spelling, silently unhandled for months).
+**An enumeration of spellings loses a spelling per round.** The complete set is
+the only one that does not need a third round.
+
+`entities@8.0.0` — **BSD-2-Clause, zero dependencies, zero peer dependencies**,
+`engines: node >=20.19.0` (this repo is on Node 20.6+/24). It is the decoder
+behind `cheerio`/`parse5`/`htmlparser2`.
+
+**Stated accurately, because the convenient version of this claim is false:**
+`entities` *is* present in the root tree today — but as a **dev-only**
+transitive of `parse5` ← `jsdom` (the frontend test environment). Adding it to
+**`server/package.json` `dependencies`** therefore introduces a **genuine new
+production dependency** for the server. It is not "already there". The cost is
+judged acceptable — zero transitive deps, ~100 KB, permissive licence, in a
+server that already ships `epub2`, `pdf-parse`, `sharp` and `undici` — but it is
+a real cost and the owner is approving it, not being told it is free.
+
+Relying on the hoisted root copy instead would be a **phantom dependency** and
+is not an option: it resolves today only by accident of npm hoisting from a dev
+tree, and would break a production install.
+
+### Why `decodeHTMLStrict` and not `decodeHTML` — measured
+
+`decodeHTML` implements HTML5's **legacy semicolon-less** entity rule and
+**corrupts ordinary prose containing a bare ampersand**:
+
+| Input | `decodeHTML` | `decodeHTMLStrict` |
+|---|---|---|
+| `Fish &notice this` | `Fish ¬ice this` ❌ | `Fish &notice this` ✅ |
+| `Copyright &copy 2026` | `Copyright © 2026` ❌ | `Copyright &copy 2026` ✅ |
+| `Smith & Sons` / `AT&T and R&D` | unchanged ✅ | unchanged ✅ |
+| `&amp;lt;` | `&lt;` ✅ | `&lt;` ✅ |
+| `&amp;ndash;` | `&ndash;` ✅ | `&ndash;` ✅ |
+
+`decodeHTMLStrict` requires the terminating semicolon, so `AT&T`, `Smith & Sons`
+and `&notice` are untouched, while `&amp;lt;` correctly single-passes to `&lt;`
+rather than double-unescaping to `<`. **`decodeHTML` is not an acceptable
+substitute and the plan must pin the difference with a test.**
+
+## Finding 6 — two edge cases the swap must handle deliberately
+
+Both were found by probe, and a naive "replace the five `.replace()` calls with
+`decodeHTMLStrict(s)`" gets both wrong.
+
+### 6a. Invalid numeric references — a real regression
+
+`decodeNumericEntities` documents an explicit contract at
+`html-utils.ts:15-16`: *"Invalid or out-of-range references are left untouched
+rather than dropped."* `decodeHTMLStrict` **violates it** — it maps them to
+U+FFFD:
+
+| Input | current | `decodeHTMLStrict` |
+|---|---|---|
+| `A&#99999999;B` | `A&#99999999;B` | `A\uFFFDB` |
+| `A&#x110000;B` | `A&#x110000;B` | `A\uFFFDB` |
+| `A&#0;B` | `A<NUL>B` (**decodes**) | `A\uFFFDB` |
+| `A&#xD800;B` | `A<lone surrogate>B` (**decodes**) | `A\uFFFDB` |
+
+U+FFFD is **not** stripped by `stripUnsafeForTts`, so it would reach the engine.
+This contract is documented in a comment but **not pinned by any test** — the 22
+tests in `html-utils.test.ts` cover only valid references. The plan adds that
+missing test.
+
+**Correction, caught by probing rather than reading — an earlier revision of
+this spec got the last two rows wrong.** `codePointOr` guards only
+`!Number.isFinite`, `< 0`, and `> 0x10ffff`, so `&#0;` and `&#xD800;` **do**
+decode today, to NUL and to a lone surrogate; `stripUnsafeForTts`'
+`CONTROL_CHARS` and `UNPAIRED_SURROGATE` then remove both downstream. Only
+genuinely out-of-range (`&#99999999;`, `&#x110000;`) and malformed (`&#;`,
+`&#x;`) references are left literal.
+
+The regression is therefore narrower than first claimed, but the two remaining
+rows are real and the resolution is unchanged. **The plan's test must assert
+only the rows that actually hold** — asserting all four would ship a red test,
+which is exactly how this error surfaced.
+
+**Resolution:** scope the library call to *named* references only —
+`s.replace(/&[a-zA-Z][a-zA-Z0-9]*;/g, (m) => decodeHTMLStrict(m))` — and leave
+`decodeNumericEntities` untouched and still responsible for numerics. A
+leftmost-match `replace` does not rescan its own output, so `&amp;ndash;` →
+`&ndash;` correctly (verified).
+
+### 6b. `&nbsp;` whitespace kind
+
+Today `&nbsp;` → `' '` (U+0020). `decodeHTMLStrict` yields **U+00A0**, which
+would newly flow into the body text and past `[ \t]+\n` collapsing.
+
+**Resolution — and the obvious version of it is not quite enough.** Keeping the
+existing `.replace(/&nbsp;/g, ' ')` line before the general pass preserves
+`&nbsp;` byte-for-byte, but **misses HTML5's aliases**: probe shows
+`&NonBreakingSpace;` still decodes to U+00A0. So the fold must be on the
+*character*, not the spelling — apply `.replace(/ /g, ' ')` **after** the
+named pass and **before** `decodeNumericEntities`. Positioned there it catches
+every named spelling and alias, while leaving `&#160;` → U+00A0 exactly as
+today, since the numeric decode runs afterwards.
+
+That pre-existing named/numeric NBSP asymmetry is **noted, not changed** —
+altering it is a separate behaviour question with no bearing on this defect.
+
+### 6c. `&shy;` / `&thinsp;` become real invisible characters
+
+Newly decodable entities include U+00AD SOFT HYPHEN (`&shy;`) and U+2009 THIN
+SPACE (`&thinsp;`). Today these reach TTS as the literal text `"&shy;"` — read
+aloud as gibberish — so decoding them is **strictly an improvement**. But
+U+00AD is not covered by `ZERO_WIDTH_AND_BIDI`
+(`text-normalize.ts:76`, which spans U+200B–U+200F, U+202A–U+202E, U+2060,
+U+FEFF), so it would reach the engine as an invisible character with no audio
+mapping — the exact class that file exists to strip.
+
+This is a chore **this change makes owed**, not a pre-existing one to file and
+walk past: adding U+00AD to that character class is one character of regex plus
+a paired test, and the plan includes it as its own task.
+
+## Do the `dialogueOpen` entity alternatives become redundant?
+
+**They become redundant for freshly-parsed body text, and they stay anyway — but
+the first version of this section justified that with a fact that is false, and
+the corrected reason is both different and stronger.**
+
+### The wrong reason (retracted)
+
+An earlier revision argued the shims must stay because `state.json`'s
+`chapters[].body` retains entity-laden text. **`BookStateJson.chapters[]` has no
+`body` field at all** (`server/src/workspace/scan.ts:63-100` — `id`, `title`,
+`slug`, `uuid`, `duration`, `excluded`, `held`, `audio*`, `generation*`), and
+`routes/import.ts:312-317` explicitly re-maps to `{id, title, slug, excluded}`
+before writing. Every `ChapterHint.body` producer traces to a fresh
+`parseManuscript()`. **Retracted in full.** It was also filed under "what I could
+not establish" when it was one grep away — presenting a checkable fact as
+unestablished is precisely the deferral this repo's rules forbid.
+
+### The right reason
+
+**The text that reaches TTS is persisted, and it is not re-derived from the
+source.** Per [Finding 0](#finding-0--the-ticket-omits-a-model-shaped-link-in-its-own-chain),
+TTS reads the stage-2 model's returned `SentenceOutput.text`, and that text is
+persisted in two places that a re-parse does **not** refresh:
+
+- **`manuscript-edits.json`** — durable, inside the book's own directory
+  (`server/src/export/manuscript-sentences.ts:2-6`);
+- **`server/handoff/cache/{manuscriptId}.json`** — the analysis cache.
+
+A book analysed before this ships has entity-laden sentence text in both. More
+fundamentally, `parser.ts`/`legibility.ts`/`aligner.ts` normalise **LLM-returned
+text**, which can echo an entity *whatever* `stripHtml` did — the model is not
+bound by the parser's output. So the shims are not merely back-compat for old
+books; they guard a class of input that remains reachable indefinitely.
+
+Removing them would regress dialogue **attribution** — strictly worse than the
+mispronunciation being fixed. Keeping them costs ~20 characters of regex
+alternation, with no correctness risk (they cannot match decoded text).
+
+**Decision: keep all of them** — `dialogueOpen` in
+`server/src/analyzer/dialogue-structure/lang/{es,fr,ru}.ts`, the `DASH` constant
+in `dialogue-structure/parser.ts:10` and `legibility.ts:3`, and `aligner.ts`'s
+7-char atom at `:92-94` (six files, one shim shape). Amend their comments to
+name `stripHtml` as the primary decode layer and record that they guard
+model-returned and already-persisted text.
+
+This disposes of the ticket's framing that option 1 makes #2289's change "dead
+weight to be reverted": **#2289 remains correct and load-bearing**, for a better
+reason than the ticket supposed.
+
+## Test strategy
+
+Four layers, so that a future change at any one of them cannot silently reopen
+this.
+
+1. **`html-utils.test.ts` — the decode itself.** `&ndash;`/`&mdash;`/`&eacute;`/
+   `&hellip;`/`&laquo;`/`&apos;` decode; `AT&T`, `Smith & Sons`, `&notice`,
+   `&copy 2026` untouched (the `decodeHTMLStrict`-vs-`decodeHTML` pin);
+   `&amp;lt;` → `&lt;`; `&amp;ndash;` → `&ndash;`; `&nbsp;` → U+0020 **not**
+   U+00A0; **invalid numeric refs still left literal** (the currently-unpinned
+   contract from Finding 6a).
+2. **End-to-end text handed to the engine** — the ticket's explicit requirement.
+   `normaliseForTts(stripHtml('<p>&ndash; …</p>'), lang)` **equals**
+   `normaliseForTts(stripHtml('<p>– …</p>'), lang)` for `es`, `fr`, `ru`, with
+   the glyph in each pair matched to the entity (`&ndash;`↔`–`, `&mdash;`↔`—`).
+
+   **Two vacuity holes this must close, both found by review:**
+
+   - **`LEADING_DASH = /^\s*[–—]\s*/` collapses en *and* em dash to the same
+     `'... '`**, so an equality assertion alone passes even if the decode
+     produced the *wrong* dash — it proves "something dash-like emerged", not
+     the right codepoint. The test therefore also asserts on the **pre-
+     normalisation `stripHtml` output**, where the two dashes are still
+     distinguishable.
+   - **Equality holds if both sides are equally broken.** The test additionally
+     pins that no `&name;` survives and that the marker actually became a pause.
+
+   **The sentence text is fixed explicitly — no model in the loop.** Per
+   Finding 0 the production body path runs through stage-2, so a test that
+   round-tripped a real model would pass or fail by model version. This test
+   deliberately pins the *decode → normalise* composition, which is the literal
+   production path for **titles** and the "model echoed verbatim" case for
+   bodies.
+
+2b. **The model-independent title path.** `buildChapterTitleNarration` on a
+   title carrying `&eacute;`/`&mdash;`, through `normaliseForTts`, yields no
+   surviving entity. This is the assertion that reproduces regardless of model
+   behaviour, and it is the better acceptance evidence.
+3. **Attribution unchanged** — `parseChapterStructure` still classifies the
+   decoded paragraph as `dialogue` in all three languages, pinning that the
+   glyph branch carries the load once the entity branch stops firing.
+4. **`epub.ts` `decodeEntities`** — Finding 4's metadata path, same widening,
+   plus the hex-apostrophe case it currently misses.
+
+### The vacuous-fixture trap — explicit, because it has already shipped twice
+
+`&nbsp;` is one of the five entities `stripHtml` **does** decode, so a fixture
+using `&nbsp;` to represent "an entity that survives" is vacuous while looking
+correct. That exact mistake shipped in #2289 and was corrected to `&hellip;`.
+
+**This change re-arms that trap one level up.** `parser.test.ts:709-713` is
+#2289's negative control:
+
+```
+it('#2289: negative control — an unrelated entity (&hellip;) does not open dialogue', …)
+// "&hellip; survives stripHtml so this control is realistic end-to-end"
+```
+
+Under option 1, **`&hellip;` no longer survives `stripHtml`**, so that comment
+becomes false and the control stops being realistic end-to-end. Widening to the
+complete named set means **no** entity survives, so no substitute fixture can
+restore the property.
+
+**Disposition — improved by review.** The first revision proposed a comment-only
+rewrite, downgrading the control to a unit-level mutation guard on the claim
+that "no entity survives, so no fixture can restore the property". **That claim
+is false:** `decodeHTMLStrict` leaves *unknown* named references untouched
+(probed: `&zzz;` → `&zzz;`, `&notanentity;` → `&notanentity;`).
+
+So the control **stays realistic end-to-end** by swapping the fixture to an
+unknown entity, which is strictly better than relabelling it. The plan swaps
+`&hellip;` → `&zzz;` **and** fixes the comment, since `&hellip;` genuinely stops
+surviving. A stale comment left behind here is exactly the trap re-armed for the
+next reader.
+
+## What I could not establish
+
+- **How many real-world EPUBs carry named entities in body text.** No corpus
+  measurement was run; `C:\AudiobookWorkspace` is read-only and was not
+  surveyed. The class is established from the code path, not from prevalence.
+  The fix's *correctness* does not depend on prevalence, but its *priority*
+  does, and I am not claiming a frequency.
+- **Whether the stage-2 model echoes a surviving entity into its returned
+  sentence text.** This is the conditional in Finding 0, and it decides whether
+  the *body-line* symptom reproduces on today's model. It needs a live analyzer
+  run, which this design pass did not do. **It does not gate the fix**: the
+  chapter-title path reproduces unconditionally, and options 1/2 act before the
+  model either way. Recorded as on-box acceptance rather than guessed at.
+- ~~Whether any persisted `state.json` body contains entities.~~ **Withdrawn** —
+  `state.json` carries no body at all (Appendix B, finding 1). This was listed
+  as unestablished in v1 when it was one grep away.
+- **Adjacent observation, not folded in:** `softenDashes` renders
+  `— Кто там? — спросил он.` as `"... Кто там?, спросил он."` — a comma directly
+  after a question mark. Pre-existing, unrelated to entities, and fixing it
+  needs its own decision about dashes following terminal punctuation. Noted so
+  it is not mistaken for a regression introduced by this change.
+
+## Appendix A — probe transcripts
+
+Probes were run with `server/node_modules/.bin/tsx` against this worktree and
+with `node` against `entities@8.0.0`; scripts are throwaway and live in the
+session scratchpad, not the repo.
+
+**Which entities survive `stripHtml`** (`stripHtml('<p>ENTITY X</p>')`):
+
+```
+&nbsp; &lt; &gt; &quot; &amp;      -> decoded
+&#8211; &#x2014; &#160;           -> decoded (numeric)
+&ndash; &mdash; &hellip; &apos;
+&rsquo; &laquo; &raquo; &ldquo;
+&eacute; &shy; &thinsp;           -> SURVIVE
+```
+
+**End-to-end `normaliseForTts`:**
+
+```
+entity, lang=es -> "&ndash; Un momento &mdash; dijo &eacute;l."
+glyph,  lang=es -> "... Un momento, dijo él."
+&#8211; Un momento.  -> "... Un momento."      <- already correct today
+```
+
+`decodeHTML` vs `decodeHTMLStrict` and the invalid-numeric divergence are
+tabulated inline above (Finding 6, "Why `decodeHTMLStrict`").
+
+## Appendix B — assumption-checker findings
+
+A Premium-tier `assumption-checker` pass was run against v1 per CLAUDE.md's
+mandatory spec-review gate. It was substantially right, and v2 changed the
+*justification* for one decision and the *scope* of another. **No finding
+changed the recommendation.**
+
+| # | Finding | Severity | Disposition |
+|---|---|---|---|
+| 1 | **`state.json` carries no `chapters[].body`** — the sole stated reason to keep the dash shims is false | Critical | **Accepted, retracted, replaced.** Verified independently (`scan.ts:63-100`). The real reason is persisted *sentence* text (`manuscript-edits.json`, the analysis cache) plus the fact that the shims normalise **LLM-returned** text. Decision unchanged, reasoning rewritten. |
+| 2 | **Three entity-set copies, not two** — `extractFirstHeading` is the third, and it feeds the *spoken chapter title*; `epub.ts:430` NCX labels a fourth site | Critical | **Accepted.** Finding 4 rewritten; both brought in scope. Converges with the coordinator's independent finding that titles are the model-independent route. |
+| 3 | **`&NewLine;`/`&Tab;` decode before the whitespace collapse** and can change paragraph structure; decoded quotes/ellipses newly fire the audio-tag inserters | Significant | **Accepted.** New "blast radius the first revision missed" section. Audio-tag firing judged the fix working, not a regression, and said so explicitly. |
+| 4 | **`entities` is a *dev* transitive** — this is a new production dep | Significant | **Already corrected** before the report landed (independently probed via the root lockfile). |
+| 5 | **Unknown entities survive**, so the `&hellip;` control can stay realistic by swapping the fixture | Significant | **Accepted — better than my proposal.** Plan now swaps to `&zzz;` rather than relabelling the test. |
+| 6 | **The e2e equality assertion can pass vacuously** — `LEADING_DASH` collapses en and em dash alike | Significant | **Accepted.** Test strategy now asserts on pre-normalisation `stripHtml` output too. (The specific mismatch alleged did not exist — the entity/glyph pairs were correctly matched — but the vacuity hole is real.) |
+| 7 | Finding 1's positive control proves *reachability*, not *prevalence* | Significant | **Accepted as a wording fix.** Named references are far more common than numeric in real serializer output, so the behaviour delta is larger in practice than "one character already decodes" suggests. |
+| 8 | Shim paths omitted `analyzer/`; "25 tests" (actually 22); "four shims" then six files | Nit | **Fixed** throughout. |
+
+**One finding I did not accept as stated.** The report lists Finding 6a's four
+invalid-numeric rows as verified correct. My own probe shows `&#0;` and
+`&#xD800;` **do** decode under the *current* code (`codePointOr` guards only
+non-finite, `<0`, `>0x10ffff`). Both statements are compatible — the reviewer
+verified `decodeHTMLStrict`'s output, not the status quo's — but the spec now
+carries the narrower, probed version, and the plan's test asserts only the two
+rows that hold. See the correction under Finding 6a.


### PR DESCRIPTION
## Summary

Phase-1 design pass for #2310 — an HTML entity that opens dialogue is read aloud
verbatim by the TTS engine. **Docs only; no production code changes.** The ticket
asked for one decision — *which layer decodes the entity* — and this delivers a
defended recommendation the owner can approve with a yes, plus the implementation
plan contingent on that approval.

**Recommendation: option 1** — widen `stripHtml`'s named-entity decode to the
complete HTML5 set, via `entities`' `decodeHTMLStrict` scoped to named
references only.

**The strongest fact behind it:** `&#8211;` — the *same dash*, expressed
numerically — already produces correct audio today through the unmodified
pipeline. The desired behaviour isn't a new capability to build at some layer;
it's behaviour the codebase already has for one spelling and lacks for the other.

**Why the entity set is small — the question the ticket said this class turns
on:** `git log -S` traces it to `a922c075`, the first server commit, introduced
whole as the XML predefined set (`&amp; &lt; &gt; &quot; &apos;`) plus `&nbsp;`
— the standard hand-rolled "unescape XML" idiom. It was never narrowed on
purpose and never considered-and-rejected for widening. The narrowness is
incidental, so nothing load-bearing is preserved by keeping it.

### Findings beyond the ticket

- **The defect class is much larger than two dash entities.** `&eacute;`,
  `&rsquo;`, `&laquo;`, `&hellip;`, `&apos;`, `&shy;` all survive and are spoken.
  `&eacute;` corrupts *every accented word* in a French book, not just openers —
  which is what disqualifies option 3 (TTS-side softening).
- **TTS does not read the parsed body.** It reads the stage-2 model's returned
  `SentenceOutput.text`, so the body-line symptom is conditional on the model
  echoing the entity — not verified here, and not assumed. **Chapter titles
  bypass the model entirely** and are the unconditional instance; that path is
  also immune to model behaviour, which is independent evidence for options 1/2
  over 3.
- **Three copies of the entity list exist**, not one — `stripHtml`,
  `extractFirstHeading` (which feeds the *spoken chapter title*), and `epub.ts`'s
  `decodeEntities` (whose "matches stripHtml" comment is already false). The plan
  collapses them into one shared helper.
- **The `dialogueOpen` entity alternatives stay** — they normalise LLM-returned
  text, which can echo an entity whatever the parser did. So #2289 is not dead
  weight to be reverted.
- Three edge cases a naive swap gets wrong are measured and handled:
  `decodeHTML` vs `decodeHTMLStrict` (the former corrupts `AT&T`-shaped prose),
  the invalid-numeric contract, and `&nbsp;`'s whitespace kind.

## Test plan

No code changes, so nothing to run — the deliverables are a spec, a plan, and an
issue brief.

Claims in both documents were **verified empirically rather than argued**, using
throwaway `tsx`/`node` probes against this worktree and `entities@8.0.0`: which
entities survive `stripHtml`, the exact `normaliseForTts` output for entity vs
glyph vs numeric input, `decodeHTML`-vs-`decodeHTMLStrict` on bare-ampersand
prose, the double-unescape cases, and **every test assertion written into the
plan** — which is how two wrong assertions were caught before they shipped as
red tests, and how one wrong claim in the spec's own first revision was found.

The mandatory Premium-tier `assumption-checker` pass ran against the spec; its
findings and dispositions are recorded in the spec's Appendix B. It contradicted
one Critical claim (the justification for retaining the dash shims), which was
verified independently, retracted, and replaced with a stronger reason.

**Per CLAUDE.md this is a docs-only PR and is therefore exempt from the
independent `pr-review-gate` review.** Release-notes entries are skipped: no
shippable delta yet — they land with the implementation PR.

**Do not merge as an approval of option 1.** Merging records the design; the
plan is explicitly marked contingent on the owner choosing option 1, which also
carries a new production dependency on `entities`.

Refs #2310
