### PR TITLE
docs(docs): design the re-open bound and the tag-clause guard for #2315

### DIFF
--- a/docs/superpowers/plans/2026-08-13-primary-pair-straddle.md
+++ b/docs/superpowers/plans/2026-08-13-primary-pair-straddle.md
@@ -1,0 +1,578 @@
+# The re-open bound and the tag-clause guard (#2315) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> ## ⛔ Task 0 — THREE OWNER DECISIONS ARE OWED BEFORE ANY CODE IS WRITTEN
+>
+> This plan does **not** start at Task 1. The design pass reached two rules it
+> recommends and, in reaching them, found that **three stated acceptance items
+> cannot be met as written** — one because its number does not refer to what it
+> says it refers to, one because the criterion contradicts the fix, and one
+> because its instrument counts legitimate gains. None is an implementation
+> judgement call. All three are answered here and recorded in the design doc
+> before Task 1 begins.
+>
+> **Decision A — text-preserving splits.** `0 SPLIT` against the pre-#2288
+> baseline is unachievable by any rule that stops a container run swallowing the
+> turn inside it, because un-swallowing *is* a split to an overlap classifier.
+> **No substitute criterion is offered** — an earlier revision proposed
+> `TEXT-LOSING` and the adversarial pass showed a truncate-and-resume rule
+> cannot fail it. The question is the real one:
+>
+> > Is a split that loses no speech text, where **85 % of the new spans sit next
+> > to a speech tag** (4,003 of 4,732) and 15 % are quoted words promoted to
+> > their own span, an acceptable price for 1,231 paragraphs across seven
+> > languages parsing turn-by-turn where they merged?
+>
+> *Refusing means Tasks 1–7 do not happen and #2315 closes as answer 3 in full.*
+> **Tasks 8–9 (the tag-clause guard) are unaffected and should ship regardless.**
+>
+> **Decision B — the 396, not the 579.** "The 579 goes to 0" has no referent:
+> `579` is a **corruption** count on a shape set defined by the **widened**
+> table (the destroyed count there is 1,704). Measured as the ticket describes —
+> each language's own `quotePairs` — the figure is **396 of 805**. The re-open
+> bound takes it to **172**, at the cost of 20 `ru` regressions in M2's
+> families. Accept a partial fix, or hold out for zero? *The only measured rule
+> below 172 that keeps nesting is `R4`, whose price is the suppression class;
+> below that is `R2`, whose price is 601,392 characters of real speech.*
+>
+> **Decision C — how the tag-cut criterion is stated.** The brief asks for "0
+> gained runs truncating a tag span over the corpus, and the 265/92 re-measured
+> to 0". That figure is **reproduced exactly** (265 across 92 paragraphs) and the
+> guard takes it to 156 — but the residual is quoted titles and foreign phrases
+> inside verb-bearing narration, not tag clauses naming a speaker, and the proxy
+> **cannot decide 257 of its own 265** because CJK has no case distinction. Bind
+> instead to the attribution-aware family — **0 of 42 speakers lost, positive
+> control 42/42, firing control 21 lost** — and report the corpus proxy as scale
+> and adjudicated residual rather than as a gate?
+>
+> Full framing, every number, and the price of each answer: the design's
+> **"The decisions for the owner, and their price"**.
+>
+> - [ ] Put all three decisions to the repo owner with the tables above.
+> - [ ] Record the answers in a `### Decided, <date>` subsection of the design
+>       doc, in the shape M2's spec uses, and say what they supersede.
+> - [ ] If Decision A is refused: skip Tasks 1–7, keep Task 7's residual pins as
+>       the whole #2315 deliverable, and go straight to Task 8.
+
+**Goal:** Fix two defects in the same acceptance loop.
+
+- **Defect 1 (#2315)** — `scanQuoteRuns` destroys a turn when a paragraph
+  re-opens a quote glyph it never closed. Live on `main` today, on correctly
+  typeset input, using only a language's own `quotePairs`. **396 of 805 shapes.**
+- **Defect 2 (found by the review gate on PR #2286)** — a run *gained* by the
+  widening lands inside a **tag clause**, truncates it, and the adjacent real
+  turn **loses its speaker**, so it is read in the wrong voice. The turn
+  survives, so every turns-destroyed instrument reads 0. **21 of 42 constructed
+  cases; 265 corpus opportunities.**
+
+**Architecture:** Two independent changes, one in each half of `findQuoteRuns`
+(`server/src/analyzer/dialogue-structure/parser.ts`), plus one small helper each.
+No new field, no table change, no new source file.
+
+- The **re-open bound** lives in `scanQuoteRuns` (`:390`) and changes behaviour
+  on today's tables.
+- The **tag-clause guard** lives in `findQuoteRuns`'s secondary-admission loop
+  (`:363`) and is a **measured no-op** until #2286 lands, because every shipped
+  `secondaryQuotePairs` is empty.
+
+The guard needs the language's verb stems, which `findQuoteRuns`'s current
+signature does not carry — it gains a `conv` parameter from its single call site
+in `parseQuoteParagraph`, where `conv` is already in scope.
+
+**Tech Stack:** TypeScript (Node, ESM), Vitest. Server suite only.
+
+**Design of record:**
+[`docs/superpowers/specs/2026-08-13-primary-pair-straddle-design.md`](../specs/2026-08-13-primary-pair-straddle-design.md).
+**Read it before Task 2** — "Defect 1 — the mechanism" records why every
+acceptance-order rule is structurally incapable of fixing 65 % of it,
+"Candidate rules evaluated" records what each rejected rule costs, and
+"Residuals" records what this does *not* fix, which Task 7 pins as tests.
+
+**Consumer waiting on this:** PR
+[#2286](https://github.com/dudarenok-maker/Castwright/pull/2286) is **held in
+draft** until this lands. It moves nine pairs into `secondaryQuotePairs`; the
+tag-clause guard is what makes that safe for attribution.
+
+**Predecessors:** M1
+[`2026-08-12-quote-delimiter-validity.md`](2026-08-12-quote-delimiter-validity.md)
+(`e839a939`) and M2
+[`2026-08-13-gap-seeded-straddle.md`](2026-08-13-gap-seeded-straddle.md)
+(`69ced6c5`). Their invariants are inherited whole.
+
+---
+
+## Global Constraints
+
+The acceptance items, **verbatim from the two briefs**:
+
+1. The 579 goes to **0**, or answer 3 is chosen explicitly with a measured
+   prevalence figure.
+2. **Nesting still resolves to the OUTER run** in `en` and `zh`. Every prior
+   candidate rule in this strand died on this invariant.
+3. **M1's corpus result does not regress:** 938 clean repairs / 0 merged / 0 lost
+   / 0 gained / 0 split, scored with `2288-metric.mts`'s overlap classifier.
+4. **M2's criteria still hold:** 0 turns destroyed across all three sweep
+   families, 0 of 21 on the suppression class.
+5. Runs stay **disjoint**. #1601 stays fixed. `crossExamine`'s `dialogueOpen`
+   contract untouched.
+6. The **307-test** `dialogue-structure` + `narrator-default` suite stays green.
+7. **0 gained runs truncating a tag span**, measured with an **attribution-aware**
+   metric over the corpus — and the 265/92 figure re-measured to 0. The
+   instrument must show it can *see* the class with a control that fires.
+
+| item | status | where |
+|---|---|---|
+| 1 | **restated by Decision B** — 396 → 172; answer 3 for the residual, prevalence 5,267 of 239,725 (2.20 %) | Task 0, Task 7 |
+| 2 | **met, and extended to depth 3** — nesting is cross-glyph *at depth 2*; depth 3 re-uses depth 1's glyph and the proviso is what refuses to fragment it | Tasks 3, 6 |
+| 3 | **restated by Decision A** — 938 / 0 / 0 / 0 holds; `SPLIT` is 34 (English), all text-preserving | Task 0, Task 10 |
+| 4 | **met** — pairwise: +1,762 / −20, **0 nesting regressions**, suppression **0 of 21** | Task 9 |
+| 5 | **met** — half-open intervals; the truncated run ends where the next begins | Task 6 |
+| 6 | **7 tests fail and must be re-baselined**, one of which exists to pin defect 1 | Task 5 |
+| 7 | **restated by Decision C** — attribution family **21 → 0 of 42** with both controls firing; corpus proxy 265 → 156, residual adjudicated as legitimate gains | Task 0, Tasks 8–9 |
+
+Three things the implementation must NOT do, all of which have been tried:
+
+- **Do not reach for the cross-glyph case.** Every rule that bounds a run at an
+  interior opener of a *different* class either breaks nesting outright (`R2`:
+  601,392 characters of real speech lost, all four depth-3 anchors fail) or
+  reintroduces the suppression class (`R4`: a quoted word in narration changes
+  how a later turn parses).
+- **Do not delete the truncated run.** It is emitted with `closeLen: 0` and its
+  text is read as speech even when that text is narration — the reading of
+  record. Deleting it loses 367,436 characters of real speech (mutant `dropRun`).
+- **Do not make the tag-clause guard roster-aware.** Declining a secondary
+  candidate whose interior is a cast name would need `findQuoteRuns` to take the
+  `NameIndex`, and it fails on a turn that is a bare name
+  (`«Антон!», сказала она.`). The sentence-boundary discriminator needs no roster.
+
+---
+
+## Task 1 — RED: the same-glyph re-open destroys a turn
+
+**Files:** `server/src/analyzer/dialogue-structure/parser.test.ts`
+
+- [ ] Add `describe('parser — #2315: the re-open bound')` with the three
+      sub-mechanisms. All three FAIL before Task 2.
+
+```ts
+describe('parser — #2315: the re-open bound', () => {
+  /* Case 1 — same-glyph re-open. `fr` has a single quote pair, so turn 2's
+     opener is the same glyph as the stray. The per-opener scan resumes at the
+     END of the accepted run, so turn 2 produces NO CANDIDATE AT ALL: no
+     acceptance-order rule can reach this, which is why the fix is in the scan.
+     Design § "Defect 1 — the mechanism", case 1. */
+  it('fr: an unterminated « does not swallow the next turn', () => {
+    expect(
+      speechOf('«Bonjour», dit-il, regardant le «panneau de Faust. «Et toi», demanda-t-elle.', conventionsFor('fr')!),
+    ).toEqual(['Bonjour', 'panneau de Faust. ', 'Et toi']);
+  });
+  it('es: the design’s worked example keeps both turns', () => {
+    expect(speechOf('«Hola, dijo él. «Adiós», dijo ella.', conventionsFor('es')!)).toEqual([
+      'Hola, dijo él. ', 'Adiós',
+    ]);
+  });
+  /* The shape a real book produces when a CLOSING quote is typed as an OPENING
+     one. `toEqual`, not `toContain`: a superset assertion cannot see a rule
+     that ADDS a span, which is how an earlier candidate rule passed every
+     anchor while inventing a spurious speech span. */
+  it('en: a closing quote typed as an opening one keeps both turns', () => {
+    expect(speechOf('“Hello,“ he said. “Goodbye,” she said.', conventionsFor('en')!)).toEqual([
+      'Hello,', ' he said. ', 'Goodbye,',
+    ]);
+  });
+});
+```
+
+- [ ] **Verify:** `cd server && npx vitest run src/analyzer/dialogue-structure/parser.test.ts -t '#2315'` — all three RED, and **check each failure message**: the `got` must be the merged single run the design quotes, not an empty list or a crash.
+
+---
+
+## Task 2 — GREEN: the re-open bound, plain form
+
+**Files:** `server/src/analyzer/dialogue-structure/parser.ts`
+
+Task 2 ships the **plain** form deliberately, so Task 3's test can go red
+against it.
+
+```ts
+/** #2315. A quotation run may not contain a further occurrence of its OWN
+    opening glyph: a quotation cannot re-open without having closed.
+
+    Why this is not an acceptance rule. The per-opener scan resumes at the end
+    of an accepted run (`pos = end.at + end.glyph.length` below), so a re-opened
+    glyph inside that range never becomes a candidate at all — there is nothing
+    for any ordering, election, or tiering rule to choose. 258 of the 396 shapes
+    in the design's family are this case, and `fr`, whose table has one pair, is
+    entirely this case. */
+function reopenCut(line: string, interiorStart: number, endAt: number, open: string): number | null {
+  const at = line.indexOf(open, interiorStart);
+  return at >= 0 && at < endAt ? at : null;
+}
+```
+
+```ts
+      /* #2315: end the run at a re-open rather than letting it swallow the next
+         turn. The run is still EMITTED, with no closing delimiter — deleting it
+         destroys a turn, the harm this strand refuses; the spurious speech span
+         it can produce is the accepted lesser harm. Resuming at `cut` is what
+         lets the next turn be seen at all. */
+      const cut = reopenCut(line, interiorStart, end.at, open);
+      if (cut !== null && cut > interiorStart && cut < end.at) {
+        candidates.push({ start, end: cut, openLen: open.length, closeLen: 0 });
+        pos = cut;
+        continue;
+      }
+```
+
+- [ ] **Verify:** Task 1's three tests GREEN.
+- [ ] **Verify the depth-2 nesting invariant did not move**, before going on:
+      `speechOf('“He said ‘hi’ to me,” she explained.', en)` is
+      `['He said ‘hi’ to me,']` and `「他说『你好』然后走了」` resolves to the outer run.
+
+---
+
+## Task 3 — RED then GREEN: the plain-prefix proviso (depth ≥ 3)
+
+**Files:** `parser.test.ts`, then `parser.ts`
+
+**This is the task the first revision of the design got wrong.** No language
+nests a pair inside itself; they alternate by depth, so **depth 3 re-uses depth
+1's glyph**. Task 2's form fragments every such turn.
+
+- [ ] Add the RED tests. `main` is *already* wrong on these (it truncates at the
+      depth-3 closer) — these do not ask for the right answer, they ask that the
+      turn is not **fragmented into a one-word speech span**, which is a
+      different and worse harm class.
+
+```ts
+  /* DEPTH 3 — the proviso's reason to exist. `main` already mis-parses these;
+     the requirement is only that the fix does not make it worse by promoting a
+     depth-3 quoted word to its own speech span, which the render then
+     attributes and voices separately. Design § "Depth ≥ 3". */
+  it.each([
+    ['en', '“He told me, ‘She said “no” to him,’ and walked off,” Mary explained.', 'no'],
+    ['zh', '「他说『她说「不」了』然后走了」她解释说。', '不'],
+    ['ru', '«Он сказал „она сказала «нет» ему“ мне», объяснил он.', 'нет'],
+    /* straight from the corpus: se/charlotte-perkins-gilman_moving-the-mountain */
+    ['en', '“Mother had an old storybook,” Nellie remarked, “where somebody said, ‘You can’t always have your “druthers” ’—like home.”', 'druthers'],
+  ])('%s: depth-3 nesting is not fragmented into a one-word span', (lang, body, fragment) => {
+    expect(speechOf(body, conventionsFor(lang)!)).not.toContain(fragment);
+  });
+```
+
+- [ ] **Verify:** all four RED against Task 2's form, and the `got` shows the
+      container plus the one-word span. If it is anything else, stop.
+- [ ] Add the proviso:
+
+```ts
+function reopenCut(
+  line: string,
+  interiorStart: number,
+  endAt: number,
+  open: string,
+  openers: Set<string>,
+): number | null {
+  const at = line.indexOf(open, interiorStart);
+  if (at < 0 || at >= endAt) return null;
+  /* No language nests a pair inside itself — conventions alternate BY DEPTH, so
+     depth 3 re-uses depth 1's glyph. An opener of any class between this run's
+     own opener and the re-occurrence means a nest is in play, and the
+     re-occurrence is a nesting delimiter rather than a re-open. Refusing to act
+     whenever nesting is anywhere in play costs family shapes (164 -> 172) and
+     no real turns. */
+  for (const o of openers) {
+    const k = line.indexOf(o, interiorStart);
+    if (k >= 0 && k < at) return null;
+  }
+  return at;
+}
+```
+
+- [ ] **Verify:** Tasks 1 and 3 all GREEN.
+- [ ] **Verify the cost:** the design measured `+10–13 %` on `findQuoteRuns` over
+      726,385 paragraphs. Re-run `scratchpad/s2315/perf.mts` and record it in the
+      PR body; if it exceeds `+50 %`, stop and report rather than optimising.
+
+---
+
+## Task 4 — RED then GREEN: the closer-as-opener collision
+
+**Files:** `parser.test.ts`
+
+The sub-mechanism the ticket does not describe: **no stray glyph, no drift, both
+turns well-formed**, and a turn still disappears.
+
+```ts
+  /* Case 3 — `ru`'s `“` closes turn 1 AND opens a pair, so the scan seeds a run
+     there, that run is discarded for overlapping turn 1, and the cursor has by
+     then passed turn 2's genuine `“`. Surfaced by the family instrument's own
+     no-stray control, which exists to prove it does not cry wolf. */
+  it('ru: turn 1’s own closing „…“ does not consume turn 2’s opener', () => {
+    expect(speechOf('„Привет“, сказал он. “Пока”, сказала она.', conventionsFor('ru')!)).toEqual([
+      'Привет', 'Пока',
+    ]);
+  });
+```
+
+- [ ] **Verify:** RED before Task 2 (`got` is `['Привет']`), GREEN after.
+
+---
+
+## Task 5 — re-baseline the seven tests this changes
+
+**Files:** `parser.test.ts`, `tier-sweep.test.ts`
+
+Measured by running the suite against a prototype patch. **Each edit carries its
+reason in a comment**; a re-baselined number with no reason is indistinguishable
+from a number bent to fit.
+
+- [ ] `parser.test.ts` › `residual 1: the straddle inside a language's own PRIMARY pairs is untouched (design residual 1)` — **invert it.** This test exists to pin #2315; it is now the fix's own regression test. Keep the M2 cross-reference, add the #2315 one, do **not** delete it.
+- [ ] `tier-sweep.test.ts` — six `tiered differs from ref on N scored shapes` counts: `F2 es 88→96`, `F2 ru 225→261`, `F2 en 114→133`, `F3 es 116→124`, `F3 ru 618→662`, `F3 en 258→277`. **Re-measure each rather than copying these numbers**, and record that the purpose (proving the tier is engaged) is unchanged.
+- [ ] **Verify:** `cd server && npx vitest run src/analyzer/dialogue-structure src/analyzer/narrator-default.test.ts` — all green, total is 308 + the tests this plan adds, nothing skipped or deleted.
+
+---
+
+## Task 6 — the inherited invariants, asserted not assumed
+
+**Files:** `parser.test.ts`
+
+```ts
+  it('runs stay disjoint when a run is truncated at a re-open', () => {
+    const body = '«Hola, dijo él. «Adiós», dijo ella.';
+    const spans = parseChapterStructure(body, buildNameIndex([], conventionsFor('es')!))
+      .flatMap((p) => p.spans)
+      .sort((a, b) => a.start - b.start);
+    for (let i = 1; i < spans.length; i++) expect(spans[i].start).toBeGreaterThanOrEqual(spans[i - 1].end);
+  });
+
+  it('a truncated run never produces an empty speech span', () => {
+    /* `cut > interiorStart` guarantees this; the degenerate `««` input falls
+       through to the shipped behaviour instead. */
+    expect(speechOf('««Hola», dijo él.', conventionsFor('es')!).every((s) => s.length > 0)).toBe(true);
+  });
+```
+
+- [ ] **Verify:** the existing M1 and #1601 tests still pass untouched —
+      `-t 'M1'` and `-t '1601'`. Do not edit them.
+
+---
+
+## Task 7 — pin the residual AS a residual
+
+**Files:** `parser.test.ts`
+
+The cross-glyph and symmetric-delimiter straddles are **not** fixed and that is
+the recommendation, not an oversight. Pin them so a later change cannot silently
+alter them in either direction.
+
+```ts
+describe('parser — #2315 residuals, accepted (design § Residuals)', () => {
+  /* 1a — the CROSS-GLYPH straddle. This interval geometry is byte-for-byte a
+     legitimate nest, and it occurs in 5,267 of 239,725 real corpus paragraphs
+     where it is overwhelmingly correct. Every rule that acts on it was
+     measured: `R2` removes 601,392 characters of real speech; `R4` lets a
+     quoted word in narration change how a later turn parses. */
+  it('residual 1a: a cross-glyph straddle still swallows the next turn', () => {
+    expect(
+      speechOf('«Hola», dijo él, mirando el “cartel de Fausto. «Y tú», preguntó ella, cerca de la galería”.', conventionsFor('es')!),
+    ).toEqual(['Hola', 'cartel de Fausto. «Y tú», preguntó ella, cerca de la galería']);
+  });
+  /* 1b — the SYMMETRIC delimiter. With `"` the opener and the closer are the
+     same character, so an odd count means one is unpaired and nothing local can
+     say which. Irreducible: even `R2`, the ceiling, leaves this class. */
+  it('residual 1b: a stray ASCII " still swallows the next turn', () => {
+    expect(
+      speechOf('“Hi”, he said, passing the "Faust poster. "Bye", she said, near the gallery".', conventionsFor('en')!),
+    ).toEqual(['Hi', 'Faust poster. ', ', she said, near the gallery']);
+  });
+  /* 3 — depth >= 3 nesting is STILL mis-parsed; `main` truncates at the
+     depth-3 closer and this change leaves that untouched. Pinned so the
+     pre-existing defect is visible rather than assumed fixed. */
+  it('residual 3: depth-3 nesting is still truncated at the depth-3 closer', () => {
+    expect(speechOf('“He told me, ‘She said “no” to him,’ and walked off,” Mary explained.', conventionsFor('en')!))
+      .toEqual(['He told me, ‘She said “no']);
+  });
+});
+```
+
+- [ ] **Verify:** all GREEN, and **re-measure every expectation from the real
+      parser** rather than trusting the strings above — they came from the
+      design's prototype, not from shipped code.
+
+---
+
+## Task 8 — RED: a gained secondary run cuts a tag clause and costs a speaker
+
+**Files:** `server/src/analyzer/dialogue-structure/parser.test.ts`
+
+**Defect 2.** This is the first test in this strand that reads the `speaker`
+field. Every existing instrument builds `buildNameIndex([], conv)` — an empty
+roster — so `speaker` is never populated and never compared; "0 lost / 0 merged /
+0 split" is silent about attribution **by construction**.
+
+```ts
+describe('parser — #2315 defect 2: a gained secondary run must not cut a tag clause', () => {
+  const ru = conventionsFor('ru')!;
+  const tiered = { ...ru, secondaryQuotePairs: [['‘', '’']] as Array<[string, string]> };
+  const roster = [{ id: 'anton', name: 'Антон' }];
+  const speakersOf = (body: string, conv: typeof ru) =>
+    parseChapterStructure(body, buildNameIndex(roster as never, conv))
+      .flatMap((p) => p.spans)
+      .filter((s) => s.kind === 'speech')
+      .map((s) => [body.slice(s.start, s.end), s.speaker?.characterId ?? null]);
+
+  /* POSITIVE CONTROL, and it must come first: without it a zero below could
+     mean "the metric cannot read a speaker at all". */
+  it('control: with no secondary pair the turn is attributed', () => {
+    expect(speakersOf('«Привет», сказал ‘Антон’.', ru)).toEqual([['Привет', 'anton']]);
+  });
+
+  it('the tag keeps its name when the tier is declared', () => {
+    expect(speakersOf('«Привет», сказал ‘Антон’.', tiered)).toEqual([['Привет', 'anton']]);
+  });
+
+  /* MUST STILL WORK: a genuine secondary-convention SECOND TURN, which the
+     guard must admit. The discriminator is the sentence boundary after the
+     tag, not the verb. */
+  it('a genuine secondary-convention second turn is still recovered', () => {
+    expect(speakersOf('«Привет», сказал Антон. ‘Пока’, сказал Антон.', tiered)).toEqual([
+      ['Привет', 'anton'], ['Пока', 'anton'],
+    ]);
+  });
+});
+```
+
+- [ ] **Verify:** the control and the third test pass on unmodified `main`; the
+      second is RED, and its `got` shows `[['Привет', null], ['Антон', null]]` —
+      the tag truncated and the speaker gone. Any other `got` means the fixture
+      is wrong.
+
+---
+
+## Task 9 — GREEN: the tag-clause guard
+
+**Files:** `server/src/analyzer/dialogue-structure/parser.ts`
+
+`findQuoteRuns` gains a `conv` parameter from its single call site in
+`parseQuoteParagraph`, where `conv` is already in scope.
+
+```ts
+/** Sentence-final punctuation, including the CJK full-width forms — without
+    them `zh`/`ja` read every tag as one unbroken clause. */
+const SENTENCE_END = /[.!?…。！？；;]/u;
+
+/** #2315 defect 2. A gained SECONDARY run that lands INSIDE a tag clause
+    truncates it, `findRosterName` never reaches the name, and the adjacent real
+    turn loses its speaker — so it is read in the wrong voice. The turn
+    survives, so every turns-destroyed instrument in this strand reads 0.
+
+    The discriminator is a SENTENCE BOUNDARY, not a verb alone:
+      `, сказал `      verb, no sentence end -> inside the tag clause -> decline
+      `, сказал он. `  verb, sentence end    -> a new sentence, a turn -> admit
+      ` en la portada. ` no verb             -> narration; M2's suppression
+                                                class                  -> admit
+
+    The window is the CLAUSE, not the whole gap: scoping it to the gap was
+    measured and only moved the corpus figure 265 -> 165, because a long
+    paragraph's gap contains earlier sentence-final punctuation. Secondary-tier
+    only, so it is a measured no-op on every shipped table. */
+function cutsATagClause(line: string, cand: QuoteRun, primaryRuns: QuoteRun[], conv: LanguageConventions): boolean {
+  const stems = [...conv.speechVerbStems, ...conv.beatVerbStems];
+  let from = 0;
+  for (const r of primaryRuns) if (r.end <= cand.start && r.end > from) from = r.end;
+  for (let i = cand.start - 1; i >= from; i--) {
+    if (SENTENCE_END.test(line[i])) { from = i + 1; break; }
+  }
+  const clause = line.slice(from, cand.start).toLowerCase();
+  return stems.some((s) => clause.includes(s.toLowerCase()));
+}
+```
+
+…and one line in the secondary-admission loop, after the straddle test:
+
+```ts
+    if (cutsATagClause(line, c, primaryRuns, conv)) continue;
+```
+
+- [ ] **Verify:** Task 8's second test GREEN, the other two still GREEN.
+- [ ] **Verify the no-op claim rather than asserting it.** With every shipped
+      table (all `secondaryQuotePairs` empty) the guard must change nothing:
+      re-run `s2315/family.mts`, `s2315/anchors.mts` and
+      `s2315/corpus.mts … A` with and without it and require **identical**
+      output (172, 19/22, `938 / 0 / 0 / 0 / 0` + SPLIT 34).
+- [ ] **Verify M2's suppression class is untouched:** `s2315/m2check.mts` must
+      still read `SUPP 21 shapes, 0 destroyed, 0 regressed`.
+
+---
+
+## Task 10 — the generated sweeps, with controls that can go red
+
+**Files:** `server/src/analyzer/dialogue-structure/reopen-sweep.test.ts` (new)
+
+M2's committed sweep passed under three separate mutations of the rule it existed
+to pin, and `sweep-six-langs`'s "0 destroyed of 51,608" is a **constant** — it
+reads 0 with both tier guards deleted. **Do not reuse that family as a gate.**
+
+- [ ] Port the design's 805-shape family (`scratchpad/s2315/family.mts`) into a
+      committed test through the **real** parser — no env vars, no patched module
+      copies, no reimplementation. Restrict to `de`/`ru`/`en` (104 + 150 + 54 of
+      the 396) if the whole set exceeds ~2 s; **never thin the cross-product
+      within a language.**
+- [ ] Port the **attribution family** (`scratchpad/s2315/attrib.mts`) with its
+      two controls. This is the gate for defect 2.
+- [ ] Assertions, and the controls are what make the first one mean anything:
+  - `expect(destroyed).toBe(<measured>)` per language, and
+    `expect(speakersLost).toBe(0)`.
+  - **positive control:** the attribution family with no secondary pair must
+    attribute every case (42 of 42).
+  - **firing control:** the same family with the guard bypassed must lose 21.
+  - **no-stray control:** family shapes with no stray opener must destroy 0.
+- [ ] **Verify by mutation, and record the output in the PR body.** Make each
+      change, confirm RED, revert:
+      (a) `pos = cut` → `pos = end.at + end.glyph.length` (family → 396);
+      (b) drop the truncated run instead of pushing it;
+      (c) remove the proviso loop in `reopenCut` (depth-3 tests fail);
+      (d) remove the `cutsATagClause` call (attribution → 21 lost);
+      (e) scope the guard's window to the gap instead of the clause.
+      **A mutation that leaves the suite green is a defect in this task.**
+
+---
+
+## Task 11 — corpus re-verification, docs, ship
+
+- [ ] Re-run the design's corpus instruments against the **shipped** code, not
+      the prototype: `METRIC_LIB=1 tsx s2315/corpus.mts <rule> both`,
+      `METRIC_LIB=1 tsx s2315/adjudicate.mts <rule>`, `tsx s2315/tagcut.mts <rule>`,
+      `tsx s2315/attrib.mts <rule>`. Expect ARM A `938 / 0 / 0 / 0 / 0` with
+      `SPLIT 34`; `1,231 changed / 1,231 text-preserving / 0 characters lost / 0
+      mid-word`; tag-cut proxy `265 → 156`; attribution `0 of 42`. **If any
+      figure differs from the design, stop and report** — the prototype and the
+      shipped code have diverged.
+- [ ] `npm run test:server` and `npm run verify:fast:branch`.
+- [ ] Design doc → `status: stable`; fill this plan's Ship notes.
+- [ ] `docs/release-notes-next.md` (technical, PR-refed) **and** `RELEASE_NOTES.md`
+      (brand voice, in-progress section). The user-visible delta is real and
+      twofold: turns that were read as part of the previous speaker's line are now
+      their own turn in seven languages, and a line whose tag quotes a character's
+      name keeps that character's voice.
+- [ ] **On-box acceptance:** a row is owed. The change alters run boundaries on
+      real books in seven languages, and whether a truncated narration span
+      *sounds* acceptable when voiced is not something any test here answers. Add
+      the row to `docs/testing/onbox-acceptance-register.md`, the live view, and
+      this plan, per CLAUDE.md's before-shipping step 3. Say what to observe:
+      generate a chapter of a `zh` or `ja` book containing a continuation
+      paragraph (the design quotes two) and confirm the recovered inner turn is
+      voiced as its own turn with its own cast voice.
+- [ ] **Unblock the consumer:** comment on PR
+      [#2286](https://github.com/dudarenok-maker/Castwright/pull/2286) that the
+      tag-clause guard has landed, and take it out of draft.
+- [ ] PR body: `Closes #2315`, the measured tables from the design's Summary, the
+      mutation outputs from Task 10, and an explicit line naming the accepted
+      residuals and the three Task 0 decisions.
+
+---
+
+## Ship notes
+
+*(filled at merge)*

--- a/docs/superpowers/specs/2026-08-13-primary-pair-straddle-design.md
+++ b/docs/superpowers/specs/2026-08-13-primary-pair-straddle-design.md
@@ -1,0 +1,785 @@
+# The primary-pair straddle, and the tag-clause cut — design
+
+Status: **active — recommendation made, three owner decisions owed (Task 0)** ·
+Issue: [#2315](https://github.com/dudarenok-maker/Castwright/issues/2315) ·
+Blocks: [#2286](https://github.com/dudarenok-maker/Castwright/pull/2286) (held in
+draft until this lands) ·
+Follows: M1
+[`2026-08-12-quote-delimiter-validity-design.md`](2026-08-12-quote-delimiter-validity-design.md)
+(shipped `e839a939`, PR [#2300](https://github.com/dudarenok-maker/Castwright/pull/2300))
+and M2
+[`2026-08-13-gap-seeded-straddle-design.md`](2026-08-13-gap-seeded-straddle-design.md)
+(shipped `69ced6c5`, PR [#2319](https://github.com/dudarenok-maker/Castwright/pull/2319)) —
+this is that document's **residual 1**, plus a defect in its shipped rule that
+its own residual pricing did not anticipate.
+
+Implementation plan:
+[`docs/superpowers/plans/2026-08-13-primary-pair-straddle.md`](../plans/2026-08-13-primary-pair-straddle.md)
+
+---
+
+## Summary
+
+**This design covers two defects, not one.** They live in the same acceptance
+loop, and a rule for either must not reintroduce the other.
+
+**Defect 1 — the primary-pair straddle (#2315).** A turn is destroyed when a
+paragraph re-opens a quote glyph it never closed. Live on `main` today, on
+correctly typeset input, using only a language's own `quotePairs`.
+
+**Defect 2 — the tag-clause cut** (found by the review gate on PR #2286, added to
+this pass by the repo owner). A run *gained* by the widening lands inside a **tag
+clause**, truncates it, and the adjacent real turn **loses its speaker** — so it
+is read in the wrong voice. The turn survives, so every turns-destroyed
+instrument in this strand reads 0.
+
+Two rules, one in each half of `findQuoteRuns`, independent by construction:
+
+> **The RE-OPEN BOUND** (defect 1, primary scan). A quotation run may not contain
+> a further occurrence of its own opening glyph, **provided no opener glyph of
+> any class appears between the run's own opener and that occurrence**. When it
+> does, the run ends there — with no closing delimiter, still emitted — and the
+> scan resumes from there.
+>
+> **The TAG-CLAUSE GUARD** (defect 2, secondary admission). A secondary-tier
+> candidate is declined when the **clause** its opener sits in — from the later
+> of the preceding primary run's end and the last sentence-final punctuation —
+> carries a speech or beat verb stem.
+
+| | shipped (today) | **both rules** |
+|---|---:|---:|
+| straddle family, turns destroyed | **396 of 805** | **172 of 805** |
+| invariant anchors | 17 of 22 | **19 of 22** |
+| **attribution: turns that lose their speaker** | **21 of 42** | **0 of 42** |
+| corpus, English, M1's tuple | 938 / 0 / 0 / 0 / 0 | **938 / 0 / 0 / 0 / 0**, SPLIT 34 |
+| corpus, 7 languages, speech text lost | — | **0 characters, 0 mid-word cuts** |
+| M2's families, shapes repaired / regressed | — | **+1,762 / −20**, nesting regressions **0**, suppression **0 of 21** |
+| the 308-test suite | — | **7 fail**, all number-pinning |
+
+The re-open bound does not take the destroyed count to zero and **no rule
+measured here does**. The residual — 172 shapes, all *cross-glyph* and
+*symmetric-delimiter* straddles — is answer 3 of the ticket, proposed **with the
+measured prevalence figure the ticket demands**: the geometry it hides in occurs
+in **5,267 of 239,725 real corpus paragraphs (2.20%)**, is byte-for-byte
+identical to legitimate nesting, and the rule that acts on it removes **601,392
+characters of real speech**.
+
+Five findings about the *evidence* matter as much as the result:
+
+1. **The ticket's headline number is a different number.** `579` is a
+   **corruption** count, not a destruction count, on a shape set defined by the
+   **widened** table. Measured as the ticket describes it: **396 destroyed of
+   805**, seven languages including `de`, which the earlier family omitted.
+2. **For the dominant sub-case there is no candidate to choose between.** The
+   scan resumes at the end of an accepted run, so a same-glyph re-open never
+   produces a candidate. Every acceptance-order rule is *structurally incapable*
+   of fixing 258 of the 396.
+3. **A third sub-mechanism the ticket does not describe**: a paragraph with **no
+   stray glyph at all** loses a turn when one glyph is both a closer of one pair
+   and the opener of another (`ru`'s `“`).
+4. **Depth ≥ 3 nesting re-uses depth 1's glyph.** The first revision of this
+   document recommended a rule that fragmented every such turn. Found by the
+   adversarial pass; the proviso is the fix and four anchors pin it.
+5. **Three of the acceptance criteria cannot be met as written** — one because
+   its number has no referent, one because it contradicts the fix, and one
+   (the new tag-cut criterion) because its corpus proxy counts legitimate gains.
+   § *The acceptance items that are not met*.
+
+---
+
+## The ticket's number
+
+The ticket states: *"`findQuoteRuns` destroys 579 of 2,456 well-formed two-turn
+shapes on `main` today, using only a language's own primary `quotePairs`."*
+
+Reproduced (`m2-primary-residual.mts`, unchanged):
+
+```
+lang  table   shapes  corrupt  destroyed
+es    main       117       36         85
+fr    main       117       18        108
+ru    main       775      215        457
+en    main       336       96        210
+zh    main       775      150        568
+ja    main       336       64        276
+TOTAL           2456      579       1704
+```
+
+`579` is the **corrupt** column — a speech span containing a narration word. The
+destroyed column on that shape set is `1,704`. M2's spec quotes 579 correctly, as
+a corruption figure; the ticket carries the number across to the word "destroys".
+
+The shape set is also not the one the sentence describes: `wellFormed` is
+evaluated against the **widened** table and the glyph universe is
+`main ∪ widened`, so the `main` row mixes genuine straddles with turns typeset in
+conventions `main` does not carry — the same objection M2's own spec raises
+against reading `1,704` as a straddle count, one level further.
+
+**Measured as the ticket describes it** (`s2315/family.mts`): every glyph from
+the language's own `quotePairs`; both turns pairing an opener with *its own*
+declared closer; no widening anywhere. Ground truth is the construction, not a
+parser reading.
+
+```
+lang  shapes  DESTROYED  corrupt   |  no-stray control
+de       176        104      104   |  16 shapes, 0 destroyed
+en       117         54       54   |   9 shapes, 0 destroyed
+es        28         16       16   |   4 shapes, 0 destroyed
+fr         3          2        2   |   1 shape,  0 destroyed
+ja        28         16       16   |   4 shapes, 0 destroyed
+ru       336        150      136   |  16 shapes, 1 DESTROYED  <- see case 3
+zh       117         54       54   |   9 shapes, 0 destroyed
+TOTAL    805        396      382
+```
+
+**396 of 805.** "The 579 goes to 0" therefore has no well-defined referent; it is
+restated as *"the 396 goes to 0"*, and the recommendation does not meet it.
+
+---
+
+## Defect 1 — the mechanism
+
+`findQuoteRuns` → `scanQuoteRuns`
+(`server/src/analyzer/dialogue-structure/parser.ts:390`) builds one candidate per
+opener occurrence and accepts leftmost-first. Three distinct shapes make a turn
+disappear.
+
+### Case 1 — the same-glyph re-open (258 of 396)
+
+```
+fr  «Bonjour», dit-il, regardant le «panneau de Faust. «Et toi», demanda-t-elle.
+    today   ["Bonjour", "panneau de Faust. «Et toi"]
+```
+
+An unterminated `«` takes the next `»` — turn 2's own closer. **Turn 2 produces
+no candidate at all**: the per-opener scan sets `pos = end.at + end.glyph.length`
+(`parser.ts:488`), so the second `«` is inside the accepted range and is never
+visited.
+
+This reframes the ticket. Its answer 1 is "intra-tier gap-scoping by some
+ordering", and M2's rejected-rules table is entirely acceptance-order rules.
+**There is nothing to order.** A candidate list with one candidate has one
+acceptance. The fix must change what the *scan* produces. `fr`, whose table has a
+single pair, is entirely this case.
+
+### Case 2 — the cross-glyph stray (137 of 396)
+
+```
+es  «Hola», dijo él, mirando el “cartel de Fausto. «Y tú», preguntó ella, cerca de la galería”.
+    today   ["Hola", "cartel de Fausto. «Y tú», preguntó ella, cerca de la galería"]
+```
+
+Turn 2 *does* produce a candidate; leftmost-wins discards it. This interval
+geometry is **byte-for-byte the geometry of a legitimate nest**
+(`“He said ‘hi’ to me,”`). M2 separated the two with a *tier* fact; within one
+tier there is no tier fact. § *Why the cross-glyph case is not decidable here*.
+
+### Case 3 — the closer-as-opener collision (the ticket does not describe this one)
+
+```
+ru  „Привет“, сказал он. “Пока”, сказала она.
+    today   ["Привет"]                          <- turn 2 destroyed
+```
+
+**No stray glyph. No drift. Both turns well-formed under `ru`'s own table.** `ru`
+pairs both `„“` and `“”`, so the `“` closing turn 1 is also a valid opener. The
+run it seeds is discarded for overlapping turn 1 — and the cursor has by then
+passed turn 2's genuine `“`. Surfaced by the family instrument's own no-stray
+control, which exists to prove it does not cry wolf on clean input.
+
+### Depth ≥ 3 — already broken, and a careless fix makes it worse
+
+No language nests a pair inside itself; they **alternate by depth**, so **depth 3
+re-uses depth 1's glyph**:
+
+```
+en  “He told me, ‘She said “no” to him,’ and walked off,” Mary explained.
+    today   ["He told me, ‘She said “no"]     <- ALREADY wrong, truncated at depth 3's closer
+```
+
+`main` is already wrong here; that is a **pre-existing defect, out of scope**. A
+rule that treats *any* re-occurrence as a re-open turns it into a **worse** one:
+
+```
+    plain re-open bound  ["He told me, ‘She said ", "no"]
+```
+
+— one turn becomes a container plus a **one-word speech span**, which the render
+attributes and voices separately. That is not the harm class the reading of
+record accepts; it is a turn fragmented. The proviso refuses it and four anchors
+(18–21, one of them a corpus paragraph) pin it. **No family or anchor in this
+document's first revision covered depth ≥ 3** — the same structural gap M2 was
+caught with on `gap × nest`.
+
+### Why the cross-glyph case is not decidable here
+
+Bounding at *any* interior opener (`R2`) is the ceiling: 396 → **52**. Its price
+on the 331 supported-language books:
+
+```
+R2_anyOpener   changed paragraphs 6221
+lang   changed  TEXT-PRESERVING  TEXT-LOSING  alnum chars lost  MIDWORD
+en        3002              728         2274            436755       20
+zh        2686              784         1902            142596      300
+…
+TOTAL     6221             1954         4267            601392      321
+```
+
+**601,392 characters of real speech stop being speech**, 321 runs end mid-word,
+anchors fall to 10 of 22. The population it acts on is **5,267 of 239,725 corpus
+paragraphs with runs (2.20%)**, and a random sample of it is legitimate nesting
+throughout. That is the answer-3 prevalence figure: *the residual hides inside a
+population that is overwhelmingly correct, and any rule acting on it has to be
+right about all 5,267.*
+
+---
+
+## Defect 2 — the tag-clause cut
+
+Added to this design pass by the repo owner after a review gate on PR #2286.
+**M2's shipped rule B has it**, and M2's own residual pricing did not anticipate
+it.
+
+```
+ru, roster [{id:'anton', name:'Антон'}]
+
+  «Привет», сказал ‘Антон’.
+    main   speech[anton]="Привет" | tag[-]=", сказал ‘Антон’."
+    M2     speech[-]="Привет" | tag[-]=", сказал " | speech[-]="Антон" | narration[-]="."
+```
+
+The gained secondary run sits in the gap, M2's tier admits it (no primary opener
+inside, so it is not a straddle), it **truncates the tag**, and `findRosterName`
+never reaches `Антон`. The turn survives with **no speaker**, and is then read in
+the narrator's voice or the wrong character's. Identical in `es`, `fr`, `en`,
+`zh`, `ja`.
+
+### Why every existing instrument is blind to it
+
+The corpus comparison builds `buildNameIndex([], conv)` — an **empty roster** —
+and classifies on speech-run `[start, end)` geometry alone. Speaker fields are
+never populated, so never compared. **"0 lost / 0 merged / 0 split" is silent
+about attribution by construction, not by measurement.** The generated sweeps and
+the committed `parser.test.ts` residual pins compare span *strings* only.
+
+### The correction to M2's residual pricing
+
+M2's design of record prices rule B's residual as *"narration spoken aloud —
+audible, attributable, and recoverable by a later rule"*, and the owner approved
+rule B on that pricing. **That sentence is now known to be understated.** The
+residual also contains **a real turn losing its speaker**, which is neither
+audible as an error nor attributable nor obviously recoverable: the line simply
+plays in the wrong voice, and nothing downstream flags it. This design records
+the correction rather than repeating the original sentence; it does not reopen
+the decision, because the fix below removes the class rather than re-pricing it.
+
+### The rule
+
+> A secondary-tier candidate is declined when the **clause** its opener sits in
+> carries a speech or beat verb stem. The clause runs from the later of (the
+> preceding primary run's end) and (just after the last sentence-final
+> punctuation before the candidate) up to the candidate's opener.
+
+The discriminator is a **sentence boundary**, not a verb alone:
+
+```
+, сказал            verb, NO sentence end  -> inside the tag clause      -> DECLINE
+, сказал он.        verb, sentence end     -> a new sentence, a turn     -> ADMIT
+ en la portada.     no verb                -> narration (M2's SUPP class)-> ADMIT
+```
+
+Scoping the window to the **gap** rather than to the **clause** was measured
+first and only moved the corpus proxy from 265 to 165: in a long paragraph the
+gap contains earlier sentence-final punctuation, so the guard read "a new
+sentence starts here" for a candidate sitting mid-clause several sentences later.
+
+**It is secondary-tier only, so it is a measured no-op on every shipped table**
+(all `secondaryQuotePairs` are empty): the family, the anchors and both corpus
+arms are byte-identical with and without it. It costs nothing until #2286 lands,
+and #2286 is the consumer waiting on it.
+
+---
+
+## Candidate rules evaluated
+
+All rules reuse the shipped (post-M1, post-M2) scan and tier verbatim, with one
+parameter added each, so any column difference is attributable to the one
+mechanism that moved. The port is asserted byte-identical to the unpatched parser
+across 1,190,634 corpus paragraphs before any rule is scored.
+
+FAMILY = turns destroyed of 805. ANCHORS = the 22 invariant cases. ARM A = the
+140-book English corpus vs the pre-#2288 baseline. LOST/GAINED = alphanumeric
+characters that stop/start being speech, 7 languages, 331 books. ATTRIB =
+speakers lost of 42.
+
+| rule | FAMILY | ANCHORS | ARM A tuple | ARM A SPLIT | changed | LOST | GAINED | MERGED | ATTRIB |
+|---|---:|---:|---|---:|---:|---:|---:|---:|---:|
+| `shipped` (today) | 396 | 17/22 | 938 / 0 / 0 / 0 / 0 | 0 | — | — | — | — | **21** |
+| `none` — negative control | 805 | 4/22 | — | — | — | — | — | — | — |
+| **B** shortest-first (ticket answer 1) | 274 | 11/22 | not measured | — | 5,278 | **1,226,585** | — | — | — |
+| **R2** bound at ANY interior opener | **52** | 10/22 | not measured | — | 6,221 | **601,392** | — | — | — |
+| **R3** bound at an UNRESOLVED interior opener | 164 | 15/22 | not measured | — | — | — | — | — | — |
+| **R4** established class (ticket answer 2) | **123** | 15/22 | 938 / 0 / 0 / 0 / 0 | 125 | 1,410 | not measured | — | — | — |
+| **R1** re-open bound, plain | 164 | 15/22 | 938 / 0 / 0 / 0 / 0 | 125 | 1,399 | **0** | — | 1 | — |
+| **R1b** + nested-run exemption | 164 | 15/22 | 938 / 0 / 0 / 0 / 0 | 118 | 1,391 | **0** | 393 | 1 | — |
+| **R1c** + plain-prefix proviso ★ | **172** | **19/22** | **938 / 0 / 0 / 0 / 0** | **34** | **1,231** | **0** | **65** | **0** | 21 |
+| **R1c + G** (both rules) ★ | **172** | **19/22** | **938 / 0 / 0 / 0 / 0** | **34** | **1,231** | **0** | **65** | **0** | **0** |
+
+★ recommended. The last two rows are identical everywhere except ATTRIB, which is
+the measured proof that the guard is a no-op on today's tables and that the two
+rules are independent.
+
+**Why each rejected rule is out**, one line each:
+
+- **Shortest-first** returns `["hi"]` for `“He said ‘hi’ to me,”` and loses
+  1,226,585 characters of real speech. Re-measured here rather than cited from
+  M2, so the instrument is shown reproducing the failure it was built to catch.
+- **R2** is the ceiling, not a candidate. Its value is the *bound on what any
+  bounding rule can achieve* — even R2 leaves 52 (32 with a symmetric ASCII `"`
+  stray, 20 with a `„` stray). **That 52 is the floor of this approach.**
+- **R3** never fires where R1 does not: in this family the inner opener always
+  resolves inside the outer run.
+- **R4** is the ticket's answer 2 in its only non-destructive form. It buys 41
+  shapes over R1 and **fails anchor 16**:
+
+  ```
+  en  He wrote ‘hi’ on the board. “He said ‘hi’ to me,” she added.
+      R4  ["hi", "He said ", "hi"]        <- the nest is cut in half
+  ```
+
+  A quoted *word in narration* changes how a later turn parses: the
+  **suppression class that disqualified M2's rule A**, reincarnated one level
+  down. It also fails anchors 14, 15 and all four depth-3 anchors, and adds 4
+  mid-word breaks on the English corpus that R1c does not.
+- **R1** breaks **155 legitimate `ru` nests** in M2's F3 cross-product.
+- **R1b** fixes that and still fails all four depth-3 anchors. It is retained as
+  **R1c's own mutant** — R1c with the proviso removed — and is how the proviso is
+  shown to be load-bearing.
+
+---
+
+## The recommended rules
+
+### Re-open bound — four properties
+
+1. **It truncates, it never deletes.** `«Bonjour», … le «panneau de Faust. «Et
+   toi», …` → `["Bonjour", "panneau de Faust. ", "Et toi"]`: turn 2 recovered,
+   the middle span narration read as speech — the accepted lesser harm. Deleting
+   instead (mutant `dropRun`) loses **367,436 characters** of real speech.
+2. **It resumes at the cut.** This is what lets turn 2 be seen at all in case 1.
+   Not resuming (mutant `noResume`) returns the family score to **exactly** the
+   shipped 396 and loses 192,525 characters.
+3. **It refuses whenever nesting is in play.** The proviso is the signature of an
+   unterminated quotation followed by the next turn and not of any nest at any
+   depth: a nest always puts a lower-depth opener in between.
+4. **It is cheap.** `+10–13%` on `findQuoteRuns` over 726,385 paragraphs
+   (measured twice). The analyzer is model-bound by three orders of magnitude.
+
+### What it fixes, on real books
+
+1,231 paragraphs across all seven languages change, and **every one is
+text-preserving**:
+
+```
+lang   changed  TEXT-PRESERVING  TEXT-LOSING  alnum chars lost  MIDWORD
+de          97               97            0                 0        0
+en          34               34            0                 0        0
+es          46               46            0                 0        0
+fr         232              232            0                 0        0
+ja          75               75            0                 0        0
+ru           3                3            0                 0        0
+zh         744              744            0                 0        0
+TOTAL     1231             1231            0                 0        0
+```
+
+Overwhelmingly one shape — a paragraph continuing a quotation (opening delimiter,
+no closer of its own) that also contains a quoted turn, which today merges into
+one run ending at the *inner* turn's closer:
+
+```
+zh  …眾鬼嘩然並出，曰：「爾恃符咒拘遣我，今符咒已失，不畏爾矣。」聚而攢擊。…
+    today  ["…眾鬼嘩然並出，曰：「爾恃符咒拘遣我，今符咒已失，不畏爾矣。"]
+    R1c    ["…眾鬼嘩然並出，曰：", "爾恃符咒拘遣我，今符咒已失，不畏爾矣。"]
+```
+
+The recovered run sits next to its own speech tag (`曰：`), so the change improves
+attribution as well as boundaries. **1,231 paragraphs per 331 books** — worth
+stating plainly, because the corpus was previously reported as having nothing to
+say about this class.
+
+---
+
+## Invariants preserved, and how each was verified
+
+| invariant | verification | result |
+|---|---|---|
+| **Runs stay disjoint** | the truncated run ends at `cut`; the scan resumes at `cut`; half-open intervals | by construction; asserted in the plan |
+| **Nesting → OUTER run** (`en`, `zh`) at depth 2 | anchors 1–4, three exact-match; M2's F3, 11,140 shapes | 4/4; **0 nesting regressions** |
+| **Nesting not FRAGMENTED at depth ≥ 3** | anchors 18–21, one a corpus paragraph | 4/4 (R1, R1b, R2, R4: 0/4) |
+| **M1's rules survive** | anchors 5–7 | 3/3 |
+| **#1601 stays fixed** | anchor 8, `de` | pass |
+| **Never delete a run** | the truncated run is emitted; corpus | **0 characters lost, 0 mid-word**, all 331 books |
+| **No over-generation on the fixed cases** | anchors 1, 9, 12, 13 assert the **exact** span list | 4/4 |
+| **Attribution is not lost** | attribution-aware family, real roster, both controls firing | **0 of 42** (shipped: 21) |
+| **The guard is a no-op on shipped tables** | family, anchors and arm A run with and without it | byte-identical: 172, 19/22, 938/0/0/0/0 + SPLIT 34 |
+| **M1's corpus tuple** | 140-book English, overlap classifier | **938 / 0 MERGED / 0 LOST / 0 GAINED — met. `0 SPLIT` NOT met: 34.** |
+| **M2's criteria** | pairwise over F1/F2/F3 + suppression class, #2286's pairs as `secondaryQuotePairs` | repaired 1,762, regressed 20, nesting regressions 0, **suppression 0 of 21**. "0 destroyed" NOT met: 20. |
+| **`crossExamine`'s `dialogueOpen` contract** | not on any code path this changes | by construction |
+| **`isSpokenLine`** | computes no run boundary; untouched | by construction |
+| **308-test suite** | run against a throwaway prototype patch, then reverted | **7 fail**, all number-pinning |
+
+M2's pairwise detail, identical with and without the guard:
+
+```
+family  shapes  shipped-destroy  R1c(+G)-destroy  REPAIRED  REGRESSED | NEST-REGR
+F1        2356              565              255       310          0 |         0
+F2        2456              812              401       415          4 |         0
+F3       11140             6964             5943      1037         16 |         0
+SUPP        21                0                0         0          0 |         0
+```
+
+An absolute destroy count on these families is **not** comparable with M2's,
+which scored only shapes whose reference reading was already right. The delta on
+one fixed shape set is.
+
+---
+
+## The acceptance items that are not met
+
+Four items across the two briefs are not met. All are stated here, in the section
+that says so — an earlier revision demoted one into a residual and the
+adversarial pass called it.
+
+### 1. `0 SPLIT` on the English corpus — 34 splits (1,225 across seven languages)
+
+**The earlier proposal to replace `SPLIT` with `TEXT-LOSING` is withdrawn.** The
+adversarial pass established that `TEXT-LOSING` is near-unfailable *for a
+truncate-and-resume rule by construction*: the emitted prefix plus the resumed run
+re-cover the text, and the never-delete fallback closes the last escape. Offering
+it as a replacement for the criterion that contains the harm would be loosening
+the bar to fit the result. It is reported as a figure, not proposed as a
+criterion.
+
+What is offered instead is the **full enumeration**. All 4,732 fresh speech spans
+across the 1,231 changed paragraphs, classified by size and by whether a
+speech/beat verb stem sits within 60 characters on either side:
+
+```
+                      fresh spans   TAGGED (turn-shaped)   untagged
+all 7 languages             4,732                  4,003        729
+of which English               42                     13         29
+```
+
+**85% of the recovered spans sit next to a speech tag.** English is the weakest
+language for this and also the smallest change (34 paragraphs of 174,267): its
+fresh spans are mostly short quoted matter inside quoted letters and documents,
+where today's parse and the new one are both defensible and neither loses text.
+
+The honest trade: **a text-preserving split turns one speech span into two, which
+the render attributes and voices separately.** Where the second span is a turn
+with its own tag (4,003 of 4,732) that is a repair; where it is a quoted word
+(729) it is a new one-span turn that did not exist. No rule in the evidence gets
+the first without some of the second.
+
+### 2. "0 turns destroyed across all three sweep families" — 20 regressions
+
+All `ru`, all one mechanism:
+
+```
+ru  «Он сказал „привет“ мне», объяснил он, глядя на “Фауста. «Пока», сказала она, около галереи”.
+    shipped  ["Он сказал „привет“ мне", "Пока"]
+    R1c      ["Он сказал „привет“ мне", "Фауста. «Пока», сказала она, около галереи"]
+```
+
+Shipped gets this right **by accident**: the phantom `“` candidate seeded at turn
+1's closer consumes the `“` scan cursor and thereby prevents the stray `“` from
+being visited. Resuming at the cut removes the accident and the shape falls
+through to the cross-glyph residual. Net: **1,762 repaired, 20 regressed.**
+
+### 3. "0 gained runs truncating a tag span, over the corpus" — 156, and the criterion is the wrong instrument
+
+The coordinator's figure is **reproduced exactly**: 265 gained runs across 92
+paragraphs (zh 84, es 4, ja 3, fr 1), over 111,835 paragraphs carrying a `main`
+tag span. The guard takes it to **156 across 71**. It does **not** reach 0, and
+the residual is **not the defect class**. Sampled:
+
+```
+es  … un vendedor pregonaba patatas asadas, llamándolas "chuletas de huerta", …
+ja  … 「靑草の生ひ茂りたる愁しみ。」… "Sudden Light" …
+ja  … 「書物の喜び」 "biblio-bliss" という言葉は …
+```
+
+These are quoted titles, foreign-language phrases and coinages inside long
+narration passages that `main` reclassified as `tag` because a speech verb
+appears *somewhere* in them. Separating them out costs no speaker; several are
+improvements.
+
+Sharpened orthographically — only a gained run carrying a **name-shaped token**
+can cost a speaker, since that is what `findRosterName` reads — the proxy reports
+**6 of the 265** in Latin scripts, with **257 in CJK where the proxy cannot
+decide** (no case distinction). The guard moves the Latin-script figure 6 → 5,
+and the combined rule reports 7. **The proxy is too blunt to serve as the
+acceptance criterion**: it counts opportunities, and its numbers move for reasons
+unrelated to attribution.
+
+**The criterion that can be met, and is:** the attribution-aware family, where
+the roster is known by construction and the speaker field is actually read.
+
+```
+                                                   cases  ATTRIBUTED  SPEAKER-LOST  EXTRA-SPEECH-SPANS
+main tables (POSITIVE CONTROL, no secondary pair)     42          42             0                   0
+wide tables, shipped M2 tier                          42          21            21                  21
+wide tables, + tag-clause guard                       42          42             0                   0
+```
+
+Both required controls fire: the positive control proves the metric can read a
+speaker at all; the shipped row proves it can see the class. **21 → 0.**
+
+### 4. The 308-test suite — 7 tests fail
+
+Run for real against a throwaway patch of `parser.ts`, reverted immediately
+(`git status` clean afterwards). All seven are expectations pinning a number, and
+one pins the defect itself:
+
+| test | what happens |
+|---|---|
+| `parser.test.ts` › `residual 1: the straddle inside a language's own PRIMARY pairs is untouched` | expects `['Hola, dijo él. «Adiós']`, gets `['Hola, dijo él. ', 'Adiós']`. **This test exists to pin #2315.** Invert it, do not repair it. |
+| `tier-sweep.test.ts` × 6 (`F2`/`F3` × `en`/`es`/`ru`) | "differs from ref on N scored shapes": `88→96`, `116→124`, `225→261`, `618→662`, `114→133`, `258→277`. Mutation-proof controls to re-baseline; purpose unchanged. |
+
+> Under `R1b` there was an eighth, substantive failure — a spurious `gallery`
+> span on M2's showcase example. R1c's proviso removes it. Recorded because the
+> earlier revision argued that failure was acceptable and it turned out not to
+> have to be.
+
+---
+
+## Instruments, controls, and proof they can fail
+
+Reused unchanged: `2288-metric.mts` (overlap classifier plus ten positive
+controls that fire on import — the only reused instrument that can see a merge),
+`2288-corpus-lib.mts` + the corpus (491 books, of which **331** are in the seven
+supported languages — 726,385 paragraphs, the same set and count M2 measured),
+`rules.mjs`, `m2-primary-residual.mts` (to reproduce the 579).
+
+New, all under `scratchpad/s2315/`, all in memory, none touching
+`C:\AudiobookWorkspace`, none editing a production file:
+
+| file | what it is |
+|---|---|
+| `setup.mjs` | builds two patched copies of the module tree — `main/` and `wide/` (#2286's nine pairs as `secondaryQuotePairs`) — delegating at the **call site**, so a rule can see `conv` |
+| `engine.mjs` | verbatim port of the shipped scan + tier, every candidate rule, the guard, and two mutants |
+| `equivalence.mts` | **control 0** — the port vs the real parser over the whole corpus |
+| `family.mts` | the 805-shape family, scored against the construction |
+| `anchors.mts` | 22 invariant cases: `want` (superset), `forbid` (over-generation), `exact` |
+| **`attrib.mts`** | **the attribution-aware metric** — real roster, speaker fields read and compared, with its positive and firing controls |
+| **`tagcut.mts`** | the tag-cut class at corpus scale, raw and orthographically sharpened |
+| `corpus.mts` | arm A (M1's tuple) and arm B (7 languages, own tables) |
+| `adjudicate.mts` | `TEXT-PRESERVING` / `TEXT-LOSING` / `MIDWORD` per changed paragraph |
+| `classify-splits.mts` | every fresh span, by size and speech-tag adjacency |
+| `gain.mts` | narration that becomes speech, and the run-count delta |
+| `m2check.mts` | M2's F1/F2/F3 + suppression class, pairwise |
+| `prevalence.mts` | the residual geometry's size in real books |
+| `perf.mts` | cost |
+
+### Control 0 — the harness itself
+
+```
+S2315_RULE=shipped         paragraphs 1190634  DIFFERING 0
+S2315_RULE=R1_sameOpener   paragraphs 1190634  DIFFERING 1379
+```
+
+The second line is the control on the first: without it, "identical" is also what
+a harness that never wired the delegation up reports — the failure `m2-setup.mjs`
+hit during M2. Re-run after the injection moved to the call site. The classifier
+is calibrated the same way: arm A under `shipped` reproduces M1's published tuple
+**exactly** — `SAME 173,317 / MOVED 950 / 938 / 0 / 0 / 0 / 0`.
+
+### Every zero has a positive control
+
+| zero | control | result |
+|---|---|---|
+| family destroyed at all | `none` | **805 of 805, 4/22 anchors** |
+| the family does not cry wolf on clean input | the no-stray rows | 59 shapes, **1 destroyed** — a real defect (case 3) |
+| the anchors can fail | `R2`, `B_shortest`, `shipped` | 10/22, 11/22, 17/22 |
+| the anchors can see OVER-generation | anchors 1, 9, 12, 13 are exact-match | R1b's spurious `gallery` span fails an exact anchor a superset anchor passes |
+| depth-3 fragmentation is detectable | `R1`, `R1b`, `R2`, `R4` | **0 of 4** depth-3 anchors each |
+| nesting breakage is detectable | `R1` on M2's F3 | **155 nesting regressions** |
+| corpus text-loss is detectable | `R2`, `B_shortest` | **601,392** and **1,226,585** characters |
+| **the attribution metric can read a speaker** | main tables, no secondary pair | **42 of 42 attributed** |
+| **the attribution metric can see the class** | wide tables, shipped M2 tier | **21 of 42 speakers lost** |
+| the corpus can report LOST/MERGED | the classifier's ten controls | all pass, asserted on import |
+
+### Mutation — each mechanism has its own mutant
+
+| mutation | family | corrupt | anchors | TEXT-LOSING | chars lost | ATTRIB |
+|---|---:|---:|---:|---:|---:|---:|
+| **R1c + G** (none) | **172** | 390 | **19/22** | **0 of 1,231** | **0** | **0** |
+| `noResume` — do not resume at the cut | **396** | 382 | 17/22 | 1,225 of 1,225 | 192,525 | — |
+| `dropRun` — truncate by deleting the run | 172 | **164** | 17/22 | 1,225 of 1,231 | 367,436 | — |
+| **proviso removed** (= rule `R1b`) | 164 | 390 | **15/22** — all four depth-3 anchors fail | 0 of 1,391 | 0 | — |
+| **guard removed** (= rule `R1c`) | 172 | 390 | 19/22 | 0 of 1,231 | 0 | **21** |
+| **guard scoped to the GAP not the CLAUSE** | 172 | 390 | 19/22 | 0 | 0 | 0, but corpus proxy 265→165 not →156 |
+
+`noResume` returns the family to *exactly* the shipped 396 — the sharpest
+available evidence that the family instrument measures the mechanism and not
+something adjacent. The last two rows are the mutants the first revision did not
+have.
+
+### What the evidence cannot say
+
+- **A corpus replay shows safety, never sufficiency.** Two wrong diagnoses in
+  this strand passed a clean replay.
+- **The 805-shape family contains no nest**, which is why `R2` wins its headline
+  metric. The counterweight is the 22 anchors and M2's F3. A family cell crossing
+  *nest × depth-3 × stray* still does not exist and is named as a gap.
+- **The attribution metric is a constructed family, not a corpus.** It proves the
+  class exists and that the guard closes it; it does not size the class in real
+  manuscripts. The corpus proxy sizes the *opportunity* at 265, and the sharpened
+  proxy cannot decide 257 of those because CJK has no case.
+- **Per-language denominators are wildly uneven**: en 174,267 paragraphs with
+  runs · zh 30,395 · de 23,666 · fr 6,427 · es 4,207 · ja 622 · **ru 141**. `ru`
+  carries 84 of the 172 residual shapes, all of case 3, and all 20 M2 regressions
+  — on 141 corpus paragraphs. **The corpus says almost nothing about `ru`.**
+- **`sweep-six-langs`'s "0 destroyed of 51,608" is a constant** — it reads 0 with
+  both tier guards deleted and with the pairs moved back to primary. It is not
+  used as a gate anywhere in this design.
+- **Nothing here measures whether a truncated run is read aloud acceptably.**
+  On-box; the plan opens a register row.
+
+---
+
+## Residuals
+
+1. **172 of 805 — the cross-glyph and symmetric-delimiter straddles.** Answer 3,
+   accepted with the 2.20% prevalence figure. `R2`'s residual (52) is a **strict
+   subset** — measured: destroyed by both 52, by R1c only 120, **by R2 only 0** —
+   so the entire distance to the ceiling is bought by destroying nesting.
+2. **20 M2-family shapes regressed, all `ru`.** § *The acceptance items that are
+   not met*, item 2.
+3. **Depth ≥ 3 nesting is still mis-parsed.** `main` truncates at the depth-3
+   closer and R1c leaves that untouched. Fixing it needs a closer search that
+   skips closers belonging to nested runs — a nesting-aware parser, a different
+   blast radius, its own design pass. R1c guarantees only that it does not make
+   it worse, and four anchors pin exactly that.
+4. **156 corpus paragraphs still show a gained run overlapping a `main` tag
+   span.** Adjudicated by sampling as quoted titles and phrases inside
+   verb-bearing narration, not tag clauses naming a speaker. Not closed, and the
+   proxy cannot close it. § item 3.
+5. **Case 3 is fixed only because it is same-glyph.** The general shape — one
+   glyph serving as closer of one pair and opener of another — is a property of
+   `ru`'s table alone today.
+6. **German is in scope here and was not before.** `de` carries 104 of the 396
+   and 97 of the 1,231 corpus paragraphs.
+7. **Same-glyph nesting is cut.** `»Er sagte »nein« zu mir«` →
+   `["Er sagte ", "nein"]`. No language's convention nests a pair inside itself.
+
+---
+
+## Rejected
+
+- **Any acceptance-order rule** for defect 1. For 65% of it there is no candidate
+  to order, so these cannot succeed even in principle.
+- **`R4` / ticket answer 2.** Reintroduces the suppression class for 41 shapes
+  and fails all four depth-3 anchors.
+- **Acting on the cross-glyph geometry at all** (`R2` and everything like it).
+  601,392 characters of real speech.
+- **Replacing `0 SPLIT` with `0 TEXT-LOSING`.** Withdrawn: the substitute cannot
+  fail for this rule class.
+- **The corpus tag-cut proxy as an acceptance criterion.** It counts legitimate
+  gains and cannot decide CJK. Replaced by the attribution-aware family, not by a
+  looser version of itself.
+- **Roster-aware run selection** (declining a secondary candidate whose interior
+  is a cast name). It would need `findQuoteRuns` to take the `NameIndex`, and it
+  fails on a turn that is a bare name (`«Антон!», сказала она.`). The
+  sentence-boundary discriminator needs no roster and does not have that failure.
+- **Import-time normalisation** — inherited from M2's rejected list.
+
+---
+
+## The decisions for the owner, and their price
+
+All three are Task 0 of the plan; nothing else starts until they are answered.
+None reopens the reading of record, and this design sits on the same side of it.
+
+**Decision A — text-preserving splits.** `0 SPLIT` is not achievable by any rule
+that stops a container swallowing the turn inside it, because un-swallowing *is*
+a split. No substitute criterion is offered.
+
+> Is a split that loses no speech text, where **85% of the new spans sit next to
+> a speech tag** and 15% are quoted words promoted to their own span, an
+> acceptable price for 1,231 paragraphs across seven languages parsing
+> turn-by-turn where they merged?
+
+- *Accept*: the re-open bound ships — 34 English splits, 1,225 across seven
+  languages, 0 characters of speech lost, 0 mid-word cuts, 65 characters of
+  narration read as speech.
+- *Refuse*: nothing in the bound family can ship, defect 1 stays at 396 of 805,
+  and #2315 closes as answer 3 in full. **The tag-clause guard is unaffected and
+  should ship regardless** — it is a separate rule for a separate defect.
+
+**Decision B — the 396, not the 579.** The stated target has no referent. The
+re-open bound takes the corrected figure from **396 to 172**, at the cost of 20
+`ru` regressions in M2's families. Accept a partial fix, or hold out for zero?
+
+- *Accept*: 224 of 396 fixed net; both decidable sub-mechanisms closed; the
+  undecidable one documented with a measured prevalence and pinned by tests.
+- *Hold out*: the only measured rule below 172 that keeps nesting is `R4`, whose
+  price is the suppression class; below that is `R2`, whose price is 601,392
+  characters. There is no third option in the evidence.
+
+**Decision C — how the tag-cut criterion is stated.** The brief asks for *"0
+gained runs truncating a tag span, measured over the corpus, and the 265/92
+re-measured to 0"*. That proxy counts legitimate gains (quoted titles in
+verb-bearing narration) and cannot decide 257 of its own 265 because CJK has no
+case. Bind instead to the **attribution-aware family — 0 of 42 speakers lost,
+with a positive control that attributes 42 of 42 and a firing control that loses
+21** — and report the corpus proxy (265 → 156) as *scale and adjudicated
+residual* rather than as a gate?
+
+- *Accept*: the criterion measures the harm it names, and the guard meets it.
+- *Refuse*: the criterion cannot be met by this rule or, on the evidence, by any
+  rule — the residual it counts is not the defect.
+
+---
+
+## Scope
+
+**In:** the re-open bound with its plain-prefix proviso in `scanQuoteRuns`; the
+tag-clause guard in `findQuoteRuns`'s secondary admission; tests for all three
+sub-mechanisms of defect 1, both nesting depths, defect 2 with a real roster, M1's
+three rules, #1601, the M2 pairwise deltas, and the residuals pinned as
+residuals; re-baselining the seven tests listed above.
+
+**Out:** the cross-glyph and symmetric-delimiter straddles (residual 1); depth ≥ 3
+nesting (residual 3 — pre-existing, needs its own design pass); `dialogueOpen`;
+`isSpokenLine`; the `quotePairs` table additions themselves (#2286 lands them
+once this ships); import-time normalisation.
+
+---
+
+## Assumption-checker findings
+
+A mandatory adversarial pass (fresh non-fork subagent, Opus) was run on revision 1
+of this document, which recommended `R1b` and covered defect 1 only. It re-ran
+every instrument. Dispositions:
+
+| # | finding | disposition |
+|---|---|---|
+| ⚠ | **The recommended rule's central premise is false** — "nesting is cross-glyph in every shipped table". Every language alternates by DEPTH, so depth 3 re-uses depth 1's glyph and R1b cuts `“He told me, ‘She said “no” to him,’ …”` into a container plus a one-word span. Verified in en/zh/ru/de. `nest × depth ≥ 3` appeared in no family and no anchor. | **Accepted, and it changed the recommendation.** Reproduced independently. R1c designed and measured; four depth-3 anchors added, one a corpus paragraph; R1b retained as R1c's own mutant. |
+| A1 | The 118 English SPLITs were asserted to be repairs and none was adjudicated; 50 recover a span of ≤3 words, 65 are depth-3 alternation, including a real turn (`druthers`) fragmented. | **Accepted.** R1c removes the depth-3 cases (118 → 34 English). All 4,732 fresh spans are now classified by size and speech-tag adjacency. |
+| A2 | **The `SPLIT` → `TEXT-LOSING` restatement is a criterion the rule cannot fail.** | **Accepted; withdrawn.** `0 SPLIT` is reported as unmet with the population enumerated instead. |
+| A3 | A third binding item ("0 destroyed across all three sweep families", 23 regressions) was demoted to a residual. | **Accepted.** Promoted; the section lists all unmet items. |
+| B1 | "R1b meets that on all seven languages" was contradicted by arm B: 8 GAINED, 1 MERGED. | **Accepted.** R1c has 0 MERGED and 6 GAINED; claims are per-figure. |
+| B2 | R1b's own harm class was never priced while R2's was priced to six digits. | **Accepted.** GAINED characters (65) and the run-count delta (+4,732) are columns; `gain.mts` is a listed instrument. |
+| B3 | "Every failure is an expectation pinning a number" was contradicted by the document's own table. | **Accepted and now true**: under R1c the substantive eighth failure disappears. |
+| B4 | The corpus safety claim is near-empty where the defect concentrates — `ru` has 141 paragraphs with runs. | **Accepted.** Per-language denominators stated, with the explicit warning about `ru`. |
+| B5 | The family contains no nest, which is why `R2` wins its headline metric. | **Accepted.** Stated as a limitation; the missing `nest × depth-3 × stray` cell recorded as a gap. |
+| B6 | The family and anchors could not distinguish R1b from R1; the nest exemption had no mutant. | **Accepted.** The proviso now has four anchors and its own mutant row. |
+| B7 | Family `corrupt` regresses 382 → 390; anchors used a superset predicate blind to over-generation; perf was +9.7% not +13%. | **Accepted.** `corrupt` is in the family output; four anchors are exact-match and four are `forbid`; perf is quoted as a range. |
+| — | *Survived attack:* control 0; every family figure; the "579 is a corruption count" correction; both mutants biting; the M2 pairwise table including R1's 155 nesting regressions; R4's price and anchor 16's realism; "shipped is right by accident" on the `ru` regressions; the 2.20% prevalence; case 1's "there is nothing to order". | Recorded as-is. |
+
+**What changed after the pass, from the coordinating thread's new requirement:**
+defect 2 (the tag-clause cut) was added to scope with its own rule, its own
+attribution-aware instrument and controls, and its own owner decision;
+M2's residual pricing was corrected; the corpus proxy the requirement named was
+built, reproduced at 265/92, and then shown to be the wrong gate.


### PR DESCRIPTION
## Summary

Design of record and implementation plan for **#2315** — `findQuoteRuns` destroying a dialogue turn when a paragraph re-opens a quote glyph it never closed (M2's residual 1, live on `main` today on correctly typeset input) — **and** for the **tag-clause cut** found by the review gate on PR #2286, which the repo owner added to this pass.

**Docs only. No production code, no test changes.**

Two rules, one in each half of `findQuoteRuns`, independent by construction:

- **The re-open bound** (primary scan): a run may not contain a further occurrence of its own opening glyph, *provided no opener of any class appears in between*. When it does, the run ends there — still emitted, no closing delimiter — and the scan resumes from there.
- **The tag-clause guard** (secondary admission): a secondary-tier candidate is declined when the *clause* its opener sits in carries a speech or beat verb stem. Secondary-tier only, so a **measured** no-op until #2286 lands.

| | shipped | both rules |
|---|---:|---:|
| straddle family, turns destroyed | **396 of 805** | **172 of 805** |
| invariant anchors | 17 of 22 | **19 of 22** |
| **turns that lose their speaker** | **21 of 42** | **0 of 42** |
| English corpus, M1's tuple | 938 / 0 / 0 / 0 / 0 | **938 / 0 / 0 / 0 / 0**, SPLIT 34 |
| 7 languages, speech text lost | — | **0 characters, 0 mid-word** |
| M2's F1/F2/F3, pairwise | — | **+1,762 / −20**, nesting regressions **0**, suppression **0 of 21** |

### Five findings that change how the ticket reads

1. **The 579 is a corruption count**, not a destruction count (1,704 on that shape set), on a shape set defined by the *widened* table. Measured as the ticket describes — each language's own `quotePairs` — it is **396 of 805**, seven languages including `de`, which carries the largest single share (104).
2. **65 % of the defect has no candidate to choose between.** The per-opener scan resumes at the end of an accepted run, so a same-glyph re-open never produces a candidate. Every acceptance-order rule is *structurally incapable* of reaching 258 of the 396 — the fix must be in the scan.
3. **A third sub-mechanism the ticket does not describe**: `„Привет“, сказал он. “Пока”, сказала она.` loses turn 2 with no stray glyph and no drift, because `ru`'s `“` is both a closer and an opener.
4. **Depth ≥ 3 nesting re-uses depth 1's glyph.** The first revision recommended a rule that fragmented every such turn into a container plus a one-word speech span. Found by the adversarial pass; the proviso is the fix and four anchors pin it.
5. **M2's residual pricing is understated.** Its design of record prices rule B's residual as "narration spoken aloud — audible, attributable, and recoverable"; the tag-clause cut is a real turn *losing its speaker*, which is none of those. The correction is recorded rather than the original sentence repeated.

### Three acceptance items cannot be met as written — the plan's blocking Task 0

- **`0 SPLIT`** — un-swallowing a turn *is* a split. An earlier revision proposed replacing it with `TEXT-LOSING`; the adversarial pass showed that predicate is near-unfailable for a truncate-and-resume rule, so **the substitution is withdrawn** and the population is enumerated instead: all 4,732 fresh spans classified, **85 % adjacent to a speech tag**.
- **"0 destroyed across all three sweep families"** — 20 `ru` regressions, where shipped is right by accident.
- **"0 gained runs truncating a tag span over the corpus"** — the 265/92 figure is **reproduced exactly**, the guard takes it to 156, and the residual is quoted titles and foreign phrases inside verb-bearing narration, not tag clauses naming a speaker. The proxy cannot decide 257 of its own 265 (CJK has no case). Binding to the attribution-aware family instead.

The residual (172 shapes, cross-glyph and symmetric-delimiter) is the ticket's **answer 3 with the prevalence figure it demands**: the geometry occurs in **5,267 of 239,725 corpus paragraphs (2.20 %)**, is byte-for-byte a legitimate nest, and the rule that acts on it removes **601,392 characters of real speech**.

`Refs #2315`. `Refs #2286` — held in draft until this lands.

## Test plan

No code changed, so no automated test moves. What was run:

- **Harness validity (control 0):** the patched module copy's `shipped` rule is **byte-identical to the real parser over 1,190,634 corpus paragraphs**; the same comparison under a candidate rule differs on 1,379, proving the delegation is live. Re-run after the injection moved to the call site.
- **Classifier calibration:** corpus arm A under `shipped` reproduces M1's published tuple exactly — `SAME 173,317 / MOVED 950 / 938 / 0 / 0 / 0 / 0`.
- **The 805-shape family**, scored against the construction rather than against `main`, with a `none` control (805/805 destroyed, 4/22 anchors) and a no-stray control that found sub-mechanism 3.
- **22 invariant anchors** — 4 nesting at depth 2, 4 at depth 3, 4 exact-match against over-generation, 4 `forbid` sets. `R2` scores 10/22 and shortest-first 11/22, reproducing the nesting failure it was previously known for.
- **The attribution-aware metric** — real roster, `speaker` fields read and compared — with **both required controls firing**: positive control 42/42 attributed, firing control 21 of 42 lost.
- **The tag-cut corpus proxy**, raw and orthographically sharpened, reproducing the review gate's 265/92 exactly.
- **Corpus adjudication** on all 331 supported-language books: 1,231 changed paragraphs, **1,231 text-preserving, 0 characters lost, 0 mid-word**.
- **M2's F1/F2/F3 + the 21-shape suppression class**, pairwise, on tables carrying #2286's nine pairs as `secondaryQuotePairs`.
- **Mutation proof, five mutants**, each red on more than one instrument: `noResume` returns the family to *exactly* the shipped 396; `dropRun` loses 367,436 characters; removing the proviso fails all four depth-3 anchors; removing the guard returns attribution to 21 lost; scoping the guard to the gap instead of the clause moves the corpus proxy to 165 rather than 156.
- **The 308-test suite** was run twice against throwaway prototype patches of `parser.ts` to get the real failure lists (8 under the first candidate, **7** under the recommended one); both patches were reverted and `git status` is clean.

`C:\AudiobookWorkspace` was not written to.

## Review gate

Docs-only PR — **exempt from the mandatory `pr-review-gate` pass** per CLAUDE.md's Model routing section (same file-set test as CONTRIBUTING.md's doc-only CI fast-path). The spec did receive its mandatory Premium-tier `assumption-checker` pass; its finding changed the recommendation, and all dispositions are recorded in the document.



Refs #2315
Refs #2286
