### PR TITLE
fix(server): quarantine the flaky #2235 export revoke test

### DIFF
--- a/docs/testing/flaky-register.md
+++ b/docs/testing/flaky-register.md
@@ -25,7 +25,7 @@ it never gates a merge.
 | Test | File | Class | Symptom | Tracking issue | Quarantined |
 |------|------|-------|---------|----------------|-------------|
 | #1981 — a stale cast PUT does not erase a concurrently /assign-planted voice | `server/src/routes/book-state-preserve-voices.test.ts` | intermittent under full-suite box contention | Fails intermittently in a full `test:server` run under box contention; passes 7/7 in isolation. Observed 2026-08-07: `1 failed / 6741 passed`, `[fail] test:server (exit 1, took 746.6s)`. | #2226 | Not quarantined — still gates |
-| #2235 — revokes the older same-format manifest when a re-export of the same format finishes | `server/src/routes/export.test.ts` | intermittent under full-suite box contention | Fails on its first attempt and passes on retry inside a full `npm run test:server` run; surfaced only as a `[retry-hazard]` warning because vitest's `retry:1` absorbs it. Observed 2026-08-11 in the `dbcf36c5` pre-commit run (506 files / 7079 tests passed). | #2235 | Not quarantined — still gates |
+| #2235 — revokes the older same-format manifest when a re-export of the same format finishes | `server/src/routes/export.test.ts` | intermittent under full-suite box contention | Fails on its first attempt and passes on retry inside a full `npm run test:server` run; surfaced only as a `[retry-hazard]` warning because vitest's `retry:1` absorbs it. Observed 2026-08-11 in the `dbcf36c5` pre-commit run (506 files / 7079 tests passed). | #2235 | Quarantined — routes through `quarantinedIt` (2026-08-13); runs only under `RUN_QUARANTINE=1` |
 
 _Otherwise empty — no other tests are currently quarantined or tracked here._
 

--- a/server/src/routes/export.test.ts
+++ b/server/src/routes/export.test.ts
@@ -4,6 +4,7 @@
    the download endpoint streams the zip with the expected Content-Type. */
 
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { quarantinedIt } from '../test-utils/quarantine.js';
 import {
   mkdtempSync,
   mkdirSync,
@@ -431,7 +432,19 @@ describeIfFfmpeg('POST /api/books/:bookId/exports + GET status + download', () =
      assertion about a manifest file. The 404 test's own fix (poll the
      assertion instead of trusting one shot under load) is at its call site
      below. */
-  it('revokes the older same-format manifest when a re-export of the same format finishes', async () => {
+  // QUARANTINED(#2235): flaky under full-suite box contention — this case
+  // drives two REAL ffmpeg-based mp3-zip builds back-to-back, and a loaded
+  // runner (vitest retry:1 absorbing it) intermittently starves ffmpeg past
+  // waitForDone's 5 s window, failing first attempt with status 'failed' /
+  // timeout and passing on retry. That is resource contention, not a logic
+  // bug in the revoke code path (exercised green on every idle run). The
+  // crash-class sibling of #2235 — the archive-step cleanup running while a
+  // staged chapter read is still in flight, dying the process with an
+  // uncaught ENOENT — is closed by the read-stream error forwarding in
+  // build-mp3-zip.ts / build-codec-zip.ts + the _awaitInFlightExportJobs
+  // drain; this assertion remains quarantined until it is rewritten to not
+  // depend on real ffmpeg timing. See docs/testing/flaky-register.md.
+  quarantinedIt('revokes the older same-format manifest when a re-export of the same format finishes', async () => {
     const first = await request(app)
       .post(`/api/books/${bookId}/exports`)
       .send({ format: 'mp3-zip', destination: 'download' });


### PR DESCRIPTION
﻿Closes #2235

## Problem

`server/src/routes/export.test.ts` intermittently fails the whole file with an uncaught ENOENT on a chapter MP3 inside the export staging dir (`.bonus-story.zip.partial-exp_X.staging-<pid>-<ts>/02 - Chapter Two.mp3`). Under full-suite box contention it is ~1-in-2 standalone, and it reads as an infrastructure crash rather than a test failure.

## Root cause

Two distinct faces, both keyed on the export staging directory under `<bookDir>/exports/`:

1. **The process-dying crash class is already closed on `main`** (no change needed here):
   - `build-mp3-zip.ts` / `build-codec-zip.ts` forward every chapter read-stream `'error'` (the exact ENOENT in the issue) into `pipeline.rejectBuild()` - a normal rejection instead of an uncaught exception (commit `aca8ea36`).
   - Staging cleanup `rm(stagingDir)` only runs in the builder `finally` after `await pipeline.donePromise` - the archive step completes before teardown, exactly as the issue's acceptance requires.
   - `_awaitInFlightExportJobs()` (called in `beforeEach`/`afterAll` before any `rmSync`) drains pre-flight AND every in-flight job promise (including the job's own `finally`), so a fire-and-forget job can't still be writing when teardown removes the workspace.

2. **The residual gating flake** (the live `#2235` row in `docs/testing/flaky-register.md`): the **"revokes the older same-format manifest..."** case drives **two real ffmpeg-based mp3-zip builds back-to-back**. Under contention ffmpeg gets starved past `waitForDone`'s 5 s window - the export genuinely fails/times out on first attempt, absorbed only by vitest `retry:1`. This is resource contention, **not** a logic bug - it passes green on every idle run.

## Fix (the spec-compliant quarantine route)

A deterministic fix for the contended-ffmpeg case isn't reachable without mocking the build (destroying its integration value), so per the issue's acceptance / CLAUDE.md:

- `server/src/routes/export.test.ts` - imported `quarantinedIt` from `../test-utils/quarantine.js` and converted the flaky case, with a `// QUARANTINED(#2235): ...` comment. It is now skipped in every gating run and only runs in the `RUN_QUARANTINE=1` lane (`npm run test:quarantine`).
- `docs/testing/flaky-register.md` - flipped the `#2235` row from "Not quarantined - still gates" to "Quarantined - runs only under `RUN_QUARANTINE=1`".

## Verification

- `tsc --noEmit -p server` - clean.
- Gating run (`RUN_QUARANTINE` unset): **25 passed | 1 skipped** - the revoke case is correctly skipped, suite green.
- Quarantine lane (`RUN_QUARANTINE=1`): **26 passed (26)** - the revoke case still runs.
