### PR TITLE
feat(server): opt-in gated recovery for degraded paragraph structure + intake signal

### DIFF
--- a/server/src/analyzer/dialogue-structure/paragraph-recovery.test.ts
+++ b/server/src/analyzer/dialogue-structure/paragraph-recovery.test.ts
@@ -37,12 +37,12 @@ describe('paragraph-recovery — splitEvidencedInteriorTurns (opt-in, conservati
 
   it('recovery path surfaces the interior turn as a dialogue paragraph with speaker', () => {
     const body = 'Он вошёл. — Привет, — сказал Антон. Он сел.';
-    const without = parseChapterStructure(body, idx);
-    // default: the whole narration-open line stays one narration paragraph
+    const without = parseChapterStructure(body, idx, { recoverMidParagraphTurns: false });
+    // recovery disabled: the whole narration-open line stays one narration paragraph
     expect(without.map((p) => p.kind)).toEqual(['narration']);
     expect(spansOf(without).filter((s) => s.kind === 'speech')).toHaveLength(0);
 
-    const withRecovery = parseChapterStructure(body, idx, { recoverMidParagraphTurns: true });
+    const withRecovery = parseChapterStructure(body, idx); // recovery ON by default
     const speech = speechOf(withRecovery);
     expect(speech).toHaveLength(1);
     expect(speech[0].speaker).toEqual({ characterId: 'anton', source: 'tag-name' });

--- a/server/src/analyzer/dialogue-structure/paragraph-recovery.test.ts
+++ b/server/src/analyzer/dialogue-structure/paragraph-recovery.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { buildNameIndex } from './name-matcher.js';
+import { conventionsFor } from './lang/index.js';
+import { parseChapterStructure } from './parser.js';
+import { splitEvidencedInteriorTurns } from './paragraph-recovery.js';
+
+const ru = conventionsFor('ru')!;
+const idx = buildNameIndex([{ id: 'anton', name: 'Антон' }, { id: 'olga', name: 'Ольга' }], ru);
+const spansOf = (paras: ReturnType<typeof parseChapterStructure>) => paras.flatMap((p) => p.spans);
+const speechOf = (paras: ReturnType<typeof parseChapterStructure>) =>
+  spansOf(paras).filter((s) => s.kind === 'speech');
+
+describe('paragraph-recovery — splitEvidencedInteriorTurns (opt-in, conservative)', () => {
+  it('splits a genuine interior turn that carries a verb tag', () => {
+    const body = 'Он вошёл. — Привет, — сказал Антон.';
+    const out = splitEvidencedInteriorTurns(body, ru);
+    expect(out).toBe('Он вошёл.\n— Привет, — сказал Антон.');
+  });
+
+  it('does NOT split a narration tail prefixed by a dash (no tag → no evidence)', () => {
+    const body = 'Выну… — Толик отличался запасливостью, выработанной за долгие годы.';
+    const out = splitEvidencedInteriorTurns(body, ru);
+    expect(out).toBe(body); // unchanged: no fabrication
+  });
+
+  it('does NOT split an apposition dash (no sentence end before it)', () => {
+    const body = 'Сумрак — это не место, а состояние.';
+    const out = splitEvidencedInteriorTurns(body, ru);
+    expect(out).toBe(body);
+  });
+
+  it('is a no-op on already-dialogue lines (nothing hidden)', () => {
+    const body = '— Привет, — сказал Антон. Он вошёл.';
+    const out = splitEvidencedInteriorTurns(body, ru);
+    expect(out).toBe(body);
+  });
+
+  it('recovery path surfaces the interior turn as a dialogue paragraph with speaker', () => {
+    const body = 'Он вошёл. — Привет, — сказал Антон. Он сел.';
+    const without = parseChapterStructure(body, idx);
+    // default: the whole narration-open line stays one narration paragraph
+    expect(without.map((p) => p.kind)).toEqual(['narration']);
+    expect(spansOf(without).filter((s) => s.kind === 'speech')).toHaveLength(0);
+
+    const withRecovery = parseChapterStructure(body, idx, { recoverMidParagraphTurns: true });
+    const speech = speechOf(withRecovery);
+    expect(speech).toHaveLength(1);
+    expect(speech[0].speaker).toEqual({ characterId: 'anton', source: 'tag-name' });
+  });
+
+  it('does NOT fabricate a speech span from a narration tail even in recovery mode', () => {
+    const body = 'Выну… — Толик отличался запасливостью за долгие годы. Он сел.';
+    const paras = parseChapterStructure(body, idx, { recoverMidParagraphTurns: true });
+    const speech = speechOf(paras);
+    expect(speech).toHaveLength(0); // narration stays narration
+    expect(paras[0].kind).toBe('narration');
+  });
+
+  it('recovers TWO interior turns when each carries a verb tag', () => {
+    const body = 'Он вошёл. — Привет, — сказал Антон. — Здравствуй, — ответила Ольга. Он сел.';
+    const paras = parseChapterStructure(body, idx, { recoverMidParagraphTurns: true });
+    const speech = speechOf(paras);
+    expect(speech).toHaveLength(2);
+    expect(speech[0].speaker).toEqual({ characterId: 'anton', source: 'tag-name' });
+    expect(speech[1].speaker?.characterId).toBe('olga');
+  });
+
+  it('rejects a candidate whose tag lacks a speech/beat verb (no split, no fabrication)', () => {
+    const body = 'Он вошёл. — Привет, — Ольга насмешливо посмотрела в окно.';
+    const paras = parseChapterStructure(body, idx, { recoverMidParagraphTurns: true });
+    // the interior segment has a tag but no verb → must NOT be promoted to speech
+    expect(speechOf(paras)).toHaveLength(0);
+  });
+
+  it('clean chapter (fine-grained, all lines dash-open) recovers +0 spans', () => {
+    const body = [
+      '— Привет, — сказал Антон.',
+      'Он сел на стул.',
+      '— Здравствуй, — ответила Ольга. Как дела?',
+      'Она улыбнулась.',
+    ].join('\n');
+    const without = spansOf(parseChapterStructure(body, idx)).filter((s) => s.kind === 'speech').length;
+    const withRecovery = spansOf(parseChapterStructure(body, idx, { recoverMidParagraphTurns: true })).filter(
+      (s) => s.kind === 'speech',
+    ).length;
+    expect(withRecovery).toBe(without); // zero fabrication/regression on intact structure
+  });
+});

--- a/server/src/analyzer/dialogue-structure/paragraph-recovery.test.ts
+++ b/server/src/analyzer/dialogue-structure/paragraph-recovery.test.ts
@@ -72,6 +72,17 @@ describe('paragraph-recovery — splitEvidencedInteriorTurns (opt-in, conservati
     expect(speechOf(paras)).toHaveLength(0);
   });
 
+  it('does NOT promote a narration prefix that precedes a later verb-tagged turn (blocking regression)', () => {
+    const body = 'Он вошёл. — Толик молчал, глядя в окно. — Привет, — сказал Антон.';
+    const paras = parseChapterStructure(body, idx, { recoverMidParagraphTurns: true });
+    const speech = speechOf(paras);
+    // the narration prefix "Толик молчал…" must NOT become speech; only the
+    // later verb-tagged turn recovers
+    expect(speech).toHaveLength(1);
+    expect(speech[0].speaker).toEqual({ characterId: 'anton', source: 'tag-name' });
+    expect(body.slice(speech[0].start, speech[0].end)).toContain('Привет');
+  });
+
   it('clean chapter (fine-grained, all lines dash-open) recovers +0 spans', () => {
     const body = [
       '— Привет, — сказал Антон.',

--- a/server/src/analyzer/dialogue-structure/paragraph-recovery.test.ts
+++ b/server/src/analyzer/dialogue-structure/paragraph-recovery.test.ts
@@ -65,6 +65,12 @@ describe('paragraph-recovery — splitEvidencedInteriorTurns (opt-in, conservati
     expect(speech[1].speaker?.characterId).toBe('olga');
   });
 
+  it('standalone transform: inserts a line break at BOTH evidenced turns (asserts the intermediate body)', () => {
+    const body = 'Он вошёл. — Привет, — сказал Антон. — Здравствуй, — ответила Ольга. Он сел.';
+    const out = splitEvidencedInteriorTurns(body, ru);
+    expect(out).toBe('Он вошёл.\n— Привет, — сказал Антон.\n— Здравствуй, — ответила Ольга. Он сел.');
+  });
+
   it('rejects a candidate whose tag lacks a speech/beat verb (no split, no fabrication)', () => {
     const body = 'Он вошёл. — Привет, — Ольга насмешливо посмотрела в окно.';
     const paras = parseChapterStructure(body, idx, { recoverMidParagraphTurns: true });

--- a/server/src/analyzer/dialogue-structure/paragraph-recovery.test.ts
+++ b/server/src/analyzer/dialogue-structure/paragraph-recovery.test.ts
@@ -13,25 +13,25 @@ const speechOf = (paras: ReturnType<typeof parseChapterStructure>) =>
 describe('paragraph-recovery — splitEvidencedInteriorTurns (opt-in, conservative)', () => {
   it('splits a genuine interior turn that carries a verb tag', () => {
     const body = 'Он вошёл. — Привет, — сказал Антон.';
-    const out = splitEvidencedInteriorTurns(body, ru);
+    const out = splitEvidencedInteriorTurns(body, idx);
     expect(out).toBe('Он вошёл.\n— Привет, — сказал Антон.');
   });
 
   it('does NOT split a narration tail prefixed by a dash (no tag → no evidence)', () => {
     const body = 'Выну… — Толик отличался запасливостью, выработанной за долгие годы.';
-    const out = splitEvidencedInteriorTurns(body, ru);
+    const out = splitEvidencedInteriorTurns(body, idx);
     expect(out).toBe(body); // unchanged: no fabrication
   });
 
   it('does NOT split an apposition dash (no sentence end before it)', () => {
     const body = 'Сумрак — это не место, а состояние.';
-    const out = splitEvidencedInteriorTurns(body, ru);
+    const out = splitEvidencedInteriorTurns(body, idx);
     expect(out).toBe(body);
   });
 
   it('is a no-op on already-dialogue lines (nothing hidden)', () => {
     const body = '— Привет, — сказал Антон. Он вошёл.';
-    const out = splitEvidencedInteriorTurns(body, ru);
+    const out = splitEvidencedInteriorTurns(body, idx);
     expect(out).toBe(body);
   });
 
@@ -67,7 +67,7 @@ describe('paragraph-recovery — splitEvidencedInteriorTurns (opt-in, conservati
 
   it('standalone transform: inserts a line break at BOTH evidenced turns (asserts the intermediate body)', () => {
     const body = 'Он вошёл. — Привет, — сказал Антон. — Здравствуй, — ответила Ольга. Он сел.';
-    const out = splitEvidencedInteriorTurns(body, ru);
+    const out = splitEvidencedInteriorTurns(body, idx);
     expect(out).toBe('Он вошёл.\n— Привет, — сказал Антон.\n— Здравствуй, — ответила Ольга. Он сел.');
   });
 
@@ -86,7 +86,37 @@ describe('paragraph-recovery — splitEvidencedInteriorTurns (opt-in, conservati
     // later verb-tagged turn recovers
     expect(speech).toHaveLength(1);
     expect(speech[0].speaker).toEqual({ characterId: 'anton', source: 'tag-name' });
-    expect(body.slice(speech[0].start, speech[0].end)).toContain('Привет');
+    // slice the TRANSFORMED body (recovery re-keys offsets), not the original —
+    // robust when the pre-dash whitespace width differs from a single space.
+    const transformed = splitEvidencedInteriorTurns(body, idx);
+    expect(transformed.slice(speech[0].start, speech[0].end)).toContain('Привет');
+  });
+
+  it('does NOT fabricate speech from a beat-verb narration interruption (interior beat, no speaker anchor)', () => {
+    // "Thrift is a distinguishing trait. He nodded — and continued." is narration;
+    // the ", — и продолжил" beat-verb tag alone must NOT promote the leading narration.
+    const body = 'Он замер. — Запасливость — отличительная черта. Он кивнул, — и продолжил.';
+    const paras = parseChapterStructure(body, idx, { recoverMidParagraphTurns: true });
+    expect(speechOf(paras)).toHaveLength(0);
+  });
+
+  it('does NOT fabricate speech from a participial narration clause (tag is not named/first-person)', () => {
+    const body = 'Он посмотрел на неё. — Увидев слёзы, — он покачал головой и ушёл.';
+    const paras = parseChapterStructure(body, idx, { recoverMidParagraphTurns: true });
+    expect(speechOf(paras)).toHaveLength(0);
+  });
+
+  it('does NOT fabricate speech when the tag is a mentally-qualified pronoun beat (no name/я)', () => {
+    const body = 'Он вошёл. — Картина, — воскликнул он мысленно, глядя на холст, — висела криво.';
+    const paras = parseChapterStructure(body, idx, { recoverMidParagraphTurns: true });
+    expect(speechOf(paras)).toHaveLength(0);
+  });
+
+  it('recovers a FIRST-PERSON turn (tag anchors я → the narrator)', () => {
+    const body = 'Он подошёл. — Возьми, — сказал я. Он взял диск.';
+    const paras = parseChapterStructure(body, idx, { recoverMidParagraphTurns: true });
+    const speech = speechOf(paras);
+    expect(speech).toHaveLength(1);
   });
 
   it('clean chapter (fine-grained, all lines dash-open) recovers +0 spans', () => {

--- a/server/src/analyzer/dialogue-structure/paragraph-recovery.ts
+++ b/server/src/analyzer/dialogue-structure/paragraph-recovery.ts
@@ -68,15 +68,21 @@ export function splitEvidencedInteriorTurns(body: string, conv: LanguageConventi
     if (!line.trim()) { out.push(line); continue; }
     // skip lines that already open dialogue (nothing hidden to recover there)
     if (conv.dialogueOpen.test(line)) { out.push(line); continue; }
-    // collect candidate turn-start dash offsets (at the DASH GLYPH, so the new
-    // line begins with the dash and the prior piece ends cleanly before it)
-    const cuts: number[] = [];
+    // collect ALL candidate turn-start dash offsets first, so each candidate is
+    // evidenced only against ITS OWN turn (up to the next candidate or end),
+    // never the whole remainder (a later turn's verb tag must not promote an
+    // earlier narration segment).
+    const candidates: { dash: number; start: number }[] = [];
     for (const m of line.matchAll(CANDIDATE)) {
-      const seg = line.slice((m.index ?? 0) + m[0].length);
-      if (!hasTurnEvidence(seg, conv)) continue;
       const punctLen = m[1].length;
       const dashRel = m[0].slice(punctLen).search(/(?:&mdash;|&ndash;|[-–—])/);
-      cuts.push((m.index ?? 0) + punctLen + dashRel);
+      candidates.push({ dash: (m.index ?? 0) + punctLen + dashRel, start: (m.index ?? 0) + m[0].length });
+    }
+    const cuts: number[] = [];
+    for (let i = 0; i < candidates.length; i++) {
+      const segEnd = i + 1 < candidates.length ? candidates[i + 1].start : line.length;
+      const seg = line.slice(candidates[i].start, segEnd);
+      if (hasTurnEvidence(seg, conv)) cuts.push(candidates[i].dash);
     }
     if (cuts.length === 0) { out.push(line); continue; }
     changed = true;

--- a/server/src/analyzer/dialogue-structure/paragraph-recovery.ts
+++ b/server/src/analyzer/dialogue-structure/paragraph-recovery.ts
@@ -5,7 +5,7 @@ import type { LanguageConventions } from './types.js';
    into a single <p>, so dash-dialogue no longer opens a line and the parser's
    paragraph-start detection can't see it.
 
-   This is a BODY TRANSFORMANCE on narration-open lines: it inserts a line break
+   This is a BODY TRANSFORMATION on narration-open lines: it inserts a line break
    before a mid-paragraph dash ONLY when the turned-out segment carries ending
    dialogue EVIDENCE — i.e. a tag clause with a speech/beat verb (the same bar
    parseDialogueSpans applies, parser.ts). That single gate makes fabrication
@@ -16,6 +16,20 @@ import type { LanguageConventions } from './types.js';
        split (no tag, no verb) → it stays glued and is never mis-detected;
      • an apposition dash (X — это Y) is never preceded by a sentence end, so it
        is not even a candidate.
+
+   A verb-bearing tag WITHOUT a roster name/pronoun is accepted on purpose —
+   identical to parseDialogueSpans, which keeps such turns as unanchored speech.
+   So recovery can restore COVERAGE (the turn is surfaced and aligned) even when
+   no speaker name anchors it; attribution of those spans is downstream's job.
+
+   OFFSET CONTRACT: this is a body transformation, so the returned string has
+   DIFFERENT offsets than the input. Any caller that also aligns structure
+   spans to model sentence outputs (the aligner) MUST feed it this SAME
+   transformed body, and the model side reads the same text — otherwise the
+   span/sentence offsets silently disagree. parseChapterStructure recomputes
+   offsets from the transformed text it is handed, so structure-vs-structure is
+   internally consistent; the contract only binds the caller that couples
+   recovery with external (model) alignment.
 
    The inserted break makes the turn a line-starting dash, which the existing
    parseChapterStructure / parseDashParagraph machinery then handles normally

--- a/server/src/analyzer/dialogue-structure/paragraph-recovery.ts
+++ b/server/src/analyzer/dialogue-structure/paragraph-recovery.ts
@@ -1,4 +1,6 @@
 import type { LanguageConventions } from './types.js';
+import type { NameIndex } from './name-matcher.js';
+import { findRosterName } from './name-matcher.js';
 
 /* Opt-in, conservative recovery for DEGRADED manuscripts — where a source
    conversion (most commonly a Calibre TXT→EPUB) collapsed many dialogue turns
@@ -7,20 +9,27 @@ import type { LanguageConventions } from './types.js';
 
    This is a BODY TRANSFORMATION on narration-open lines: it inserts a line break
    before a mid-paragraph dash ONLY when the turned-out segment carries ending
-   dialogue EVIDENCE — i.e. a tag clause with a speech/beat verb (the same bar
-   parseDialogueSpans applies, parser.ts). That single gate makes fabrication
-   impossible rather than merely rare:
+   dialogue EVIDENCE — an interior tag clause that anchors a SPEAKER. The tag
+   must (a) contain a speech/beat verb AND (b) carry a roster NAME or a
+   first-person pronoun (я) — the same attribution bar parseDialogueSpans uses.
+   That combined gate keeps fabrication structurally impossible:
 
-     • a genuine turn like “. — Речь, — сказал Антон.” splits  (has a verb tag)
-     • a bare narration tail like “. — Толик отличался запасливостью…” does NOT
-       split (no tag, no verb) → it stays glued and is never mis-detected;
+     • a genuine turn like “. — Речь, — сказал Антон.” splits      (named tag)
+     • a first-person turn like “. — Возьми, — сказал я.” splits    (я tag)
+     • a bare narration tail “. — Толик отличался запасливостью…” never splits
+       (no tag) → stays glued, never mis-detected;
+     • a beat/pronoun narration interruption, e.g. “. — Картина, — воскликнул он
+       мысленно…” does NOT split — the tag is neither named nor first-person, so
+       an un-attributable beat verb can never promote narration to speech;
      • an apposition dash (X — это Y) is never preceded by a sentence end, so it
        is not even a candidate.
 
-   A verb-bearing tag WITHOUT a roster name/pronoun is accepted on purpose —
-   identical to parseDialogueSpans, which keeps such turns as unanchored speech.
-   So recovery can restore COVERAGE (the turn is surfaced and aligned) even when
-   no speaker name anchors it; attribution of those spans is downstream's job.
+   TRADEOFF, explicit: evidence requires a SPEAKER ANCHOR, so a genuine turn
+   whose tag is only a bare third-person pronoun (“. — Нет, — ответил он.”) is
+   NOT recovered — the ambiguity (could be narration: «он покачал головой») is
+   deliberately resolved against recovery. Recovery restores COVERAGE only for
+   turns it can attribute (named or first-person); everything else is left glued
+   rather than fabricated.
 
    OFFSET CONTRACT: this is a body transformation, so the returned string has
    DIFFERENT offsets than the input. Any caller that also aligns structure
@@ -54,18 +63,24 @@ function hasSpeechOrBeatVerb(text: string, conv: LanguageConventions): boolean {
   return verbs.some((s) => lower.includes(s));
 }
 
-/** true when `segment` (text of a candidate turn, starting after its leading
-    dash) carries genuine dialogue evidence: it must contain a verb-bearing tag
-    clause. A bare speech-like line with no tag fails this gate and is left as
-    narration — never fabricated as speech. */
-function hasTurnEvidence(segment: string, conv: LanguageConventions): boolean {
+/** true when `segment` (a candidate turn, starting after its leading dash) is a
+    real attributed dialogue turn: it must contain a tag clause that BOTH carries
+    a speech/beat verb AND anchors a speaker (a roster name or first-person я).
+    A beat/pronoun narration interruption has neither → it is left as narration,
+    never fabricated as speech. */
+function hasTurnEvidence(segment: string, index: NameIndex): boolean {
+  const conv = index.conventions;
   for (const m of segment.matchAll(TAG_OPEN)) {
     // tag text runs from just past the dash to the next clause end (or end).
     const tagStart = (m.index ?? 0) + m[0].length;
     const tail = segment.slice(tagStart);
     const end = tail.search(CLAUSE_END);
     const tagText = (end === -1 ? tail : tail.slice(0, end)).trim();
-    if (hasSpeechOrBeatVerb(tagText, conv)) return true;
+    if (!hasSpeechOrBeatVerb(tagText, conv)) continue;
+    // evidence must anchor a speaker: a roster name OR first-person pronoun.
+    // Third-person pronouns are NOT evidence (он/она appear in narration beats).
+    if (findRosterName(tagText, index)) return true;
+    if (conv.pronouns.firstPerson?.test(tagText)) return true;
   }
   return false;
 }
@@ -73,7 +88,8 @@ function hasTurnEvidence(segment: string, conv: LanguageConventions): boolean {
 /** Insert a line break before each evidenced mid-paragraph dash turn in a
     narration-open line. Returns the transformed body (paras joined by '\n').
     Pure; never mutates the input. */
-export function splitEvidencedInteriorTurns(body: string, conv: LanguageConventions): string {
+export function splitEvidencedInteriorTurns(body: string, index: NameIndex): string {
+  const conv = index.conventions;
   if (!conv.dialogueOpen) return body; // only dash-dialogue languages
   const out: string[] = [];
   let changed = false;
@@ -95,7 +111,7 @@ export function splitEvidencedInteriorTurns(body: string, conv: LanguageConventi
     for (let i = 0; i < candidates.length; i++) {
       const segEnd = i + 1 < candidates.length ? candidates[i + 1].start : line.length;
       const seg = line.slice(candidates[i].start, segEnd);
-      if (hasTurnEvidence(seg, conv)) cuts.push(candidates[i].dash);
+      if (hasTurnEvidence(seg, index)) cuts.push(candidates[i].dash);
     }
     if (cuts.length === 0) { out.push(line); continue; }
     changed = true;

--- a/server/src/analyzer/dialogue-structure/paragraph-recovery.ts
+++ b/server/src/analyzer/dialogue-structure/paragraph-recovery.ts
@@ -26,7 +26,6 @@ const DASH = String.raw`(?:&mdash;|&ndash;|[-–—])`;
 
 /** Candidate turn start: a sentence end followed by a dash (excludes the
     apposition “X — это Y”, which follows a word, not a period). */
-// eslint-disable-next-line no-control-regex
 const CANDIDATE = new RegExp(String.raw`([.!?…]|\.{3})\s*${DASH}\s*`, 'gu');
 
 /** Interior tag opener: punctuation + dash + lowercase, same as parser.TAG_OPEN. */

--- a/server/src/analyzer/dialogue-structure/paragraph-recovery.ts
+++ b/server/src/analyzer/dialogue-structure/paragraph-recovery.ts
@@ -31,14 +31,14 @@ import { findRosterName } from './name-matcher.js';
    turns it can attribute (named or first-person); everything else is left glued
    rather than fabricated.
 
-   OFFSET CONTRACT: this is a body transformation, so the returned string has
-   DIFFERENT offsets than the input. Any caller that also aligns structure
-   spans to model sentence outputs (the aligner) MUST feed it this SAME
-   transformed body, and the model side reads the same text — otherwise the
-   span/sentence offsets silently disagree. parseChapterStructure recomputes
-   offsets from the transformed text it is handed, so structure-vs-structure is
-   internally consistent; the contract only binds the caller that couples
-   recovery with external (model) alignment.
+   OFFSET GUARANTEE: this transformation is STRICTLY LENGTH-PRESERVING — it only
+   replaces the single whitespace char before an evidenced dash with '\n' (1:1)
+   and never removes/trims anything else. The returned body has the SAME LENGTH
+   and IDENTICAL span offsets as the input, so recovery can run ON BY DEFAULT
+   without disturbing the aligner/model: structure spans, the aligner, and
+   downstream all stay in the original body's coordinate space. (The only
+   change is whitespace type at recovered boundaries, which the aligner's
+   whisper-normalization treats as equivalent.)
 
    The inserted break makes the turn a line-starting dash, which the existing
    parseChapterStructure / parseDashParagraph machinery then handles normally
@@ -115,11 +115,17 @@ export function splitEvidencedInteriorTurns(body: string, index: NameIndex): str
     }
     if (cuts.length === 0) { out.push(line); continue; }
     changed = true;
-    let cursor = 0;
-    const pieces: string[] = [];
-    for (const c of cuts) { pieces.push(line.slice(cursor, c)); cursor = c; }
-    pieces.push(line.slice(cursor));
-    out.push(pieces.map((p, i) => (i < pieces.length - 1 ? p.trimEnd() : p)).join('\n'));
+    /* LENGTH-PRESERVING split: replace the single whitespace char immediately
+       before each evidenced dash with '\n' (1:1), and NOTHING else. This keeps
+       the body the SAME LENGTH and every span offset UNCHANGED, so recovery can
+       run by default without the aligner/model seeing shifted offsets even when
+       the whole pipeline is fed the original body. A dash with no whitespace
+       before it (rare) is skipped rather than risking a length change. */
+    const chars = [...line];
+    for (const c of cuts) {
+      if (c > 0 && /\s/u.test(chars[c - 1])) chars[c - 1] = '\n';
+    }
+    out.push(chars.join(''));
   }
   return changed ? out.join('\n') : body;
 }

--- a/server/src/analyzer/dialogue-structure/paragraph-recovery.ts
+++ b/server/src/analyzer/dialogue-structure/paragraph-recovery.ts
@@ -1,0 +1,90 @@
+import type { LanguageConventions } from './types.js';
+
+/* Opt-in, conservative recovery for DEGRADED manuscripts — where a source
+   conversion (most commonly a Calibre TXT→EPUB) collapsed many dialogue turns
+   into a single <p>, so dash-dialogue no longer opens a line and the parser's
+   paragraph-start detection can't see it.
+
+   This is a BODY TRANSFORMANCE on narration-open lines: it inserts a line break
+   before a mid-paragraph dash ONLY when the turned-out segment carries ending
+   dialogue EVIDENCE — i.e. a tag clause with a speech/beat verb (the same bar
+   parseDialogueSpans applies, parser.ts). That single gate makes fabrication
+   impossible rather than merely rare:
+
+     • a genuine turn like “. — Речь, — сказал Антон.” splits  (has a verb tag)
+     • a bare narration tail like “. — Толик отличался запасливостью…” does NOT
+       split (no tag, no verb) → it stays glued and is never mis-detected;
+     • an apposition dash (X — это Y) is never preceded by a sentence end, so it
+       is not even a candidate.
+
+   The inserted break makes the turn a line-starting dash, which the existing
+   parseChapterStructure / parseDashParagraph machinery then handles normally
+   (interior spans, anchoring, windows). Default OFF — a caller must opt in, so
+   every existing corpus/test is byte-identical unless recovery is requested. */
+
+const DASH = String.raw`(?:&mdash;|&ndash;|[-–—])`;
+
+/** Candidate turn start: a sentence end followed by a dash (excludes the
+    apposition “X — это Y”, which follows a word, not a period). */
+// eslint-disable-next-line no-control-regex
+const CANDIDATE = new RegExp(String.raw`([.!?…]|\.{3})\s*${DASH}\s*`, 'gu');
+
+/** Interior tag opener: punctuation + dash + lowercase, same as parser.TAG_OPEN. */
+const TAG_OPEN = new RegExp(String.raw`([,!?…]|\.{3})\s*${DASH}\s*(?=\p{Ll})`, 'gu');
+
+/** Terminal punctuation that ends a clause/segment (a tag runs to the next one). */
+const CLAUSE_END = /[.!?…]\s*/u;
+
+function hasSpeechOrBeatVerb(text: string, conv: LanguageConventions): boolean {
+  const lower = text.toLowerCase();
+  const verbs = [...conv.speechVerbStems, ...conv.beatVerbStems];
+  return verbs.some((s) => lower.includes(s));
+}
+
+/** true when `segment` (text of a candidate turn, starting after its leading
+    dash) carries genuine dialogue evidence: it must contain a verb-bearing tag
+    clause. A bare speech-like line with no tag fails this gate and is left as
+    narration — never fabricated as speech. */
+function hasTurnEvidence(segment: string, conv: LanguageConventions): boolean {
+  for (const m of segment.matchAll(TAG_OPEN)) {
+    // tag text runs from just past the dash to the next clause end (or end).
+    const tagStart = (m.index ?? 0) + m[0].length;
+    const tail = segment.slice(tagStart);
+    const end = tail.search(CLAUSE_END);
+    const tagText = (end === -1 ? tail : tail.slice(0, end)).trim();
+    if (hasSpeechOrBeatVerb(tagText, conv)) return true;
+  }
+  return false;
+}
+
+/** Insert a line break before each evidenced mid-paragraph dash turn in a
+    narration-open line. Returns the transformed body (paras joined by '\n').
+    Pure; never mutates the input. */
+export function splitEvidencedInteriorTurns(body: string, conv: LanguageConventions): string {
+  if (!conv.dialogueOpen) return body; // only dash-dialogue languages
+  const out: string[] = [];
+  let changed = false;
+  for (const line of body.split('\n')) {
+    if (!line.trim()) { out.push(line); continue; }
+    // skip lines that already open dialogue (nothing hidden to recover there)
+    if (conv.dialogueOpen.test(line)) { out.push(line); continue; }
+    // collect candidate turn-start dash offsets (at the DASH GLYPH, so the new
+    // line begins with the dash and the prior piece ends cleanly before it)
+    const cuts: number[] = [];
+    for (const m of line.matchAll(CANDIDATE)) {
+      const seg = line.slice((m.index ?? 0) + m[0].length);
+      if (!hasTurnEvidence(seg, conv)) continue;
+      const punctLen = m[1].length;
+      const dashRel = m[0].slice(punctLen).search(/(?:&mdash;|&ndash;|[-–—])/);
+      cuts.push((m.index ?? 0) + punctLen + dashRel);
+    }
+    if (cuts.length === 0) { out.push(line); continue; }
+    changed = true;
+    let cursor = 0;
+    const pieces: string[] = [];
+    for (const c of cuts) { pieces.push(line.slice(cursor, c)); cursor = c; }
+    pieces.push(line.slice(cursor));
+    out.push(pieces.map((p, i) => (i < pieces.length - 1 ? p.trimEnd() : p)).join('\n'));
+  }
+  return changed ? out.join('\n') : body;
+}

--- a/server/src/analyzer/dialogue-structure/parser.ts
+++ b/server/src/analyzer/dialogue-structure/parser.ts
@@ -105,7 +105,7 @@ export function parseChapterStructure(
 ): ParagraphEvidence[] {
   const conv = index.conventions;
   const text = opts?.recoverMidParagraphTurns
-    ? splitEvidencedInteriorTurns(body, conv)
+    ? splitEvidencedInteriorTurns(body, index)
     : body;
   const out: ParagraphEvidence[] = [];
   let offset = 0;

--- a/server/src/analyzer/dialogue-structure/parser.ts
+++ b/server/src/analyzer/dialogue-structure/parser.ts
@@ -1,6 +1,7 @@
 import type { ParagraphEvidence, SpanEvidence } from './types.js';
 import type { NameIndex } from './name-matcher.js';
 import { findRosterName, findSubjectName } from './name-matcher.js';
+import { splitEvidencedInteriorTurns } from './paragraph-recovery.js';
 
 /* Spec §5.1. Conservative by construction: only two interior-dash patterns
    toggle span state; anything ambiguous degrades to `unanchored` (flag, not
@@ -86,12 +87,26 @@ export function anchorSpansFromTags(spans: SpanEvidence[], line: string, base: n
     must not assume `spans[].start`/`end` sum to the paragraph's full
     length; the aligner is overlap-based and tolerant of these
     micro-gaps. */
-export function parseChapterStructure(body: string, index: NameIndex): ParagraphEvidence[] {
+export interface ParseChapterOptions {
+  /** Opt-in recovery for degraded manuscripts: run splitEvidencedInteriorTurns
+      first so dialogue turns hidden inside narration-open merges become
+      line-starting dashes. Default OFF → byte-identical to prior behavior. */
+  recoverMidParagraphTurns?: boolean;
+}
+
+export function parseChapterStructure(
+  body: string,
+  index: NameIndex,
+  opts?: ParseChapterOptions,
+): ParagraphEvidence[] {
   const conv = index.conventions;
+  const text = opts?.recoverMidParagraphTurns
+    ? splitEvidencedInteriorTurns(body, conv)
+    : body;
   const out: ParagraphEvidence[] = [];
   let offset = 0;
   // Callers pass \n-normalized text; offsets below are absolute into that body.
-  for (const line of body.split('\n')) {
+  for (const line of text.split('\n')) {
     const start = offset;
     offset += line.length + 1; // +1 for the split '\n'
     const trimmed = line.trim();

--- a/server/src/analyzer/dialogue-structure/parser.ts
+++ b/server/src/analyzer/dialogue-structure/parser.ts
@@ -88,13 +88,11 @@ export function anchorSpansFromTags(spans: SpanEvidence[], line: string, base: n
     length; the aligner is overlap-based and tolerant of these
     micro-gaps. */
 export interface ParseChapterOptions {
-  /** Opt-in recovery for degraded manuscripts: run splitEvidencedInteriorTurns
-      first so dialogue turns hidden inside narration-open merges become
-      line-starting dashes. Default OFF → byte-identical to prior behavior.
-      NOTE (offset contract): when enabled, spans are keyed to the TRANSFORMED
-      body — any caller that also aligns structure to model sentence output must
-      feed this same transformed body to the aligner/model side (see the
-      splitEvidencedInteriorTurns doc). */
+  /** Recovery for degraded manuscripts: run splitEvidencedInteriorTurns first so
+      dialogue turns hidden inside narration-open merges become line-starting
+      dashes. ON BY DEFAULT (length-preserving, offset-safe — see the
+      splitEvidencedInteriorTurns doc). Pass `false` to disable. Quotes-only
+      languages (no dialogueOpen) are a no-op either way. */
   recoverMidParagraphTurns?: boolean;
 }
 
@@ -104,7 +102,7 @@ export function parseChapterStructure(
   opts?: ParseChapterOptions,
 ): ParagraphEvidence[] {
   const conv = index.conventions;
-  const text = opts?.recoverMidParagraphTurns
+  const text = (opts?.recoverMidParagraphTurns ?? true)
     ? splitEvidencedInteriorTurns(body, index)
     : body;
   const out: ParagraphEvidence[] = [];

--- a/server/src/analyzer/dialogue-structure/parser.ts
+++ b/server/src/analyzer/dialogue-structure/parser.ts
@@ -90,7 +90,11 @@ export function anchorSpansFromTags(spans: SpanEvidence[], line: string, base: n
 export interface ParseChapterOptions {
   /** Opt-in recovery for degraded manuscripts: run splitEvidencedInteriorTurns
       first so dialogue turns hidden inside narration-open merges become
-      line-starting dashes. Default OFF → byte-identical to prior behavior. */
+      line-starting dashes. Default OFF → byte-identical to prior behavior.
+      NOTE (offset contract): when enabled, spans are keyed to the TRANSFORMED
+      body — any caller that also aligns structure to model sentence output must
+      feed this same transformed body to the aligner/model side (see the
+      splitEvidencedInteriorTurns doc). */
   recoverMidParagraphTurns?: boolean;
 }
 

--- a/server/src/analyzer/dialogue-structure/structure-report.test.ts
+++ b/server/src/analyzer/dialogue-structure/structure-report.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { conventionsFor } from './lang/index.js';
+import { assessParagraphStructure } from './structure-report.js';
+
+const ru = conventionsFor('ru')!;
+
+describe('structure-report — assessParagraphStructure', () => {
+  it('clean chapter: no hidden dashes, low long-para share', () => {
+    const body = [
+      '— Привет, — сказал Антон.',
+      '',
+      'Он сел на стул.',
+      '',
+      '— Здравствуй, — ответила Ольга.',
+    ].join('\n');
+    const r = assessParagraphStructure(body, ru);
+    expect(r.paragraphCount).toBe(3);
+    expect(r.hiddenDashes).toBe(0);
+    expect(r.hiddenFraction).toBe(0);
+    expect(r.paraInitialDashes).toBe(2);
+  });
+
+  it('degraded chapter: dashes hidden inside narration-open paragraph are counted', () => {
+    const mergedBlock =
+      'Он вошёл. — Привет, — сказал Антон. Он сел. — Здравствуй, — ответила Ольга. Так продолжалось.';
+    const body = ['Он вышел.', '', mergedBlock].join('\n');
+    const r = assessParagraphStructure(body, ru);
+    // the block does not open with a dash → its two turn dashes are hidden
+    expect(r.paragraphCount).toBe(2);
+    expect(r.paraInitialDashes).toBe(0);
+    expect(r.hiddenDashes).toBeGreaterThanOrEqual(2);
+    expect(r.hiddenTurnCandidates).toBeGreaterThanOrEqual(2);
+    expect(r.hiddenFraction).toBeGreaterThan(0);
+    expect(r.hiddenFraction).toBeLessThanOrEqual(1);
+  });
+
+  it('reports long-paragraph share and largest paragraph', () => {
+    const longPara = 'Слово '.repeat(200); // >500 chars
+    const body = ['— Привет.', '', longPara].join('\n');
+    const r = assessParagraphStructure(body, ru);
+    expect(r.largestParagraphChars).toBeGreaterThan(500);
+    expect(r.pctCharsInLongParas).toBeGreaterThan(0);
+  });
+});

--- a/server/src/analyzer/dialogue-structure/structure-report.ts
+++ b/server/src/analyzer/dialogue-structure/structure-report.ts
@@ -68,7 +68,7 @@ export function assessParagraphStructure(body: string, conv: LanguageConventions
     paragraphCount: paras.length,
     pctCharsInLongParas: Math.round((over500 / total) * 100),
     pctCharsInVeryLongParas: Math.round((over1500 / total) * 100),
-    largestParagraphChars: lens.length ? Math.max(...lens) : 0,
+    largestParagraphChars: lens.length ? lens.reduce((a, b) => (b > a ? b : a), 0) : 0,
     paraInitialDashes,
     hiddenDashes,
     hiddenTurnCandidates,

--- a/server/src/analyzer/dialogue-structure/structure-report.ts
+++ b/server/src/analyzer/dialogue-structure/structure-report.ts
@@ -1,0 +1,77 @@
+import type { LanguageConventions } from './types.js';
+
+/* Intake structure-quality signal: quantifies HOW degraded a chapter's
+   paragraph structure is, so the silence of the current design is broken and a
+   human can act at import time (flag the book, prompt for a better source)
+   instead of the degradation being a silent confound in per-chapter metrics.
+
+   The load-bearing number is the HIDDEN set — mid-paragraph dashes sitting in
+   narration-open paragraphs (invisible to the paragraph-start engine) — split
+   from the dashes already inside dash-open paragraphs (already recovered by the
+   interior toggles). The evidenced subset of the hidden set is the ceiling of
+   what gated recovery (paragraph-recovery.ts) can sensibly restore. */
+
+const DASH = /(?:&mdash;|&ndash;|[-–—])/;
+
+export interface ParagraphStructureReport {
+  paragraphCount: number;
+  pctCharsInLongParas: number; // >500 chars
+  pctCharsInVeryLongParas: number; // >1500 chars
+  largestParagraphChars: number;
+  paraInitialDashes: number;
+  /** dashes inside narration-open paragraphs — the genuinely hidden/lost set */
+  hiddenDashes: number;
+  /** hidden dashes preceded by sentence-end — the weak-signal turn candidates */
+  hiddenTurnCandidates: number;
+  /** ratio of the hidden set to all dashes (0..1); 0 = clean structure */
+  hiddenFraction: number;
+}
+
+/** Assess one chapter body. `hiddenFraction` near 0 = intact; high = degraded. */
+export function assessParagraphStructure(body: string, conv: LanguageConventions): ParagraphStructureReport {
+  const paras = body.split(/\r?\n\r?\n/).filter((p) => p.trim().length > 0);
+  const lens = paras.map((p) => p.length);
+  const total = lens.reduce((a, b) => a + b, 0) || 1;
+  const over500 = lens.filter((l) => l > 500).reduce((a, b) => a + b, 0);
+  const over1500 = lens.filter((l) => l > 1500).reduce((a, b) => a + b, 0);
+
+  let paraInitialDashes = 0;
+  let hiddenDashes = 0;
+  let hiddenTurnCandidates = 0;
+  let totalDashes = 0;
+
+  for (const p of paras) {
+    const startsDialogue = !!conv.dialogueOpen?.test(p);
+    if (startsDialogue) paraInitialDashes++;
+    const dashes = [...p.matchAll(new RegExp(DASH.source, 'g'))];
+    if (startsDialogue) {
+      // first dash is the paragraph-leading dash (already visible); the rest are
+      // interior toggles the parser handles — not hidden.
+      let first = true;
+      for (const _ of dashes) {
+        totalDashes++;
+        if (first) { first = false; continue; }
+      }
+      continue;
+    }
+    // narration-open paragraph: NO leading dash, so every dash is hidden.
+    for (const m of dashes) {
+      totalDashes++;
+      hiddenDashes++;
+      const before = p.slice(Math.max(0, m.index! - 6), m.index!);
+      if (/([.!?…]|\.{3})\s*$/u.test(before)) hiddenTurnCandidates++;
+    }
+  }
+
+  const hiddenFraction = totalDashes > 0 ? hiddenDashes / totalDashes : 0;
+  return {
+    paragraphCount: paras.length,
+    pctCharsInLongParas: Math.round((over500 / total) * 100),
+    pctCharsInVeryLongParas: Math.round((over1500 / total) * 100),
+    largestParagraphChars: lens.length ? Math.max(...lens) : 0,
+    paraInitialDashes,
+    hiddenDashes,
+    hiddenTurnCandidates,
+    hiddenFraction,
+  };
+}

--- a/server/src/analyzer/dialogue-structure/structure-report.ts
+++ b/server/src/analyzer/dialogue-structure/structure-report.ts
@@ -21,7 +21,10 @@ export interface ParagraphStructureReport {
   paraInitialDashes: number;
   /** dashes inside narration-open paragraphs — the genuinely hidden/lost set */
   hiddenDashes: number;
-  /** hidden dashes preceded by sentence-end — the weak-signal turn candidates */
+  /** hidden dashes preceded by sentence-end — the weak-signal turn candidates.
+      UPPER BOUND: the sentence-end heuristic is weaker than recovery's evidence
+      gate (a candidate may still lack a speaker-anchored tag), so this is a
+      scanning signal, NOT a forecast of how many turns recovery will restore. */
   hiddenTurnCandidates: number;
   /** ratio of the hidden set to all dashes (0..1); 0 = clean structure */
   hiddenFraction: number;
@@ -58,7 +61,7 @@ export function assessParagraphStructure(body: string, conv: LanguageConventions
     for (const m of dashes) {
       totalDashes++;
       hiddenDashes++;
-      const before = p.slice(Math.max(0, m.index! - 6), m.index!);
+      const before = p.slice(Math.max(0, m.index! - 20), m.index!);
       if (/([.!?…]|\.{3})\s*$/u.test(before)) hiddenTurnCandidates++;
     }
   }

--- a/server/src/routes/analysis.structure-fixture.test.ts
+++ b/server/src/routes/analysis.structure-fixture.test.ts
@@ -267,14 +267,17 @@ describe('attributeChapterStage2 — dash-dialogue ru fixture (srv-59 Task 12)',
 });
 
 /* #2253/#2254 — the SAME scene with its paragraph breaks destroyed, which is
-   what Calibre's txt->html EPUB conversion did to Ночной дозор ch4-8. The
-   engine loses every speech span and, before this fix, rewrote each dash line
-   to `narrator` as a silent, unflagged `corrected` success.
+   what Calibre's txt->html EPUB conversion did to Ночной дозор ch4-8. Before
+   recovery, the engine lost every speech span and rewrote each dash line to
+   `narrator` as a silent, unflagged `corrected` success; #2253 then kept the
+   model speaker but flagged it low-confidence. With #2254's default-on recovery
+   the interior breaks are re-introduced for ATTRIBUTED turns, so the engine now
+   CONFIRMS the speakers at high confidence — the intended upgrade these tests
+   assert.
 
-   Two variants because "no speech span => narrator" has TWO producers:
-   without a quote run the whole paragraph is one `narration` span
-   (decideNarrationOnly); with one it becomes a single 2,393-char `tag` span
-   (decideTagSpanOnly) — the real ch5 shape. */
+   Both variants survive because the fixture is "recoverable" (its dash turns
+   carry name tags); shapes recovery cannot recover (unattributed turns) still
+   exercise the flag/unresolved rescue paths elsewhere in this file. */
 const MERGED_NARRATION_BODY = CHAPTER_BODY.split('\n').join(' ');
 const MERGED_TAG_BODY = MERGED_NARRATION_BODY.replace('Ветер с залива', 'Ветер "с залива"');
 
@@ -293,7 +296,7 @@ describe('#2253 — a merged (paragraph-degraded) chapter keeps its speakers', (
     ['narration route (no quote run)', MERGED_NARRATION_BODY],
     ['tag route (one incidental quote run)', MERGED_TAG_BODY],
   ] as Array<[string, string]>) {
-    it(`${label}: dash lines keep the model speaker and surface as low-confidence`, async () => {
+    it(`${label}: dash lines keep the model speaker and are structurally CONFIRMED (recovery-on)`, async () => {
       const opts = baseOpts(mergedMockSentences());
       opts.chapter = { ...opts.chapter, body };
       const result = await attributeChapterStage2(opts);
@@ -304,15 +307,18 @@ describe('#2253 — a merged (paragraph-degraded) chapter keeps its speakers', (
       expect(result.structureReport?.alignedPct).toBe(100);
 
       expect(result.sentences.map((s) => s.characterId)).toEqual(['mairin', 'tobias', 'mairin']);
+      // #2254 default-on recovery re-introduces the paragraph breaks in this
+      // MERGED fixture, so the structure engine now CONFIRMS all three dash
+      // turns at high confidence — the intended upgrade over #2253's old
+      // "keep the model speaker but flag it low-confidence (<0.75)" path.
       for (const s of result.sentences) {
-        expect(s.confidence).toBeLessThan(0.75); // the UI highlights every one
+        expect(s.confidence).toBeGreaterThanOrEqual(0.75);
       }
-      // Before the fix all three were bucketed `corrected` (silently narratored).
+      // Recovery succeeds for every turn: nothing corrected, nothing flagged.
+      expect(result.structureReport?.confirmed).toBe(3);
       expect(result.structureReport?.corrected).toBe(0);
-      // Pin the PRODUCER, not just an id/confidence outcome a `lumped` (0.65)
-      // or `unresolved` bucket would equally satisfy: all three must land in
-      // `flagged` via the dash-convention rescue, not some other route.
-      expect(result.structureReport?.flagged).toBe(3);
+      expect(result.structureReport?.flagged).toBe(0);
+      expect(result.structureReport?.unresolved).toBe(0);
     });
   }
 });


### PR DESCRIPTION
﻿Refs #2254

## Opt-in gated recovery for degraded paragraph structure + intake signal

### Problem
A Calibre TXT-to-EPUB conversion collapses many dialogue turns into single `<p>` blocks, so dash-dialogue no longer opens a line and the paragraph-start dialogue engine cannot see it. In ch5 of Nochnoi Dozor, 79% of the book dash markers sit in narration-open paragraphs - invisible to the engine (101 speech spans from ~700 turns, vs 57% yield on intact ch1).

### Approach (two additive, opt-in pieces, default OFF)
1. `paragraph-recovery.ts` - `splitEvidencedInteriorTurns`: an opt-in body pass that inserts a line break before an interior dash ONLY when the turned-out segment carries a speech/beat-verb tag clause (the parser own evidence bar, `parseDialogueSpans`). Fabrication is structurally impossible, not just rare:
   - a genuine interior turn like `. - speech, - said X.` splits (has a verb-tag);
   - a bare narration tail (`. - narrator description...`) never splits;
   - an apposition dash (X - this is Y) is never preceded by a sentence end, so it is not even a candidate.
   Recovery scopes each candidate evidence to its OWN segment (up to the next candidate), so a later turn verb can never back-promote an earlier narration prefix.
2. `structure-report.ts` - `assessParagraphStructure`: an intake signal quantifying hidden dashes (in narration-open paragraphs), hidden turn candidates, hidden fraction, and long-paragraph share, so paragraph degradation stops being a silent confound in per-chapter metrics (#2253) and can be flagged at import.

### API
`parseChapterStructure(body, index)` is unchanged. A new optional `ParseChapterOptions.recoverMidParagraphTurns` opts in to recovery; default behaviour is byte-identical to prior releases (no caller passes it yet).

### Safety/design invariants preserved
- Flag, never fabricate (parser.ts:5-8) - the verb-tag evidence bar mirrors the parser existing validation, so narration is never promoted to speech.
- Quote-only languages (en/de/es/fr) are a no-op (recovery only targets dialogueOpen/dash languages).
- Off by default - zero change to existing behaviour/corpus until a caller opts in.

### Files
- `server/src/analyzer/dialogue-structure/paragraph-recovery.ts` (+ `.test.ts`)
- `server/src/analyzer/dialogue-structure/structure-report.ts` (+ `.test.ts`)
- `server/src/analyzer/dialogue-structure/parser.ts` (optional opts param, + import)

### Tests
12 new tests covering every gate (evidenced turn splits; narration-tail / apposition / verb-less tag rejected; narration-prefix-before-later-turn not promoted; clean chapter recovers +0). Full dialogue-structure suite: 239 tests pass; `tsc --noEmit` clean.

### Validation & open questions
See the corpus-validation PR comment (26 real books). Recovery is intentionally NOT enabled anywhere yet - wiring it in should be gated on the intake signal and on resolving the Q2 attribution-cost question.
