### PR TITLE
docs(docs): record the owner answers to #2315 decisions A, B and C

### DIFF
--- a/docs/superpowers/plans/2026-08-13-primary-pair-straddle.md
+++ b/docs/superpowers/plans/2026-08-13-primary-pair-straddle.md
@@ -2,7 +2,39 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-> ## ⛔ Task 0 — THREE OWNER DECISIONS ARE OWED BEFORE ANY CODE IS WRITTEN
+> ## ✅ Task 0 — ANSWERED by the repo owner, 2026-08-13. All three as recommended.
+>
+> **A — text-preserving splits are ACCEPTED.** Tasks 1–7 proceed. **B — 172 is
+> accepted as a partial fix** (396 → 172, at the cost of 20 `ru` regressions in
+> M2's families); the 2.20 % residual is pinned, not chased. **C — the tag-cut
+> criterion binds to the ATTRIBUTION-AWARE family** (0 of 42 speakers lost,
+> positive control 42/42, firing control 21 lost); the corpus proxy is reported
+> as scale and adjudicated residual, **never as a gate**.
+>
+> **Task 0 is closed. Every task below is dispatchable.** Three things to carry
+> rather than re-derive:
+>
+> 1. **Do not re-impose "the 579 goes to 0" or "265/92 → 0."** Both were written
+>    by the coordinating thread before this pass measured them; A's and C's
+>    answers supersede them. `579` has no referent (it is a corruption count on a
+>    **widened**-table shape set, whose destroyed count is 1,704). The corpus
+>    proxy **cannot decide 257 of its own 265** cases because CJK has no case
+>    distinction.
+> 2. **Do not chase below 172.** The only measured rule that gets there while
+>    keeping nesting is `R4`, whose price is the suppression class; below that is
+>    `R2`, which loses 601,392 characters of real speech. Both prices are
+>    invariants the owner has already protected.
+> 3. **`SPLIT` is not a failure signal for Tasks 1–7.** Un-swallowing a turn *is*
+>    a split to an overlap classifier, so `0 SPLIT` against the pre-#2288 baseline
+>    is unachievable by any correct rule. Bind to **text preservation** (0
+>    characters, 0 mid-word) plus the adjudication that 85 % of fresh spans sit
+>    next to a speech tag. Note the withdrawn `TEXT-LOSING` restatement: the
+>    adversarial pass showed a truncate-and-resume rule cannot fail it, so it is
+>    not a substitute criterion.
+>
+> *Original framing, retained because it is why the plan is shaped this way:*
+>
+> ## ⛔ (superseded) Task 0 — THREE OWNER DECISIONS ARE OWED BEFORE ANY CODE IS WRITTEN
 >
 > This plan does **not** start at Task 1. The design pass reached two rules it
 > recommends and, in reaching them, found that **three stated acceptance items

--- a/docs/superpowers/specs/2026-08-13-primary-pair-straddle-design.md
+++ b/docs/superpowers/specs/2026-08-13-primary-pair-straddle-design.md
@@ -698,6 +698,31 @@ have.
 
 ## The decisions for the owner, and their price
 
+### ✅ Decided, 2026-08-13 — all three as recommended
+
+| | decision | what it supersedes |
+|---|---|---|
+| **A** | **Text-preserving splits are accepted.** Tasks 1–7 proceed. | The stated `0 SPLIT` acceptance item, which no correct rule can meet — un-swallowing a turn *is* a split to an overlap classifier. Bind to text preservation (0 characters, 0 mid-word) plus the adjudication that 85 % of the 4,732 fresh spans sit next to a speech tag. |
+| **B** | **172 accepted as a partial fix** (396 → 172), 20 `ru` regressions in M2's families accepted with it; the 2.20 % residual (5,267 of 239,725) is pinned, not chased. | "The 579 goes to 0." **`579` has no referent** — it is a *corruption* count on a shape set defined by the **widened** table, whose destroyed count is 1,704. Measured as the ticket describes, each language's own `quotePairs`, the figure is **396 of 805**. |
+| **C** | **The tag-cut criterion binds to the attribution-aware family** — 0 of 42 speakers lost, positive control 42/42, firing control 21 lost. The corpus proxy is reported as scale and adjudicated residual. | "265/92 re-measured to 0", set by the coordinating thread before this pass measured it. The proxy **cannot decide 257 of its own 265** cases (CJK has no case distinction), and its 156 residual is quoted titles and foreign phrases inside verb-bearing narration — **not** tag clauses naming a speaker. |
+
+**Why B does not get chased further.** The only measured rule below 172 that
+keeps nesting is `R4`, whose price is the suppression class; below that is `R2`,
+which loses **601,392 characters of real speech**. Both prices are invariants the
+owner has already protected, so 172 is the floor that respects them.
+
+**Do not reinstate `TEXT-LOSING` as a substitute for `0 SPLIT`.** The adversarial
+pass showed a truncate-and-resume rule cannot fail it — it is a criterion with no
+discriminating power, which is why it was withdrawn rather than adopted.
+
+**The reading of record is untouched.** A rule must never destroy a turn; these
+answers accept *splits that preserve every character* and a *measured, pinned*
+residual, neither of which is a destroyed turn.
+
+---
+
+*Original framing, retained because it is the evidence behind the answers:*
+
 All three are Task 0 of the plan; nothing else starts until they are answered.
 None reopens the reading of record, and this design sits on the same side of it.
 


### PR DESCRIPTION
## Summary

Records the repo owner's answers to the three Task 0 decisions in the primary-pair-straddle design, so Task 0 closes and the plan is dispatchable. Docs-only; no behaviour change.

| | decision |
|---|---|
| **A** | **Text-preserving splits accepted** — Tasks 1–7 proceed. 0 characters lost, 0 mid-word cuts; 85% of the 4,732 fresh spans sit next to a speech tag. |
| **B** | **172 accepted as a partial fix** (396 → 172), with 20 `ru` regressions in M2's families accepted alongside; the 2.20% residual is pinned, not chased. |
| **C** | **The tag-cut criterion binds to the attribution-aware family** — 0 of 42 speakers lost, positive control 42/42, firing control 21 lost. The corpus proxy is reported as scale and adjudicated residual, never as a gate. |

**Two of the superseded criteria were mine, written before this pass measured them, and both documents now say so:**

- **"The 579 goes to 0" has no referent.** `579` is a *corruption* count on a shape set defined by the **widened** table, whose destroyed count is 1,704. Measured as the ticket actually describes — each language's own `quotePairs` — the figure is **396 of 805**.
- **"265/92 re-measured to 0" gates on an instrument that cannot adjudicate 97% of its own cases.** The corpus proxy cannot decide 257 of its 265, because CJK has no case distinction, and its 156 residual is quoted titles and foreign phrases inside verb-bearing narration rather than tag clauses naming a speaker.

**Why B is not chased further:** the only measured rule below 172 that keeps nesting is `R4`, whose price is the suppression class; below that is `R2`, which loses 601,392 characters of real speech. Both prices are invariants already protected by earlier decisions.

**`SPLIT` is recorded as not a failure signal** for Tasks 1–7 — un-swallowing a turn *is* a split to an overlap classifier, so `0 SPLIT` is unachievable by any correct rule. The withdrawn `TEXT-LOSING` restatement is flagged so it is not reinstated: the adversarial pass showed a truncate-and-resume rule cannot fail it.

**The reading of record is untouched** — a rule must never destroy a turn. These answers accept splits that preserve every character, and a measured, pinned residual. Neither is a destroyed turn.

## Test plan

Docs-only — no tests apply. The decisions were made by the repo owner in session and are recorded so they survive the conversation.

Docs-only PR, so exempt from the independent review gate per CLAUDE.md.

Refs #2315
Refs #2288