### PR TITLE
chore(server): make stage-1 cloud TPM reservation roster-aware (#1691)

### DIFF
--- a/server/src/analyzer/stage1-chunk.test.ts
+++ b/server/src/analyzer/stage1-chunk.test.ts
@@ -164,13 +164,18 @@ describe('stage1ChunkBudgetForEngine', () => {
 
    RED/GREEN: with the prior 0-token reservation the body filled the full 12k
    cap and this construction estimated ~19.8k tokens (roster=60) — well OVER the
-   16000 guard. With STAGE1_CLOUD_RESERVED_TOKENS=7000 it estimates ~13.2k. */
-describe('#1682 — worst-case Cyrillic stage-1 request clears the Gemma TPM guard', () => {
+   16000 guard. With STAGE1_CLOUD_RESERVED_TOKENS=7000 it estimates ~13.2k.
+
+   #1691: the roster is now LARGE (150 entries — past the old ~130-cast wall
+   where the fixed-only reservation crossed the guard) and is fed into the
+   body-size resolver, so the reservation scales with the whole-book cast. */
+describe('#1682/#1691 — worst-case Cyrillic stage-1 request clears the Gemma TPM guard', () => {
   const GEMMA_TPM = 16000;
   const MARGIN_CEILING = 14500; // 16000 − 1500 safety margin
 
-  /* A conservative running roster for a single book: 60 characters, Cyrillic
-     names, in the compact {id,name,role} shape buildStage1ChapterInbox renders. */
+  /* A conservative running roster for a very large ensemble book: 150 characters,
+     Cyrillic names, in the compact {id,name,role} shape buildStage1ChapterInbox
+     renders. 150 deliberately exceeds the old fixed-reservation wall (~130). */
   const worstCaseRoster = (n: number): CharacterOutput[] =>
     Array.from({ length: n }, (_, i) => ({
       id: `personazh-imya-familiya-${i}`,
@@ -183,15 +188,20 @@ describe('#1682 — worst-case Cyrillic stage-1 request clears the Gemma TPM gua
     const skill = await loadSkill('per_chapter_stage1');
     const systemInstruction = buildSystemInstruction(skill, 'ru', 'per_chapter_stage1');
 
-    // Body sized exactly the way the route sizes it for a huge Cyrillic chapter.
-    const bodyBudget = resolveStage1ChunkCharBudget('gemini', 'а'.repeat(120000));
+    // 150-entry running roster — the whole-book cast of a large ensemble.
+    const roster = worstCaseRoster(150);
+
+    // Body sized exactly the way the route sizes it for a huge Cyrillic chapter,
+    // with the same roster fed into the resolver so the reservation shrinks the
+    // body budget by the roster's injected size (#1691).
+    const bodyBudget = resolveStage1ChunkCharBudget('gemini', 'а'.repeat(120000), roster);
     const body = 'а'.repeat(bodyBudget);
 
     const inbox = buildStage1ChapterInbox(
       'm_1682',
       'Ночной дозор',
       { id: 12, title: 'Глава двенадцатая', body },
-      worstCaseRoster(60),
+      roster,
       [],
       'Сергей Лукьяненко',
     );
@@ -215,5 +225,14 @@ describe('#1682 — worst-case Cyrillic stage-1 request clears the Gemma TPM gua
     // The reservation genuinely shrinks the body budget by ~7000 tokens worth of
     // Cyrillic chars (7000 × 2.5), which is what buys back the TPM headroom.
     expect(reservedBudget).toBe(zeroReserveBudget - STAGE1_CLOUD_RESERVED_TOKENS * 2.5);
+  });
+
+  it('scales the reservation with the running roster — a 150-cast roster shrinks the budget below a 60-cast one (#1691)', () => {
+    // The whole point of #1691: the body budget must SHRINK as the book's cast
+    // grows, else the worst-case request crosses the guard at ~130 cast.
+    const cyr = 'а'.repeat(120000);
+    const budget60 = resolveStage1ChunkCharBudget('gemini', cyr, worstCaseRoster(60));
+    const budget150 = resolveStage1ChunkCharBudget('gemini', cyr, worstCaseRoster(150));
+    expect(budget150).toBeLessThan(budget60);
   });
 });

--- a/server/src/analyzer/stage1-chunk.ts
+++ b/server/src/analyzer/stage1-chunk.ts
@@ -107,7 +107,9 @@ export function resolveStage1ChunkCharBudget(
     // reservation hit a wall (~130 speaking cast — past it the total estimate
     // crossed 16000 & RequestExceedsTpmError dropped the chapter). Reserving
     // the roster's actual rendered size keeps the worst-case estimate under the
-    // guard regardless of cast size.
+    // guard across the cast sizes a book realistically accumulates (cloudBody-
+    // CharBudget's 2000-char floor is the practical ceiling — past ~290 all-
+    // Cyrillic cast the roster's own tokens dominate).
     return cloudBodyCharBudget(
       body ?? '',
       stage1RosterReservedChars(runningRoster),

--- a/server/src/analyzer/stage1-chunk.ts
+++ b/server/src/analyzer/stage1-chunk.ts
@@ -49,8 +49,10 @@ export const DEFAULT_STAGE1_CHUNK_CHAR_BUDGET = 24000;
    cap, so a dense Cyrillic chapter (~2.5 chars/token) estimated at ~18-20k
    tokens and tripped the guard — dropping the chapter, since RequestExceedsTpm
    is not an AnalyzerTruncatedError the adaptive re-split can catch. Reserving
-   7000 tokens keeps the worst-case Cyrillic request (full body + a ~60-80 char
-   running roster) at ~13-14k estimated tokens, comfortably below 16000. Measured
+   7000 tokens keeps the worst-case Cyrillic request (full body + scaffold) at
+   ~13-14k estimated tokens, comfortably below 16000. The running roster is NOT
+   covered by this fixed constant — its growing, whole-book size is reserved
+   separately in char space in resolveStage1ChunkCharBudget (#1691). Measured
    in stage1-chunk.test.ts against the real prompt so a future skill growth
    re-trips the guard test. Token-space (not char-space) so it is script-correct:
    the reservation is the same token cost whether the body is Latin or Cyrillic;
@@ -76,12 +78,41 @@ export function stage1ChunkBudgetForEngine(
   return Math.max(2000, Math.min(configured, numCtxDerived));
 }
 
-export function resolveStage1ChunkCharBudget(engine?: 'gemini' | 'local', body?: string): number {
+/* Marginal char-space overhead the running roster adds to the stage-1 inbox.
+   Must mirror buildStage1ChapterInbox's compact {id,name,role} render — the
+   stage-1 regression lock (stage1-chunk.test.ts) measures the REAL inbox via
+   buildStage1ChapterInbox, so a drift here re-trips the lock instead of silently
+   dropping chapters again (#1691). */
+function stage1RosterReservedChars(runningRoster: CharacterOutput[]): number {
+  if (runningRoster.length === 0) return 0;
+  return JSON.stringify(
+    runningRoster.map((c) => ({ id: c.id, name: c.name, role: c.role })),
+    null,
+    2,
+  ).length;
+}
+
+export function resolveStage1ChunkCharBudget(
+  engine?: 'gemini' | 'local',
+  body?: string,
+  runningRoster: CharacterOutput[] = [],
+): number {
   if (engine !== 'local') {
     // Cloud: size the BODY to the per-request token cap MINUS stage-1's fixed
     // system-instruction + scaffold overhead (reserved in token space so the
-    // full request — not just the body — stays under the finite TPM guard).
-    return cloudBodyCharBudget(body ?? '', 0, STAGE1_CLOUD_RESERVED_TOKENS);
+    // full request — not just the body — stays under the finite TPM guard),
+    // and MINUS the injected running-roster's own char footprint (reserved in
+    // char space via the reservedChars param cloudBodyCharBudget exposes).
+    // #1691: the roster accumulates the whole book's cast, so a fixed-only
+    // reservation hit a wall (~130 speaking cast — past it the total estimate
+    // crossed 16000 & RequestExceedsTpmError dropped the chapter). Reserving
+    // the roster's actual rendered size keeps the worst-case estimate under the
+    // guard regardless of cast size.
+    return cloudBodyCharBudget(
+      body ?? '',
+      stage1RosterReservedChars(runningRoster),
+      STAGE1_CLOUD_RESERVED_TOKENS,
+    );
   }
   return stage1ChunkBudgetForEngine(
     configValue<number>('analyzer.stage1.chunkCharBudget'),

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -3972,7 +3972,15 @@ export async function runMainAnalyzerJob(
                 call: () =>
                   runStage1ChapterChunked({
                     body: ch.body,
-                    charBudget: resolveStage1ChunkCharBudget(selection.engine, ch.body),
+                    charBudget: resolveStage1ChunkCharBudget(
+                      selection.engine,
+                      ch.body,
+                      // #1691 — roster-aware reservation: the running roster
+                      // grows with the whole book's cast, so the body budget must
+                      // shrink by its injected size or the worst-case request
+                      // crosses the Gemma TPM guard (~130 speaking cast).
+                      Array.from(rebuildRoster().values()),
+                    ),
                     mergeRosters: mergeRosterChapter,
                     onChunk: (sec) => {
                       /* Feed section progress into the live ETA so the first
@@ -6302,7 +6310,12 @@ export async function runSubsetAnalyzerJob(
               call: () =>
                 runStage1ChapterChunked({
                   body: ch.body,
-                  charBudget: resolveStage1ChunkCharBudget(selection.engine, ch.body),
+                  charBudget: resolveStage1ChunkCharBudget(
+                    selection.engine,
+                    ch.body,
+                    // #1691 — roster-aware reservation, mirroring the full route.
+                    Array.from(rebuildRoster().values()),
+                  ),
                   mergeRosters: mergeRosterChapter,
                   onChunk: (sec) =>
                     log(


### PR DESCRIPTION
﻿## Summary

Stage-1 (cast-detection) cloud requests are sized against the finite Gemma TPM guard (16000/min). #1682 reserved a fixed `STAGE1_CLOUD_RESERVED_TOKENS = 7000` in *token* space for the system instruction + inbox scaffold, then sized the body in char space. That reservation did not scale with the **running roster**, which accumulates the whole book's cast. Past ~130 speaking-cast entries the worst-case request estimate crossed 16000, threw `RequestExceedsTpmError` (not an `AnalyzerTruncatedError`), and dropped the chapter.

This makes the reservation roster-aware: `resolveStage1ChunkCharBudget` now also reserves the running roster's rendered size (char space, mirroring `buildStage1ChapterInbox`'s compact `{id,name,role}` render) via the `reservedChars` param `cloudBodyCharBudget` already exposes, on top of the fixed token reservation. Both stage-1 call sites feed the live `rebuildRoster()` map in. The estimate stays under the guard regardless of cast size; the small/typical-cast path is unchanged (empty roster → 0 reserved chars).

Closes #1691

## Test plan

- [x] `tsc --noEmit` — green
- [x] `vitest run src/analyzer/stage1-chunk.test.ts src/analyzer/token-budget.test.ts` — 20/20 pass (incl. the #1691 150-entry-roster regression lock + a test asserting the budget shrinks as the cast grows)
- [x] `vitest run src/analyzer/stage2-chunk.test.ts` + `src/routes/analysis.test.ts` (200 tests) — green; no regression to the small/typical-cast or stage-2 paths
- [ ] `npm run verify:fast:branch` — full battery runs in cloud `verify.yml` (authoritative gate)
