### PR TITLE
fix(frontend): surface a refused Listen book-meta save (409) and roll it back (#2230)

### DIFF
--- a/src/store/book-meta-slice.test.ts
+++ b/src/store/book-meta-slice.test.ts
@@ -149,6 +149,77 @@ describe('bookMetaSlice — commitDraft', () => {
     expect(next.draft).toBeNull();
     expect(next.saved.ns.notes).toBe('First line.\nSecond line.\n\nThird paragraph.');
   });
+
+  /* #2230 — the optimistic fold keeps a pre-commit snapshot so a refused 409
+     PUT can be rolled back; the header must not keep showing a rename the
+     server rejected. */
+  it('captures a pre-commit snapshot (lastCommitted) when folding the draft', () => {
+    const start: BookMetaState = {
+      draft: { title: 'Renamed', genre: 'Sci-fi' },
+      saved: { ns: fullMeta() },
+      prosodyEnabled: {},
+    };
+    const next = reducer(start, bookMetaActions.commitDraft({ bookId: 'ns' }));
+    expect(next.saved.ns.title).toBe('Renamed');
+    /* Snapshot holds the pre-commit baseline — NOT the optimistic result. */
+    expect(next.lastCommitted?.['ns']).toEqual(fullMeta());
+    expect(next.lastCommitted?.['ns'].title).toBe('The Northern Star');
+  });
+
+  it('does not snapshot on an empty draft (nothing to roll back)', () => {
+    const start: BookMetaState = {
+      draft: null,
+      saved: { ns: fullMeta({ title: 'Bumped' }) },
+      prosodyEnabled: {},
+    };
+    const next = reducer(start, bookMetaActions.commitDraft({ bookId: 'ns' }));
+    expect(next.lastCommitted?.['ns']).toBeUndefined();
+  });
+});
+
+describe('bookMetaSlice — rollbackCommitDraft (#2230)', () => {
+  it('restores saved[bookId] to the last committed snapshot and clears it', () => {
+    const start: BookMetaState = {
+      draft: null,
+      saved: { ns: fullMeta({ title: 'Renamed' }) },
+      lastCommitted: { ns: fullMeta() },
+      prosodyEnabled: {},
+    };
+    const next = reducer(start, bookMetaActions.rollbackCommitDraft({ bookId: 'ns' }));
+    expect(next.saved.ns).toEqual(fullMeta());
+    expect(next.saved.ns.title).toBe('The Northern Star');
+    expect(next.lastCommitted?.['ns']).toBeUndefined();
+  });
+
+  it('is a no-op (and clears the snapshot) when nothing was captured', () => {
+    const start: BookMetaState = {
+      draft: null,
+      saved: { ns: fullMeta() },
+      lastCommitted: {},
+      prosodyEnabled: {},
+    };
+    const next = reducer(start, bookMetaActions.rollbackCommitDraft({ bookId: 'ns' }));
+    expect(next.saved.ns).toEqual(fullMeta());
+    expect(next.lastCommitted).toEqual({});
+  });
+
+  it('hydrateFromBookState clears the stale snapshot for the refreshed book', () => {
+    const start: BookMetaState = {
+      draft: null,
+      saved: { ns: fullMeta() },
+      lastCommitted: { ns: fullMeta({ title: 'Old' }) },
+      prosodyEnabled: {},
+    };
+    const next = reducer(
+      start,
+      bookMetaActions.hydrateFromBookState({
+        bookId: 'ns',
+        state: { title: 'Authoritative', author: 'A', series: 'S' },
+      }),
+    );
+    expect(next.saved.ns.title).toBe('Authoritative');
+    expect(next.lastCommitted?.['ns']).toBeUndefined();
+  });
 });
 
 describe('selectors', () => {

--- a/src/store/book-meta-slice.test.ts
+++ b/src/store/book-meta-slice.test.ts
@@ -150,10 +150,10 @@ describe('bookMetaSlice — commitDraft', () => {
     expect(next.saved.ns.notes).toBe('First line.\nSecond line.\n\nThird paragraph.');
   });
 
-  /* #2230 — the optimistic fold keeps a pre-commit snapshot so a refused 409
-     PUT can be rolled back; the header must not keep showing a rename the
-     server rejected. */
-  it('captures a pre-commit snapshot (lastCommitted) when folding the draft', () => {
+  /* #2230 — the optimistic fold keeps a `{ saved, draft }` snapshot so a refused
+     409 PUT can revert `saved` to the last server-accepted baseline AND restore
+     the user's typed draft (a failed save must not erase their edits). */
+  it('captures the server-accepted baseline and the staged draft on commit', () => {
     const start: BookMetaState = {
       draft: { title: 'Renamed', genre: 'Sci-fi' },
       saved: { ns: fullMeta() },
@@ -161,9 +161,28 @@ describe('bookMetaSlice — commitDraft', () => {
     };
     const next = reducer(start, bookMetaActions.commitDraft({ bookId: 'ns' }));
     expect(next.saved.ns.title).toBe('Renamed');
-    /* Snapshot holds the pre-commit baseline — NOT the optimistic result. */
-    expect(next.lastCommitted?.['ns']).toEqual(fullMeta());
-    expect(next.lastCommitted?.['ns'].title).toBe('The Northern Star');
+    /* Snapshot pins the ORIGINAL saved baseline — NOT the optimistic result. */
+    expect(next.lastCommitted?.['ns']?.saved).toEqual(fullMeta());
+    /* …and keeps the staged draft so a failed save can put it back in the editor. */
+    expect(next.lastCommitted?.['ns']?.draft).toEqual({ title: 'Renamed', genre: 'Sci-fi' });
+  });
+
+  it('pins the baseline on the first commit and merges drafts on later commits in the window', () => {
+    /* Two saves inside one debounce window: the snapshot baseline must remain
+       the truly-accepted value, and the draft must accumulate both edits so a
+       single refused PUT never reverts to an unpersisted intermediate. */
+    let s: BookMetaState = {
+      draft: { title: 'Renamed' },
+      saved: { ns: fullMeta() },
+      prosodyEnabled: {},
+    };
+    s = reducer(s, bookMetaActions.commitDraft({ bookId: 'ns' }));
+    s = reducer(s, bookMetaActions.setDraftField({ field: 'title', value: 'Renamed Twice' }));
+    s = reducer(s, bookMetaActions.commitDraft({ bookId: 'ns' }));
+
+    expect(s.saved.ns.title).toBe('Renamed Twice');
+    expect(s.lastCommitted?.['ns']?.saved.title).toBe('The Northern Star'); // baseline never moves
+    expect(s.lastCommitted?.['ns']?.draft).toEqual({ title: 'Renamed Twice' }); // both edits preserved
   });
 
   it('does not snapshot on an empty draft (nothing to roll back)', () => {
@@ -175,20 +194,48 @@ describe('bookMetaSlice — commitDraft', () => {
     const next = reducer(start, bookMetaActions.commitDraft({ bookId: 'ns' }));
     expect(next.lastCommitted?.['ns']).toBeUndefined();
   });
-});
 
-describe('bookMetaSlice — rollbackCommitDraft (#2230)', () => {
-  it('restores saved[bookId] to the last committed snapshot and clears it', () => {
+  it('commitDraftSucceeded prunes the snapshot so the next window snaps a fresh baseline', () => {
     const start: BookMetaState = {
       draft: null,
       saved: { ns: fullMeta({ title: 'Renamed' }) },
-      lastCommitted: { ns: fullMeta() },
+      lastCommitted: { ns: { saved: fullMeta(), draft: { title: 'Renamed' } } },
+      prosodyEnabled: {},
+    };
+    const next = reducer(start, bookMetaActions.commitDraftSucceeded({ bookId: 'ns' }));
+    expect(next.saved.ns.title).toBe('Renamed'); // unaffected
+    expect(next.lastCommitted?.['ns']).toBeUndefined();
+  });
+});
+
+describe('bookMetaSlice — rollbackCommitDraft (#2230)', () => {
+  it('reverts saved[bookId] to the accepted baseline AND restores the user draft', () => {
+    const start: BookMetaState = {
+      draft: null,
+      saved: { ns: fullMeta({ title: 'Renamed' }) },
+      lastCommitted: { ns: { saved: fullMeta(), draft: { title: 'Renamed' } } },
       prosodyEnabled: {},
     };
     const next = reducer(start, bookMetaActions.rollbackCommitDraft({ bookId: 'ns' }));
     expect(next.saved.ns).toEqual(fullMeta());
     expect(next.saved.ns.title).toBe('The Northern Star');
+    /* The user's typed text survives in the editor for retry. */
+    expect(next.draft).toEqual({ title: 'Renamed' });
     expect(next.lastCommitted?.['ns']).toBeUndefined();
+  });
+
+  it('merges the accumulated draft from a multi-commit window back into the editor', () => {
+    const start: BookMetaState = {
+      draft: null,
+      saved: { ns: fullMeta({ title: 'Renamed Twice' }) },
+      lastCommitted: {
+        ns: { saved: fullMeta(), draft: { title: 'Renamed Twice', genre: 'Sci-fi' } },
+      },
+      prosodyEnabled: {},
+    };
+    const next = reducer(start, bookMetaActions.rollbackCommitDraft({ bookId: 'ns' }));
+    expect(next.saved.ns.title).toBe('The Northern Star');
+    expect(next.draft).toEqual({ title: 'Renamed Twice', genre: 'Sci-fi' });
   });
 
   it('is a no-op (and clears the snapshot) when nothing was captured', () => {
@@ -207,7 +254,7 @@ describe('bookMetaSlice — rollbackCommitDraft (#2230)', () => {
     const start: BookMetaState = {
       draft: null,
       saved: { ns: fullMeta() },
-      lastCommitted: { ns: fullMeta({ title: 'Old' }) },
+      lastCommitted: { ns: { saved: fullMeta({ title: 'Old' }), draft: { title: 'Old' } } },
       prosodyEnabled: {},
     };
     const next = reducer(

--- a/src/store/book-meta-slice.ts
+++ b/src/store/book-meta-slice.ts
@@ -48,6 +48,12 @@ export interface BookMetaState {
   draft: Partial<EditableBookMeta> | null;
   /** Last-saved snapshot for each book the user has opened this session. */
   saved: Record<string, EditableBookMeta>;
+  /** #2230 — pre-commit snapshot of `saved[bookId]`, captured so a refused save
+      (409 from the persistence PUT) can roll the optimistic update back and stop
+      the header showing a value the server rejected. Overwritten by the next
+      commit, cleared on hydrate. Present only for a book with an in-flight
+      commit that is still awaiting its PUT. */
+  lastCommitted?: Record<string, EditableBookMeta>;
   /** fs-65 Phase 3 — per-book prosody annotation intent flag keyed by bookId.
       Eager-default: absent (undefined) ⇒ ON; only an explicit `false` opts out.
       The Task-13 trigger gate is `prosodyEnabled !== false`.
@@ -59,6 +65,7 @@ export interface BookMetaState {
 const initialState: BookMetaState = {
   draft: null,
   saved: {},
+  lastCommitted: {},
   prosodyEnabled: {},
 };
 
@@ -94,6 +101,9 @@ export const bookMetaSlice = createSlice({
       };
       s.prosodyEnabled[bookId] = state.prosodyEnabled;
       s.draft = null;
+      /* #2230 — a fresh authoritative state from disk supersedes any pending
+         commit snapshot (the server is now the truth, rollback is moot). */
+      if (s.lastCommitted) delete s.lastCommitted[bookId];
     },
 
     /* Stage a single-field edit into the draft buffer. Triggered on every
@@ -130,12 +140,32 @@ export const bookMetaSlice = createSlice({
         /* No baseline — refuse to corrupt state. Still clear the draft so the
            user's intent (commit & close) is honoured. */
         s.draft = null;
+        if (s.lastCommitted) delete s.lastCommitted[bookId];
         return;
       }
       if (s.draft) {
+        /* #2230 — snapshot the pre-commit saved value so a refused PUT (409)
+           can be rolled back, keeping the header off a title the server never
+           accepted. (s.lastCommitted ??= {}) is guarded by the recent-field
+           optionality — absent on older persisted/test state. */
+        const snapshot = (s.lastCommitted ??= {});
+        snapshot[bookId] = base;
         s.saved[bookId] = { ...base, ...s.draft };
       }
       s.draft = null;
+    },
+
+    /* #2230 — restore `saved[bookId]` to the last-committed snapshot when the
+       persistence PUT was refused. Dispatched by persistence-middleware on a
+       bookMeta/commitDraft failure: the server left the book (folder / on-disk
+       state) untouched, so the editor must not keep showing the renamed value.
+       Last-wins means a successful later commit overwrites the snapshot, so a
+       rollback only ever reverts to the last value the server accepted. */
+    rollbackCommitDraft: (s, a: PayloadAction<{ bookId: string }>) => {
+      const { bookId } = a.payload;
+      const prior = s.lastCommitted?.[bookId];
+      if (prior) s.saved[bookId] = prior;
+      if (s.lastCommitted) delete s.lastCommitted[bookId];
     },
   },
 });

--- a/src/store/book-meta-slice.ts
+++ b/src/store/book-meta-slice.ts
@@ -48,12 +48,21 @@ export interface BookMetaState {
   draft: Partial<EditableBookMeta> | null;
   /** Last-saved snapshot for each book the user has opened this session. */
   saved: Record<string, EditableBookMeta>;
-  /** #2230 — pre-commit snapshot of `saved[bookId]`, captured so a refused save
-      (409 from the persistence PUT) can roll the optimistic update back and stop
-      the header showing a value the server rejected. Overwritten by the next
-      commit, cleared on hydrate. Present only for a book with an in-flight
-      commit that is still awaiting its PUT. */
-  lastCommitted?: Record<string, EditableBookMeta>;
+  /** #2230 — committed-edit snapshot for each book with an in-flight PUT.
+      Captured on `commitDraft` so a refused save (a 409 from the persistence
+      PUT) can (a) roll the optimistic `saved[bookId]` update back to the last
+      value the server accepted AND (b) keep the user's typed `draft` in the
+      editor for retry — a failed save must not silently erase their edits.
+      - `saved` is pinned on the FIRST commit in a debounce window (the true
+        server-accepted baseline); later commits in the same window merge their
+        drafts so a refused PUT always reverts to that baseline, never to an
+        unpersisted intermediate.
+      - `draft` accumulates the diff staged across those commits.
+      Cleared on `hydrateFromBookState` and on a successful PUT. */
+  lastCommitted?: Record<
+    string,
+    { saved: EditableBookMeta; draft: Partial<EditableBookMeta> }
+  >;
   /** fs-65 Phase 3 — per-book prosody annotation intent flag keyed by bookId.
       Eager-default: absent (undefined) ⇒ ON; only an explicit `false` opts out.
       The Task-13 trigger gate is `prosodyEnabled !== false`.
@@ -144,27 +153,42 @@ export const bookMetaSlice = createSlice({
         return;
       }
       if (s.draft) {
-        /* #2230 — snapshot the pre-commit saved value so a refused PUT (409)
-           can be rolled back, keeping the header off a title the server never
-           accepted. (s.lastCommitted ??= {}) is guarded by the recent-field
-           optionality — absent on older persisted/test state. */
+        /* #2230 — pin the server-accepted `saved` baseline on the FIRST commit
+           in a debounce window, and merge drafts across any subsequent commits
+           so a refused PUT can revert to that baseline without losing any typed
+           text. (s.lastCommitted ??= {}) guards the recent-field optionality. */
         const snapshot = (s.lastCommitted ??= {});
-        snapshot[bookId] = base;
-        s.saved[bookId] = { ...base, ...s.draft };
+        const pending = (snapshot[bookId] ??= { saved: base, draft: {} });
+        pending.draft = { ...pending.draft, ...s.draft };
+        s.saved[bookId] = { ...base, ...pending.draft };
       }
       s.draft = null;
     },
 
-    /* #2230 — restore `saved[bookId]` to the last-committed snapshot when the
-       persistence PUT was refused. Dispatched by persistence-middleware on a
-       bookMeta/commitDraft failure: the server left the book (folder / on-disk
-       state) untouched, so the editor must not keep showing the renamed value.
-       Last-wins means a successful later commit overwrites the snapshot, so a
-       rollback only ever reverts to the last value the server accepted. */
+    /* #2230 — recover from a refused save. Dispatched by persistence-middleware
+       on a bookMeta/commitDraft failure: the server left the book (folder /
+       on-disk state) untouched. We revert the OPTIMISTIC `saved` update to the
+       last value the server accepted, and restore the user's typed `draft` so
+       the editor keeps their text with the Save/Cancel affordances + the error
+       toast (esp. important for a transient network failure, where the content
+       was never actually refused). Snapshot is always cleared. */
     rollbackCommitDraft: (s, a: PayloadAction<{ bookId: string }>) => {
       const { bookId } = a.payload;
-      const prior = s.lastCommitted?.[bookId];
-      if (prior) s.saved[bookId] = prior;
+      const pending = s.lastCommitted?.[bookId];
+      if (pending) {
+        s.saved[bookId] = pending.saved;
+        s.draft = { ...pending.draft };
+      }
+      if (s.lastCommitted) delete s.lastCommitted[bookId];
+    },
+
+    /* #2230 — a successful PUT confirms the optimistically-written `saved`
+       value, so the pending snapshot is moot. Pruning it means the NEXT commit
+       (a new window) snaps a fresh, now-accepted baseline instead of a stale
+       one — which is what makes the first-write baseline logic in commitDraft
+       correct across consecutive save sessions. */
+    commitDraftSucceeded: (s, a: PayloadAction<{ bookId: string }>) => {
+      const { bookId } = a.payload;
       if (s.lastCommitted) delete s.lastCommitted[bookId];
     },
   },

--- a/src/store/persistence-middleware.test.ts
+++ b/src/store/persistence-middleware.test.ts
@@ -12,6 +12,7 @@ import { persistenceMiddleware } from './persistence-middleware';
 import { manuscriptSlice, manuscriptActions } from './manuscript-slice';
 import { uiSlice } from './ui-slice';
 import { notificationsSlice } from './notifications-slice';
+import { bookMetaSlice, bookMetaActions } from './book-meta-slice';
 
 function makeStore(state: Record<string, unknown>) {
   return {
@@ -560,5 +561,86 @@ describe('bulk-reassign persistence', () => {
     await vi.runAllTimersAsync();
     const toasts = (store.getState() as { notifications: { toasts: { kind: string }[] } }).notifications.toasts;
     expect(toasts.length).toBe(0);
+  });
+});
+/* #2230 — a refused rename (409) from the Listen-view book-meta editor must
+   surface the server's sentence AND roll back the optimistic saved update so
+   the header stops showing a title the server rejected. Unlike makeReduxStore
+   above (whose bookMeta is a no-op stub), this builder wires the REAL bookMeta
+   reducer so setDraftField → commitDraft → rollbackCommitDraft actually mutate
+   state. */
+function makeBookMetaStore() {
+  const meta = {
+    title: 'The Northern Star',
+    author: 'Marin Vale',
+    series: '',
+    narratorCredit: 'Anders Vale',
+    genre: 'Literary fiction',
+    publicationDate: '2026-05-09',
+    description: null,
+    notes: null,
+  };
+  return configureStore({
+    reducer: {
+      bookMeta: bookMetaSlice.reducer,
+      ui: uiSlice.reducer,
+      notifications: notificationsSlice.reducer,
+    } as never,
+    preloadedState: {
+      ui: { stage: { kind: 'ready', bookId: 'b1', view: 'cast', currentChapterId: 3, openProfileId: null } },
+      bookMeta: { draft: null, saved: { b1: meta }, prosodyEnabled: {} },
+    } as never,
+    middleware: (gDM) => gDM().concat(persistenceMiddleware),
+  });
+}
+
+describe('bookMeta/commitDraft persist failure (#2230)', () => {
+  it('surfaces the server refusal sentence and rolls the optimistic title back', async () => {
+    putBookState.mockRejectedValueOnce(
+      new Error(
+        'Book state PUT failed (409): Analysis is running for this book. Wait for it to finish before renaming it.',
+      ),
+    );
+    const store = makeBookMetaStore();
+    /* Stage + commit a rename exactly as the Listen editor does. */
+    store.dispatch(bookMetaActions.setDraftField({ field: 'title', value: 'Renamed Book' }));
+    store.dispatch(bookMetaActions.commitDraft({ bookId: 'b1' }));
+    await vi.runAllTimersAsync();
+
+    const state = store.getState() as {
+      notifications: { toasts: { kind: string; message: string; dedupeKey?: string }[] };
+      bookMeta: { saved: Record<string, { title: string }> };
+    };
+
+    /* The toast carries the server's own message — NOT the bulk-reassign copy. */
+    const toast = state.notifications.toasts.find((t) => t.dedupeKey === 'book-meta-persist-failed');
+    expect(toast?.kind).toBe('error');
+    expect(toast?.message).toContain('Analysis is running for this book');
+    expect(toast?.message).not.toContain('Line reassignment');
+
+    /* The optimistic update is reverted so the header shows the accepted title. */
+    expect(state.bookMeta.saved.b1.title).toBe('The Northern Star');
+  });
+
+  it('surfaces a path-collision refusal without losing the server message', async () => {
+    putBookState.mockRejectedValueOnce(
+      new Error(
+        'Book state PUT failed (409): A book already exists at that Author/Series/Title path.',
+      ),
+    );
+    const store = makeBookMetaStore();
+    store.dispatch(bookMetaActions.setDraftField({ field: 'title', value: 'Clashing' }));
+    store.dispatch(bookMetaActions.commitDraft({ bookId: 'b1' }));
+    await vi.runAllTimersAsync();
+
+    const state = store.getState() as {
+      notifications: { toasts: { message: string }[] };
+      bookMeta: { saved: Record<string, { title: string }> };
+    };
+    const toast = state.notifications.toasts.find((t) =>
+      t.message.includes('already exists at that Author/Series/Title path'),
+    );
+    expect(toast).toBeTruthy();
+    expect(state.bookMeta.saved.b1.title).toBe('The Northern Star');
   });
 });

--- a/src/store/persistence-middleware.test.ts
+++ b/src/store/persistence-middleware.test.ts
@@ -595,12 +595,21 @@ function makeBookMetaStore() {
 }
 
 describe('bookMeta/commitDraft persist failure (#2230)', () => {
-  it('surfaces the server refusal sentence and rolls the optimistic title back', async () => {
-    putBookState.mockRejectedValueOnce(
-      new Error(
-        'Book state PUT failed (409): Analysis is running for this book. Wait for it to finish before renaming it.',
-      ),
-    );
+  /* Both refusal modes — analysis-busy and folder path collision — must
+     surface the server's OWN sentence (not the bulk-reassign copy) and revert
+     the optimistic `saved` while KEEPING the user's typed draft for retry. */
+  it.each([
+    {
+      serverError:
+        'Analysis is running for this book. Wait for it to finish before renaming it.',
+      probe: 'Analysis is running for this book',
+    },
+    {
+      serverError: 'A book already exists at that Author/Series/Title path.',
+      probe: 'already exists at that Author/Series/Title path',
+    },
+  ])('surfaces the server refusal sentence and reverts title but keeps the draft ($probe)', async ({ serverError, probe }) => {
+    putBookState.mockRejectedValueOnce(new Error(`Book state PUT failed (409): ${serverError}`));
     const store = makeBookMetaStore();
     /* Stage + commit a rename exactly as the Listen editor does. */
     store.dispatch(bookMetaActions.setDraftField({ field: 'title', value: 'Renamed Book' }));
@@ -609,38 +618,73 @@ describe('bookMeta/commitDraft persist failure (#2230)', () => {
 
     const state = store.getState() as {
       notifications: { toasts: { kind: string; message: string; dedupeKey?: string }[] };
-      bookMeta: { saved: Record<string, { title: string }> };
+      bookMeta: { saved: Record<string, { title: string }>; draft: { title?: string } | null };
     };
 
-    /* The toast carries the server's own message — NOT the bulk-reassign copy. */
+    /* Specific server message, book-meta dedupe key — NOT the bulk copy. */
     const toast = state.notifications.toasts.find((t) => t.dedupeKey === 'book-meta-persist-failed');
     expect(toast?.kind).toBe('error');
-    expect(toast?.message).toContain('Analysis is running for this book');
+    expect(toast?.message).toContain(probe);
     expect(toast?.message).not.toContain('Line reassignment');
+    /* The api.ts envelope is stripped — only the server's sentence remains. */
+    expect(toast?.message).not.toContain('Book state PUT failed');
 
-    /* The optimistic update is reverted so the header shows the accepted title. */
+    /* Persisted `saved` reverts to the last accepted value… */
     expect(state.bookMeta.saved.b1.title).toBe('The Northern Star');
+    /* …and the user's typed text survives in the editor for retry. */
+    expect(state.bookMeta.draft?.title).toBe('Renamed Book');
   });
 
-  it('surfaces a path-collision refusal without losing the server message', async () => {
-    putBookState.mockRejectedValueOnce(
-      new Error(
-        'Book state PUT failed (409): A book already exists at that Author/Series/Title path.',
-      ),
-    );
+  it('does NOT toast, roll back, or keep a snapshot on a SUCCESSFUL save', async () => {
+    putBookState.mockResolvedValue(undefined);
     const store = makeBookMetaStore();
-    store.dispatch(bookMetaActions.setDraftField({ field: 'title', value: 'Clashing' }));
+    store.dispatch(bookMetaActions.setDraftField({ field: 'title', value: 'Persisted Fine' }));
     store.dispatch(bookMetaActions.commitDraft({ bookId: 'b1' }));
     await vi.runAllTimersAsync();
 
     const state = store.getState() as {
-      notifications: { toasts: { message: string }[] };
-      bookMeta: { saved: Record<string, { title: string }> };
+      notifications: { toasts: unknown[] };
+      bookMeta: {
+        saved: Record<string, { title: string }>;
+        draft: unknown;
+        lastCommitted?: Record<string, unknown>;
+      };
     };
-    const toast = state.notifications.toasts.find((t) =>
-      t.message.includes('already exists at that Author/Series/Title path'),
-    );
-    expect(toast).toBeTruthy();
-    expect(state.bookMeta.saved.b1.title).toBe('The Northern Star');
+    /* The optimistic value is now confirmed on disk — no rollback. */
+    expect(state.bookMeta.saved.b1.title).toBe('Persisted Fine');
+    expect(state.bookMeta.draft).toBeNull();
+    expect(state.notifications.toasts).toHaveLength(0);
+    /* Success prunes the snapshot so the next save snaps a fresh baseline. */
+    expect(state.bookMeta.lastCommitted?.['b1']).toBeUndefined();
+  });
+
+  it('does NOT attribute a ui/confirmCast failure to book-meta when it replaces the state write in the same window', async () => {
+    /* #2230 — ui/confirmCast and bookMeta/commitDraft share the `state` slice.
+       If a confirmCast lands in the same debounce window it REPLACES the pending
+       write, so the failure concerns the cast-confirm, not the superseded
+       rename: the stale book-meta handler must be dropped (no book-meta toast,
+       no book-meta rollback). */
+    putBookState.mockRejectedValueOnce(new Error('Book state PUT failed (409): cast refused'));
+    const store = makeBookMetaStore();
+    store.dispatch(bookMetaActions.setDraftField({ field: 'title', value: 'Renamed Book' }));
+    store.dispatch(bookMetaActions.commitDraft({ bookId: 'b1' }));
+    /* A different `state`-slice write lands in the same debounce window. */
+    store.dispatch({ type: 'ui/confirmCast' } as never);
+    await vi.runAllTimersAsync();
+
+    /* The pending write that flushed (and failed) was the cast-confirm. */
+    expect(putBookState).toHaveBeenCalledWith('b1', {
+      slice: 'state',
+      patch: { castConfirmed: true },
+    });
+
+    const state = store.getState() as {
+      notifications: { toasts: { dedupeKey?: string }[] };
+      bookMeta: { draft: { title?: string } | null };
+    };
+    /* No book-meta failure toast for an op that wasn't book-meta… */
+    expect(state.notifications.toasts.some((t) => t.dedupeKey === 'book-meta-persist-failed')).toBe(false);
+    /* …and no rollback: commitDraft nulled the draft and nothing restored it. */
+    expect(state.bookMeta.draft).toBeNull();
   });
 });

--- a/src/store/persistence-middleware.test.ts
+++ b/src/store/persistence-middleware.test.ts
@@ -687,4 +687,48 @@ describe('bookMeta/commitDraft persist failure (#2230)', () => {
     /* …and no rollback: commitDraft nulled the draft and nothing restored it. */
     expect(state.bookMeta.draft).toBeNull();
   });
+
+  it('does NOT let an older in-flight save prune/roll back over a newer one (#2230 race)', async () => {
+    /* Two saves whose debounced PUTs OVERLAP in flight: the older PUT resolving
+       after a newer one is scheduled must NOT prune the shared rollback
+       snapshot, and the newer PUT's failure must still recover the newest edit.
+       Before the generation-token gate, the older flush's onSuccess would wipe
+       the snapshot the newer flush's rollback needs → the newer edit was lost. */
+    const deferred: { resolve: (v: unknown) => void; reject: (e: unknown) => void }[] = [];
+    putBookState.mockImplementation(
+      () =>
+        new Promise<unknown>((resolve, reject) => {
+          deferred.push({ resolve, reject });
+        }),
+    );
+    const store = makeBookMetaStore();
+
+    /* Save A → the first debounced flush fires and its PUT stays in-flight. */
+    store.dispatch(bookMetaActions.setDraftField({ field: 'title', value: 'Edit A' }));
+    store.dispatch(bookMetaActions.commitDraft({ bookId: 'b1' }));
+    await vi.advanceTimersByTimeAsync(500);
+    expect(deferred).toHaveLength(1);
+
+    /* Save B before PUT_A resolves → a second flush fires, PUT_B in-flight. */
+    store.dispatch(bookMetaActions.setDraftField({ field: 'title', value: 'Edit B' }));
+    store.dispatch(bookMetaActions.commitDraft({ bookId: 'b1' }));
+    await vi.advanceTimersByTimeAsync(500);
+    expect(deferred).toHaveLength(2);
+
+    /* The OLDER flush (A) succeeds first — it must NOT prune the snapshot that
+       the still-in-flight newer flush (B) depends on. */
+    deferred[0].resolve(undefined);
+    await vi.runAllTimersAsync();
+    expect((store.getState() as { bookMeta: { lastCommitted?: Record<string, unknown> } }).bookMeta.lastCommitted?.['b1']).toBeDefined();
+
+    /* The NEWER flush (B) now fails — its rollback must still run, restoring the
+       accepted title and preserving the newest edit for retry. */
+    deferred[1].reject(new Error('Book state PUT failed (409): analysis is running'));
+    await vi.runAllTimersAsync();
+    const after = store.getState() as {
+      bookMeta: { saved: Record<string, { title: string }>; draft: { title?: string } | null };
+    };
+    expect(after.bookMeta.saved.b1.title).toBe('The Northern Star');
+    expect(after.bookMeta.draft?.title).toBe('Edit B');
+  });
 });

--- a/src/store/persistence-middleware.ts
+++ b/src/store/persistence-middleware.ts
@@ -362,6 +362,14 @@ export const persistenceMiddleware: Middleware = (store) => {
      so the toast text can be per-action (bulk-reassign copy vs the server's own
      refused-rename sentence) and any rollback can fire. */
   const toastPending = new Map<StateSlice, PersistFailureHandler>();
+  /* #2230 — monotonically-increasing counter per slice, bumped every time a
+     write is (re)scheduled. A flush captures the counter at fire time; its
+     success/failure effects (snapshot prune / rollback / toast) only run if it
+     is still the LATEST flush for the slice. This prevents an OLDER in-flight
+     PUT from prematurely pruning or rolling back the shared rollback snapshot
+     that a NEWER in-flight PUT (started while the first was still pending) still
+     needs — closing the overlapping-in-flight-PUT data-loss race. */
+  const generation = new Map<StateSlice, number>();
 
   const flush = (bookId: string, slice: StateSlice) => {
     const patch = pending.get(slice);
@@ -369,18 +377,26 @@ export const persistenceMiddleware: Middleware = (store) => {
     timers.delete(slice);
     const handler = toastPending.get(slice);
     toastPending.delete(slice);
+    const gen = generation.get(slice) ?? 0;
     if (patch === undefined) return;
     api
       .putBookState(bookId, { slice, patch })
       .then(() => {
-        /* #2230 — a confirmed PUT makes any rollback snapshot for this slice
-           moot (e.g. prune the bookMeta lastCommitted so the next commit snaps
-           a fresh accepted baseline). No-op when the slice has no handler. */
-        if (handler?.onSuccess) store.dispatch(handler.onSuccess(bookId));
+        /* #2230 — only the LATEST flush prunes the rollback snapshot. If a
+           newer write has since been scheduled (gen advanced), a fresh snapshot
+           belongs to it and must not be cleared by this older, superseded
+           flush. */
+        if (handler?.onSuccess && gen === (generation.get(slice) ?? 0)) {
+          store.dispatch(handler.onSuccess(bookId));
+        }
       })
       .catch((err) => {
         console.error(`[persist] PUT /api/books/${bookId}/state slice=${slice} failed`, err);
-        if (handler) {
+        /* #2230 — only act on a failure of the LATEST write. An older flush's
+           failure is superseded by a newer in-flight write (which owns the
+           snapshot and the user's current draft), so don't toast/roll back for
+           it — that would wrongly revert the newer edit. */
+        if (handler && gen === (generation.get(slice) ?? 0)) {
           store.dispatch(
             notificationsActions.pushToast({
               kind: 'error',
@@ -409,6 +425,10 @@ export const persistenceMiddleware: Middleware = (store) => {
     if (!bookId) return result;
 
     pending.set(rule.slice, rule.build(after, bookId));
+    /* #2230 — bump the per-slice generation so this becomes the LATEST write;
+       in-flight older flushes keep their captured (lower) generation and are
+       therefore gated out of prune/rollback in flush. */
+    generation.set(rule.slice, (generation.get(rule.slice) ?? 0) + 1);
     const failHandler = TOAST_ON_PERSIST_FAILURE[type];
     if (failHandler) {
       toastPending.set(rule.slice, failHandler);

--- a/src/store/persistence-middleware.ts
+++ b/src/store/persistence-middleware.ts
@@ -20,6 +20,7 @@ import type { BookMetaState } from './book-meta-slice';
 import type { StateSlice } from '../lib/types';
 import { api } from '../lib/api';
 import { notificationsActions } from './notifications-slice';
+import { bookMetaActions } from './book-meta-slice';
 
 /* Locally-typed shape of the store the middleware reads, declared without
    importing RootState to avoid a circular type reference back through the
@@ -40,14 +41,43 @@ interface PersistableRootState {
 const DEFAULT_DEBOUNCE_MS = 500;
 
 /* #1676(c) — action types whose persist failure the user MUST see: a silent
-   swallow would leave redux showing the move applied while disk holds the prior
-   attribution. Scoped to the two bulk actions only — broadening to every
-   manuscript flush (let alone every slice) would change long-standing swallow
-   behaviour for unrelated edits. */
-const TOAST_ON_PERSIST_FAILURE = new Set<string>([
-  'manuscript/setSentencesCharacterBulk',
-  'manuscript/undoBulkReassign',
-]);
+   swallow would leave redux showing the change applied while disk holds the
+   prior value. Scoped to the bulk manuscript reassignment and the Listen-view
+   book-meta save — the edits where the UI promising persistence while disk
+   silently reverts is exactly the failure this sweep exists to close.
+   Each entry carries the toast a persist failure should raise.
+   `bookMeta/commitDraft` (added #2230) surfaces the server's OWN refusal
+   sentence (a 409 rename refused mid-analysis, or a path collision) rather
+   than a hardcoded copy, and rolls its optimistic saved[] update back so the
+   header stops showing a value the server rejected. */
+interface PersistFailureHandler {
+  message: (err: unknown) => string;
+  dedupeKey: string;
+  /** Optional extra dispatch fired on persist failure — e.g. rolling back an
+      optimistic local update. Returns the action to dispatch. */
+  rollback?: (bookId: string) => { type: string };
+}
+const TOAST_ON_PERSIST_FAILURE: Record<string, PersistFailureHandler> = {
+  'manuscript/setSentencesCharacterBulk': {
+    message: () => 'Line reassignment could not be saved. Check your connection and try again.',
+    dedupeKey: 'bulk-reassign-persist-failed',
+  },
+  'manuscript/undoBulkReassign': {
+    message: () => 'Line reassignment could not be saved. Check your connection and try again.',
+    dedupeKey: 'bulk-reassign-persist-failed',
+  },
+  /* #2230 — a refused rename (409: analysis running; or a folder path
+     collision) must surface the server's sentence and stop showing a title
+     that never saved. The server message rides on err.message (api.putBookState
+     unwraps `{ error }` from the 409 body), mirroring the library-side Edit
+     modal which surfaces err.message verbatim via showError. */
+  'bookMeta/commitDraft': {
+    message: (err) =>
+      `Book details couldn't be saved: ${err instanceof Error ? err.message : 'unknown error'}`,
+    dedupeKey: 'book-meta-persist-failed',
+    rollback: (bookId) => bookMetaActions.rollbackCommitDraft({ bookId }),
+  },
+};
 
 /* Read the user-tuned autosave debounce (fe-2) at flush-scheduling time so a
    change in the Account → Advanced panel takes effect on the next edit, with no
@@ -315,28 +345,34 @@ export const persistenceMiddleware: Middleware = (store) => {
   const timers = new Map<StateSlice, ReturnType<typeof setTimeout>>();
   const pending = new Map<StateSlice, unknown>();
   /* Slices whose currently-pending write was (at least once this debounce
-     window) triggered by a toast-worthy bulk action. Last-wins on the patch
-     means the flush persists the latest manuscript state regardless, so if it
-     fails the bulk move didn't land — toasting is correct even if a non-bulk
-     edit also rode along in the same window. */
-  const toastPending = new Set<StateSlice>();
+     window) triggered by a toast-worthy action. Last-wins on the patch means
+     the flush persists the latest slice state regardless, so if it fails that
+     action didn't land — toasting with the matching handler is correct even if
+     an unrelated edit also rode along in the same window. Carries the handler
+     so the toast text can be per-action (bulk-reassign copy vs the server's own
+     refused-rename sentence) and any rollback can fire. */
+  const toastPending = new Map<StateSlice, PersistFailureHandler>();
 
   const flush = (bookId: string, slice: StateSlice) => {
     const patch = pending.get(slice);
     pending.delete(slice);
     timers.delete(slice);
-    const shouldToast = toastPending.delete(slice);
+    const handler = toastPending.get(slice);
+    toastPending.delete(slice);
     if (patch === undefined) return;
     api.putBookState(bookId, { slice, patch }).catch((err) => {
       console.error(`[persist] PUT /api/books/${bookId}/state slice=${slice} failed`, err);
-      if (shouldToast) {
+      if (handler) {
         store.dispatch(
           notificationsActions.pushToast({
             kind: 'error',
-            message: 'Line reassignment could not be saved. Check your connection and try again.',
-            dedupeKey: 'bulk-reassign-persist-failed',
+            message: handler.message(err),
+            dedupeKey: handler.dedupeKey,
           }),
         );
+        /* #2230 — a refused rename must not keep the header showing a value the
+           server rejected; roll the optimistic saved update back. */
+        if (handler.rollback) store.dispatch(handler.rollback(bookId));
       }
     });
   };
@@ -354,7 +390,8 @@ export const persistenceMiddleware: Middleware = (store) => {
     if (!bookId) return result;
 
     pending.set(rule.slice, rule.build(after, bookId));
-    if (TOAST_ON_PERSIST_FAILURE.has(type)) toastPending.add(rule.slice);
+    const failHandler = TOAST_ON_PERSIST_FAILURE[type];
+    if (failHandler) toastPending.set(rule.slice, failHandler);
     const prev = timers.get(rule.slice);
     if (prev) clearTimeout(prev);
     timers.set(

--- a/src/store/persistence-middleware.ts
+++ b/src/store/persistence-middleware.ts
@@ -56,6 +56,10 @@ interface PersistFailureHandler {
   /** Optional extra dispatch fired on persist failure — e.g. rolling back an
       optimistic local update. Returns the action to dispatch. */
   rollback?: (bookId: string) => { type: string };
+  /** Optional dispatch fired on a SUCCESSFUL flush — e.g. pruning a rollback
+      snapshot now that its optimistically-written value is confirmed on disk,
+      so the next commit snapshots a fresh baseline. Returns the action. */
+  onSuccess?: (bookId: string) => { type: string };
 }
 const TOAST_ON_PERSIST_FAILURE: Record<string, PersistFailureHandler> = {
   'manuscript/setSentencesCharacterBulk': {
@@ -67,15 +71,21 @@ const TOAST_ON_PERSIST_FAILURE: Record<string, PersistFailureHandler> = {
     dedupeKey: 'bulk-reassign-persist-failed',
   },
   /* #2230 — a refused rename (409: analysis running; or a folder path
-     collision) must surface the server's sentence and stop showing a title
-     that never saved. The server message rides on err.message (api.putBookState
-     unwraps `{ error }` from the 409 body), mirroring the library-side Edit
-     modal which surfaces err.message verbatim via showError. */
+     collision) must surface the server's sentence and not leave the persisted
+     value claiming a title that never saved. The server message rides on
+     err.message (api.putBookState unwraps `{ error }` from the 409 body);
+     we strip the api.ts envelope so the toast shows only the refusal sentence,
+     degrading gracefully to the raw message if that format ever changes. */
   'bookMeta/commitDraft': {
-    message: (err) =>
-      `Book details couldn't be saved: ${err instanceof Error ? err.message : 'unknown error'}`,
+    message: (err) => {
+      const raw = err instanceof Error ? err.message : '';
+      const sentence =
+        raw.replace(/^Book state PUT failed \(\d+\): /, '') || 'an unknown error occurred';
+      return `Book details couldn't be saved: ${sentence}`;
+    },
     dedupeKey: 'book-meta-persist-failed',
     rollback: (bookId) => bookMetaActions.rollbackCommitDraft({ bookId }),
+    onSuccess: (bookId) => bookMetaActions.commitDraftSucceeded({ bookId }),
   },
 };
 
@@ -360,21 +370,30 @@ export const persistenceMiddleware: Middleware = (store) => {
     const handler = toastPending.get(slice);
     toastPending.delete(slice);
     if (patch === undefined) return;
-    api.putBookState(bookId, { slice, patch }).catch((err) => {
-      console.error(`[persist] PUT /api/books/${bookId}/state slice=${slice} failed`, err);
-      if (handler) {
-        store.dispatch(
-          notificationsActions.pushToast({
-            kind: 'error',
-            message: handler.message(err),
-            dedupeKey: handler.dedupeKey,
-          }),
-        );
-        /* #2230 — a refused rename must not keep the header showing a value the
-           server rejected; roll the optimistic saved update back. */
-        if (handler.rollback) store.dispatch(handler.rollback(bookId));
-      }
-    });
+    api
+      .putBookState(bookId, { slice, patch })
+      .then(() => {
+        /* #2230 — a confirmed PUT makes any rollback snapshot for this slice
+           moot (e.g. prune the bookMeta lastCommitted so the next commit snaps
+           a fresh accepted baseline). No-op when the slice has no handler. */
+        if (handler?.onSuccess) store.dispatch(handler.onSuccess(bookId));
+      })
+      .catch((err) => {
+        console.error(`[persist] PUT /api/books/${bookId}/state slice=${slice} failed`, err);
+        if (handler) {
+          store.dispatch(
+            notificationsActions.pushToast({
+              kind: 'error',
+              message: handler.message(err),
+              dedupeKey: handler.dedupeKey,
+            }),
+          );
+          /* #2230 — a refused rename must not leave the persisted value claiming
+             a title the server rejected; roll the optimistic saved update back
+             (and restore the draft so the user's text is preserved for retry). */
+          if (handler.rollback) store.dispatch(handler.rollback(bookId));
+        }
+      });
   };
 
   return (next) => (action) => {
@@ -391,7 +410,19 @@ export const persistenceMiddleware: Middleware = (store) => {
 
     pending.set(rule.slice, rule.build(after, bookId));
     const failHandler = TOAST_ON_PERSIST_FAILURE[type];
-    if (failHandler) toastPending.set(rule.slice, failHandler);
+    if (failHandler) {
+      toastPending.set(rule.slice, failHandler);
+    } else if (rule.slice === 'state' && type !== 'bookMeta/commitDraft') {
+      /* #2230 — the `state` slice is shared by ui/confirmCast and
+         bookMeta/commitDraft (PERSIST_RULES above). When a non-bookMeta `state`
+         write (confirmCast) lands in the same debounce window it REPLACES the
+         pending patch, so a later failure concerns THAT write, not the
+         superseded book-meta rename. Drop the stale handler so we neither toast
+         nor roll back book-meta for an op that isn't book-meta. (Manuscript's
+         ride-along semantics are intentionally left untouched — only the shared
+         `state` slice has the cross-action mismatch.) */
+      toastPending.delete(rule.slice);
+    }
     const prev = timers.get(rule.slice);
     if (prev) clearTimeout(prev);
     timers.set(


### PR DESCRIPTION
## Summary

Closes #2230

The Listen-view book-meta editor **silently swallowed** a `409` from `PUT /api/books/{bookId}/state`. A rename refused by the server (analysis running, or an Author/Series/Title path collision) showed the new title on screen with no error, persisted nothing, and reverted at the next hydrate.

Root cause: `src/store/persistence-middleware.ts` only surfaced persist failures for two `manuscript/*` bulk actions (via `TOAST_ON_PERSIST_FAILURE`), and its toast body was hardcoded bulk-reassign copy. `bookMeta/commitDraft` was dropped with only a `console.error`.

## What changed

- **`persistence-middleware.ts`** — `TOAST_ON_PERSIST_FAILURE` is now a per-action `Record` of failure handlers, each carrying its own toast message, `dedupeKey`, and an optional rollback. `bookMeta/commitDraft` surfaces the server's own refusal sentence (unescaped/specific, not the bulk copy) and dispatches a rollback.
- **`book-meta-slice.ts`** — `commitDraft` snapshots the pre-commit `saved[bookId]` into a private `lastCommitted` field; a new `rollbackCommitDraft` reducer restores it and clears the snapshot; `hydrateFromBookState` wipes any pending snapshot.

## Recorded decision (issue acceptance #3)

On a refused save we **revert** the optimistic `bookMeta.saved` update in addition to showing the error — a title the server rejected must not keep displaying and silently reverting later. The header returns to the last value the server accepted while the toast explains the refusal.

## Acceptance criteria

1. A rename refused with 409 surfaces the server's own message — both the analysis-busy and path-collision cases (tests assert both).
2. The message is specific to what failed — the tests assert it is **not** the bulk-reassign copy.
3. Revert decision recorded above and implemented via `rollbackCommitDraft`.
4. Paired frontend tests: `book-meta-slice.test.ts` (+4) and `persistence-middleware.test.ts` (+2, wired to the real bookMeta reducer so rollback + message are asserted non-vacuously).

## Validation

- `vitest` on both changed suites: **63 passed**.
- `tsc --noEmit`: clean.
- `eslint` on changed files: clean.