### PR TITLE
chore(docs,scripts): widen pr-review-gate into the full PR review process

### DIFF
--- a/.claude/skills/model-routing/SKILL.md
+++ b/.claude/skills/model-routing/SKILL.md
@@ -79,94 +79,15 @@ for subagent dispatch above.
   — do not keep looping automatically past the cap.
 - **Judgment-call carve-out**: see below.
 
-## Mandatory independent review (PRs)
+## PR review
 
-- **Sequence**: finalize implementation → local `npm run verify:fast:branch`
-  (cloud `verify.yml` is the enforcing gate) → `gh pr
-  create` → work through `CLAUDE.md`'s before-shipping checklist item by
-  item (each done or explicitly marked not-applicable), committing and
-  pushing along the way → once every applicable item is addressed and
-  everything is pushed, that is "fully staged" and this review triggers on
-  that state (not on an earlier, incomplete push).
-- **Exemption**: a docs-only PR — changed-file set entirely under `docs/**`,
-  root-level `*.md`, or `.github/*.md` (the same file-set test
-  CONTRIBUTING.md's "Doc-only PR fast-path" already uses for the `verify.yml`
-  `paths-ignore` skip) — is exempt from this gate entirely; no review
-  pass runs.
-- **Effort level**: for every other PR, scales with the PR's commit
-  type/scope, reusing CONTRIBUTING.md's existing commit-convention
-  vocabulary rather than a new classification:
-  - **`low`** — single-scope `chore`, `test`, `build`, or `ci` (mechanical,
-    no user-facing behavior change).
-  - **`medium`** — single-scope `feat` or `fix`.
-  - **`high`** — `refactor`, `perf`, or any multi-scope PR (CONTRIBUTING.md's
-    own "use sparingly" multi-scope guidance already flags these as
-    higher-risk) — today's unchanged default.
+Moved out of this file 2026-08-13. The sequence, the docs-only exemption, the
+effort ladder, dispatch, the PR comment, findings triage, the re-review trigger
+and loop cap, and issue verification at PR creation all live in
+[`pr-review-gate`](../pr-review-gate/SKILL.md). Routing keeps routing; that file
+owns the PR process.
 
-  A PR whose commits mix types takes the highest tier any single commit
-  would earn on its own (e.g. one `fix` commit + one `refactor` commit →
-  `high`). `ultra` is never auto-selected here — it is billed and requires
-  explicit user opt-in (`/code-review ultra`, or the user asking for it by
-  name), per the Workflow tool's own rule.
-- **Mechanism**: invoke the `pr-review-gate` skill, which dispatches a
-  **non-fork** subagent at this table's **Premium** tier carrying the
-  adversarial gate brief, at the effort level determined above, once fully
-  staged — a findings report only, triaged by hand; the subagent edits nothing.
-  The same bar applies when the user runs `/code-review` themselves: no `--fix`.
-  `--fix` applies whatever the pass surfaced wholesale, and there's no per-finding
-  confidence filter to gate it on, so triage happens by hand instead — see
-  Findings handling. This is a working/branch-diff review — not the separate
-  `/review` PR-comment slash command, and not the
-  `code-review@claude-plugins-official` plugin command either: that plugin
-  reviews a GitHub PR, discards every finding below 80% confidence, and
-  posts a public comment on the PR instead of returning a report to triage.
-  - **Why not invoke the built-in `code-review` skill directly**: it is
-    user-invocable only — `Skill(skill: "code-review")` fails with "cannot
-    be used with Skill tool due to disable-model-invocation", and a
-    dispatched subagent hits the same wall, so "dispatch an agent and have
-    it invoke the skill" is not a workaround. It remains available and is
-    the *better* reviewer: the user may type `/code-review <level>` at any
-    point, and when they do it supersedes the agent pass for that round.
-  - **Never report the gate as having run when it did not.** If the agent
-    pass was substituted, or skipped, say so plainly in the user-facing
-    summary.
-- **Findings handling**: triage the report by hand, then **fix in this round**.
-  Every finding gets a dispatched fix agent — one finding, one fix, one paired
-  test — committed and pushed before merge. Clear-cut findings (unambiguous
-  bug, obvious dead code, a straightforward CLAUDE.md violation) are the
-  ordinary case, not the only case. **Cleanup-only findings are in scope too** —
-  a reuse/simplification/efficiency nit, a staled derived artifact, a missing
-  index or register row, an unwired knob. They are cheaper to dispatch than a
-  bug, not a lesser class of work, and "it's only a chore" / "it's not
-  user-visible" is not a deferral. (This is a *fixing* rule, not a re-review
-  rule: cleanup-only findings still do not re-trigger a pass — see below.) The
-  one exception stays taste: a reviewer preferring a different shape for code
-  that is correct and consistent with its neighbours is declined, not filed.
-  **The single finding allowed to leave the round unfixed is one needing a
-  design pass** — more than one defensible outcome, a decision the user has a
-  stake in — which routes through the judgment-call carve-out below and gets an
-  issue naming that decision as its deliverable. Everything else is fixed now:
-  "it expands the PR's scope", "it's pre-existing", "it needs its own test",
-  and "we can batch these" are **not** deferral grounds — see [CLAUDE.md →
-  Incidental
-  findings](../../../CLAUDE.md#incidental-findings-report-fix-record) for the
-  full void-reasons list and the defect/chore/taste seam. A ten-finding report
-  ends as ten fix commits, not a follow-up epic. None of this licenses `--fix`:
-  the fixes are dispatched and reviewed per finding, never applied wholesale.
-- **Re-review trigger**: only when the initial pass surfaced ≥1 finding
-  that is an actual correctness bug (wrong behavior, crash, security issue —
-  not a reuse/simplification/efficiency-only cleanup nit). Fixing and
-  pushing those re-triggers a pass. If the initial pass came back empty, or
-  surfaced only cleanup-only findings, fix-and-push (or push nothing) does
-  **not** re-trigger a re-review — re-running it in that case just burns
-  tokens for no new signal. This mirrors the spec/plan loop's severity-gated
-  shape (above), rather than firing on every push. Re-review re-derives the
-  effort level from the PR's current commit set (above) rather than
-  reusing the initial pass's tier — a fix commit can raise the tier the
-  same way any other commit would.
-- **Loop cap**: 2 re-review rounds, same numeric cap as the spec/plan loop
-  above (initial pass + up to 2 re-review rounds, 3 total).
-- **Judgment-call carve-out**: see below.
+The judgment-call carve-out below is shared by both review loops and stays here.
 
 ## Judgment-call carve-out (shared by both review loops)
 
@@ -176,34 +97,3 @@ and routes through the normal ask-first behavior in `CLAUDE.md`'s "Think
 before coding" — it does not get silently resolved just to keep the loop
 moving. This is the same failure mode in both loops: an automated loop
 mistaking a decision for a defect.
-
-## PR-gate issue verification
-
-- **Trigger**: every `gh pr create` for non-trivial work, including
-  bug-shaped work.
-- **Check**: the PR body must contain `Closes #NN` or `Refs #NN` referencing
-  an existing GitHub issue, outside of any inline-code/fenced-code span (a
-  backtick-wrapped `` `Closes #NN` `` does not actually auto-close on
-  GitHub — write it plain).
-- **Missing case**: auto-file a new issue capturing the work, then add
-  `Closes #NN` to the PR body — proceed without pausing to ask, in every
-  case including bug-shaped work (a deliberate, explicit override of
-  `CLAUDE.md`'s general "user files bugs" convention, scoped to this one
-  gate). Label per `CONTRIBUTING.md`'s actual two-shape convention:
-  - **Bug-shaped** (fixing existing broken behavior, no design decision):
-    standalone `bug` label, plain descriptive title. No `area:`/`type:`/
-    `moscow:`.
-  - **Backlog-shaped** (new/changed behavior): `area:<prefix>` +
-    (`type:feature` or `type:chore`). `moscow:` left unset for the user.
-    Use `type:chore` when the work matches this repo's commit-type-`chore`
-    shape (codegen, version bumps, tidy-up — no user-facing behavior
-    change); `type:feature` otherwise.
-- **Timing**: at PR creation — distinct from, and prior to, the mandatory
-  independent review above, which reviews code + docs combined once the PR
-  (and its issue link) already exist.
-- **Mechanical backstop**: `.github/workflows/pr-issue-link.yml` fails the
-  PR check if neither `Closes #\d+` nor `Refs #\d+` appears in the body
-  (outside code spans) — the one gate in this file with a real, external
-  enforcement, not just this convention. It does not check labeling or
-  whether the auto-file step above ran correctly, only that some issue
-  reference exists.

--- a/.claude/skills/pr-review-gate/SKILL.md
+++ b/.claude/skills/pr-review-gate/SKILL.md
@@ -1,96 +1,271 @@
 ---
 name: pr-review-gate
-description: Use when a PR is fully staged and ready for its mandatory independent review, or when running CLAUDE.md's before-shipping "Independent PR review" step. This is the skill to invoke to actually dispatch the reviewer — for choosing the tier/effort level or the rest of the review-gate mechanics, consult `model-routing` instead. Dispatches a non-fork, Premium-tier subagent carrying an adversarial reviewer brief — a findings report only, never auto-applied.
+description: Use when preparing to ship a PR, staging one for merge, or running CLAUDE.md's before-shipping "Independent PR review" step. This is the full PR review runbook — preconditions, the docs-only exemption, the effort ladder, dispatching the reviewer, posting the pass comment, findings triage, the re-review loop, and issue verification at PR creation. For choosing a subagent's model tier outside a PR review, or the spec/plan adversarial-review loop, consult `model-routing` instead. Dispatches a non-fork subagent at the routing table's Premium tier carrying an adversarial reviewer brief — a findings report only, never auto-applied.
 ---
 
 # PR review gate
 
 The mandated mechanism for [CLAUDE.md's before-shipping step
-10](../../../CLAUDE.md) and
-[`model-routing`'s "Mandatory independent review
-(PRs)"](../model-routing/SKILL.md#mandatory-independent-review-prs) — that
-file owns the effort ladder, the exemption, the re-review trigger, and the
-loop cap; this file is the reviewer brief itself, not a restatement of the
-mechanics. Read it there, not here. (Three safety-critical rules — never
-report a gate that didn't run, `/code-review` supersedes this pass, no
-auto-apply — are deliberately repeated in both files rather than owned by
-just one; don't delete the duplication in a future cleanup pass.)
+10](../../../CLAUDE.md#before-shipping-checklist) — this file is the full
+spec for what this repo expects of a PR review: the procedure the shipping
+session runs, the rubric the reviewer applies
+([`references/reviewer-brief.md`](references/reviewer-brief.md)), what
+happens to the findings
+([`references/findings-triage.md`](references/findings-triage.md)), and the
+durable record each pass leaves on the PR itself. `model-routing` keeps the
+model-tier routing table and the spec/plan adversarial-review loop; this file
+owns everything PR-specific.
 
 ## When this fires
 
 A PR is fully staged: implementation finalized, `verify:fast:branch` green,
-every applicable before-shipping checklist item addressed (or explicitly
-marked not-applicable), and everything pushed. Not on an earlier, incomplete
-push. Except a docs-only PR, which is exempt entirely — see
-`model-routing`'s *Exemption* for the file-set test.
+every applicable [before-shipping checklist](../../../CLAUDE.md#before-shipping-checklist)
+item addressed (or explicitly marked not-applicable), and everything pushed.
+Not on an earlier, incomplete push.
+
+## Exemption
+
+A docs-only PR — changed-file set entirely under `docs/**`, root-level
+`*.md`, or `.github/*.md` (the same file-set test
+[CONTRIBUTING.md's "Doc-only PR fast-path"](../../../CONTRIBUTING.md#doc-only-pr-fast-path)
+already uses for the `verify.yml` `paths-ignore` skip) — is exempt from this
+gate entirely; no review pass runs.
+
+Exempt does not mean silent: post a one-line exemption note on the PR naming
+the file-set test that exempted it (see [The PR comment](#the-pr-comment)).
+A large share of this repo's PRs are docs-only, so without the note the
+durable record would be missing exactly where the volume is.
+
+## Effort level
+
+For every non-exempt PR, effort scales with the PR's commit type/scope,
+reusing CONTRIBUTING.md's existing commit-convention vocabulary rather than a
+new classification:
+
+- **`low`** — single-scope `chore`, `test`, `build`, or `ci` (mechanical, no
+  user-facing behavior change).
+- **`medium`** — single-scope `feat` or `fix`.
+- **`high`** — `refactor`, `perf`, or any multi-scope PR (CONTRIBUTING.md's
+  own "use sparingly" multi-scope guidance already flags these as
+  higher-risk) — today's unchanged default.
+
+A PR whose commits mix types takes the highest tier any single commit would
+earn on its own (e.g. one `fix` commit + one `refactor` commit → `high`).
+`ultra` is never auto-selected here — it is billed and requires explicit user
+opt-in (`/code-review ultra`, or the user asking for it by name), per the
+Workflow tool's own rule.
+
+State the level explicitly in the dispatch prompt so the subagent calibrates
+depth instead of guessing.
 
 ## Dispatch
 
-- **Premium tier** (per the routing table), **non-fork**. A fork inherits
-  the dispatching session's own context — its framing, its reasoning, its
-  blind spots — which is the opposite of independent review. A fork also
-  always runs on the dispatching session's model, ignoring model routing
-  entirely; a Premium-tier review needs a real non-fork dispatch to land on
-  Opus.
-- **Effort level** is passed in by the caller, not decided here — `low`,
-  `medium`, or `high`, derived from the PR's commit type/scope per
-  `model-routing`'s ladder (`ultra` is opt-in only, never auto-selected).
-  State the level explicitly in the dispatch prompt so the subagent
-  calibrates depth instead of guessing.
-- **Never auto-apply.** The subagent edits nothing. It returns a findings
-  report, triaged by hand per `model-routing`'s "Findings handling". (If the
-  user runs `/code-review` themselves instead, the same bar holds: no `--fix`.)
-- **The reviewer reads the rubric itself.** The dispatch prompt instructs it to
-  read `.claude/skills/pr-review-gate/references/reviewer-brief.md` in full
-  before it starts. Triage rules for what comes back are in
-  `.claude/skills/pr-review-gate/references/findings-triage.md`.
+- **Premium tier** (per [`model-routing`'s routing
+  table](../model-routing/SKILL.md#routing-table)), **non-fork**. A fork
+  inherits the dispatching session's own context — its framing, its
+  reasoning, its blind spots — which is the opposite of independent review. A
+  fork also always runs on the dispatching session's model, ignoring model
+  routing entirely; a Premium-tier review needs a real non-fork dispatch to
+  land on Opus.
+- **Fresh context** — not a continuation of any earlier pass in this session.
+- **Never auto-apply.** The subagent edits nothing (verified by [the tree
+  check](#the-tree-check), not trusted). It returns a findings report,
+  triaged by hand per [Triage](#triage). If the user runs `/code-review`
+  themselves instead, the same bar holds: no `--fix`. `--fix` applies
+  whatever the pass surfaced wholesale, and there's no per-finding confidence
+  filter to gate it on, so triage happens by hand instead. This is a
+  working/branch-diff review — not the separate `/review` PR-comment slash
+  command, and not the `code-review@claude-plugins-official` plugin command
+  either: that plugin reviews a GitHub PR, discards every finding below 80%
+  confidence, and posts a public comment on the PR instead of returning a
+  report to triage.
+- **The reviewer reads the rubric itself.** The dispatch prompt points it at
+  [`references/reviewer-brief.md`](references/reviewer-brief.md) **by path**
+  and instructs it to read the file in full before it starts — not a
+  paraphrase retyped into the prompt. Triage rules for what comes back are in
+  [`references/findings-triage.md`](references/findings-triage.md).
+- **Why not invoke the built-in `code-review` skill directly**: it is
+  user-invocable only — `Skill(skill: "code-review")` fails with "cannot be
+  used with Skill tool due to disable-model-invocation", and a dispatched
+  subagent hits the same wall, so "dispatch an agent and have it invoke the
+  skill" is not a workaround. It remains available and is the *better*
+  reviewer: the user may type `/code-review <level>` at any point, and when
+  they do it supersedes the agent pass for that round.
+- **Never report the gate as having run when it did not.** If the agent pass
+  was substituted, or skipped, say so plainly in the user-facing summary.
 
-## The brief to carry into the subagent prompt
+### Per-agent mapping
 
-**Framing: this is a gate, not a collaborator.** The reviewer's job is to
-find what's wrong with the change, not to appreciate it. Don't soften
-findings to be encouraging, and don't reward effort.
+The properties above are stated as reviewer *capabilities*, not one agent's
+tool names, so the mechanism ports:
 
-**Findings only.** Never edit the tree, never apply a fix, never run
-`--fix`. Return a report for the dispatching session to triage.
+- **Claude Code** — a non-fork `Agent` dispatch at the routing table's
+  Premium tier.
+- **Cline** — dispatches subagents. Whether that subagent starts cold is
+  recorded in `docs/testing/agent-skill-resolution-probe.md`. Until it reads
+  `CLINE_SUBAGENT_COLD: yes`, a Cline-run pass is labelled a **self-run**,
+  not the independent gate: reporting a fork as the gate is exactly the
+  substitution the standing rule forbids.
+- **Any agent that genuinely cannot dispatch** runs the rubric in-session and
+  reports it as a **self-run pass, never as the independent gate** — the same
+  rule that forbids reporting a gate as having run when it did not.
 
-**Feed it the load-bearing claims, not just a diff.** Name the specific
-files, the exact measured numbers, and the technical assertion the change
-rests on — the things a shallow pass would take on faith rather than check.
-A reviewer handed only "review this PR" burns its budget re-deriving context
-the dispatching session already has; a reviewer handed the claims can spend
-that budget attacking them instead.
+## The tree check
 
-**Say what's already mutation-verified**, and by what proof — e.g. "guard X
-was confirmed to fail before the fix and pass after." That tells the
-reviewer which ground is covered so it hunts elsewhere instead of re-proving
-work that's already done.
+Before dispatching, capture:
 
-**Per finding, require all three:**
-- a **severity**;
-- a **`file:line`**;
-- a **concrete failure scenario** — specific inputs or state that produce a
-  specific wrong output. "This could be fragile" is not a finding; the
-  reviewer must show the break, not gesture at a risk.
+    git rev-parse HEAD && git status --porcelain
 
-**Split correctness bugs from cleanup nits — mandatory, not a nicety.**
-Every finding is labeled one or the other. This split is exactly what
-`model-routing`'s *Re-review trigger* reads: ≥1 actual correctness bug
-re-triggers a review once fixed and pushed; a pass with only cleanup-only
-findings, or none, does not. A report without this split cannot drive that
-loop — the dispatching session would have to re-derive it by re-reading
-every finding, which defeats the point of a structured report.
+Re-run both after the pass returns. **Any delta is a gate failure** — report
+it as such, do not absorb it. This is the one behavioural property of the
+pass verifiable from outside it, so it is the one that gets verified. The
+guard test cannot check it, and does not claim to.
 
-**"Found nothing" is a valid, expected outcome — say so explicitly in the
-brief.** A reviewer that believes it must produce findings to justify its
-own dispatch will manufacture them. A manufactured finding costs a needless
-re-review round and erodes trust in every report after it.
+## The PR comment
 
-## After the pass returns
+Every pass posts one summary comment on the PR the moment it returns,
+**before any fixes**, so the thread reads as found → fixed → re-verified in
+order.
 
-Triage per `model-routing`'s *Findings handling* and *Re-review trigger* —
-not restated here. **Never report the gate as having run when it did not.**
-If the user's own `/code-review` superseded this pass for the round, or the
-pass was substituted or skipped for any other reason, say so plainly in the
-user-facing summary rather than letting the checklist item read as
-satisfied.
+Format, following the three comments on [PR
+#2320](https://github.com/dudarenok-maker/Castwright/pull/2320):
+
+```
+## PR review — pass N (head <sha>, effort <level>)
+
+Scope: <files reviewed> · verified: <suite counts, typecheck> before
+adversarially probing <what>.
+
+### 🔴 Blocking — <claim>
+<concrete repro: exact input → wrong output, file:line>
+
+### 🟠 Significant — <claim>
+### 🟡 Minor
+### ✅ What is solid
+### Verdict
+```
+
+Two elements are required rather than stylistic:
+
+- **the head SHA in the heading** — it is what makes a comment interpretable
+  months later, when the branch has moved on;
+- **on a re-review, each prior finding's disposition** (`VERIFIED RESOLVED`,
+  or still open and why), so the thread is a chain rather than three
+  unrelated opinions.
+
+Severity maps onto the split [Triage](#triage) reads: 🔴 and 🟠 are
+correctness bugs and re-trigger a pass once fixed and pushed; 🟡 is cleanup —
+fixed this round, but not a re-trigger.
+
+### The reviewer posts its own comment
+
+The **reviewer posts its own comment directly** — `gh pr comment <number>
+--body-file <file>` — one hop, before returning its report to the dispatching
+session. Nothing sits between finding and record: the session does not relay
+it, and does not compare what gets posted against what the reviewer found,
+because nothing sits in between to compare.
+
+The reviewer's boundary is a prohibition, not a capability limit: **it must
+not modify tracked files.** That is enforced by [the tree
+check](#the-tree-check), not trusted.
+
+The session then confirms the comment actually landed (`gh pr view <number>
+--json comments`) before starting triage. A pass that returned a report but
+posted nothing is reported as a pass that did not complete.
+
+### A pass that finds nothing still posts
+
+"Found nothing" is an explicitly valid outcome, so it gets the same header
+and a `### ✅ No findings` body. Without this, the record cannot distinguish
+*reviewed and clean* from *never reviewed* — the single distinction the whole
+record exists to preserve.
+
+For the same reason, a docs-only PR — exempt from the pass entirely, per
+[Exemption](#exemption) — posts a one-line exemption note naming the
+file-set test that exempted it. Absence of a review becomes a recorded fact
+rather than a silence.
+
+**Re-review comments state deltas only** — each prior finding's disposition,
+plus anything new. They do not re-list the solid items. Three passes plus fix
+commits is already the cap; re-listing would make the thread unreadable at
+exactly the point it matters most.
+
+**Standing authorization.** Posting to a public PR is an outward-facing
+action. The repo owner has authorized it as a standing part of this process,
+recorded here, so the agent posts each round without pausing to ask.
+
+## Triage
+
+The full rubric for what the reviewer checks and how it must report a
+finding is [`references/reviewer-brief.md`](references/reviewer-brief.md).
+What happens to what comes back — the fix-now bar, the defect / chore /
+taste seam, the void deferral reasons, the design-pass carve-out, and one
+dispatched fix agent per finding with one paired test — is
+[`references/findings-triage.md`](references/findings-triage.md). Not
+restated here.
+
+## Re-review trigger and loop cap
+
+- **Re-review trigger**: only when the initial pass surfaced ≥1 finding that
+  is an actual correctness bug (wrong behavior, crash, security issue — not a
+  reuse/simplification/efficiency-only cleanup nit). Fixing and pushing those
+  re-triggers a pass. If the initial pass came back empty, or surfaced only
+  cleanup-only findings, fix-and-push (or push nothing) does **not**
+  re-trigger a re-review — re-running it in that case just burns tokens for
+  no new signal. This mirrors the spec/plan loop's severity-gated shape (see
+  [`model-routing`'s adversarial-review
+  loop](../model-routing/SKILL.md#mandatory-adversarial-review-specs--plans)),
+  rather than firing on every push. Re-review re-derives the effort level
+  from the PR's current commit set (per [Effort level](#effort-level))
+  rather than reusing the initial pass's tier — a fix commit can raise the
+  tier the same way any other commit would.
+- **Loop cap**: 2 re-review rounds, same numeric cap as the spec/plan loop
+  (initial pass + up to 2 re-review rounds, 3 total). Still tripping the
+  trigger after that stops the loop and hands it to the user — do not keep
+  looping automatically past the cap.
+- **Judgment-call carve-out**: a finding that requires a decision only the
+  user can make suspends the fix-and-re-review loop and routes through the
+  normal ask-first behavior in [CLAUDE.md's "Think before
+  coding"](../../../CLAUDE.md#think-before-coding) — shared with the
+  spec/plan review loop, see [`model-routing`'s judgment-call
+  carve-out](../model-routing/SKILL.md#judgment-call-carve-out-shared-by-both-review-loops).
+
+## Issue verification at PR creation
+
+- **Trigger**: every `gh pr create` for non-trivial work, including
+  bug-shaped work.
+- **Check**: the PR body must contain `Closes #NN` or `Refs #NN` referencing
+  an existing GitHub issue, outside of any inline-code/fenced-code span (a
+  backtick-wrapped `` `Closes #NN` `` does not actually auto-close on
+  GitHub — write it plain).
+- **Missing case**: auto-file a new issue capturing the work, then add
+  `Closes #NN` to the PR body — proceed without pausing to ask, in every
+  case including bug-shaped work (a deliberate, explicit override of
+  `CLAUDE.md`'s general "user files bugs" convention, scoped to this one
+  gate). Label per `CONTRIBUTING.md`'s actual two-shape convention:
+  - **Bug-shaped** (fixing existing broken behavior, no design decision):
+    standalone `bug` label, plain descriptive title. No `area:`/`type:`/
+    `moscow:`.
+  - **Backlog-shaped** (new/changed behavior): `area:<prefix>` +
+    (`type:feature` or `type:chore`). `moscow:` left unset for the user.
+    Use `type:chore` when the work matches this repo's commit-type-`chore`
+    shape (codegen, version bumps, tidy-up — no user-facing behavior
+    change); `type:feature` otherwise.
+- **Timing**: at PR creation — distinct from, and prior to, the mandatory
+  independent review above, which reviews code + docs combined once the PR
+  (and its issue link) already exist.
+- **Mechanical backstop**: `.github/workflows/pr-issue-link.yml` fails the
+  PR check if neither `Closes #\d+` nor `Refs #\d+` appears in the body
+  (outside code spans) — the one gate in this file with a real, external
+  enforcement, not just this convention. It does not check labeling or
+  whether the auto-file step above ran correctly, only that some issue
+  reference exists.
+
+## Merge
+
+Once triage is closed — every finding fixed and pushed, or the sole
+design-pass carve-out routed to its own issue naming the decision owed — and
+any re-review round the trigger required has landed clean, merge per
+[CLAUDE.md's Branching workflow → Opening the
+PR](../../../CLAUDE.md#opening-the-pr) ("Create a merge commit"; squash/rebase
+disabled at the repo level; head branch auto-deleted on merge).

--- a/.claude/skills/pr-review-gate/SKILL.md
+++ b/.claude/skills/pr-review-gate/SKILL.md
@@ -212,9 +212,9 @@ recorded here, so the agent posts each round without pausing to ask.
 
 The full rubric for what the reviewer checks and how it must report a
 finding is [`references/reviewer-brief.md`](references/reviewer-brief.md).
-What happens to what comes back — the fix-now bar, the defect / chore /
-taste seam, the void deferral reasons, the design-pass carve-out, and one
-dispatched fix agent per finding with one paired test — is
+What happens to what comes back — the fix-in-this-round rule, the defect /
+chore / taste seam, the void deferral reasons, the design-pass carve-out, and
+one dispatched fix agent per finding with one paired test — is
 [`references/findings-triage.md`](references/findings-triage.md). Not
 restated here.
 

--- a/.claude/skills/pr-review-gate/SKILL.md
+++ b/.claude/skills/pr-review-gate/SKILL.md
@@ -101,11 +101,25 @@ tool names, so the mechanism ports:
 
 - **Claude Code** — a non-fork `Agent` dispatch at the routing table's
   Premium tier.
-- **Cline** — dispatches subagents. Whether that subagent starts cold is
-  recorded in `docs/testing/agent-skill-resolution-probe.md`. Until it reads
-  `CLINE_SUBAGENT_COLD: yes`, a Cline-run pass is labelled a **self-run**,
-  not the independent gate: reporting a fork as the gate is exactly the
-  substitution the standing rule forbids.
+- **Cline** — dispatches subagents via `spawn_agent`, and they start cold
+  (recorded in `docs/testing/agent-skill-resolution-probe.md`). **That is not
+  sufficient on its own.** Cline cannot select its subagent's model — the
+  probe records `CLINE_TIER_SELECTABLE: no`, observed running
+  `deepseek-v4-flash` — so a Cline-run pass is independent but **flash-tier**,
+  and this section's Premium requirement is unmet. Two conditions, both
+  required, and the tier one is the easier to forget because independence is
+  the property people check:
+
+  | Condition | Cline today |
+  |---|---|
+  | Fresh context, not a fork | yes (self-reported, not independently reproduced) |
+  | Premium tier | **no** |
+
+  So a Cline pass is recorded as a **flash-tier independent pass**, never as
+  this gate. It is worth running and worth reading; it does not discharge the
+  merge gate, and a summary that calls it "the review gate" is a false
+  completion claim. Same outcome if `CLINE_SUBAGENT_COLD` ever reads anything
+  but `yes` — then it is a self-run as well as untiered.
 - **Any agent that genuinely cannot dispatch** runs the rubric in-session and
   reports it as a **self-run pass, never as the independent gate** — the same
   rule that forbids reporting a gate as having run when it did not.

--- a/.claude/skills/pr-review-gate/SKILL.md
+++ b/.claude/skills/pr-review-gate/SKILL.md
@@ -40,6 +40,10 @@ push. Except a docs-only PR, which is exempt entirely — see
 - **Never auto-apply.** The subagent edits nothing. It returns a findings
   report, triaged by hand per `model-routing`'s "Findings handling". (If the
   user runs `/code-review` themselves instead, the same bar holds: no `--fix`.)
+- **The reviewer reads the rubric itself.** The dispatch prompt instructs it to
+  read `.claude/skills/pr-review-gate/references/reviewer-brief.md` in full
+  before it starts. Triage rules for what comes back are in
+  `.claude/skills/pr-review-gate/references/findings-triage.md`.
 
 ## The brief to carry into the subagent prompt
 

--- a/.claude/skills/pr-review-gate/references/findings-triage.md
+++ b/.claude/skills/pr-review-gate/references/findings-triage.md
@@ -102,8 +102,9 @@ reads:
   cleanup-only findings, fix-and-push (or push nothing) does **not**
   re-trigger a re-review — re-running it in that case just burns tokens for
   no new signal. (This is a *fixing* rule, not a re-review rule: 🟡-only
-  findings are still fixed this round per the fix-now bar above — they just
-  don't reopen the loop.) Re-review re-derives the effort level from the
+  findings are still fixed this round per "Fix in this round (the
+  report-fix-record rule)" above — they just don't reopen the loop.)
+  Re-review re-derives the effort level from the
   PR's current commit set rather than reusing the initial pass's tier — a
   fix commit can raise the tier the same way any other commit would.
 - **Loop cap**: initial pass + up to 2 re-review rounds (3 total). Still

--- a/.claude/skills/pr-review-gate/references/findings-triage.md
+++ b/.claude/skills/pr-review-gate/references/findings-triage.md
@@ -1,0 +1,110 @@
+# Findings triage
+
+What happens after a review pass's comment lands. This file is read by the
+shipping session, not the reviewer — the reviewer's contract for producing
+findings lives in [`reviewer-brief.md`](reviewer-brief.md).
+
+## The fix-now bar
+
+Triage the report by hand, then **fix in this round**. Every finding gets a
+dispatched fix agent — one finding, one fix, one paired test — committed and
+pushed before merge. Clear-cut findings (unambiguous bug, obvious dead code,
+a straightforward CLAUDE.md violation) are the ordinary case, not the only
+case. **Cleanup-only findings are in scope too** — a reuse/simplification/
+efficiency nit, a staled derived artifact, a missing index or register row,
+an unwired knob. They are cheaper to dispatch than a bug, not a lesser class
+of work, and "it's only a chore" / "it's not user-visible" is not a
+deferral. A ten-finding report ends as ten fix commits, not a follow-up
+epic. None of this licenses `--fix`: the fixes are dispatched and reviewed
+per finding, never applied wholesale.
+
+## The defect / chore / taste seam
+
+A finding is a **defect** (correctness bug) or a **chore** (a derived
+artifact your change staled, a bookkeeping row your change made owed, a knob
+that landed without its wiring, dead or duplicated code the work exposed, a
+seam with no test, a stale comment your change made false) — both are fixed
+in this round, on the same footing. The bug/chore label is a routing detail,
+not a priority ruling.
+
+## Void deferral reasons
+
+Reproduced verbatim from [CLAUDE.md → Incidental findings: report, fix,
+record](../../../../CLAUDE.md#incidental-findings-report-fix-record). Each
+has been used to justify deferring a finding; each is void:
+
+- **"it would expand the scope of this PR"** — a finding the work surfaced
+  is in scope by definition. The PR body declares the fix and that settles
+  it.
+- **"it needs a judgement call"** — every fix needs judgement. The bar is
+  needing a *decision*, not needing thought. Weighing two implementations of
+  one agreed behaviour is not a design pass; picking which behaviour is
+  right is.
+- **"it's pre-existing"** / "the branch doesn't touch that file" / "it's
+  next door" — adjacency stopped being the test.
+- **"it needs its own test / its own regression plan"** — write the test in
+  this PR. That is the standing requirement anyway.
+- **"it's cheaper to batch these later"** — it is not. Ten open tickets cost
+  strictly more than ten dispatched agents, and they cost it in the user's
+  time.
+- **"the user can decide later whether it's worth fixing"** — the user asked
+  for working code, not a triage inbox.
+- **"it's only a chore"** — the label is the board's routing, not a priority
+  ruling, and a chore is the *cheapest* thing on this list to dispatch.
+  "It's not user-visible" and "nothing is broken yet" are the same excuse: a
+  stale derived artifact or an unwired knob is a defect that has not been
+  noticed yet.
+
+## The design-pass carve-out — the only way to leave a finding unfixed
+
+**The single finding allowed to leave the round unfixed is one needing a
+design pass** — more than one defensible outcome, a decision the user has a
+stake in. This is the judgment-call carve-out shared with the spec/plan
+review loop
+([`model-routing`](../../model-routing/SKILL.md#judgment-call-carve-out-shared-by-both-review-loops)): a
+finding that requires a decision only the user can make suspends the
+fix-and-re-review loop and routes through the normal ask-first behavior in
+CLAUDE.md's "Think before coding" rather than being silently resolved just
+to keep the loop moving.
+
+**Its issue must name the decision owed**, not just restate the finding.
+"Needs design" without the decision named is a deferral in disguise — see
+CLAUDE.md's same rule. File it in the same round via the normal backlog
+path, labelled per CONTRIBUTING.md's two-shape convention; that issue is the
+whole deliverable for this finding.
+
+Everything else — "it expands the PR's scope", "it's pre-existing", "it
+needs its own test", "we can batch these" — is not a design pass and is
+fixed now.
+
+## One fix agent per finding
+
+Each finding gets its own dispatched fix agent: one finding, one fix, one
+paired test. Not a single agent working the whole list, and not a fix
+folded into an unrelated commit — each fix is traceable back to the finding
+that produced it, committed and pushed before merge.
+
+## How the split drives the re-review trigger and the loop cap
+
+Every finding is labeled 🔴 Blocking / 🟠 Significant (a correctness bug —
+wrong behavior, crash, security issue) or 🟡 Minor (a reuse/simplification/
+efficiency-only cleanup nit). This label is what the re-review trigger
+reads:
+
+- **Re-review trigger**: only when the pass surfaced at least one finding
+  that is an actual 🔴/🟠 correctness bug. Fixing and pushing those
+  re-triggers a pass. If the pass came back empty, or surfaced only 🟡
+  cleanup-only findings, fix-and-push (or push nothing) does **not**
+  re-trigger a re-review — re-running it in that case just burns tokens for
+  no new signal. (This is a *fixing* rule, not a re-review rule: 🟡-only
+  findings are still fixed this round per the fix-now bar above — they just
+  don't reopen the loop.) Re-review re-derives the effort level from the
+  PR's current commit set rather than reusing the initial pass's tier — a
+  fix commit can raise the tier the same way any other commit would.
+- **Loop cap**: initial pass + up to 2 re-review rounds (3 total). Still
+  tripping the trigger after that stops the loop and hands it to the user —
+  do not keep looping automatically past the cap.
+
+A report without the 🔴/🟠 vs 🟡 split cannot drive this loop — the
+dispatching session would have to re-derive it by re-reading every finding,
+which defeats the point of a structured report.

--- a/.claude/skills/pr-review-gate/references/findings-triage.md
+++ b/.claude/skills/pr-review-gate/references/findings-triage.md
@@ -4,7 +4,12 @@ What happens after a review pass's comment lands. This file is read by the
 shipping session, not the reviewer — the reviewer's contract for producing
 findings lives in [`reviewer-brief.md`](reviewer-brief.md).
 
-## The fix-now bar
+## Fix in this round (the report-fix-record rule)
+
+CLAUDE.md retired the old four-conjunct "fix-now bar" name: that bar
+*licensed deferral*, whereas [the current rule](../../../../CLAUDE.md#incidental-findings-report-fix-record)
+gates deferring instead — a historical doc that cites "the fix-now bar" is
+not precedent under this rule.
 
 Triage the report by hand, then **fix in this round**. Every finding gets a
 dispatched fix agent — one finding, one fix, one paired test — committed and

--- a/.claude/skills/pr-review-gate/references/reviewer-brief.md
+++ b/.claude/skills/pr-review-gate/references/reviewer-brief.md
@@ -1,0 +1,109 @@
+# PR reviewer brief
+
+Read this file in full before starting. It is the rubric — what to check and
+how to report it. The dispatching session's runbook is
+[`../SKILL.md`](../SKILL.md); you do not need it.
+
+**Framing: this is a gate, not a collaborator.** Your job is to find what's
+wrong with the change, not to appreciate it. Don't soften findings to be
+encouraging, and don't reward effort.
+
+## Half one: house gates
+
+Mechanically checkable, and you are expected to actually check them rather
+than assume the author did:
+
+- the paired test is a real regression test — red before the fix, green
+  after, and red *for the reason claimed*;
+- on-box acceptance recorded across all three surfaces (register, per-feature
+  run sheet, live view) when the PR ships hardware-provable behaviour;
+- the release-notes pair (`docs/release-notes-next.md` + `RELEASE_NOTES.md`),
+  or an explicit not-applicable;
+- `Closes #NN` / `Refs #NN` present and outside any code span;
+- `cast.json` writes locked per the four rules, and lock-timeout errors
+  routed through the correct curation seam;
+- a new config knob carrying its registry entry, `config:sync`, Settings row
+  and `.env.example` line;
+- derived artifacts regenerated — `src/lib/api-types.ts`, `docs/BACKLOG.md`,
+  brand PNGs;
+- incidental findings fixed in this round rather than filed, and declared in
+  the PR body.
+
+## Half two: recurring defect shapes
+
+Curated, roughly ten, each stated as *how it hides* rather than as a rule to
+recite:
+
+1. **A guard that fails open on absent evidence** — the input it inspects is
+   missing, so it passes.
+2. **A guard that enumerates syntax** — it loses one spelling per round to
+   anything it did not list.
+3. **A test that cannot fail** — or that went red before the fix for a
+   different reason than the one claimed.
+4. **A metric blind to a case it must score** — deletion counted as repair, a
+   merge counted as repair, the dominant shape excluded.
+5. **An acceptance criterion blind to its own feature** — it would pass on a
+   null observation.
+6. **Success reported while doing nothing** — the most common shape in this
+   repo's history, including inside guards written to catch it.
+7. **A fix unreachable at the default configuration** — correct code that
+   runs zero times as shipped.
+8. **A control group labelled clean but never measured.**
+9. **The defect is in the instrument or the document, not the code** — a
+   stale comment the change made false, a figure measured under one rule
+   reused as evidence for another.
+10. **One instance fixed, the class left armed** — sibling call sites, other
+    entry points, the second copy.
+
+### Keeping the catalogue current
+
+A catalogue written once is a snapshot that decays, and the next new shape
+gets transmitted nowhere — which is the problem this file exists to solve.
+So it gets an explicit trigger and owner rather than good intentions:
+**when a gate round surfaces a defect shape the catalogue above does not
+already name, appending it here is part of that round's fix work**, in the
+same PR, on the same footing as any other chore the work made owed. This is
+a living file with a maintenance rule, not an appendix.
+
+## The finding contract
+
+**Per finding, require all three:**
+- a **severity**;
+- a **`file:line`**;
+- a **concrete failure scenario** — specific inputs or state that produce a
+  specific wrong output. "This could be fragile" is not a finding; show the
+  break, don't gesture at a risk.
+
+**Split correctness bugs from cleanup nits — mandatory, not a nicety.**
+Every finding is labeled one or the other. This split is what the re-review
+trigger in [`findings-triage.md`](findings-triage.md) reads: ≥1 actual
+correctness bug re-triggers a review once fixed and pushed; a pass with only
+cleanup-only findings, or none, does not.
+
+**"Found nothing" is a valid, expected outcome.** A reviewer that believes it
+must produce findings to justify its own dispatch will manufacture them. A
+manufactured finding costs a needless re-review round and erodes trust in
+every report after it.
+
+## Post your own findings before returning
+
+Post one comment on the PR with `gh pr comment <number> --body-file <file>`
+BEFORE returning your report. Do not hand it to the dispatching session to
+publish — nothing would compare what it posts against what you found.
+
+**The PR number and head SHA come from the dispatch prompt.** Do not infer
+them: `gh pr view` on the wrong branch, or in a worktree whose HEAD moved,
+posts a review onto someone else's PR. If the prompt did not give you both,
+stop and say so rather than guessing — a review comment on the wrong PR cannot
+be quietly withdrawn.
+
+Heading: `## PR review — pass N (head <sha>, effort <level>)`. The head SHA is
+required; without it the comment is uninterpretable once the branch moves.
+
+If you found nothing, post anyway with `### ✅ No findings`. A record that
+cannot distinguish "reviewed and clean" from "never reviewed" is not a record.
+
+**Modify no tracked file.** Posting a comment is not a modification; editing,
+committing, or staging anything is. The dispatching session compares
+`git rev-parse HEAD` and `git status --porcelain` before and after this pass,
+and any delta is reported as a gate failure.

--- a/.claude/skills/pr-review-gate/references/reviewer-brief.md
+++ b/.claude/skills/pr-review-gate/references/reviewer-brief.md
@@ -87,6 +87,12 @@ every report after it.
 
 ## Post your own findings before returning
 
+**Write that body file to the OS temp directory, NEVER inside the repository.**
+A scratch file in the worktree dirties `git status --porcelain`, and the
+dispatching session treats any delta as a gate failure — so a clean review
+would be reported as a failed one, *after* you had already posted it. Use
+`$env:TEMP` / `$TMPDIR` (Node: `os.tmpdir()`), and delete it when done.
+
 Post one comment on the PR with `gh pr comment <number> --body-file <file>`
 BEFORE returning your report. Do not hand it to the dispatching session to
 publish — nothing would compare what it posts against what you found.

--- a/.claude/skills/run-app/SKILL.md
+++ b/.claude/skills/run-app/SKILL.md
@@ -87,9 +87,23 @@ EOF
 # imports (`@playwright/test`) against the CWD's node_modules, not the
 # script's own (temp-dir) location — a plain `node "$VERIFY_DIR/…mjs"` would
 # throw ERR_MODULE_NOT_FOUND instead.
-VERIFY_SCREENSHOT="$VERIFY_DIR/verify-screenshot.png" node --input-type=module < "$VERIFY_DIR/verify-drive.mjs"
-# then Read "$VERIFY_DIR/verify-screenshot.png" and LOOK at it
+# `export` (not a bare prefix assignment) so VERIFY_SCREENSHOT survives as a
+# shell variable for the cygpath calls below, not just inside node's own env.
+export VERIFY_SCREENSHOT="$VERIFY_DIR/verify-screenshot.png"
+node --input-type=module < "$VERIFY_DIR/verify-drive.mjs"
+# Print the ABSOLUTE WINDOWS paths now, in THIS shell. Each Bash tool call is
+# a fresh shell — $VERIFY_DIR will be GONE by the next step, so this is the
+# only chance to hand the path forward. Print, don't rely on the variable.
+echo "VERIFY_DIR_WIN=$(cygpath -w "$VERIFY_DIR")"
+echo "VERIFY_SCREENSHOT_WIN=$(cygpath -w "$VERIFY_SCREENSHOT")"
 ```
+
+Then **Read the `VERIFY_SCREENSHOT_WIN` path printed above** — e.g.
+`C:\Users\...\AppData\Local\Temp\tmp.XXXXXXXXXX\verify-screenshot.png` — and
+LOOK at it. Use that Windows-style path, not the Git-Bash POSIX form
+(`/tmp/tmp.XXXXXXXXXX/verify-screenshot.png`): the POSIX form resolves fine
+*inside* Git Bash itself, but the Read tool runs outside Git Bash and measures
+it as "File does not exist" — only the `cygpath -w` output works there.
 
 **What a healthy run looks like** (this is the regression net for the plan-167 stack):
 - Heading renders (`Welcome back, Mike` on `#/`, or the view's heading) — proves
@@ -111,5 +125,13 @@ screenshot — don't trust the exit code alone.
 ```bash
 # stop a stray Vite holding :5173 (PowerShell — taskkill on the bash PID misses the node child)
 # Get-NetTCPConnection -LocalPort 5173 -State Listen | %{ Stop-Process -Id $_.OwningProcess -Force }
-rm -rf "$VERIFY_DIR"   # unconditional — a failed run (the case you're cleaning up FOR) must not skip this
+
+# This is a FRESH shell — $VERIFY_DIR from STEP 2 is unset here. Paste the
+# VERIFY_DIR_WIN value STEP 2 printed (the directory, not the screenshot):
+VERIFY_DIR_WIN="C:\Users\...\AppData\Local\Temp\tmp.XXXXXXXXXX"   # <- paste STEP 2's printed VERIFY_DIR_WIN
+if [ -z "$VERIFY_DIR_WIN" ]; then
+  echo "VERIFY_DIR_WIN is empty -- refusing to rm -rf" >&2
+else
+  rm -rf "$VERIFY_DIR_WIN"   # unconditional once non-empty — a failed run (the case you're cleaning up FOR) must not skip this
+fi
 ```

--- a/.claude/skills/run-app/SKILL.md
+++ b/.claude/skills/run-app/SKILL.md
@@ -56,7 +56,7 @@ via `.env.local` — check the wt-new output. The primary checkout uses `:5173`/
 Launch in the background and wait for ready:
 
 ```bash
-npm run dev:frontend > /tmp/dev.log 2>&1 &
+VITE_USE_MOCKS=true npm run dev:frontend > /tmp/dev.log 2>&1 &
 for i in $(seq 1 30); do curl -s -o /dev/null http://localhost:5173/ && { echo ready; break; }; sleep 1; done
 ```
 

--- a/.claude/skills/run-app/SKILL.md
+++ b/.claude/skills/run-app/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: run-app
+description: Launch and drive the Audiobook Generator app to verify a change works in the real browser (Vite + React frontend, Node/Express server, Python TTS sidecar). Use when asked to run/start/verify the app, confirm a change works in the real app (not just tests), or screenshot a view.
+---
+
+# Running & verifying the Audiobook Generator app
+
+The app is a Vite + React SPA (`src/`) talking to a Node/Express server
+(`server/`) that owns a Python TTS sidecar. The frontend can run **standalone
+in mock mode** (`VITE_USE_MOCKS`, set in `.env.development`) with no server or
+sidecar — that's the fastest way to verify a frontend/stack change.
+
+## STEP 0 — after pulling or switching branches: reinstall FIRST
+
+**This is the #1 gotcha.** A running `npm run dev` does NOT reinstall
+`node_modules` or restart Vite. If `package.json` changed (a dep bump, a branch
+switch, a `git pull`), the live server keeps serving the OLD stack — you'll see
+old versions even though the source on disk is new ("why is it running on the
+old stack?"). Relaunching is not reinstalling.
+
+```bash
+npm install                 # root deps
+npm install --prefix server # server deps (separate tree)
+```
+
+Confirm the stack actually flipped before trusting a run:
+
+```bash
+node -e "for (const m of ['react','vite','vitest','react-router-dom','typescript']) console.log(m, require(\`./node_modules/\${m}/package.json\`).version)"
+```
+
+Current stack (post plan 167, 2026-06-02): React 19, Vite 8 (Rolldown), Vitest 4,
+react-router-dom 7, TypeScript 6.
+
+## STEP 1 — launch
+
+| Goal | Command | Ports |
+|---|---|---|
+| Frontend only (mock mode — best for a quick verify) | `npm run dev:frontend` | Vite `:5173` |
+| Full dev (frontend + server + sidecar) | `npm run dev` | `:5173` + `:8080` |
+| Production bundle smoke | `npm run build && npm run preview` | preview port |
+
+In a worktree, `scripts/wt-new.mjs` assigns per-worktree ports (e.g. `:5193`/`:8100`)
+via `.env.local` — check the wt-new output. The primary checkout uses `:5173`/`:8080`.
+
+Launch in the background and wait for ready:
+
+```bash
+npm run dev:frontend > /tmp/dev.log 2>&1 &
+for i in $(seq 1 30); do curl -s -o /dev/null http://localhost:5173/ && { echo ready; break; }; sleep 1; done
+```
+
+## STEP 2 — DRIVE it in a real browser (don't just curl)
+
+`curl` only returns the empty `index.html` shell — it can't tell you whether
+React rendered or threw. Drive it with the project's Playwright chromium. Drop
+this one-shot driver at the repo root and `node` it:
+
+```js
+// verify-drive.mjs  (delete after use)
+import { chromium } from '@playwright/test';
+const errors = [];
+const browser = await chromium.launch();
+const page = await browser.newPage();
+page.on('console', (m) => m.type() === 'error' && errors.push('console.error: ' + m.text()));
+page.on('pageerror', (e) => errors.push('pageerror: ' + e.message));
+await page.goto('http://localhost:5173/', { waitUntil: 'domcontentloaded' });
+await page.waitForSelector('text=/Welcome back|Your audiobooks|New book/i', { timeout: 20000 }); // boot rendered
+const heading = await page.locator('h1,h2').first().innerText();
+try { await page.getByRole('button', { name: /^Voices$/ }).click({ timeout: 5000 }); } catch {}
+await page.waitForTimeout(800);
+await page.screenshot({ path: 'verify-screenshot.png' });
+console.log('HEADING=' + heading, '| NAV_URL=' + page.url(), '| ERRORS=' + errors.length);
+errors.forEach((e) => console.log('  ' + e));
+await browser.close();
+```
+
+```bash
+node verify-drive.mjs && rm verify-drive.mjs   # then Read verify-screenshot.png and LOOK at it
+```
+
+**What a healthy run looks like** (this is the regression net for the plan-167 stack):
+- Heading renders (`Welcome back, Mike` on `#/`, or the view's heading) — proves
+  **redux-persist rehydrated** (the Rolldown CJS-interop bug made `storage.getItem`
+  undefined and broke boot; fixed by importing `redux-persist/es/storage`).
+- Clicking a nav tab moves `NAV_URL` to `#/voices` etc. — proves **hash-router
+  navigation** works (react-router 6 dropped `navigate()` from effects under
+  React 19; react-router 7 fixed it).
+- `ERRORS=0`.
+- The footer reads `<version> · <gitSha> · <branch> · <time>` — confirm the
+  `gitSha` matches the commit you expect (catches a stale, never-restarted process).
+
+A blank frame, a missing heading, a `storage.getItem is not a function` console
+error, or a `NAV_URL` that never leaves `#/` = a failed verify. Look at the
+screenshot — don't trust the exit code alone.
+
+## STEP 3 — clean up
+
+```bash
+# stop a stray Vite holding :5173 (PowerShell — taskkill on the bash PID misses the node child)
+# Get-NetTCPConnection -LocalPort 5173 -State Listen | %{ Stop-Process -Id $_.OwningProcess -Force }
+rm -f verify-drive.mjs verify-screenshot.png   # never commit these
+```

--- a/.claude/skills/run-app/SKILL.md
+++ b/.claude/skills/run-app/SKILL.md
@@ -6,9 +6,18 @@ description: Launch and drive the Audiobook Generator app to verify a change wor
 # Running & verifying the Audiobook Generator app
 
 The app is a Vite + React SPA (`src/`) talking to a Node/Express server
-(`server/`) that owns a Python TTS sidecar. The frontend can run **standalone
-in mock mode** (`VITE_USE_MOCKS`, set in `.env.development`) with no server or
-sidecar — that's the fastest way to verify a frontend/stack change.
+(`server/`) that owns a Python TTS sidecar. Tracked `.env.development` sets
+`VITE_USE_MOCKS=false` — **mocks are OFF by default**, so a bare `npm run
+dev:frontend` talks to the real server and errors loudly (502s) if it isn't
+running. To run the frontend **standalone in mock mode**, with no server or
+sidecar, opt in explicitly:
+
+```bash
+VITE_USE_MOCKS=true npm run dev:frontend
+```
+
+That's the fastest way to verify a frontend/stack change that doesn't need
+the real backend.
 
 ## STEP 0 — after pulling or switching branches: reinstall FIRST
 
@@ -36,7 +45,8 @@ react-router-dom 7, TypeScript 6.
 
 | Goal | Command | Ports |
 |---|---|---|
-| Frontend only (mock mode — best for a quick verify) | `npm run dev:frontend` | Vite `:5173` |
+| Frontend only, against the real server (mocks OFF, the default) | `npm run dev:frontend` | Vite `:5173` |
+| Frontend only, mock mode — best for a quick verify with no server/sidecar | `VITE_USE_MOCKS=true npm run dev:frontend` | Vite `:5173` |
 | Full dev (frontend + server + sidecar) | `npm run dev` | `:5173` + `:8080` |
 | Production bundle smoke | `npm run build && npm run preview` | preview port |
 
@@ -105,7 +115,13 @@ LOOK at it. Use that Windows-style path, not the Git-Bash POSIX form
 *inside* Git Bash itself, but the Read tool runs outside Git Bash and measures
 it as "File does not exist" — only the `cygpath -w` output works there.
 
-**What a healthy run looks like** (this is the regression net for the plan-167 stack):
+**What a healthy run looks like** (this is the regression net for the plan-167
+stack). The `ERRORS=0` bar below applies to **mock mode**
+(`VITE_USE_MOCKS=true npm run dev:frontend`) or the full `npm run dev` stack —
+i.e. any launch where the backend the frontend calls is actually present. Driving
+`npm run dev:frontend` (mocks off) against no server is expected to log 502
+console errors for every hydrate call; that is not a failed verify, it is the
+absent-backend case documented above:
 - Heading renders (`Welcome back, Mike` on `#/`, or the view's heading) — proves
   **redux-persist rehydrated** (the Rolldown CJS-interop bug made `storage.getItem`
   undefined and broke boot; fixed by importing `redux-persist/es/storage`).
@@ -129,9 +145,6 @@ screenshot — don't trust the exit code alone.
 # This is a FRESH shell — $VERIFY_DIR from STEP 2 is unset here. Paste the
 # VERIFY_DIR_WIN value STEP 2 printed (the directory, not the screenshot):
 VERIFY_DIR_WIN="C:\Users\...\AppData\Local\Temp\tmp.XXXXXXXXXX"   # <- paste STEP 2's printed VERIFY_DIR_WIN
-if [ -z "$VERIFY_DIR_WIN" ]; then
-  echo "VERIFY_DIR_WIN is empty -- refusing to rm -rf" >&2
-else
-  rm -rf "$VERIFY_DIR_WIN"   # unconditional once non-empty — a failed run (the case you're cleaning up FOR) must not skip this
-fi
+[ -d "$VERIFY_DIR_WIN" ] || { echo "VERIFY_DIR_WIN does not exist -- refusing to rm -rf" >&2; exit 1; }
+rm -rf "$VERIFY_DIR_WIN"   # only reached once the directory is confirmed to exist
 ```

--- a/.claude/skills/run-app/SKILL.md
+++ b/.claude/skills/run-app/SKILL.md
@@ -53,11 +53,20 @@ for i in $(seq 1 30); do curl -s -o /dev/null http://localhost:5173/ && { echo r
 ## STEP 2 — DRIVE it in a real browser (don't just curl)
 
 `curl` only returns the empty `index.html` shell — it can't tell you whether
-React rendered or threw. Drive it with the project's Playwright chromium. Drop
-this one-shot driver at the repo root and `node` it:
+React rendered or threw. Drive it with the project's Playwright chromium.
 
-```js
-// verify-drive.mjs  (delete after use)
+**Write the driver script and its screenshot to the OS temp directory, NEVER
+the repo root.** A repo-root scratch file dirties `git status --porcelain`
+and trips the PR review gate's own tree check (see
+`.claude/skills/pr-review-gate/references/reviewer-brief.md`'s "Post your own
+findings" section, which hits the identical trap). `mktemp -d` is the
+documented temp path in this repo's Git-Bash-on-Windows environment — it
+resolves under Windows' own temp root (confirmed: `/tmp/tmp.XXXXXXXXXX` maps
+to `%TEMP%`), unlike `$TMPDIR`, which Git Bash leaves unset here.
+
+```bash
+VERIFY_DIR="$(mktemp -d)"
+cat > "$VERIFY_DIR/verify-drive.mjs" <<'EOF'
 import { chromium } from '@playwright/test';
 const errors = [];
 const browser = await chromium.launch();
@@ -69,14 +78,17 @@ await page.waitForSelector('text=/Welcome back|Your audiobooks|New book/i', { ti
 const heading = await page.locator('h1,h2').first().innerText();
 try { await page.getByRole('button', { name: /^Voices$/ }).click({ timeout: 5000 }); } catch {}
 await page.waitForTimeout(800);
-await page.screenshot({ path: 'verify-screenshot.png' });
+await page.screenshot({ path: process.env.VERIFY_SCREENSHOT });
 console.log('HEADING=' + heading, '| NAV_URL=' + page.url(), '| ERRORS=' + errors.length);
 errors.forEach((e) => console.log('  ' + e));
 await browser.close();
-```
-
-```bash
-node verify-drive.mjs && rm verify-drive.mjs   # then Read verify-screenshot.png and LOOK at it
+EOF
+# --input-type=module + stdin, run from the repo root: Node resolves bare
+# imports (`@playwright/test`) against the CWD's node_modules, not the
+# script's own (temp-dir) location — a plain `node "$VERIFY_DIR/…mjs"` would
+# throw ERR_MODULE_NOT_FOUND instead.
+VERIFY_SCREENSHOT="$VERIFY_DIR/verify-screenshot.png" node --input-type=module < "$VERIFY_DIR/verify-drive.mjs"
+# then Read "$VERIFY_DIR/verify-screenshot.png" and LOOK at it
 ```
 
 **What a healthy run looks like** (this is the regression net for the plan-167 stack):
@@ -99,5 +111,5 @@ screenshot — don't trust the exit code alone.
 ```bash
 # stop a stray Vite holding :5173 (PowerShell — taskkill on the bash PID misses the node child)
 # Get-NetTCPConnection -LocalPort 5173 -State Listen | %{ Stop-Process -Id $_.OwningProcess -Force }
-rm -f verify-drive.mjs verify-screenshot.png   # never commit these
+rm -rf "$VERIFY_DIR"   # unconditional — a failed run (the case you're cleaning up FOR) must not skip this
 ```

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,8 @@ dist/
 .idea/
 .vscode/
 *.swp
-.claude/
+.claude/*
+!.claude/skills/
 .claude-*
 # Superpowers brainstorming visual-companion mockups (local-only scratch)
 .superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -484,7 +484,9 @@ Design rationale:
   vars. No hex literals in component code.
 - **Mocks behind `VITE_USE_MOCKS`** — `src/lib/api.ts` exports
   `api = USE_MOCKS ? mock : real`. Components only ever import from `api.*`;
-  they never know which is which. `.env.development` sets the flag on.
+  they never know which is which. `.env.development` sets the flag **off**
+  (`VITE_USE_MOCKS=false`) — the default dev run talks to the real server;
+  opt into mocks with `VITE_USE_MOCKS=true npm run dev:frontend`.
 - **RTK immer** — slice reducers mutate via Immer drafts. Don't rewrite to spreads.
 - **`server/src/gpu/` reaches a route module through a leaf gate, never an
   import** — a static import, a dynamic `import()`, and even `import type`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,6 +421,15 @@ Design rationale:
   Run from a checkout that has `apps/android/android/key.properties` + `upload-keystore.jks`
   (git-ignored). Pure helpers unit-tested in `scripts/tests/build-companion-apk.test.mjs`.
 - `npm run openapi:types` — regenerate `src/lib/api-types.ts` from `openapi.yaml`.
+- `npm run skills:sync` — mirror `.claude/skills/pr-review-gate/` into
+  `~/.agents/skills/`, the only skill store Cline (and the five other agents
+  sharing it) resolves — it does **not** read a workspace `.claude/skills/`
+  (probed 2026-08-13, `docs/testing/agent-skill-resolution-probe.md`). A
+  **per-machine** step: the target is under `$HOME`, so CI cannot run it and a
+  fresh clone has no mirror. Re-run after any change under that directory; the
+  drift guard in `scripts/tests/review-gate-mechanism.test.mjs` catches a stale
+  mirror **only on a machine that has one** — it skips, loudly, where the path
+  is absent.
 - `cd server && npm run dev` — local analysis backend on `:8080`. Reads `server/.env`
   (Node 20.6+ native `process.loadEnvFile`, no dotenv dep). **The analyzer engine
   is chosen in the UI (Account → analyzer settings) / `user-settings.json`, not

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,8 +304,8 @@ so a drift gets an explicit sentence naming it and asking whether to switch.
   entirely. Otherwise effort scales with the PR's commit type/scope
   (CONTRIBUTING.md's commit-convention vocabulary): `low` for a single-scope
   `chore`/`test`/`build`/`ci`, `medium` for a single-scope `feat`/`fix`,
-  `high` for `refactor`/`perf` or any multi-scope PR — see the model-routing
-  skill for the full split.
+  `high` for `refactor`/`perf` or any multi-scope PR — see the
+  `pr-review-gate` skill for the full split.
 
 Full escalation logic, the "fails"/"drifted" definitions, the review-gate
 mechanics (in-session vs. subagent dispatch, re-review loop caps, the
@@ -709,11 +709,11 @@ Run this before declaring any non-trivial task "done." Skipping a step is fine w
    `npm run check:onbox-register` (`.github/workflows/onbox-register-check.yml`, ops-43) mechanically backstops the register's own internal arithmetic — glance-table counts vs. body row headings, and the stated total vs. the glance table — on every PR touching the file. It cannot tell you a row is missing, only that the ones already there don't add up.
 4. **Update `docs/features/INDEX.md`** if the plan is new or moved (new entry under its area, or move to `## Shipped (archive)` per `archive/README.md` when shipping a plan).
 5. **Update the two release-notes documents, in this PR.** Append an entry to `docs/release-notes-next.md` (technical register, PR-refed) AND a matching user-facing, brand-voice line to the in-progress version section at the top of `RELEASE_NOTES.md`. Land both PR-by-PR, not reconstructed from git history at cut time — that's the whole point of this step. The first-PR-after-a-cut bootstrap case (resetting both files) is documented once, in [CONTRIBUTING.md "Release notes"](CONTRIBUTING.md#release-notes) — check there, don't re-derive it. Skip only when the change has no shippable delta (pure docs/process, CI-only, internal chore with no user- or operator-visible effect) — say so explicitly rather than silently omitting.
-6. **Close or advance the linked issue.** Put `Closes #NN` in the PR body for a full delivery (`Refs #NN` for a partial), and confirm the issue's `area:`/`moscow:` labels still reflect reality. Bugs link their `bug` issue with `Closes #NN` too. This link is verified, not assumed — if none exists at PR-creation time, one is auto-filed and linked without pausing to ask, including for bug-shaped work (a deliberate, scoped override of "The backlog" section's general "the user files [bugs] as they hit them" convention, for this gate only — see [Model routing → PR-gate issue verification](.claude/skills/model-routing/SKILL.md#pr-gate-issue-verification)); `.github/workflows/pr-issue-link.yml` mechanically backstops the check on every PR, and (since 2026-07-06) a missing link blocks merge outright via `main`'s required-status-check ruleset — see `docs/features/235-model-routing-review-gates.md`.
+6. **Close or advance the linked issue.** Put `Closes #NN` in the PR body for a full delivery (`Refs #NN` for a partial), and confirm the issue's `area:`/`moscow:` labels still reflect reality. Bugs link their `bug` issue with `Closes #NN` too. This link is verified, not assumed — if none exists at PR-creation time, one is auto-filed and linked without pausing to ask, including for bug-shaped work (a deliberate, scoped override of "The backlog" section's general "the user files [bugs] as they hit them" convention, for this gate only — see [PR review → issue verification](.claude/skills/pr-review-gate/SKILL.md#issue-verification-at-pr-creation)); `.github/workflows/pr-issue-link.yml` mechanically backstops the check on every PR, and (since 2026-07-06) a missing link blocks merge outright via `main`'s required-status-check ruleset — see `docs/features/235-model-routing-review-gates.md`.
 7. **Run `npm run verify:fast:branch`** locally (same battery as pre-push) — or the full `npm run verify` if you want more than the branch-scoped subset. Cloud `verify.yml` is the required, authoritative gate either way (see "Commit gate").
 8. **If shipping a plan** (status → `stable`): fill its **Ship notes** section with the shipped date and the commit SHA, then `git mv` it under `docs/features/archive/` and re-link any active plan that pointed at it.
 9. **Surface what changed** in the end-of-turn summary in 1–2 sentences. Do not narrate the diff — point at the user-visible delta and the test that locks it.
-10. **Independent PR review.** Once every item above is done (or explicitly marked not-applicable) and the branch is pushed, run the mandatory gate via the `pr-review-gate` skill — see [Model routing → Mandatory independent review (PRs)](.claude/skills/model-routing/SKILL.md#mandatory-independent-review-prs). Triage and fold findings before merge.
+10. **Independent PR review.** Once every item above is done (or explicitly marked not-applicable) and the branch is pushed, run the mandatory gate via the `pr-review-gate` skill — see [the PR review runbook](.claude/skills/pr-review-gate/SKILL.md). Triage and fold findings before merge.
 
 ## Out of scope until told otherwise
 
@@ -1050,7 +1050,7 @@ check on every PR that skips this, mirroring `pr-title-lint.yml`, and (since
 2026-07-06) a missing link blocks merge outright — wired into `main`'s
 required status checks alongside `verify.yml` in the same ruleset action;
 see [docs/features/235-model-routing-review-gates.md](docs/features/235-model-routing-review-gates.md).
-Full mechanics: [`.claude/skills/model-routing/SKILL.md`](.claude/skills/model-routing/SKILL.md#pr-gate-issue-verification).
+Full mechanics: [`.claude/skills/pr-review-gate/SKILL.md`](.claude/skills/pr-review-gate/SKILL.md#issue-verification-at-pr-creation).
 
 **Requesting a clean-room CI run on a PR.** CI now runs automatically on
 every PR push (see "Commit gate" above) and is the real, required gate —

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -411,8 +411,8 @@ see `scripts/link-sub-issues.mjs`).
 (`npm run backlog:sync`, open `type:feature` issues only, Status ≠ `Done`) —
 don't hand-edit it; edit the linked issue and re-run the sync.
 
-Design: [docs/superpowers/specs/2026-07-05-github-issues-kanban-design.md](superpowers/specs/2026-07-05-github-issues-kanban-design.md).
-Regression plan: [docs/features/archive/241-github-projects-kanban-board.md](features/archive/241-github-projects-kanban-board.md).
+Design: [docs/superpowers/specs/2026-07-05-github-issues-kanban-design.md](docs/superpowers/specs/2026-07-05-github-issues-kanban-design.md).
+Regression plan: [docs/features/archive/241-github-projects-kanban-board.md](docs/features/archive/241-github-projects-kanban-board.md).
 
 ### Plan vs. no-plan
 

--- a/docs/features/199-advanced-settings.md
+++ b/docs/features/199-advanced-settings.md
@@ -71,7 +71,7 @@ owner: null
 
 ### Manual acceptance walkthrough
 
-Run in mock mode (`VITE_USE_MOCKS=true`, default in dev) via `npm run dev`:
+Run in mock mode (`VITE_USE_MOCKS=true`, opt-in — mocks are OFF by default in dev) via `npm run dev`:
 
 1. **Navigate to `#/advanced`** — heading "Advanced configuration" visible, "LLM sampling parameters" section open (no accordion collapse needed, it's the first registry group) with its "Ollama temperature" row rendered, and the separate "Per-sentence QA gates" section — also open by default — showing "Signal QA max re-records".
 2. **Edit "Signal QA max re-records"** from 2 to 5 and press Tab — the row shows `default: 2` + a "Revert" button; no banner (apply: live).

--- a/docs/features/235-model-routing-review-gates.md
+++ b/docs/features/235-model-routing-review-gates.md
@@ -7,7 +7,19 @@ owner: null
 # Model routing & review gates
 
 > Status: active — the issue-linkage gate (`scripts/validate-pr-issue-link.mjs`) is tested + CI-enforced end-to-end (it proves the gate ran). A second guard, `scripts/tests/review-gate-mechanism.test.mjs` (ops-55), locks that the PR-review gate's *mechanism* — `pr-review-gate` staying model-invocable and cross-referenced — doesn't rot, but it does not prove the gate actually ran on any given PR. The other four gates remain self-enforced prose, not locked by automated tests, so `stable` (which this repo's INDEX.md lifecycle defines as "behavior locked by automated tests") does not yet apply.
-> Key files: `CLAUDE.md`, `.claude/skills/model-routing/SKILL.md`, `scripts/validate-pr-issue-link.mjs`, `.github/workflows/pr-issue-link.yml`, `.claude/skills/pr-review-gate/SKILL.md`, `scripts/tests/review-gate-mechanism.test.mjs`
+> Key files: `CLAUDE.md`, `.claude/skills/model-routing/SKILL.md`, `scripts/validate-pr-issue-link.mjs`, `.github/workflows/pr-issue-link.yml`, `.claude/skills/pr-review-gate/SKILL.md`, `.claude/skills/pr-review-gate/references/{reviewer-brief,findings-triage}.md`, `scripts/tests/review-gate-mechanism.test.mjs`, `scripts/sync-agent-skills.mjs`
+>
+> **Superseded in part, 2026-08-13:** the PR-review half of this plan no longer
+> lives in `model-routing/SKILL.md`. `## Mandatory independent review (PRs)` and
+> `## PR-gate issue verification` **moved into
+> [`pr-review-gate/SKILL.md`](../../.claude/skills/pr-review-gate/SKILL.md)**,
+> which is now the full runbook (preconditions, exemption, effort ladder,
+> dispatch, the per-pass PR comment, triage, re-review loop, issue verification).
+> `model-routing` keeps routing: the tier table, escalation, session drift, the
+> spec/plan `assumption-checker` loop, and the shared judgment-call carve-out.
+> A reader sent here by an older reference should follow that file, not this
+> one. Design of record:
+> [2026-08-13-pr-review-skill-design.md](../superpowers/specs/2026-08-13-pr-review-skill-design.md).
 > URL surface: n/a — process/tooling change, no application UI
 > OpenAPI ops: none
 

--- a/docs/superpowers/plans/2026-08-13-pr-review-skill.md
+++ b/docs/superpowers/plans/2026-08-13-pr-review-skill.md
@@ -1,0 +1,723 @@
+# PR Review Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Widen `.claude/skills/pr-review-gate/` from "how to dispatch a reviewer" into the single home for this repo's PR review process — the procedure, the rubric the reviewer applies, the triage rules, and a durable per-pass record on the PR itself.
+
+**Architecture:** `SKILL.md` becomes the shipping session's runbook; two `references/` files carry the reviewer rubric and the findings-triage rules, and the reviewer is pointed at the rubric **by path** so it arrives verbatim. `model-routing`'s PR-specific sections move in, leaving routing to own routing. A guard test in `scripts/tests/review-gate-mechanism.test.mjs` locks the wiring, including a new link-integrity assertion that catches the dangling anchor this move would otherwise ship.
+
+**Tech Stack:** Markdown skills (`.claude/skills/`), `node:test` via `npm run test:hooks` (`scripts/run-hooks-tests.mjs`, auto-globs `scripts/tests/*.test.mjs`), `scripts/verify-cache.mjs` input-hash cache.
+
+**Spec:** [docs/superpowers/specs/2026-08-13-pr-review-skill-design.md](../specs/2026-08-13-pr-review-skill-design.md)
+
+**Worktree:** `C:\Claude\Projects\wt-pr-review-skill` — branch `docs/docs-pr-review-skill`. All work happens there. Do not commit from the primary checkout: HEAD moves under you (it already did once during this spec's authoring).
+
+## Global Constraints
+
+- **Do not rename the skill.** Directory stays `.claude/skills/pr-review-gate/`, frontmatter `name:` stays `pr-review-gate`, and `disable-model-invocation` must never appear. Three existing guard assertions depend on all three.
+- **Reference guard assertions by their test-name string, never by number.** The file's header comment numbers them in a different order than the `test()` calls appear.
+- **The reviewer posts its own PR comment.** The shipping session does not relay it.
+- **The reviewer modifies no tracked file.** The session verifies this with a before/after `git rev-parse HEAD` + `git status --porcelain` comparison; a delta is a gate failure.
+- **Every pass posts a comment** — including one that finds nothing (`### ✅ No findings`) and including a docs-only PR's exemption note.
+- **The mirror is conditional on Task 1.** "No agent needs a mirror" is a valid outcome that cancels Task 8 entirely.
+- **`CLAUDE.md` and `model-routing/SKILL.md` edits land last**, in one commit, rebased immediately before — they are high-contention files across 17 live worktrees.
+- Commit subjects follow `<type>(<scope>): <subject>`; this work is `docs(docs)` for skill/doc-only commits and `test(scripts)` / `chore(scripts)` for guard and cache changes.
+
+---
+
+## File Structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `.claude/skills/pr-review-gate/references/reviewer-brief.md` | **Create** — house gates + defect-shape catalogue + finding contract | 2 |
+| `.claude/skills/pr-review-gate/references/findings-triage.md` | **Create** — fix-now bar, void deferral reasons, design-pass carve-out | 2 |
+| `.claude/skills/pr-review-gate/SKILL.md` | **Rewrite** — the runbook; absorbs model-routing's PR sections | 3 |
+| `.claude/skills/model-routing/SKILL.md` | **Modify** — delete two sections, leave a pointer | 6 |
+| `CLAUDE.md` | **Modify** — fix the dead anchor at :716 and the stale ladder pointer at :301-306 | 6 |
+| `scripts/tests/review-gate-mechanism.test.mjs` | **Modify** — fix header numbering, retarget one assertion, add three | 2,3,5,6 |
+| `scripts/verify-cache.mjs` | **Modify** — replace two literals with a `.claude/skills/**` glob | 4 |
+| `scripts/tests/verify-cache.test.mjs` | **Modify** — assert a reference-file diff is in scope for `test:hooks` | 4 |
+| `docs/testing/agent-skill-resolution-probe.md` | **Create** — the Task 1 probe result | 1 |
+
+---
+
+### Task 1: Canary probe — which agents resolve what
+
+Everything in Task 8 is conditional on this. Run it first and **record the result even if the answer is "nothing to do"** — a probe whose outcome is unwritten gets re-run from cold by the next person.
+
+**Files:**
+- Create: `.claude/skills/zz-canary-probe/SKILL.md` (temporary, deleted in step 6)
+- Create: `docs/testing/agent-skill-resolution-probe.md`
+
+**Interfaces:**
+- Produces: a recorded verdict `MIRROR_NEEDED: <agent list, or "none">` that Task 8 reads. Also `CLINE_SUBAGENT_COLD: yes|no|unknown`, which decides whether Cline's mapping in `SKILL.md` says "independent gate" or "self-run only".
+
+- [ ] **Step 1: Create the canary skill**
+
+```markdown
+---
+name: zz-canary-probe
+description: Temporary probe skill. If you can see this, the agent reading it resolves project-scoped .claude/skills/. Delete after the probe.
+---
+
+# Canary
+
+This file exists only to test skill resolution. Report the literal string
+CANARY-OK-7F3A if asked whether you can see it.
+```
+
+- [ ] **Step 2: Confirm the shared CLI sees it**
+
+Run: `npx --yes skills list --json`
+Expected: an entry with `"name": "zz-canary-probe"`, `"scope": "project"`. Record its `agents` array verbatim — this is the CLI's *install bookkeeping*, not proof of what any agent resolves. Do not draw a conclusion from it alone.
+
+- [ ] **Step 3: Ask the repo owner to run the agent-side half**
+
+This step cannot be automated from inside Claude Code — it needs each agent driven interactively. Ask the owner to open Cline in this workspace and ask it two questions verbatim:
+
+1. *"List your available skills. Do you see one named `zz-canary-probe`? Reply with the literal string it tells you to report."*
+2. *"When you dispatch a subagent, does it start with a fresh context, or does it inherit our conversation? Can I choose which model it runs on?"*
+
+Record both answers. Question 2 is the load-bearing one: "can dispatch" and "can dispatch an *independent* reviewer" are different claims, and only the second satisfies this gate.
+
+- [ ] **Step 4: Write the probe result**
+
+Create `docs/testing/agent-skill-resolution-probe.md`:
+
+```markdown
+# Agent skill-resolution probe (2026-08-13)
+
+Run to decide whether `.claude/skills/pr-review-gate/` needs mirroring into
+other agents' workspace paths, per
+[the PR review skill design](../superpowers/specs/2026-08-13-pr-review-skill-design.md).
+
+## Method
+
+A throwaway project skill (`zz-canary-probe`) was added, then each agent was
+asked to list its skills. Only what an agent actually reported counts —
+`npx skills list --json` shows the *path*, and its `agents` field is the shared
+CLI's install bookkeeping, not proof of resolution.
+
+## Results
+
+| Agent | Sees project `.claude/skills/`? | Evidence |
+|---|---|---|
+| Claude Code | yes | resolves this repo's three project skills today |
+| Cline | <fill> | <verbatim answer> |
+| <others tested> | <fill> | <verbatim answer> |
+
+## Verdict
+
+MIRROR_NEEDED: <comma-separated agent list, or "none">
+CLINE_SUBAGENT_COLD: <yes|no|unknown>
+
+## Not established
+
+<Any agent not actually driven. "Not tested" is the honest entry — never
+infer resolution from a binary string or a directory listing.>
+```
+
+- [ ] **Step 5: Record the verdict's consequence**
+
+If `MIRROR_NEEDED: none`, write one explicit line in the same file: *"Task 8 of the implementation plan is cancelled; no mirror script, no mirror guard assertion, no cache entries."* Then mark Task 8 skipped in this plan rather than leaving it ambiguous.
+
+- [ ] **Step 6: Delete the canary and commit**
+
+```bash
+rm -rf .claude/skills/zz-canary-probe
+git add docs/testing/agent-skill-resolution-probe.md
+git commit -m "docs(docs): record the agent skill-resolution probe result"
+```
+
+Verify the canary is gone: `npx --yes skills list --json` no longer lists `zz-canary-probe`.
+
+---
+
+### Task 2: Fix the header numbering, then create the two reference files
+
+**Files:**
+- Modify: `scripts/tests/review-gate-mechanism.test.mjs:1-31` (header comment) and append one test
+- Create: `.claude/skills/pr-review-gate/references/reviewer-brief.md`
+- Create: `.claude/skills/pr-review-gate/references/findings-triage.md`
+- Modify: `.claude/skills/pr-review-gate/SKILL.md` (name the two files)
+
+**Interfaces:**
+- Produces: the two reference paths, which Task 3's `SKILL.md` dispatch section cites by path, and which Task 4's cache glob must cover.
+
+- [ ] **Step 1: Correct the header comment's assertion numbering**
+
+The header lists them 1 exists / 2 model-routing / 3 CLAUDE.md / 4 name-matches-directory, but the `test()` calls appear exists / name-matches-directory / model-routing / CLAUDE.md. This is a chore the work made owed — an implementer reading "assertion 3" cannot tell which test is meant. Renumber the header comment to match the actual `test()` order, and add this line under it:
+
+```
+//   Assertions are referred to elsewhere BY NAME, never by number — this
+//   header and the test() order disagreed until 2026-08-13, and a plan that
+//   said "retarget assertion 3" was ambiguous between two different tests.
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `scripts/tests/review-gate-mechanism.test.mjs`:
+
+```js
+test('pr-review-gate/SKILL.md names both reference files, and they exist', () => {
+  // The dispatch prompt points the reviewer at references/reviewer-brief.md BY
+  // PATH. This layout's new failure mode is that path not resolving: the
+  // reviewer is handed no rubric at all and reviews from generic instinct,
+  // silently. Checking existence alone is not enough — a file nobody names is
+  // just as unreachable as one that isn't there.
+  const src = readNormalized(GATE_SKILL_PATH);
+  const skillDir = dirname(GATE_SKILL_PATH);
+  for (const rel of ['references/reviewer-brief.md', 'references/findings-triage.md']) {
+    assert.ok(existsSync(join(skillDir, rel)), `missing ${rel} under ${skillDir}`);
+    const literal = rel.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&');
+    assert.match(
+      src,
+      new RegExp(literal),
+      `pr-review-gate/SKILL.md never names ${rel} — a reviewer would never be ` +
+        `told to read it, so the rubric reaches it only as well as the ` +
+        `dispatching session happens to retype it`,
+    );
+  }
+});
+```
+
+- [ ] **Step 3: Run it and verify it fails**
+
+Run: `npm run test:hooks`
+Expected: FAIL — `missing references/reviewer-brief.md`.
+
+- [ ] **Step 4: Create `references/reviewer-brief.md`**
+
+Write the rubric. Two halves plus the contract, per the spec's "references/reviewer-brief.md — the rubric" section: house gates (paired test is a real regression test red-for-the-claimed-reason; on-box acceptance across all three surfaces; release-notes pair; `Closes #NN` outside code spans; `cast.json` lock rules and lock-timeout curation seam; a new knob's registry + `config:sync` + Settings row + `.env.example`; regenerated derived artifacts; incidental findings fixed not filed and declared in the PR body), then the ten defect shapes stated as *how each hides*, then the catalogue-maintenance rule, then the finding contract (severity, `file:line`, concrete failure scenario, correctness-vs-cleanup split, "found nothing" explicitly authorised).
+
+Also include the posting instructions the reviewer itself executes:
+
+```markdown
+## Post your own findings before returning
+
+Post one comment on the PR with `gh pr comment <number> --body-file <file>`
+BEFORE returning your report. Do not hand it to the dispatching session to
+publish — nothing would compare what it posts against what you found.
+
+Heading: `## PR review — pass N (head <sha>, effort <level>)`. The head SHA is
+required; without it the comment is uninterpretable once the branch moves.
+
+If you found nothing, post anyway with `### ✅ No findings`. A record that
+cannot distinguish "reviewed and clean" from "never reviewed" is not a record.
+
+**Modify no tracked file.** Posting a comment is not a modification; editing,
+committing, or staging anything is. The dispatching session compares
+`git rev-parse HEAD` and `git status --porcelain` before and after this pass,
+and any delta is reported as a gate failure.
+```
+
+- [ ] **Step 5: Create `references/findings-triage.md`**
+
+Per the spec's section of the same name: the fix-now bar; the defect / chore / taste seam; the void deferral reasons reproduced verbatim from [CLAUDE.md → Incidental findings](../../../CLAUDE.md#incidental-findings-report-fix-record); the design-pass carve-out as the sole exception, with its issue required to name the decision owed; one dispatched fix agent per finding with one paired test; and how the 🔴/🟠 vs 🟡 split drives the re-review trigger and the loop cap.
+
+- [ ] **Step 6: Name both files in `SKILL.md`**
+
+Add to the existing `## Dispatch` section (the full rewrite is Task 3):
+
+```markdown
+- **The reviewer reads the rubric itself.** The dispatch prompt instructs it to
+  read `.claude/skills/pr-review-gate/references/reviewer-brief.md` in full
+  before it starts. Triage rules for what comes back are in
+  `.claude/skills/pr-review-gate/references/findings-triage.md`.
+```
+
+- [ ] **Step 7: Run tests and verify they pass**
+
+Run: `npm run test:hooks`
+Expected: PASS, all assertions.
+
+- [ ] **Step 8: Mutation-verify the new assertion**
+
+Temporarily rename `references/reviewer-brief.md` to `references/reviewer-brief.md.bak`, run `npm run test:hooks`, confirm RED with the "missing" message. Then restore it, delete the line naming it in `SKILL.md`, run again, confirm RED with the "never names" message. Restore. **Both halves must have been observed red** — an assertion that only ever ran green proves nothing.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add .claude/skills/pr-review-gate scripts/tests/review-gate-mechanism.test.mjs
+git commit -m "docs(docs): add the pr-review-gate reviewer brief and triage reference"
+```
+
+---
+
+### Task 3: Rewrite SKILL.md as the runbook
+
+**Files:**
+- Modify: `.claude/skills/pr-review-gate/SKILL.md` (full rewrite)
+- Modify: `scripts/tests/review-gate-mechanism.test.mjs` (retarget one assertion)
+
+**Interfaces:**
+- Consumes: the two reference paths from Task 2.
+- Produces: a `## Dispatch` section and an effort ladder inside `SKILL.md`, which the retargeted assertion reads, and which Task 6 lets `model-routing` drop.
+
+- [ ] **Step 1: Retarget the model-routing assertion (write the failing test)**
+
+Replace the test named `"model-routing/SKILL.md's PR-review Mechanism bullet references pr-review-gate"` with:
+
+```js
+test('pr-review-gate/SKILL.md carries the dispatch mechanism and the effort ladder', () => {
+  // Retargeted 2026-08-13: this assertion used to read model-routing's
+  // "## Mandatory independent review (PRs)" section, which has moved into this
+  // skill. It must read the file that now OWNS the rule, or it certifies a
+  // section that no longer exists.
+  const src = readNormalized(GATE_SKILL_PATH);
+
+  const dispatch = /\n## Dispatch\n([\s\S]*?)(?=\n## )/.exec(src);
+  assert.ok(dispatch, 'pr-review-gate/SKILL.md has no "## Dispatch" section');
+  assert.match(
+    dispatch[1],
+    /non-fork/,
+    'the Dispatch section no longer requires a non-fork reviewer — a fork ' +
+      'inherits the dispatching session, which is the opposite of independent review',
+  );
+
+  const ladder = /\n## Effort level\n([\s\S]*?)(?=\n## )/.exec(src);
+  assert.ok(ladder, 'pr-review-gate/SKILL.md has no "## Effort level" section');
+  for (const level of ['low', 'medium', 'high']) {
+    assert.match(
+      ladder[1],
+      new RegExp('`' + level + '`'),
+      `the effort ladder no longer names \`${level}\``,
+    );
+  }
+});
+```
+
+- [ ] **Step 2: Run it and verify it fails**
+
+Run: `npm run test:hooks`
+Expected: FAIL — `pr-review-gate/SKILL.md has no "## Effort level" section`.
+
+- [ ] **Step 3: Rewrite `SKILL.md`**
+
+Keep the frontmatter `name: pr-review-gate`; widen `description:` so it triggers on preparing and shipping a PR, not only on dispatching a reviewer. Sections, in order — `## When this fires` (fully-staged definition), `## Exemption` (docs-only file-set test, and the requirement to post an exemption note anyway), `## Effort level` (the `low`/`medium`/`high` ladder moved verbatim from `model-routing`), `## Dispatch` (reviewer capabilities: fresh context not a fork, strongest tier available, modifies no tracked file, reads the rubric by path; then the per-agent mapping), `## The tree check`, `## The PR comment`, `## Triage`, `## Re-review trigger and loop cap`, `## Issue verification at PR creation`, `## Merge`.
+
+For gates CLAUDE.md already owns — regression plan, paired test, on-box register, release-notes pair, `INDEX.md`, `verify:fast:branch` — **name and link them; do not restate their text.**
+
+Include the tree check as an explicit runbook step:
+
+```markdown
+## The tree check
+
+Before dispatching, capture:
+
+    git rev-parse HEAD && git status --porcelain
+
+Re-run both after the pass returns. **Any delta is a gate failure** — report it
+as such, do not absorb it. This is the one behavioural property of the pass
+verifiable from outside it, so it is the one that gets verified. The guard test
+cannot check it, and does not claim to.
+```
+
+And Cline's mapping, gated on Task 1's `CLINE_SUBAGENT_COLD`:
+
+```markdown
+- **Cline** — dispatches subagents. Whether that subagent starts cold is
+  recorded in docs/testing/agent-skill-resolution-probe.md. Until it reads
+  `CLINE_SUBAGENT_COLD: yes`, a Cline-run pass is labelled a **self-run**, not
+  the independent gate: reporting a fork as the gate is exactly the
+  substitution the standing rule forbids.
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run: `npm run test:hooks`
+Expected: PASS.
+
+- [ ] **Step 5: Mutation-verify**
+
+Delete the `## Effort level` heading, run, confirm RED. Restore. Change `non-fork` to `forked` in the Dispatch section, run, confirm RED. Restore.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .claude/skills/pr-review-gate/SKILL.md scripts/tests/review-gate-mechanism.test.mjs
+git commit -m "docs(docs): make pr-review-gate/SKILL.md the full PR review runbook"
+```
+
+---
+
+### Task 4: Close the extraFiles enumeration trap
+
+**Files:**
+- Modify: `scripts/verify-cache.mjs:236-251`
+- Modify: `scripts/tests/verify-cache.test.mjs` (append near the existing `stepTouchedByDiff` block at :414-440)
+
+**Interfaces:**
+- Consumes: the reference paths from Task 2.
+- Produces: `test:hooks` scope coverage for anything under `.claude/skills/**`, which Task 8's mirror would otherwise each need hand-registering.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `scripts/tests/verify-cache.test.mjs`:
+
+```js
+test('stepTouchedByDiff: a pr-review-gate reference-file diff is in scope for test:hooks', () => {
+  // The three .claude/skills literals this replaced could not see a file that
+  // did not exist when they were written — defect shape "a guard that
+  // enumerates loses one spelling per round". A reference file added later
+  // would print test:hooks [cached] and leave review-gate-mechanism.test.mjs
+  // stale-green on exactly the diff that breaks it.
+  const diff = ['.claude/skills/pr-review-gate/references/reviewer-brief.md'];
+  assert.equal(stepTouchedByDiff(stepByName['test:hooks'], diff), true);
+});
+
+test('stepTouchedByDiff: a brand-new skill file is in scope for test:hooks', () => {
+  const diff = ['.claude/skills/pr-review-gate/references/some-future-file.md'];
+  assert.equal(stepTouchedByDiff(stepByName['test:hooks'], diff), true);
+});
+```
+
+- [ ] **Step 2: Run it and verify it fails**
+
+Run: `npm run test:hooks`
+Expected: FAIL — both assertions get `false`, since the literals do not match either path.
+
+- [ ] **Step 3: Replace the literals with a glob**
+
+In `scripts/verify-cache.mjs`, add to the `test:hooks` `globs` array (after `'.husky/**',`):
+
+```js
+        /* .claude/skills/** is an input because review-gate-mechanism.test.mjs
+           reads those files as TEXT at RUNTIME. This was three literal paths
+           until 2026-08-13; a literal list cannot see a file that does not
+           exist yet, so every reference file added later would have needed
+           hand-registering here or its diff would print test:hooks [cached]
+           and leave the guard stale-green. Same #1847 trap as fixtures/**
+           above, with the enumeration failure mode on top. */
+        '.claude/skills/**',
+```
+
+Then delete these two now-redundant lines from `extraFiles`:
+
+```js
+        '.claude/skills/pr-review-gate/SKILL.md',
+        '.claude/skills/model-routing/SKILL.md',
+```
+
+Keep `'CLAUDE.md',` — it is not under that tree — and update the surrounding comment so it no longer claims `.claude/skills/**` is outside this step's globs, which the glob above makes false.
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run: `npm run test:hooks`
+Expected: PASS, including the pre-existing `stepTouchedByDiff` cases at :418-440 (they assert *negative* scope for sidecar/frontend/server diffs; a too-broad glob would turn one red).
+
+- [ ] **Step 5: Verify the CI half moved too**
+
+`ci-scope.mjs` derives its scope from this same `STEPS[]` entry, so the glob change affects the cloud leg as well as the local cache. Confirm nothing else reads the deleted literals:
+
+Run: `git grep -n "skills/pr-review-gate/SKILL.md" -- scripts/`
+Expected: only `scripts/tests/review-gate-mechanism.test.mjs` (which builds its own path from `join()`), no `verify-cache.mjs` hit.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/verify-cache.mjs scripts/tests/verify-cache.test.mjs
+git commit -m "chore(scripts): scope test:hooks to .claude/skills/** instead of three literals"
+```
+
+---
+
+### Task 5: Link-integrity assertion
+
+Write this **before** Task 6 moves the sections, so the dangling anchor is observed red rather than reasoned about.
+
+**Files:**
+- Modify: `scripts/tests/review-gate-mechanism.test.mjs`
+
+**Interfaces:**
+- Produces: an assertion Task 6 must satisfy before its commit is allowed to land.
+
+- [ ] **Step 1: Extend the imports**
+
+The file already imports `basename, dirname, join` from `node:path`. Add `resolve`:
+
+```js
+import { basename, dirname, join, resolve } from 'node:path';
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```js
+// Markdown links of the form ](some/relative/path.md#anchor) — http(s) links
+// are skipped, and so are bare #anchor links (no file part to resolve).
+const INTRA_REPO_ANCHOR_LINK = /\]\((?!https?:)([^)#\s]+\.md)#([^)\s]+)\)/g;
+
+/** GitHub's heading-anchor slug: strip backticks, lowercase, drop punctuation,
+ *  spaces to hyphens. Good enough for the headings in these four files. */
+function githubAnchor(heading) {
+  return heading
+    .replace(/`/g, '')
+    .toLowerCase()
+    .replace(/[^\w\- ]+/g, '')
+    .trim()
+    .replace(/ +/g, '-');
+}
+
+function headingAnchors(file) {
+  const anchors = new Set();
+  for (const line of readNormalized(file).split('\n')) {
+    const m = /^#{1,6} +(.+?)\s*$/.exec(line);
+    if (m) anchors.add(githubAnchor(m[1]));
+  }
+  return anchors;
+}
+
+test('intra-repo anchor links in CLAUDE.md and both gate skills resolve to real headings', () => {
+  // CLAUDE.md:716 links model-routing/SKILL.md#mandatory-independent-review-prs.
+  // Moving that section breaks the anchor while the existing string-match
+  // assertion ("step 10 references pr-review-gate") stays GREEN — the guard
+  // would certify the very line it broke. Presence of a word is not integrity
+  // of a link.
+  const broken = [];
+  for (const source of [CLAUDE_MD_PATH, GATE_SKILL_PATH, ROUTING_SKILL_PATH]) {
+    for (const [, relPath, anchor] of readNormalized(source).matchAll(INTRA_REPO_ANCHOR_LINK)) {
+      const target = resolve(dirname(source), relPath);
+      if (!existsSync(target)) {
+        broken.push(`${basename(source)} -> ${relPath} (file does not exist)`);
+        continue;
+      }
+      if (!headingAnchors(target).has(anchor.toLowerCase())) {
+        broken.push(`${basename(source)} -> ${relPath}#${anchor} (no such heading)`);
+      }
+    }
+  }
+  assert.deepEqual(broken, [], `dangling intra-repo anchor links:\n  ${broken.join('\n  ')}`);
+});
+```
+
+- [ ] **Step 3: Run it — and triage what it reports**
+
+Run: `npm run test:hooks`
+
+This assertion scans three long, much-edited files, so it may surface **pre-existing** dangling links that have nothing to do with this work. Triage before touching anything, per CLAUDE.md's hook-failure rule:
+
+- A link this branch broke → fix it here.
+- A link already broken on `main` → **stop and surface it to the user.** Do not silently fold unrelated fixes into this commit. Confirm with `git stash && git switch main && npm run test:hooks` (after temporarily copying the new test in), then restore.
+
+Expected at this point: PASS, because Task 6 has not yet moved the sections. If it passes, that is the correct baseline — the assertion's value is proven in step 4.
+
+- [ ] **Step 4: Mutation-verify against the real defect**
+
+Temporarily rename `## Mandatory independent review (PRs)` in `model-routing/SKILL.md` to `## Mandatory independent review`, run `npm run test:hooks`, and confirm RED naming `CLAUDE.md -> .claude/skills/model-routing/SKILL.md#mandatory-independent-review-prs`. Restore the heading. **This is the mutation that matters** — it reproduces exactly the defect Task 6 would otherwise ship.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/tests/review-gate-mechanism.test.mjs
+git commit -m "test(scripts): assert intra-repo anchor links in the gate docs resolve"
+```
+
+---
+
+### Task 6: Move the sections and fix CLAUDE.md — last, and in one commit
+
+High-contention files. Rebase immediately before starting, and keep the window between reading and committing as small as possible.
+
+**Files:**
+- Modify: `.claude/skills/model-routing/SKILL.md` (delete two sections, add pointer)
+- Modify: `CLAUDE.md:716` and `CLAUDE.md:301-306`
+- Modify: `scripts/tests/review-gate-mechanism.test.mjs` (one new assertion)
+
+**Interfaces:**
+- Consumes: `SKILL.md`'s `## Effort level` and `## Dispatch` from Task 3; the link-integrity assertion from Task 5.
+
+- [ ] **Step 1: Rebase**
+
+```bash
+git fetch origin && git rebase origin/main
+npm run test:hooks
+```
+Expected: PASS before you change anything. If red, triage per CLAUDE.md before proceeding.
+
+- [ ] **Step 2: Write the failing test**
+
+```js
+test('model-routing/SKILL.md no longer carries the moved PR-review sections', () => {
+  // The move exists to end a rule living in two places. Without this, a future
+  // edit can paste either section back and both files drift apart silently —
+  // the exact failure the move was meant to fix.
+  const src = readNormalized(ROUTING_SKILL_PATH);
+  assert.doesNotMatch(
+    src,
+    /^## Mandatory independent review \(PRs\)$/m,
+    'model-routing/SKILL.md still carries "## Mandatory independent review (PRs)" — ' +
+      'it moved to pr-review-gate/SKILL.md; two copies will drift',
+  );
+  assert.doesNotMatch(
+    src,
+    /^## PR-gate issue verification$/m,
+    'model-routing/SKILL.md still carries "## PR-gate issue verification" — ' +
+      'it moved to pr-review-gate/SKILL.md; two copies will drift',
+  );
+  assert.match(
+    src,
+    /pr-review-gate/,
+    'model-routing/SKILL.md must keep a pointer to where the PR sections went',
+  );
+});
+```
+
+- [ ] **Step 3: Run it and verify it fails**
+
+Run: `npm run test:hooks`
+Expected: FAIL — both sections still present.
+
+- [ ] **Step 4: Delete the two sections from `model-routing/SKILL.md`**
+
+Remove `## Mandatory independent review (PRs)` and `## PR-gate issue verification` in full. Replace them with:
+
+```markdown
+## PR review
+
+Moved out of this file 2026-08-13. The sequence, the docs-only exemption, the
+effort ladder, dispatch, the PR comment, findings triage, the re-review trigger
+and loop cap, and issue verification at PR creation all live in
+[`pr-review-gate`](../pr-review-gate/SKILL.md). Routing keeps routing; that file
+owns the PR process.
+
+The judgment-call carve-out below is shared by both review loops and stays here.
+```
+
+Keep `## Routing table`, `## Escalation (subagent dispatch)`, `## Session-level drift`, `## Mandatory adversarial review (specs & plans)`, and `## Judgment-call carve-out`.
+
+- [ ] **Step 5: Fix `CLAUDE.md:716`**
+
+Change step 10's link so it no longer points at the moved section:
+
+```markdown
+10. **Independent PR review.** Once every item above is done (or explicitly marked not-applicable) and the branch is pushed, run the mandatory gate via the `pr-review-gate` skill — see [the PR review runbook](.claude/skills/pr-review-gate/SKILL.md). Triage and fold findings before merge.
+```
+
+- [ ] **Step 6: Fix `CLAUDE.md:301-306`**
+
+The bullet restates the effort ladder inline and closes with "see the model-routing skill for the full split." Keep the restatement — CLAUDE.md's quick-reference layer is deliberate — and re-aim the pointer:
+
+```markdown
+  `high` for `refactor`/`perf` or any multi-scope PR — see the
+  `pr-review-gate` skill for the full split.
+```
+
+- [ ] **Step 7: Run tests and verify they pass**
+
+Run: `npm run test:hooks`
+Expected: PASS — including the link-integrity assertion from Task 5, which is the one proving step 5 actually fixed the anchor rather than moving it.
+
+- [ ] **Step 8: Run the branch battery**
+
+Run: `npm run verify:fast:branch`
+Expected: green, or every red leg triaged as pre-existing per CLAUDE.md.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add CLAUDE.md .claude/skills/model-routing/SKILL.md scripts/tests/review-gate-mechanism.test.mjs
+git commit -m "docs(docs): move the PR-review sections from model-routing into pr-review-gate"
+```
+
+---
+
+### Task 7: Bookkeeping and PR
+
+**Files:**
+- Modify: `docs/features/235-model-routing-review-gates.md`
+- Modify: `docs/superpowers/specs/2026-08-13-pr-review-skill-design.md` (frontmatter `status:`)
+
+- [ ] **Step 1: File the issue**
+
+```bash
+gh issue create --title "ops-NN — widen pr-review-gate into the full PR review process" \
+  --label "area:ops,type:chore" \
+  --body-file -
+```
+
+Body: what moved, why, and that `docs/BACKLOG.md` needs no row because chores never render there. Use `--body-file -` and pipe the text — `--body @-` writes the literal string `@-`.
+
+- [ ] **Step 2: Update plan 235**
+
+Add to `docs/features/235-model-routing-review-gates.md` a line recording that the PR-review sections moved out of `model-routing/SKILL.md` into `pr-review-gate/SKILL.md` on 2026-08-13, so a reader of the older plan is not sent to a file that no longer holds them.
+
+- [ ] **Step 3: Flip the spec's status**
+
+Set the spec's frontmatter to `status: active`.
+
+- [ ] **Step 4: Push and open the PR**
+
+```bash
+git push -u origin docs/docs-pr-review-skill
+gh pr create --title "docs(docs): widen pr-review-gate into the full PR review process" --body-file -
+```
+
+Body must contain a literal `Closes #NN` (not backticked — a code-span `Closes` does not auto-close), a Summary, and a Test plan. State explicitly:
+
+- **Release notes: not applicable** — process/tooling change, no user- or operator-visible delta.
+- **On-box acceptance: not applicable** — no hardware-provable behaviour.
+- **Not docs-only** — touches `scripts/**`, so `verify.yml` runs in full and this gate applies to itself.
+- **Also fixed, found in passing:** the guard file's header-comment numbering, the dead `CLAUDE.md:716` anchor, the stale `CLAUDE.md:301-306` pointer, and the `extraFiles` enumeration trap.
+
+- [ ] **Step 5: Run the gate on itself**
+
+This PR is not docs-only, so it takes its own review pass — the first real exercise of the runbook it ships. Dispatch per the new `SKILL.md`, at effort `high` (multi-scope: `docs` + `scripts`). Capture the tree check before and after. The reviewer posts its own comment.
+
+---
+
+### Task 8 — CONDITIONAL: mirror script and guard
+
+**Run only if Task 1 recorded `MIRROR_NEEDED:` with at least one agent.** If it recorded `none`, mark this task skipped in the plan and in the probe doc, and do not create any of these files. Shipping a synchronization mechanism with zero consumers is how #2314's three-copy problem started.
+
+**Files (only if warranted):**
+- Create: `scripts/sync-agent-skills.mjs`
+- Modify: `scripts/tests/review-gate-mechanism.test.mjs`
+- Modify: `package.json` (a `skills:sync` script)
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+test('each agent-skill mirror matches its canonical source', () => {
+  // A mirror that silently drifts is worse than no mirror: the other agent
+  // reviews against a rubric this repo no longer believes in.
+  for (const [mirrorRel, canonicalRel] of MIRRORED_SKILL_PAIRS) {
+    const mirror = join(REPO_ROOT, mirrorRel);
+    const canonical = join(REPO_ROOT, canonicalRel);
+    assert.ok(existsSync(mirror), `missing mirror ${mirrorRel} — run npm run skills:sync`);
+    assert.equal(
+      readNormalized(mirror),
+      readNormalized(canonical),
+      `${mirrorRel} has drifted from ${canonicalRel} — run npm run skills:sync`,
+    );
+  }
+});
+```
+
+`MIRRORED_SKILL_PAIRS` is derived from the probe's agent list, declared at the top of the test file next to the other path constants.
+
+- [ ] **Step 2: Run it and verify it fails** — Run: `npm run test:hooks`. Expected: FAIL, missing mirror.
+
+- [ ] **Step 3: Write `scripts/sync-agent-skills.mjs`** — copies the canonical directory to each mirror path, exits non-zero on write failure. Add `"skills:sync": "node scripts/sync-agent-skills.mjs"` to `package.json`.
+
+- [ ] **Step 4: Run the sync, then the tests** — `npm run skills:sync && npm run test:hooks`. Expected: PASS.
+
+- [ ] **Step 5: Mutation-verify** — append a character to one mirrored file, run, confirm RED naming that file. Re-sync.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/sync-agent-skills.mjs package.json scripts/tests/review-gate-mechanism.test.mjs <mirror paths>
+git commit -m "chore(scripts): mirror pr-review-gate into the agent skill paths that need it"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** Layout → Task 2. `SKILL.md` runbook + "name and link, do not restate" → Task 3. Reviewer posts its own comment, tree check, empty pass, docs-only exemption note → Tasks 2 (brief) and 3 (runbook). Rubric halves + catalogue maintenance → Task 2 step 4. Findings triage → Task 2 step 5. Portability + Cline caveat → Tasks 1 and 3. Cross-agent sync, conditional → Tasks 1 and 8. Guard: retarget by name, reference files, no-duplicate, link integrity, conditional mirror → Tasks 2, 3, 5, 6, 8. Enumeration trap → Task 4. `model-routing` move + both CLAUDE.md fixes → Task 6. Contention/merge-order constraint → Task 6 step 1 and Global Constraints. Bookkeeping → Task 7. **No spec section is unimplemented.**
+
+**Placeholder scan.** The `<fill>` markers in Task 1 step 4 are a template the probe fills at runtime, not deferred design — the surrounding text states what counts as a valid entry. `MIRRORED_SKILL_PAIRS` in Task 8 is deliberately undefined until Task 1 names the agents; Task 8 does not run otherwise.
+
+**Type consistency.** `GATE_SKILL_PATH`, `ROUTING_SKILL_PATH`, `CLAUDE_MD_PATH`, `REPO_ROOT` and `readNormalized` are the existing names in `review-gate-mechanism.test.mjs` and are used unchanged. `stepByName` and `stepTouchedByDiff` match `verify-cache.test.mjs:416` and its import at :32. `resolve` is the one added import (Task 5 step 1). Section headings the assertions match — `## Dispatch`, `## Effort level` — are the exact strings Task 3 step 3 creates.
+
+**One ordering dependency worth restating:** Task 5 lands **before** Task 6 on purpose. Written after, its mutation test would be checking a bug already fixed; written before, it observes the real dangling anchor go red.

--- a/docs/superpowers/plans/2026-08-13-pr-review-skill.md
+++ b/docs/superpowers/plans/2026-08-13-pr-review-skill.md
@@ -352,8 +352,18 @@ The pre-rewrite `SKILL.md:11` linked
 `../model-routing/SKILL.md#mandatory-independent-review-prs` — an anchor Task 6
 deletes. The full rewrite should have removed it; confirm rather than assume:
 
-Run: `git grep -n "model-routing/SKILL.md#" -- .claude/skills/pr-review-gate/`
+Run: `git grep -n "model-routing/SKILL.md#mandatory-independent-review-prs\|model-routing/SKILL.md#pr-gate-issue-verification" -- .claude/skills/pr-review-gate/`
 Expected: no output.
+
+**Scope the grep to the two DYING anchors.** An earlier draft of this step ran
+the bare `model-routing/SKILL.md#` prefix and expected no output at all, which
+is wrong: `pr-review-gate/` legitimately links three sections `model-routing`
+*keeps* — `#routing-table`,
+`#mandatory-adversarial-review-specs--plans`, and
+`#judgment-call-carve-out-shared-by-both-review-loops` — from both `SKILL.md`
+and `references/findings-triage.md`. The bare prefix reports those as hits and
+invites someone to "fix" correct links. Only the two moved anchors must
+disappear.
 
 - [ ] **Step 7: Mutation-verify**
 

--- a/docs/superpowers/plans/2026-08-13-pr-review-skill.md
+++ b/docs/superpowers/plans/2026-08-13-pr-review-skill.md
@@ -832,50 +832,143 @@ Order matters and the dispatch prompt must carry two values the reviewer cannot 
 
 ---
 
-### Task 8 — CONDITIONAL: mirror script and guard
+### Task 8: mirror into the global agent skill store
 
-**Run only if Task 1 recorded `MIRROR_NEEDED:` with at least one agent.** If it recorded `none`, mark this task skipped in the plan and in the probe doc, and do not create any of these files. Shipping a synchronization mechanism with zero consumers is how #2314's three-copy problem started.
+**Task 1 settled the target and it is NOT what the spec assumed.** Cline was
+probed directly (`cline -p -c <repo> "list your skills"`) and reported the 23
+**global** skills from `~/.agents/skills/` with `pr-review-gate: NO`. It does
+not resolve workspace `.claude/skills/` at all. So the mirror destination is
+`~/.agents/skills/pr-review-gate/` — **outside the repo**, shared with the five
+other agents that read that store.
 
-**Files (only if warranted):**
+The owner chose the per-machine install step over dropping the mirror. Two
+consequences follow, and both are stated in the deliverable rather than hidden:
+
+**Consequence A — this guard cannot be a merge gate, and it fails open.** The
+target lives in `$HOME`, so it is absent on a fresh clone and in CI. The
+assertion therefore SKIPS when the directory does not exist. That is *exactly*
+defect shape #1 in this PR's own rubric — a guard that fails open on absent
+evidence — and it is unavoidable here rather than accidental: the alternative
+is a required check that fails on every machine that has never run the sync.
+**Say so in the test's own comment and in the PR body.** A skipped guard must
+never be reported as a passing one.
+
+**Consequence B — relative links break in the mirrored copy.** `reviewer-brief.md`
+links `../../../CLAUDE.md` and `../model-routing/SKILL.md`; from
+`~/.agents/skills/` those resolve nowhere. The sync injects a provenance header
+so the reading agent knows the paths are relative to the repo it is reviewing,
+not to the file it is reading.
+
+**Files:**
 - Create: `scripts/sync-agent-skills.mjs`
 - Modify: `scripts/tests/review-gate-mechanism.test.mjs`
-- Modify: `package.json` (a `skills:sync` script)
+- Modify: `package.json` (add `skills:sync`)
+- **Not committed:** the mirror itself. It is outside the repo — do not try to `git add` it.
 
 - [ ] **Step 1: Write the failing test**
 
 ```js
-test('each agent-skill mirror matches its canonical source', () => {
-  // A mirror that silently drifts is worse than no mirror: the other agent
-  // reviews against a rubric this repo no longer believes in.
-  for (const [mirrorRel, canonicalRel] of MIRRORED_SKILL_PAIRS) {
-    const mirror = join(REPO_ROOT, mirrorRel);
-    const canonical = join(REPO_ROOT, canonicalRel);
-    assert.ok(existsSync(mirror), `missing mirror ${mirrorRel} — run npm run skills:sync`);
+// The mirror lives OUTSIDE the repo, in the cross-agent store at
+// ~/.agents/skills/. Cline (and five other agents) read only that store —
+// verified 2026-08-13 by asking Cline in this workspace: it listed the 23
+// global skills and answered "pr-review-gate: NO".
+const AGENT_SKILL_STORE = join(homedir(), '.agents', 'skills');
+const MIRRORED_SKILL = 'pr-review-gate';
+
+test('the agent-store mirror matches its canonical source, when it exists', () => {
+  // FAILS OPEN BY CONSTRUCTION, and that is not an oversight. The target is
+  // in $HOME: absent on a fresh clone and in CI. Making this a hard failure
+  // would turn every never-synced machine red. The trade is deliberate — but
+  // it means a GREEN run here proves nothing about a machine that has not
+  // synced, so never report this as "the mirror is in sync".
+  const mirrorRoot = join(AGENT_SKILL_STORE, MIRRORED_SKILL);
+  if (!existsSync(mirrorRoot)) {
+    // Not skipped silently: say why, so a reader of CI output can tell the
+    // difference between "verified" and "not checked".
+    console.log(`[skip] no agent-store mirror at ${mirrorRoot} — run npm run skills:sync`);
+    return;
+  }
+  const canonicalRoot = join(REPO_ROOT, '.claude', 'skills', MIRRORED_SKILL);
+  for (const rel of ['SKILL.md', 'references/reviewer-brief.md', 'references/findings-triage.md']) {
+    const mirrored = join(mirrorRoot, rel);
+    assert.ok(existsSync(mirrored), `mirror is missing ${rel} — run npm run skills:sync`);
+    // Compare only the body BELOW the injected provenance header.
+    const body = readNormalized(mirrored).split(PROVENANCE_END)[1] ?? '';
     assert.equal(
-      readNormalized(mirror),
-      readNormalized(canonical),
-      `${mirrorRel} has drifted from ${canonicalRel} — run npm run skills:sync`,
+      body,
+      readNormalized(join(canonicalRoot, rel)),
+      `${rel} has drifted from its canonical copy — run npm run skills:sync`,
     );
   }
 });
 ```
 
-`MIRRORED_SKILL_PAIRS` is derived from the probe's agent list, declared at the top of the test file next to the other path constants.
+Add `import { homedir } from 'node:os';` and export `PROVENANCE_END` from the
+sync script so the test and the writer agree on one delimiter rather than two
+copies of a magic string.
 
-- [ ] **Step 2: Run it and verify it fails** — Run: `npm run test:hooks`. Expected: FAIL, missing mirror.
+- [ ] **Step 2: Run it and verify it fails**
 
-- [ ] **Step 3: Write `scripts/sync-agent-skills.mjs`** — copies the canonical directory to each mirror path, exits non-zero on write failure. Add `"skills:sync": "node scripts/sync-agent-skills.mjs"` to `package.json`.
+Run: `npm run test:hooks`
 
-- [ ] **Step 4: Run the sync, then the tests** — `npm run skills:sync && npm run test:hooks`. Expected: PASS.
+**Expected: the skip line, not a failure** — you have not synced yet, so the
+guard fails open. That is the behaviour under test. To see it actually assert,
+create `~/.agents/skills/pr-review-gate/` containing an empty `SKILL.md` and
+re-run: it must now go RED with `mirror is missing references/reviewer-brief.md`.
+Delete the stub afterwards. **Do not skip this half** — a guard whose asserting
+path was never observed is a guard nobody has tested.
 
-- [ ] **Step 5: Mutation-verify** — append a character to one mirrored file, run, confirm RED naming that file. Re-sync.
+- [ ] **Step 3: Write `scripts/sync-agent-skills.mjs`**
 
-- [ ] **Step 6: Commit**
+Copies `.claude/skills/pr-review-gate/` to `~/.agents/skills/pr-review-gate/`,
+creating directories as needed, prepending this header to every file:
+
+```
+<!-- MIRRORED COPY — do not edit here.
+     Canonical source: <repo>/.claude/skills/pr-review-gate/<rel>
+     Regenerate with `npm run skills:sync` from that repo.
+     Relative links below resolve against the REPOSITORY YOU ARE REVIEWING,
+     not against this file's location. -->
+```
+
+Export the closing `-->` line as `PROVENANCE_END`. Exit non-zero on any write
+failure. Print each path written, and a one-line reminder that this is a
+per-machine step CI cannot perform.
+
+Add `"skills:sync": "node scripts/sync-agent-skills.mjs"` to `package.json`.
+
+- [ ] **Step 4: Run the sync, then the tests**
+
+Run: `npm run skills:sync && npm run test:hooks`
+Expected: PASS, with the guard now asserting rather than skipping.
+
+- [ ] **Step 5: Verify Cline actually sees it now**
+
+The whole point of this task. Run:
 
 ```bash
-git add scripts/sync-agent-skills.mjs package.json scripts/tests/review-gate-mechanism.test.mjs <mirror paths>
-git commit -m "chore(scripts): mirror pr-review-gate into the agent skill paths that need it"
+cline -p -c "<worktree>" -t 240 "List your available skill names. Do you see one named pr-review-gate? Answer only with the list and YES or NO."
 ```
+
+Expected: `pr-review-gate: YES`. **If it still says NO, the mirror is in the
+wrong place and this task has failed** — report that rather than declaring the
+sync done because the file copy succeeded. Copying a file is not the
+deliverable; Cline seeing the skill is. (If `cline` is missing from PATH, it
+self-updated and broke itself — `npm i -g cline` repairs it. Run it from
+PowerShell if Bash cannot find it.)
+
+- [ ] **Step 6: Mutation-verify** — append a character to a mirrored file, run, confirm RED naming that file. Re-sync.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/sync-agent-skills.mjs package.json scripts/tests/review-gate-mechanism.test.mjs
+git commit -m "chore(scripts): sync pr-review-gate into the cross-agent skill store"
+```
+
+Note for the PR body and for #2314: this adds a fourth consumer to
+`~/.agents/skills/`, the store whose consolidation #2314 is already open about.
+The sync script is the mechanism that ticket may later absorb.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-13-pr-review-skill.md
+++ b/docs/superpowers/plans/2026-08-13-pr-review-skill.md
@@ -21,6 +21,8 @@
 - **Every pass posts a comment** — including one that finds nothing (`### ✅ No findings`) and including a docs-only PR's exemption note.
 - **The mirror is conditional on Task 1.** "No agent needs a mirror" is a valid outcome that cancels Task 8 entirely.
 - **`CLAUDE.md` and `model-routing/SKILL.md` edits land last**, in one commit, rebased immediately before — they are high-contention files across 17 live worktrees.
+- **Derive every edit list with `git grep`, never from a read.** The first draft of this plan named one link into a moved section; a sweep found four. Any step that says "fix the reference at X" runs the sweep first and treats its own table as a floor.
+- **`## Issue verification at PR creation` in `SKILL.md` is a load-bearing heading name** — two `CLAUDE.md` links anchor to its slug. Changing its wording breaks them, and Task 5's assertion is what catches it.
 - Commit subjects follow `<type>(<scope>): <subject>`; this work is `docs(docs)` for skill/doc-only commits and `test(scripts)` / `chore(scripts)` for guard and cache changes.
 
 ---
@@ -199,6 +201,12 @@ Post one comment on the PR with `gh pr comment <number> --body-file <file>`
 BEFORE returning your report. Do not hand it to the dispatching session to
 publish — nothing would compare what it posts against what you found.
 
+**The PR number and head SHA come from the dispatch prompt.** Do not infer
+them: `gh pr view` on the wrong branch, or in a worktree whose HEAD moved,
+posts a review onto someone else's PR. If the prompt did not give you both,
+stop and say so rather than guessing — a review comment on the wrong PR cannot
+be quietly withdrawn.
+
 Heading: `## PR review — pass N (head <sha>, effort <level>)`. The head SHA is
 required; without it the comment is uninterpretable once the branch moves.
 
@@ -328,11 +336,30 @@ And Cline's mapping, gated on Task 1's `CLINE_SUBAGENT_COLD`:
 Run: `npm run test:hooks`
 Expected: PASS.
 
-- [ ] **Step 5: Mutation-verify**
+- [ ] **Step 5: Confirm the section regexes bound to the sections you meant**
+
+`(?=\n## )` correctly stops at the next `## ` and does not match `### `, but
+binding to the *wrong* section is the exact error this file's own header
+documents — the first version of the Mechanism assertion silently matched a
+different bullet and never exercised what it existed to check. Prove it, don't
+assume it: temporarily insert a decoy `## Dispatch notes` section elsewhere in
+`SKILL.md`, run, and confirm the assertion still reads the real `## Dispatch`.
+Remove the decoy.
+
+- [ ] **Step 6: Confirm the old cross-link is gone**
+
+The pre-rewrite `SKILL.md:11` linked
+`../model-routing/SKILL.md#mandatory-independent-review-prs` — an anchor Task 6
+deletes. The full rewrite should have removed it; confirm rather than assume:
+
+Run: `git grep -n "model-routing/SKILL.md#" -- .claude/skills/pr-review-gate/`
+Expected: no output.
+
+- [ ] **Step 7: Mutation-verify**
 
 Delete the `## Effort level` heading, run, confirm RED. Restore. Change `non-fork` to `forked` in the Dispatch section, run, confirm RED. Restore.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 8: Commit**
 
 ```bash
 git add .claude/skills/pr-review-gate/SKILL.md scripts/tests/review-gate-mechanism.test.mjs
@@ -442,20 +469,50 @@ import { basename, dirname, join, resolve } from 'node:path';
 
 - [ ] **Step 2: Write the failing test**
 
+Add `readdirSync` to the `node:fs` import alongside `readFileSync, existsSync`.
+
 ```js
 // Markdown links of the form ](some/relative/path.md#anchor) — http(s) links
 // are skipped, and so are bare #anchor links (no file part to resolve).
 const INTRA_REPO_ANCHOR_LINK = /\]\((?!https?:)([^)#\s]+\.md)#([^)\s]+)\)/g;
 
-/** GitHub's heading-anchor slug: strip backticks, lowercase, drop punctuation,
- *  spaces to hyphens. Good enough for the headings in these four files. */
+/**
+ * GitHub's heading-anchor slug: strip backticks, lowercase, drop everything
+ * that is not a word char / space / hyphen, trim the ends, then replace each
+ * REMAINING SPACE WITH ONE HYPHEN.
+ *
+ * The one-for-one replacement is the whole subtlety, and an earlier draft of
+ * this helper got it wrong with `.replace(/ +/g, '-')`. GitHub does not
+ * collapse runs of spaces: `### Scope discipline > merge magic` drops the `>`
+ * and leaves TWO spaces, which slug to the DOUBLE hyphen in
+ * CONTRIBUTING.md#scope-discipline--merge-magic. A collapsing version reports
+ * that correct, live link as broken — a guard that fails on valid input, which
+ * is worse than no guard: it trains its reader to "fix" correct documents.
+ * The unit test below pins exactly that case GREEN.
+ */
 function githubAnchor(heading) {
   return heading
     .replace(/`/g, '')
     .toLowerCase()
     .replace(/[^\w\- ]+/g, '')
-    .trim()
-    .replace(/ +/g, '-');
+    .replace(/^ +| +$/g, '')
+    .replace(/ /g, '-');
+}
+
+/** Blank out fenced code blocks — a ```js sample containing a markdown-link
+ *  literal is not a link. Measured: without this, scanning this repo's own
+ *  plan docs reports their example snippets as dangling. */
+function stripFencedBlocks(text) {
+  const out = [];
+  let inFence = false;
+  for (const line of text.split('\n')) {
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    out.push(inFence ? '' : line);
+  }
+  return out.join('\n');
 }
 
 function headingAnchors(file) {
@@ -467,15 +524,43 @@ function headingAnchors(file) {
   return anchors;
 }
 
-test('intra-repo anchor links in CLAUDE.md and both gate skills resolve to real headings', () => {
+/** The scan set is DERIVED, not hand-listed: the two root governance docs plus
+ *  every markdown file under .claude/skills/**. A hand-list would reproduce the
+ *  enumeration trap Task 4 exists to close — the next skill doc added would be
+ *  unprotected for exactly the same reason the three extraFiles literals were.
+ *  Historical plan docs under docs/ are deliberately OUT of scope: measured
+ *  2026-08-13, they carry 15 pre-existing dangling links (relative paths
+ *  written as if from the repo root), none of which this work touches. */
+function linkScanSet() {
+  const skillsRoot = join(REPO_ROOT, '.claude', 'skills');
+  const skillDocs = readdirSync(skillsRoot, { recursive: true, withFileTypes: true })
+    .filter((d) => d.isFile() && d.name.endsWith('.md'))
+    .map((d) => join(d.parentPath ?? d.path, d.name));
+  return [join(REPO_ROOT, 'CLAUDE.md'), join(REPO_ROOT, 'CONTRIBUTING.md'), ...skillDocs];
+}
+
+test('githubAnchor matches GitHub slugging, including runs of spaces', () => {
+  // The green-on-awkward-input case. Without it, the collapsing bug that this
+  // helper shipped with in draft is invisible: every OTHER assertion here is a
+  // true-positive check, and a helper that over-reports passes all of them.
+  assert.equal(githubAnchor('Scope discipline > merge magic'), 'scope-discipline--merge-magic');
+  assert.equal(githubAnchor('Mandatory independent review (PRs)'), 'mandatory-independent-review-prs');
+  assert.equal(
+    githubAnchor('Incidental findings: report, fix, record'),
+    'incidental-findings-report-fix-record',
+  );
+});
+
+test('intra-repo anchor links in the governance docs and skills resolve to real headings', () => {
   // CLAUDE.md:716 links model-routing/SKILL.md#mandatory-independent-review-prs.
   // Moving that section breaks the anchor while the existing string-match
   // assertion ("step 10 references pr-review-gate") stays GREEN — the guard
   // would certify the very line it broke. Presence of a word is not integrity
   // of a link.
   const broken = [];
-  for (const source of [CLAUDE_MD_PATH, GATE_SKILL_PATH, ROUTING_SKILL_PATH]) {
-    for (const [, relPath, anchor] of readNormalized(source).matchAll(INTRA_REPO_ANCHOR_LINK)) {
+  for (const source of linkScanSet()) {
+    const text = stripFencedBlocks(readNormalized(source));
+    for (const [, relPath, anchor] of text.matchAll(INTRA_REPO_ANCHOR_LINK)) {
       const target = resolve(dirname(source), relPath);
       if (!existsSync(target)) {
         broken.push(`${basename(source)} -> ${relPath} (file does not exist)`);
@@ -490,20 +575,22 @@ test('intra-repo anchor links in CLAUDE.md and both gate skills resolve to real 
 });
 ```
 
-- [ ] **Step 3: Run it — and triage what it reports**
+- [ ] **Step 3: Run it against a measured baseline**
 
 Run: `npm run test:hooks`
+Expected: **PASS.** This is measured, not predicted — the scan set was executed against this branch on 2026-08-13 and reported *4 files scanned, 19 anchor links, 0 broken*, with all three `githubAnchor` spot-checks correct.
 
-This assertion scans three long, much-edited files, so it may surface **pre-existing** dangling links that have nothing to do with this work. Triage before touching anything, per CLAUDE.md's hook-failure rule:
+**If it goes red, suspect the helper before the documents.** The first draft of this assertion reported `CLAUDE.md -> CONTRIBUTING.md#scope-discipline--merge-magic` as broken; that link is correct and the helper was wrong. Only after the unit test above passes is a red from the second assertion evidence about a document.
 
-- A link this branch broke → fix it here.
-- A link already broken on `main` → **stop and surface it to the user.** Do not silently fold unrelated fixes into this commit. Confirm with `git stash && git switch main && npm run test:hooks` (after temporarily copying the new test in), then restore.
+If a genuine pre-existing dangling link does appear, triage per CLAUDE.md's hook-failure rule: a link this branch broke gets fixed here; one already broken on `main` gets surfaced to the user, not silently folded into this commit.
 
-Expected at this point: PASS, because Task 6 has not yet moved the sections. If it passes, that is the correct baseline — the assertion's value is proven in step 4.
+- [ ] **Step 4: Mutation-verify in both directions**
 
-- [ ] **Step 4: Mutation-verify against the real defect**
+Both halves are required. A guard verified only for true positives is exactly how the collapsing bug survived into the draft.
 
-Temporarily rename `## Mandatory independent review (PRs)` in `model-routing/SKILL.md` to `## Mandatory independent review`, run `npm run test:hooks`, and confirm RED naming `CLAUDE.md -> .claude/skills/model-routing/SKILL.md#mandatory-independent-review-prs`. Restore the heading. **This is the mutation that matters** — it reproduces exactly the defect Task 6 would otherwise ship.
+**Red on a real break:** temporarily rename `## Mandatory independent review (PRs)` in `model-routing/SKILL.md` to `## Mandatory independent review`, run `npm run test:hooks`, and confirm RED naming `CLAUDE.md -> .claude/skills/model-routing/SKILL.md#mandatory-independent-review-prs`. Restore. This reproduces exactly the defect Task 6 would otherwise ship.
+
+**Green on awkward-but-correct input:** confirm the `githubAnchor` unit test passes with `CONTRIBUTING.md:99`'s `### Scope discipline > merge magic` slugging to a double hyphen. Then temporarily restore the collapsing `.replace(/ +/g, '-')` and confirm BOTH the unit test and the link test go red. Restore.
 
 - [ ] **Step 5: Commit**
 
@@ -585,15 +672,56 @@ The judgment-call carve-out below is shared by both review loops and stays here.
 
 Keep `## Routing table`, `## Escalation (subagent dispatch)`, `## Session-level drift`, `## Mandatory adversarial review (specs & plans)`, and `## Judgment-call carve-out`.
 
-- [ ] **Step 5: Fix `CLAUDE.md:716`**
+- [ ] **Step 5: Sweep for every link into the moved anchors — do not work from a read**
 
-Change step 10's link so it no longer points at the moved section:
+An earlier draft of this plan named one affected link. A mechanical sweep found
+**four**. Derive the list rather than recalling it:
+
+```bash
+git grep -n "model-routing/SKILL.md#"
+```
+
+Expected today — four live sites, plus historical plan docs:
+
+| Site | Anchor | Disposition |
+|---|---|---|
+| `CLAUDE.md:712` | `#pr-gate-issue-verification` | re-point (step 6) |
+| `CLAUDE.md:716` | `#mandatory-independent-review-prs` | re-point (step 6) |
+| `CLAUDE.md:1053` | `#pr-gate-issue-verification` | re-point (step 6) |
+| `.claude/skills/pr-review-gate/SKILL.md:11` | `#mandatory-independent-review-prs` | **already gone** — Task 3 rewrote this file wholesale; confirm, don't re-edit |
+| `docs/superpowers/plans/2026-07-01-…md` ×4 | both | **out of scope, already broken** |
+
+Those four historical links resolve their *file* relative to
+`docs/superpowers/plans/`, so they point at `docs/superpowers/plans/.claude/…`
+and are dangling **today, before this change** — verified 2026-08-13. This work
+neither creates nor worsens them. Do not fix them here; that is unrelated
+pre-existing rot, and folding it in couples the scope.
+
+- [ ] **Step 6: Re-point all three CLAUDE.md links**
+
+`CLAUDE.md:716` — step 10:
 
 ```markdown
 10. **Independent PR review.** Once every item above is done (or explicitly marked not-applicable) and the branch is pushed, run the mandatory gate via the `pr-review-gate` skill — see [the PR review runbook](.claude/skills/pr-review-gate/SKILL.md). Triage and fold findings before merge.
 ```
 
-- [ ] **Step 6: Fix `CLAUDE.md:301-306`**
+`CLAUDE.md:712` — inside before-shipping step 6, change the parenthetical link target only, leaving the sentence intact:
+
+```markdown
+(a deliberate, scoped override of "The backlog" section's general "the user files [bugs] as they hit them" convention, for this gate only — see [PR review → issue verification](.claude/skills/pr-review-gate/SKILL.md#issue-verification-at-pr-creation))
+```
+
+`CLAUDE.md:1053` — in the Branching workflow section:
+
+```markdown
+Full mechanics: [`.claude/skills/pr-review-gate/SKILL.md`](.claude/skills/pr-review-gate/SKILL.md#issue-verification-at-pr-creation).
+```
+
+Both new anchors must match Task 3's `## Issue verification at PR creation`
+heading exactly — the link-integrity assertion from Task 5 is what proves it,
+and it will fail this commit if the heading text drifted.
+
+- [ ] **Step 7: Fix `CLAUDE.md:301-306`**
 
 The bullet restates the effort ladder inline and closes with "see the model-routing skill for the full split." Keep the restatement — CLAUDE.md's quick-reference layer is deliberate — and re-aim the pointer:
 
@@ -602,17 +730,38 @@ The bullet restates the effort ladder inline and closes with "see the model-rout
   `pr-review-gate` skill for the full split.
 ```
 
-- [ ] **Step 7: Run tests and verify they pass**
+- [ ] **Step 8: Verify the moved text is the SAME text**
+
+Every assertion in this plan checks that headings exist and that `low`/`medium`/
+`high` appear somewhere. **None of them would notice a ladder rewritten from
+memory with a changed threshold** — a move that silently edits what it moves
+passes the whole suite. Diff the moved content against its pre-move original:
+
+```bash
+git show origin/main:.claude/skills/model-routing/SKILL.md > /tmp/mr-before.md
+# The effort ladder and issue-verification bullets as they were:
+sed -n '/^## Mandatory independent review (PRs)/,/^## Judgment-call carve-out/p' /tmp/mr-before.md
+# ...against where they landed:
+sed -n '/^## Effort level/,/^## Dispatch/p' .claude/skills/pr-review-gate/SKILL.md
+```
+
+Read both. Wording may be re-flowed for the new context; **the `low`/`medium`/
+`high` criteria, the multi-scope rule, the mixed-type "highest tier wins" rule,
+the docs-only file-set test, and the `ultra` opt-in-only rule must be unchanged
+in substance.** If any threshold moved, that is a behaviour change smuggled
+inside a move — revert it and raise it separately.
+
+- [ ] **Step 9: Run tests and verify they pass**
 
 Run: `npm run test:hooks`
-Expected: PASS — including the link-integrity assertion from Task 5, which is the one proving step 5 actually fixed the anchor rather than moving it.
+Expected: PASS — including the link-integrity assertion from Task 5, which is the one proving steps 6-7 actually fixed the anchors rather than moving them.
 
-- [ ] **Step 8: Run the branch battery**
+- [ ] **Step 10: Run the branch battery**
 
 Run: `npm run verify:fast:branch`
 Expected: green, or every red leg triaged as pre-existing per CLAUDE.md.
 
-- [ ] **Step 9: Commit**
+- [ ] **Step 11: Commit**
 
 ```bash
 git add CLAUDE.md .claude/skills/model-routing/SKILL.md scripts/tests/review-gate-mechanism.test.mjs
@@ -661,7 +810,15 @@ Body must contain a literal `Closes #NN` (not backticked — a code-span `Closes
 
 - [ ] **Step 5: Run the gate on itself**
 
-This PR is not docs-only, so it takes its own review pass — the first real exercise of the runbook it ships. Dispatch per the new `SKILL.md`, at effort `high` (multi-scope: `docs` + `scripts`). Capture the tree check before and after. The reviewer posts its own comment.
+This PR is not docs-only, so it takes its own review pass — the first real exercise of the runbook it ships. Dispatch per the new `SKILL.md`, at effort `high` (multi-scope: `docs` + `scripts`).
+
+Order matters and the dispatch prompt must carry two values the reviewer cannot safely infer:
+
+1. `gh pr create` first, so a PR number exists.
+2. Capture the tree check: `git rev-parse HEAD` and `git status --porcelain`.
+3. Dispatch, passing **the PR number and the head SHA explicitly** in the prompt. A reviewer left to run `gh pr view` itself can resolve the wrong PR from a worktree whose HEAD moved — and a review comment on someone else's PR cannot be quietly withdrawn.
+4. Re-run the tree check when it returns; any delta is a gate failure.
+5. Confirm the comment landed (`gh pr view <number> --json comments`) before triaging. A pass that returned a report but posted nothing did not complete.
 
 ---
 
@@ -711,6 +868,28 @@ git commit -m "chore(scripts): mirror pr-review-gate into the agent skill paths 
 ```
 
 ---
+
+## Resolved by adversarial review
+
+The pass over the first draft of this plan is folded above. What changed, and
+the evidence that settled it:
+
+| Finding | Resolution | Evidence |
+|---|---|---|
+| `githubAnchor()` collapsed runs of spaces — reported a **correct** link as broken | One hyphen per space; a unit test pins `Scope discipline > merge magic` → `scope-discipline--merge-magic` **green** | Ran the draft helper: it flagged `CONTRIBUTING.md#scope-discipline--merge-magic`, which `CONTRIBUTING.md:99` shows is right |
+| "Expected: PASS" was a prediction | Now a measurement | Scoped set executed on this branch: **4 files, 19 anchor links, 0 broken** |
+| Plan named 1 affected link; there were 4 | Sweep step added; all three `CLAUDE.md` sites listed; 4th confirmed dissolved by Task 3 | `git grep -n "model-routing/SKILL.md#"` |
+| Scan set hand-listed — the enumeration trap Task 4 closes | Derived: two root docs + `readdirSync` over `.claude/skills/**` | — |
+| Historical plan links treated as this work's breakage | Out of scope, with evidence: they are dangling **today** | Repo-wide run: 15 pre-existing, all relative-path rot in `docs/` |
+| Code fences scanned as real links | `stripFencedBlocks()` | Repo-wide run flagged this plan's own example snippet |
+| Mutation verified in one direction only | Both directions required, incl. restoring the collapsing bug and observing red | — |
+| Nothing checked the moved text was the *same* text | Task 6 step 8 diffs against `origin/main` and names the five criteria that must be unchanged | — |
+| Reviewer had no defined source for the PR number | Dispatch prompt supplies PR number + head SHA; reviewer stops rather than inferring | — |
+| Section regex could bind to the wrong section | Decoy-section check (Task 3 step 5) — the failure this file's own header documents | — |
+
+Two claims the review could not settle stay marked as such: whether Task 3's
+section regexes bind correctly (the sections do not exist yet — hence the decoy
+check), and Cline's subagent independence (Task 1's probe).
 
 ## Self-Review
 

--- a/docs/superpowers/specs/2026-08-13-pr-review-skill-design.md
+++ b/docs/superpowers/specs/2026-08-13-pr-review-skill-design.md
@@ -51,8 +51,9 @@ is permanent and public.
 | Rubric depth | Repo bookkeeping gates + a curated catalogue of recurring defect shapes |
 | Migration | Grow `pr-review-gate` in place — no rename |
 | Portability | State reviewer *capabilities*, not one agent's tool names |
-| Cross-agent sync | Canonical copy in `.claude/skills/`, mirrored by script, drift caught by a guard |
-| Record | Every pass posts a summary comment on the PR |
+| Cross-agent sync | **Conditional on a canary probe** — canonical copy in `.claude/skills/`; a mirror + its guard are built only for agents the probe proves need one |
+| Record | Every pass posts a comment on the PR — including a pass that finds nothing, and including a docs-only PR's exemption note |
+| Who posts it | The **reviewer**, directly. The session verifies the tree is unchanged and the comment landed |
 
 ### Why grow in place rather than rename
 
@@ -108,6 +109,25 @@ retains the routing table, escalation, session-level drift, the spec/plan
 adversarial-review loop, and the judgment-call carve-out — which stays there
 because both loops share it, and is linked from `findings-triage.md`.
 
+**The move breaks two things in CLAUDE.md, and both are fixed in the same PR.**
+
+1. **`CLAUDE.md:716`** — before-shipping step 10 links
+   `.claude/skills/model-routing/SKILL.md#mandatory-independent-review-prs`.
+   That anchor dies with the section. It re-points at this skill. Note what
+   made this nearly invisible: the existing guard asserts only that the string
+   `pr-review-gate` appears on that line, so the line stays green while its
+   link 404s — hence the link-integrity assertion below.
+2. **`CLAUDE.md:301-306`** — the "Mandatory review gates" bullet already
+   **restates the whole effort ladder inline** and closes with "see the
+   model-routing skill for the full split." After the move that pointer names a
+   file that no longer holds the ladder. It re-points at this skill.
+
+The inline restatement itself **stays**. CLAUDE.md's deliberate convention is
+quick-reference-here / full-spec-in-the-skill — the same shape as its routing
+table. This design's "name and link, do not restate" constraint governs the
+*skill*, which is the full spec and must not fork it; it does not abolish
+CLAUDE.md's summary layer.
+
 ## references/reviewer-brief.md — the rubric
 
 ### Half one: house gates
@@ -156,6 +176,16 @@ recite:
    evidence for another.
 10. **One instance fixed, the class left armed** — sibling call sites, other
     entry points, the second copy.
+
+### Keeping the catalogue current
+
+A catalogue written once is a snapshot that decays, and the next new shape gets
+transmitted nowhere — which is the problem statement restated. So it gets an
+explicit trigger and owner rather than good intentions: **when a gate round
+surfaces a defect shape the catalogue does not already name, appending it is
+part of that round's fix work**, in the same PR, on the same footing as any
+other chore the work made owed. The catalogue is a living file with a
+maintenance rule, not an appendix.
 
 ### The finding contract
 
@@ -208,12 +238,51 @@ Severity maps onto the split the loop already reads: 🔴 and 🟠 are correctne
 bugs and re-trigger a pass once fixed and pushed; 🟡 is cleanup — fixed this
 round, but not a re-trigger.
 
-**The shipping session posts it, verbatim.** Header added, body untouched. The
-reviewer keeps its "changes nothing, no write access" boundary, and a session
-cannot soften its own reviewer's findings between receiving them and
-publishing them. The alternative — the subagent posting directly — removes one
-relay but hands `gh` write access to an agent whose entire value is that it
-writes nothing.
+### The reviewer posts its own comment
+
+An earlier draft had the shipping session post the report verbatim, justified
+by the reviewer having "no write access." **That justification was false.** The
+`Agent` tool exposes `description`, `prompt`, `subagent_type`, `model` and
+`isolation` — and no per-dispatch tool restriction; even the read-only-ish
+`Explore` type retains `Bash`, so it can `gh pr comment` and `git commit`
+regardless. The write access was never actually withheld, and routing the
+report through the session bought nothing except an unverified relay whose sole
+operator is the one party with a motive to soften the findings. In a repo whose
+most-documented failure shape is "success reported while doing nothing," that
+is the wrong place to put an honour rule.
+
+So the **reviewer posts its own comment directly**, one hop, before returning
+its report to the session. Nothing sits between finding and record.
+
+The reviewer's boundary is restated as what it actually is — a prohibition, not
+a capability limit: **it must not modify tracked files.** That prohibition is
+made checkable rather than trusted. The session captures `git rev-parse HEAD`
+and `git status --porcelain` immediately before dispatch and again after the
+pass returns; **any delta is a gate failure**, reported as such, never silently
+absorbed. This is the one behavioural property of the pass that is verifiable
+from outside it, so it is the one that gets verified.
+
+The session then confirms the comment actually landed (`gh pr view --json
+comments`) before starting triage. A pass that returned a report but posted
+nothing is reported as a pass that did not complete.
+
+### A pass that finds nothing still posts
+
+"Found nothing" is an explicitly valid outcome, so it gets the same header and
+a `### ✅ No findings` body. Without this, the record cannot distinguish
+*reviewed and clean* from *never reviewed* — which is the single distinction
+the whole record exists to preserve.
+
+For the same reason, a **docs-only PR** — exempt from the pass entirely — posts
+a one-line exemption note naming the file-set test that exempted it. Absence of
+a review becomes a recorded fact rather than a silence. This matters more than
+it sounds: a large share of this repo's PRs are docs-only, so without it the
+durable record would be missing exactly where the volume is.
+
+**Re-review comments state deltas only** — each prior finding's disposition,
+plus anything new. They do not re-list the solid items. Three passes plus fix
+commits is already the cap; re-listing would make the thread unreadable at
+exactly the point it matters most.
 
 **Standing authorization.** Posting to a public PR is an outward-facing
 action. The repo owner has authorized it as a standing part of this process,
@@ -227,7 +296,8 @@ names:
 - **fresh context** — not a fork of the shipping session, whose framing and
   blind spots are exactly what the pass exists to escape;
 - **the strongest tier available** to that agent;
-- **no write access** — it returns a report;
+- **modifies no tracked file** — a prohibition, not a capability limit (see
+  above), enforced by the session's before/after tree check rather than trusted;
 - **the rubric read from `references/reviewer-brief.md`**, in full.
 
 Underneath, a short per-agent mapping (Claude Code: a non-fork `Agent`
@@ -237,18 +307,41 @@ and reports it as a **self-run pass, never as the independent gate** — which
 preserves the standing rule that a gate which did not run is never reported as
 having run.
 
+**Cline's mapping is unverified and must not be written as settled.** That
+Cline dispatches subagents is reported and taken as true; what was never
+checked is the load-bearing half — whether its subagent starts **cold or
+inherits the session**, and whether its tier is selectable. "Can dispatch" and
+"can dispatch an *independent* reviewer" are different claims, and only the
+second one satisfies this gate. Establishing this is part of the probe below.
+Until it is established, Cline uses the self-run label — the conservative
+branch, because the failure it prevents (a fork reported as the independent
+gate) is the exact substitution the standing rule forbids.
+
 ## Cross-agent sync
 
-`.claude/skills/pr-review-gate/` is canonical. A committed script mirrors it
-into the workspace paths other agents read, and a guard test fails when a
-mirror drifts from its source, so staleness surfaces as a red test rather than
-a silently outdated copy. The mirror paths join `test:hooks`'s `extraFiles` in
-`scripts/verify-cache.mjs` for the same reason the reference files do — without
-that, a diff touching only mirrored files prints `[cached]` and skips the guard
-it would break.
+`.claude/skills/pr-review-gate/` is canonical. **Everything else in this
+section is conditional on a probe, and the probe runs first.**
 
-**Open, to be resolved by probe as the plan's first task: which workspace
-paths actually need a mirror.** `npx skills list --json` reports this repo's
+An earlier draft listed the mirror as a settled decision while leaving its
+target unresolved — a decision cannot be settled and its precondition open at
+the same time. The mirror script, its guard assertion, and its `extraFiles`
+entries are **contingent deliverables**: they are built for the agents the
+probe proves need them, and for no others. If the probe returns *no agent needs
+a workspace mirror*, the correct outcome is to record that finding and build
+none of it — not to ship a synchronization mechanism with zero consumers, which
+is how #2314's three-copy problem started, one paragraph from where this design
+warns about it.
+
+Where a mirror **is** warranted, the shape is: a committed script mirrors the
+canonical directory into that agent's path, a guard test fails when a mirror
+drifts from its source so staleness surfaces as a red test rather than a
+silently outdated copy, and the mirror paths join `test:hooks`'s inputs in
+`scripts/verify-cache.mjs` — without that, a diff touching only mirrored files
+prints `[cached]` and skips the guard it would break.
+
+**The probe (plan task 1) answers two things, not one:** which workspace paths
+each agent actually resolves, and — for Cline specifically — whether its
+subagent starts cold, per the portability section above. `npx skills list --json` reports this repo's
 three project skills with `"agents": ["Claude Code"]`, but that may be the
 shared CLI's install bookkeeping rather than what Cline resolves at project
 scope. Measured against `@cline/cli-windows-x64/bin/cline.exe` on 2026-08-13,
@@ -270,25 +363,93 @@ owner decision concerns the *global* skill stores.
 
 `scripts/tests/review-gate-mechanism.test.mjs` grows rather than shrinks:
 
-- **assertion 3 retargets** from `model-routing`'s
-  `## Mandatory independent review (PRs)` section to `SKILL.md`'s own dispatch
-  and effort ladder — it must move because the section it reads is being
-  moved;
+**Assertions are named, never numbered.** The file's header comment numbers
+them 1–4 in one order (exists / model-routing / CLAUDE.md /
+name-matches-directory) while the `test()` calls appear in a *different* order
+(exists / name-matches-directory / model-routing / CLAUDE.md). "Assertion 3" is
+therefore ambiguous — it names the model-routing test by file order and the
+CLAUDE.md test by the file's own numbering, and an implementer picking the
+wrong one would retarget a healthy assertion and leave the broken one reading a
+section that no longer exists. Every reference below is by test-name string.
+**Correcting that header comment to match the actual order is a chore this work
+made owed**, and lands in the same PR.
+
+- **retarget** `"model-routing/SKILL.md's PR-review Mechanism bullet references
+  pr-review-gate"` — it reads a section that is being moved, so it must now
+  read `SKILL.md`'s own dispatch and effort ladder instead;
 - **new**: both `references/*.md` exist *and* are named by `SKILL.md`. This
   layout's new failure mode is a dispatch prompt pointing at a file that is not
   there, which fails silently by handing the reviewer no rubric at all;
 - **new**: `model-routing` does not still carry a second copy of the moved
   sections, so the drift this move fixes cannot quietly reappear;
-- **new**: each mirror matches its canonical source.
+- **new — link integrity**: every intra-repo anchor link in CLAUDE.md's
+  before-shipping step 10 and in the moved sections resolves to a heading that
+  actually exists. This exists because of a defect this design would otherwise
+  have shipped: `CLAUDE.md:716` links
+  `model-routing/SKILL.md#mandatory-independent-review-prs`, and moving that
+  section **breaks the anchor while the existing string-match assertion stays
+  green** — the guard would have certified the line it broke;
+- **conditional**: each mirror matches its canonical source — built only if the
+  probe establishes a mirror is needed at all.
 
 Each new assertion is mutation-verified — broken deliberately, observed red,
 restored — rather than asserted to work.
 
+### Closing the enumeration trap rather than re-arming it
+
+`scripts/verify-cache.mjs:248-250` registers this guard's inputs as three
+**literal paths** (`.claude/skills/pr-review-gate/SKILL.md`,
+`.claude/skills/model-routing/SKILL.md`, `CLAUDE.md`), because the step's globs
+deliberately exclude `.claude/skills/**`. Simply appending two more literals for
+the reference files would work today and re-arm defect shape #2 from this
+design's own rubric — *a guard that enumerates loses one spelling per round*:
+every future reference file would need hand-registering here or its diff prints
+`[cached]` and the guard sits stale-green.
+
+So the two skill literals are replaced by a `.claude/skills/**` glob, which
+covers the existing entries, the new reference files, and anything added later.
+`CLAUDE.md` stays a literal — it is not under that tree.
+
+### What this guard does not prove
+
+Stated plainly, in the same spirit as the existing guard's own header. Every
+assertion above checks **presence**: files exist, are named, match, resolve;
+sections are absent where they should be. **None of them proves a pass ran, or
+that a comment was posted, or that a posted comment matches the report that
+produced it.** The one behavioural property that is checkable from outside the
+pass — that the reviewer modified no tracked file — is checked by the session's
+before/after tree comparison, not by this test. A summary must not imply more
+than that.
+
 ## Testing
 
-Node's `node --test` under `npm run test:hooks`, alongside the existing
-assertions. There is no runtime surface here beyond the guard, so the guard is
-the test plan.
+The `node:test` assertions live alongside the existing ones in
+`scripts/tests/review-gate-mechanism.test.mjs`, run by `npm run test:hooks` —
+which is `node scripts/run-hooks-tests.mjs` (`package.json:45`), a runner
+script, not a bare `node --test` invocation. There is no runtime surface here
+beyond the guard, so the guard is the test plan.
+
+## Resolved by adversarial review
+
+The pass over the first draft returned findings against six load-bearing
+claims; all are folded above rather than noted. Its three closing questions,
+answered:
+
+1. **What compares the posted comment against what the reviewer returned?**
+   Nothing could — so the relay was removed instead. The reviewer posts
+   directly, and the property that *is* checkable (no tracked file modified) is
+   checked by the session's before/after tree comparison.
+2. **Is the mirror conditional on the probe, or committed to regardless?**
+   Conditional. The probe is task 1, and "no agent needs a mirror" is a valid
+   outcome that cancels the mirror, its guard assertion and its cache entries.
+3. **Does a pass that finds nothing post a comment?** Yes — and a docs-only PR
+   posts an exemption note. Otherwise the record cannot distinguish
+   *reviewed and clean* from *never reviewed*, which is the distinction it
+   exists for.
+
+Three claims the draft asserted and could not support are now marked as such
+rather than dressed up: Cline's subagent independence (probe task 1b), what the
+guard does not prove, and the reviewer's write access.
 
 ## Bookkeeping
 
@@ -299,6 +460,13 @@ the test plan.
 - **On-box acceptance: not applicable** — nothing here needs hardware.
 - **Issue**: filed as `area:ops` + `type:chore`; no `docs/BACKLOG.md` row,
   since chores never render there.
+- **Contention.** This design edits four files with heavy concurrent traffic —
+  `CLAUDE.md`, `model-routing/SKILL.md`, `scripts/verify-cache.mjs` and the
+  guard test — across 17 live worktrees off one `.git`. This session already
+  lost a commit to a concurrent HEAD move while writing this spec. So: all work
+  happens in the dedicated worktree, and **the `CLAUDE.md` + `model-routing`
+  edits land last, in one commit, rebased immediately before** — the smallest
+  window between reading those files and committing them.
 - [`docs/features/235-model-routing-review-gates.md`](../../features/235-model-routing-review-gates.md)
   is updated to record that the PR-review sections moved out of
   `model-routing`.

--- a/docs/superpowers/specs/2026-08-13-pr-review-skill-design.md
+++ b/docs/superpowers/specs/2026-08-13-pr-review-skill-design.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: active
 ---
 
 # PR review skill — design

--- a/docs/superpowers/specs/2026-08-13-pr-review-skill-design.md
+++ b/docs/superpowers/specs/2026-08-13-pr-review-skill-design.md
@@ -339,9 +339,44 @@ silently outdated copy, and the mirror paths join `test:hooks`'s inputs in
 `scripts/verify-cache.mjs` — without that, a diff touching only mirrored files
 prints `[cached]` and skips the guard it would break.
 
-**The probe (plan task 1) answers two things, not one:** which workspace paths
-each agent actually resolves, and — for Cline specifically — whether its
-subagent starts cold, per the portability section above. `npx skills list --json` reports this repo's
+### Probe result (2026-08-13) — the assumption was wrong
+
+The probe ran. Cline was asked directly, headlessly, inside this repo's
+worktree (`cline -p -c <dir> "list your skills"`). It returned the 23 **global**
+skills from `~/.agents/skills/` and answered `pr-review-gate: NO`. **Cline does
+not resolve workspace `.claude/skills/` at all** — the earlier belief that it
+did was read off `npx skills list` showing the path, whose `agents` field is
+the shared CLI's install bookkeeping.
+
+So there is no workspace path to mirror into. The only store Cline reads is
+`~/.agents/skills/`, **outside the repo**, shared with five other agents.
+
+**Owner decision (2026-08-13): ship the per-machine install step** —
+`npm run skills:sync` copies the canonical skill into that store — rather than
+dropping the mirror and accepting Claude-Code-only. Two consequences are
+carried openly in the deliverable:
+
+- **The drift guard fails open.** Its target is in `$HOME`, absent on a fresh
+  clone and in CI, so it skips when the directory is missing. That is this
+  design's own rubric entry #1 — *a guard that fails open on absent evidence* —
+  and here it is unavoidable rather than accidental: the alternative is a
+  required check that reddens every machine that never ran the sync. It prints
+  a visible skip line, and a green run must never be reported as "the mirror is
+  in sync."
+- **Relative links do not resolve from the mirror.** The sync injects a
+  provenance header telling the reading agent that paths resolve against the
+  repository under review, not against the mirrored file.
+
+**A Cline-run pass is independent but flash-tier.** Asked directly, Cline
+dispatches via `spawn_agent` with a **fresh empty context** (satisfying the
+independence requirement), but **cannot select the subagent's model**; its own
+stderr disclosed `deepseek-v4-flash`. The capability phrasing above — *strongest
+tier available to that agent* — is satisfied, but the probe record states the
+actual model so a Cline pass is never recorded as equivalent to an Opus one.
+
+This adds a fourth consumer to `~/.agents/skills/`, the store #2314 is already
+open about consolidating; the sync script is the mechanism that ticket may
+later absorb. `npx skills list --json` reports this repo's
 three project skills with `"agents": ["Claude Code"]`, but that may be the
 shared CLI's install bookkeeping rather than what Cline resolves at project
 scope. Measured against `@cline/cli-windows-x64/bin/cline.exe` on 2026-08-13,

--- a/docs/superpowers/specs/2026-08-13-pr-review-skill-design.md
+++ b/docs/superpowers/specs/2026-08-13-pr-review-skill-design.md
@@ -1,0 +1,304 @@
+---
+status: draft
+---
+
+# PR review skill — design
+
+Widen `.claude/skills/pr-review-gate/` from "how to dispatch a reviewer" into
+the single place that says what this repo expects of a PR review: the
+procedure the shipping session runs, the rubric the reviewer actually applies,
+what happens to the findings, and the durable record each pass leaves on the
+PR itself.
+
+Supersedes the PR-specific half of
+[`.claude/skills/model-routing/SKILL.md`](../../../.claude/skills/model-routing/SKILL.md).
+Prior design of record for the gate mechanism:
+[2026-07-01-model-routing-and-review-gates-design.md](2026-07-01-model-routing-and-review-gates-design.md)
+and [docs/features/235-model-routing-review-gates.md](../../features/235-model-routing-review-gates.md).
+
+## The problem
+
+Three things are wrong with the current arrangement.
+
+**The process has no single home.** Running one PR review means reading
+`pr-review-gate/SKILL.md` (dispatch + brief), `model-routing/SKILL.md`
+(sequence, exemption, effort ladder, findings handling, re-review trigger,
+issue verification), CLAUDE.md's before-shipping checklist, and
+CONTRIBUTING.md's "Pull requests". The rules are good; they are just not in
+one place, and a rule split across four files is a rule that drifts.
+
+**The brief says how to format a finding, not where the bodies are buried.**
+Today's brief is a good generic reviewer prompt — severity, `file:line`,
+concrete failure scenario, correctness-vs-cleanup split, "found nothing" is
+valid. None of it is about *this* repo. The defect shapes that repeatedly
+survive into late gate rounds here (a guard that fails open on absent
+evidence, a metric blind to a case it must score, an acceptance criterion that
+would pass on a null observation, a fix unreachable at the default config) are
+transmitted nowhere, so each reviewer rediscovers them or misses them.
+
+**Review history dies with the chat.** A pass returns a report into a session
+transcript. When that context is gone, so is the record of what was checked,
+what was found, and what was done about it — even though the PR it describes
+is permanent and public.
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Scope | One skill covering both the ship procedure and the reviewer rubric |
+| Boundary with `model-routing` | Move its PR-specific sections in; routing keeps routing |
+| Structure | `SKILL.md` + `references/` the reviewer is pointed at by path |
+| Rubric depth | Repo bookkeeping gates + a curated catalogue of recurring defect shapes |
+| Migration | Grow `pr-review-gate` in place — no rename |
+| Portability | State reviewer *capabilities*, not one agent's tool names |
+| Cross-agent sync | Canonical copy in `.claude/skills/`, mirrored by script, drift caught by a guard |
+| Record | Every pass posts a summary comment on the PR |
+
+### Why grow in place rather than rename
+
+`pr-review-gate` is referenced by ten files, including a guard test that keys
+on both the directory basename and the frontmatter `name:` agreeing with it,
+and `scripts/verify-cache.mjs`'s `extraFiles` list. A rename re-points all of
+them, rewrites all four guard assertions, and leaves every archived plan
+naming a path that no longer resolves — to buy a directory name that reads
+slightly better. The name is still honest: the thing is the gate, and the
+procedure exists to reach it. Under CLAUDE.md's "surgical changes" rule,
+renaming what works is taste.
+
+## Layout
+
+```
+.claude/skills/pr-review-gate/
+  SKILL.md                       — the shipping session's runbook
+  references/reviewer-brief.md   — what the reviewer subagent reads
+  references/findings-triage.md  — what happens after the report lands
+```
+
+Two readers, two files. The shipping session loads the runbook and never needs
+the rubric; the reviewer loads the rubric and never runs the procedure. The
+dispatch prompt names `references/reviewer-brief.md` **by path** and instructs
+the reviewer to read it in full, so the rubric reaches it verbatim rather than
+as well as the dispatching session happens to retype it.
+
+Directory, frontmatter `name:`, and the absence of `disable-model-invocation`
+are all unchanged, so guard assertions 1, 2 and 4 keep passing untouched. The
+`description:` widens to trigger on preparing and shipping a PR, not only on
+dispatching the reviewer.
+
+## SKILL.md — the procedure
+
+An ordered runbook: preconditions ("fully staged") → docs-only exemption →
+effort ladder → dispatch → post the pass comment → triage (pointer to
+`findings-triage.md`) → re-review trigger and loop cap → issue verification at
+`gh pr create` → merge.
+
+**Constraint: name and link, do not restate.** For gates CLAUDE.md already
+owns — regression plan, paired test, on-box acceptance register, the
+release-notes pair, `docs/features/INDEX.md`, `verify:fast:branch` — the
+runbook names them and links them, and does not reproduce their text. A second
+copy of a rule is a rule that drifts, which is the failure
+`review-gate-mechanism.test.mjs` exists to catch. What moves *into* this skill
+is only what `model-routing` owns today and nothing else does.
+
+### What moves out of `model-routing`
+
+`model-routing/SKILL.md` loses `## Mandatory independent review (PRs)` and
+`## PR-gate issue verification`, keeping a one-line pointer to this skill. It
+retains the routing table, escalation, session-level drift, the spec/plan
+adversarial-review loop, and the judgment-call carve-out — which stays there
+because both loops share it, and is linked from `findings-triage.md`.
+
+## references/reviewer-brief.md — the rubric
+
+### Half one: house gates
+
+Mechanically checkable, and the reviewer is expected to actually check them
+rather than assume the author did:
+
+- the paired test is a real regression test — red before the fix, green after,
+  and red *for the reason claimed*;
+- on-box acceptance recorded across all three surfaces (register, per-feature
+  run sheet, live view) when the PR ships hardware-provable behaviour;
+- the release-notes pair (`docs/release-notes-next.md` + `RELEASE_NOTES.md`),
+  or an explicit not-applicable;
+- `Closes #NN` / `Refs #NN` present and outside any code span;
+- `cast.json` writes locked per the four rules, and lock-timeout errors routed
+  through the correct curation seam;
+- a new config knob carrying its registry entry, `config:sync`, Settings row
+  and `.env.example` line;
+- derived artifacts regenerated — `src/lib/api-types.ts`, `docs/BACKLOG.md`,
+  brand PNGs;
+- incidental findings fixed in this round rather than filed, and declared in
+  the PR body.
+
+### Half two: recurring defect shapes
+
+Curated, roughly ten, each stated as *how it hides* rather than as a rule to
+recite:
+
+1. **A guard that fails open on absent evidence** — the input it inspects is
+   missing, so it passes.
+2. **A guard that enumerates syntax** — it loses one spelling per round to
+   anything it did not list.
+3. **A test that cannot fail** — or that went red before the fix for a
+   different reason than the one claimed.
+4. **A metric blind to a case it must score** — deletion counted as repair, a
+   merge counted as repair, the dominant shape excluded.
+5. **An acceptance criterion blind to its own feature** — it would pass on a
+   null observation.
+6. **Success reported while doing nothing** — the most common shape in this
+   repo's history, including inside guards written to catch it.
+7. **A fix unreachable at the default configuration** — correct code that runs
+   zero times as shipped.
+8. **A control group labelled clean but never measured.**
+9. **The defect is in the instrument or the document, not the code** — a stale
+   comment the change made false, a figure measured under one rule reused as
+   evidence for another.
+10. **One instance fixed, the class left armed** — sibling call sites, other
+    entry points, the second copy.
+
+### The finding contract
+
+Unchanged from today's brief, because it works: severity, `file:line`, a
+concrete failure scenario showing the break rather than gesturing at a risk,
+the mandatory correctness-bug vs cleanup-nit split (it is what drives the
+re-review trigger), and explicit authorization for "found nothing" so a
+reviewer does not manufacture findings to justify its dispatch.
+
+## references/findings-triage.md
+
+The fix-now bar; the defect / chore / taste seam; the void deferral reasons
+reproduced verbatim from CLAUDE.md's "Incidental findings"; the design-pass
+carve-out as the single finding allowed to leave the round unfixed, and the
+requirement that its issue names the decision owed; one dispatched fix agent
+per finding, one paired test each; and how the bug/nit split feeds the
+re-review trigger and the loop cap.
+
+## The PR comment
+
+Every pass posts one summary comment on the PR the moment it returns, **before
+any fixes**, so the thread reads as found → fixed → re-verified in order.
+Format, following the three comments on
+[PR #2320](https://github.com/dudarenok-maker/Castwright/pull/2320):
+
+```
+## PR review — pass N (head <sha>, effort <level>)
+
+Scope: <files reviewed> · verified: <suite counts, typecheck> before
+adversarially probing <what>.
+
+### 🔴 Blocking — <claim>
+<concrete repro: exact input → wrong output, file:line>
+
+### 🟠 Significant — <claim>
+### 🟡 Minor
+### ✅ What is solid
+### Verdict
+```
+
+Two elements are required rather than stylistic:
+
+- **the head SHA in the heading** — it is what makes a comment interpretable
+  months later, when the branch has moved on;
+- **on a re-review, each prior finding's disposition** (`VERIFIED RESOLVED`,
+  or still open and why), so the thread is a chain rather than three
+  unrelated opinions.
+
+Severity maps onto the split the loop already reads: 🔴 and 🟠 are correctness
+bugs and re-trigger a pass once fixed and pushed; 🟡 is cleanup — fixed this
+round, but not a re-trigger.
+
+**The shipping session posts it, verbatim.** Header added, body untouched. The
+reviewer keeps its "changes nothing, no write access" boundary, and a session
+cannot soften its own reviewer's findings between receiving them and
+publishing them. The alternative — the subagent posting directly — removes one
+relay but hands `gh` write access to an agent whose entire value is that it
+writes nothing.
+
+**Standing authorization.** Posting to a public PR is an outward-facing
+action. The repo owner has authorized it as a standing part of this process,
+recorded in the skill, so the agent posts each round without pausing to ask.
+
+## Portability across agents
+
+The skill states the properties a reviewer must have, not one agent's tool
+names:
+
+- **fresh context** — not a fork of the shipping session, whose framing and
+  blind spots are exactly what the pass exists to escape;
+- **the strongest tier available** to that agent;
+- **no write access** — it returns a report;
+- **the rubric read from `references/reviewer-brief.md`**, in full.
+
+Underneath, a short per-agent mapping (Claude Code: a non-fork `Agent`
+dispatch at the routing table's Premium tier; Cline: its own subagent
+mechanism). An agent that genuinely cannot dispatch runs the rubric in-session
+and reports it as a **self-run pass, never as the independent gate** — which
+preserves the standing rule that a gate which did not run is never reported as
+having run.
+
+## Cross-agent sync
+
+`.claude/skills/pr-review-gate/` is canonical. A committed script mirrors it
+into the workspace paths other agents read, and a guard test fails when a
+mirror drifts from its source, so staleness surfaces as a red test rather than
+a silently outdated copy. The mirror paths join `test:hooks`'s `extraFiles` in
+`scripts/verify-cache.mjs` for the same reason the reference files do — without
+that, a diff touching only mirrored files prints `[cached]` and skips the guard
+it would break.
+
+**Open, to be resolved by probe as the plan's first task: which workspace
+paths actually need a mirror.** `npx skills list --json` reports this repo's
+three project skills with `"agents": ["Claude Code"]`, but that may be the
+shared CLI's install bookkeeping rather than what Cline resolves at project
+scope. Measured against `@cline/cli-windows-x64/bin/cline.exe` on 2026-08-13,
+`grep -aoE '(\.cline|\.claude|\.agents)[\\/]{1,2}skills'` returns
+`.claude/skills` ×3 and `.agents/skills` ×1 — positive evidence that Cline
+reads `.claude/skills`, but silent on whether it means the global or the
+workspace one, which is precisely the distinction that decides whether a Cline
+mirror is needed at all.
+
+So the fact gets established by test, not by reading strings out of a binary:
+drop a canary skill, ask each agent to list its skills, and mirror only where
+the canary does not appear. Building mirrors for agents that do not need them
+is how the three-copy problem in #2314 started.
+
+This work is project-scope and therefore independent of #2314, whose blocked
+owner decision concerns the *global* skill stores.
+
+## The guard
+
+`scripts/tests/review-gate-mechanism.test.mjs` grows rather than shrinks:
+
+- **assertion 3 retargets** from `model-routing`'s
+  `## Mandatory independent review (PRs)` section to `SKILL.md`'s own dispatch
+  and effort ladder — it must move because the section it reads is being
+  moved;
+- **new**: both `references/*.md` exist *and* are named by `SKILL.md`. This
+  layout's new failure mode is a dispatch prompt pointing at a file that is not
+  there, which fails silently by handing the reviewer no rubric at all;
+- **new**: `model-routing` does not still carry a second copy of the moved
+  sections, so the drift this move fixes cannot quietly reappear;
+- **new**: each mirror matches its canonical source.
+
+Each new assertion is mutation-verified — broken deliberately, observed red,
+restored — rather than asserted to work.
+
+## Testing
+
+Node's `node --test` under `npm run test:hooks`, alongside the existing
+assertions. There is no runtime surface here beyond the guard, so the guard is
+the test plan.
+
+## Bookkeeping
+
+- **Not docs-only.** The change touches `scripts/**`, so `verify.yml`'s
+  doc-only fast path does not apply and this gate applies to itself.
+- **Release notes: not applicable** — process and tooling, no user- or
+  operator-visible delta. Stated explicitly rather than skipped silently.
+- **On-box acceptance: not applicable** — nothing here needs hardware.
+- **Issue**: filed as `area:ops` + `type:chore`; no `docs/BACKLOG.md` row,
+  since chores never render there.
+- [`docs/features/235-model-routing-review-gates.md`](../../features/235-model-routing-review-gates.md)
+  is updated to record that the PR-review sections moved out of
+  `model-routing`.

--- a/docs/testing/agent-skill-resolution-probe.md
+++ b/docs/testing/agent-skill-resolution-probe.md
@@ -1,0 +1,81 @@
+# Agent skill-resolution probe (2026-08-13)
+
+Run to decide whether `.claude/skills/pr-review-gate/` needs mirroring for
+other agents, per
+[the PR review skill design](../superpowers/specs/2026-08-13-pr-review-skill-design.md).
+
+## Method
+
+Each agent was **driven directly and asked what it could see.** Only what an
+agent actually reported counts. Two weaker methods were tried first and are
+recorded here because both looked conclusive and were not:
+
+- `npx skills list --json` shows this repo's three project skills with
+  `"agents": ["Claude Code"]`. That field is the shared CLI's **install
+  bookkeeping**, not proof of what any agent resolves.
+- Grepping the Cline binary (`@cline/cli-windows-x64/bin/cline.exe`) returns
+  `.claude/skills` ×3 and `.agents/skills` ×1. Positive evidence Cline reads
+  *a* `.claude/skills`, but **silent on global vs workspace** — which is the
+  only distinction that decides anything.
+
+Cline was probed headlessly, with the repo as cwd:
+
+```bash
+cline -p -c "C:\Claude\Projects\wt-pr-review-skill" -t 240 \
+  "List the skills available to you in this workspace. Do you see one named pr-review-gate?"
+```
+
+## Results
+
+| Agent | Sees project `.claude/skills/`? | Evidence |
+|---|---|---|
+| Claude Code | **yes** | resolves this repo's three project skills today |
+| Cline 3.0.54 | **no** | listed exactly the 23 global skills from `~/.agents/skills/`; answered `pr-review-gate: NO` |
+| Gemini CLI, Copilot, Antigravity, Hermes | **not tested** | share `~/.agents/skills/` per the store's own docs; none was driven |
+
+The Cline result is strong rather than vague: it did not merely fail to find
+the skill, it returned the exact global set as a fingerprint.
+
+## Cline's subagent
+
+Asked directly, in the same session:
+
+- **Dispatch:** yes — `spawn_agent`, plus `team_spawn_teammate` / `team_run_task`.
+- **Context:** *"Fresh empty context. A dispatched sub-agent does not inherit
+  our conversation history."* → satisfies the gate's independence requirement.
+- **Model selection:** **no.** Neither tool takes a model parameter. Its own
+  stderr disclosed the backing model as `deepseek-v4-flash`.
+
+**So a Cline-run pass is genuinely independent but flash-tier.** It satisfies
+the design's stated capability ("the strongest tier available to that agent"),
+and this line exists so nobody records one as equivalent to an Opus-tier pass.
+
+Caveat held openly: items 2 and 3 are the agent's **self-report about its own
+harness**. Item 1 is stronger — a model can observe its own tool list — but
+"my subagent starts cold" is a claim about runtime behaviour that was not
+independently reproduced.
+
+## Verdict
+
+```
+MIRROR_NEEDED:        Cline (via the global store, NOT a workspace path)
+MIRROR_TARGET:        ~/.agents/skills/pr-review-gate/
+CLINE_SUBAGENT_COLD:  yes (self-reported)
+CLINE_TIER_SELECTABLE: no — observed deepseek-v4-flash
+```
+
+The design had assumed a **workspace** mirror. There is no workspace path to
+mirror into: the only store Cline reads is outside the repo. The owner chose
+the per-machine install step (`npm run skills:sync`) over dropping the mirror —
+see plan Task 8, which carries the two consequences that follow (the drift
+guard fails open because its target is in `$HOME`; relative links need a
+provenance header).
+
+## Incident during this probe
+
+The first `cline` invocation silently self-updated 3.0.53 → 3.0.54 and left the
+install broken mid-flight: `cline`, `cline.cmd` and `cline.ps1` disappeared
+from `%APPDATA%\npm`, and the package lost its own `package.json`. Symptoms in
+order were a working call, then `MODULE_NOT_FOUND`, then `command not found`.
+`npm i -g cline` repaired it (EPERM warnings on the temp dir are cosmetic).
+Suspect this before assuming a probe broke something.

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "openapi:types": "openapi-typescript ./openapi.yaml -o ./src/lib/api-types.ts",
     "stats": "node scripts/code-stats.mjs",
     "backlog:sync": "node scripts/backlog-sync.mjs",
+    "skills:sync": "node scripts/sync-agent-skills.mjs",
     "audit:stage2-coverage": "npx tsx scripts/audit-stage2-coverage.mts",
     "audit:missing-speakers": "npx tsx scripts/audit-missing-speakers.mts",
     "repair:missing-speakers": "npx tsx scripts/repair-missing-speakers.mts",

--- a/scripts/sync-agent-skills.mjs
+++ b/scripts/sync-agent-skills.mjs
@@ -45,10 +45,13 @@ const PROVENANCE_END = "     this file's location. Some point at sibling skills.
 function header(rel) {
   // <repo> is deliberately left as a literal placeholder, not the absolute
   // path of the machine that ran this sync: the header travels with the
-  // mirror into every repo Cline reviews, and "resolve against the
-  // repository you are reviewing" is the whole point — a baked-in path to
-  // THIS checkout would be actively wrong once the agent is reviewing a
-  // different one.
+  // mirror into every repo Cline reviews, but the body's relative links only
+  // resolve inside a CASTWRIGHT checkout (they point at this repo's own
+  // docs/skills, not at whatever repo the mirror happens to be read from) —
+  // so the header says so explicitly rather than implying they resolve
+  // wherever Cline is currently reviewing. A baked-in absolute path to THIS
+  // machine's checkout would be actively wrong on every other machine the
+  // mirror is synced to; <repo> stays a literal placeholder for that reason.
   return (
     '<!-- MIRRORED COPY — do not edit here.\n' +
     `     Canonical source: <repo>/.claude/skills/${SKILL_NAME}/${rel}\n` +
@@ -111,12 +114,16 @@ export function syncOneFile(srcPath, destPath, rel) {
   const canonicalContent = readFileSync(srcPath, 'utf8');
   const mirrored = buildMirrorContent(canonicalContent, rel);
 
-  mkdirSync(dirname(destPath), { recursive: true });
-  writeFileSync(destPath, mirrored, 'utf8');
-
+  // Checked BEFORE the write, like assertNoBom above: `mirrored` already
+  // exists at this point, so nothing blocks checking it first. Checking it
+  // after the write let a malformed canonical source clobber a previously
+  // good mirror with an unusable one before the throw ever fired.
   if (rel === 'SKILL.md' && !mirrored.startsWith('---\n')) {
     throw new Error(`${destPath}: frontmatter is not the first line`);
   }
+
+  mkdirSync(dirname(destPath), { recursive: true });
+  writeFileSync(destPath, mirrored, 'utf8');
 
   console.log(`wrote ${destPath}`);
   return destPath;

--- a/scripts/sync-agent-skills.mjs
+++ b/scripts/sync-agent-skills.mjs
@@ -87,10 +87,39 @@ export function buildMirrorContent(canonicalContent, rel) {
   return h + canonicalContent;
 }
 
+// Checks the CANONICAL SOURCE, not the mirrored output: the output always
+// begins with either the frontmatter delimiter '---' or the provenance
+// header's '<!--', so a check against the written file can never fire — a
+// BOM on the source is silently relocated into the middle of the mirrored
+// file (still there, just no longer at byte 0, and now past the point where
+// a frontmatter parser looks for it) rather than caught.
 function assertNoBom(buf, path) {
   if (buf.length >= 3 && buf[0] === 0xef && buf[1] === 0xbb && buf[2] === 0xbf) {
-    throw new Error(`${path}: wrote a BOM — this breaks frontmatter parsing`);
+    throw new Error(
+      `${path}: canonical source has a UTF-8 BOM — syncing would relocate it into ` +
+        'the middle of the mirrored file instead of removing it, breaking frontmatter parsing there',
+    );
   }
+}
+
+/** Syncs a single canonical file to its mirrored destination. Exported (in
+ *  addition to syncAgentSkills) so tests can exercise the real read/check/
+ *  write path against fixture paths, without touching the actual $HOME
+ *  mirror. */
+export function syncOneFile(srcPath, destPath, rel) {
+  assertNoBom(readFileSync(srcPath), srcPath);
+  const canonicalContent = readFileSync(srcPath, 'utf8');
+  const mirrored = buildMirrorContent(canonicalContent, rel);
+
+  mkdirSync(dirname(destPath), { recursive: true });
+  writeFileSync(destPath, mirrored, 'utf8');
+
+  if (rel === 'SKILL.md' && !mirrored.startsWith('---\n')) {
+    throw new Error(`${destPath}: frontmatter is not the first line`);
+  }
+
+  console.log(`wrote ${destPath}`);
+  return destPath;
 }
 
 export function syncAgentSkills() {
@@ -98,20 +127,7 @@ export function syncAgentSkills() {
   for (const rel of FILES) {
     const srcPath = join(CANONICAL_ROOT, rel);
     const destPath = join(MIRROR_ROOT, rel);
-    const canonicalContent = readFileSync(srcPath, 'utf8');
-    const mirrored = buildMirrorContent(canonicalContent, rel);
-
-    mkdirSync(dirname(destPath), { recursive: true });
-    writeFileSync(destPath, mirrored, 'utf8');
-
-    const rawBytes = readFileSync(destPath);
-    assertNoBom(rawBytes, destPath);
-    if (rel === 'SKILL.md' && !rawBytes.toString('utf8').startsWith('---\n')) {
-      throw new Error(`${destPath}: frontmatter is not the first line`);
-    }
-
-    console.log(`wrote ${destPath}`);
-    written.push(destPath);
+    written.push(syncOneFile(srcPath, destPath, rel));
   }
   return written;
 }

--- a/scripts/sync-agent-skills.mjs
+++ b/scripts/sync-agent-skills.mjs
@@ -119,7 +119,7 @@ export function syncOneFile(srcPath, destPath, rel) {
   // after the write let a malformed canonical source clobber a previously
   // good mirror with an unusable one before the throw ever fired.
   if (rel === 'SKILL.md' && !mirrored.startsWith('---\n')) {
-    throw new Error(`${destPath}: frontmatter is not the first line`);
+    throw new Error(`${srcPath}: frontmatter is not the first line`);
   }
 
   mkdirSync(dirname(destPath), { recursive: true });

--- a/scripts/sync-agent-skills.mjs
+++ b/scripts/sync-agent-skills.mjs
@@ -40,7 +40,7 @@ const FILES = ['SKILL.md', 'references/reviewer-brief.md', 'references/findings-
 // it was briefly exported so the guard test could split a mirrored file on it,
 // but the guard now compares against buildMirrorContent's own output instead,
 // so nothing outside this file needs the marker.
-const PROVENANCE_END = "     not against this file's location. -->\n";
+const PROVENANCE_END = "     this file's location. Some point at sibling skills. -->\n";
 
 function header(rel) {
   // <repo> is deliberately left as a literal placeholder, not the absolute
@@ -53,7 +53,7 @@ function header(rel) {
     '<!-- MIRRORED COPY — do not edit here.\n' +
     `     Canonical source: <repo>/.claude/skills/${SKILL_NAME}/${rel}\n` +
     '     Regenerate with `npm run skills:sync` from that repo.\n' +
-    '     Relative links below resolve against the REPOSITORY YOU ARE REVIEWING,\n' +
+    '     Relative links below resolve against a CASTWRIGHT CHECKOUT, not against\n' +
     PROVENANCE_END
   );
 }

--- a/scripts/sync-agent-skills.mjs
+++ b/scripts/sync-agent-skills.mjs
@@ -1,0 +1,131 @@
+// scripts/sync-agent-skills.mjs
+//
+// Mirrors .claude/skills/pr-review-gate/ into the cross-agent skill store at
+// ~/.agents/skills/pr-review-gate/ — the ONLY location Cline (and reportedly
+// five other agents sharing that store) resolves skills from. Verified
+// 2026-08-13: see docs/testing/agent-skill-resolution-probe.md. Cline does
+// not read this repo's workspace .claude/skills/ at all, so without this
+// mirror the mandated PR review runbook is invisible to it.
+//
+// This is a PER-MACHINE step. CI cannot run it — the target lives under
+// $HOME, which is absent on every fresh clone and every CI runner. Run
+// `npm run skills:sync` after any change under .claude/skills/pr-review-gate/.
+//
+// Three encoding/format traps bit the original hand sync this script
+// replaces. Each produces a file that LOOKS fine and is broken:
+//   1. The provenance header must go BELOW the YAML frontmatter, not above
+//      it — `---` must stay the literal first line of SKILL.md or the skill
+//      becomes undiscoverable.
+//   2. Read and write UTF-8 explicitly (readFileSync(p, 'utf8') /
+//      writeFileSync(p, s, 'utf8')) — never shell out to PowerShell, whose
+//      5.1 Get-Content reads UTF-8 as ANSI and turns every em-dash into
+//      "â€"".
+//   3. No BOM. A BOM before `---` breaks frontmatter parsing.
+
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { isDirectlyInvoked } from './lib/is-main-module.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, '..');
+const SKILL_NAME = 'pr-review-gate';
+const CANONICAL_ROOT = join(REPO_ROOT, '.claude', 'skills', SKILL_NAME);
+const MIRROR_ROOT = join(homedir(), '.agents', 'skills', SKILL_NAME);
+
+const FILES = ['SKILL.md', 'references/reviewer-brief.md', 'references/findings-triage.md'];
+
+// The provenance header's closing line, WITH its trailing newline. Module-local:
+// it was briefly exported so the guard test could split a mirrored file on it,
+// but the guard now compares against buildMirrorContent's own output instead,
+// so nothing outside this file needs the marker.
+const PROVENANCE_END = "     not against this file's location. -->\n";
+
+function header(rel) {
+  // <repo> is deliberately left as a literal placeholder, not the absolute
+  // path of the machine that ran this sync: the header travels with the
+  // mirror into every repo Cline reviews, and "resolve against the
+  // repository you are reviewing" is the whole point — a baked-in path to
+  // THIS checkout would be actively wrong once the agent is reviewing a
+  // different one.
+  return (
+    '<!-- MIRRORED COPY — do not edit here.\n' +
+    `     Canonical source: <repo>/.claude/skills/${SKILL_NAME}/${rel}\n` +
+    '     Regenerate with `npm run skills:sync` from that repo.\n' +
+    '     Relative links below resolve against the REPOSITORY YOU ARE REVIEWING,\n' +
+    PROVENANCE_END
+  );
+}
+
+/**
+ * Builds the mirrored file's full content: the canonical file with the
+ * provenance header spliced in, placed so it never displaces a leading YAML
+ * frontmatter block (trap 1).
+ *
+ * For a frontmatter-bearing file (SKILL.md) the header goes immediately AFTER
+ * the closing `---`, so the frontmatter stays the literal first line (required
+ * for the skill to be discoverable) and the rest of the document follows once.
+ * An earlier version emitted the frontmatter, the header, and then the FULL
+ * canonical content — duplicating the frontmatter block — purely so the guard
+ * could compare `split(PROVENANCE_END)[1]` against the canonical file. That
+ * put a repeated metadata block into the very file a reviewing agent reads, to
+ * save the test one line. The guard now compares against this function's own
+ * output instead (see review-gate-mechanism.test.mjs), which costs the test
+ * nothing and keeps the artifact clean.
+ */
+export function buildMirrorContent(canonicalContent, rel) {
+  const h = header(rel);
+  if (canonicalContent.startsWith('---\n')) {
+    const closeIdx = canonicalContent.indexOf('\n---\n', 4);
+    if (closeIdx === -1) {
+      throw new Error(`${rel}: starts with '---' but has no closing frontmatter delimiter`);
+    }
+    const frontmatterEnd = closeIdx + '\n---\n'.length;
+    return canonicalContent.slice(0, frontmatterEnd) + '\n' + h + canonicalContent.slice(frontmatterEnd);
+  }
+  return h + canonicalContent;
+}
+
+function assertNoBom(buf, path) {
+  if (buf.length >= 3 && buf[0] === 0xef && buf[1] === 0xbb && buf[2] === 0xbf) {
+    throw new Error(`${path}: wrote a BOM — this breaks frontmatter parsing`);
+  }
+}
+
+export function syncAgentSkills() {
+  const written = [];
+  for (const rel of FILES) {
+    const srcPath = join(CANONICAL_ROOT, rel);
+    const destPath = join(MIRROR_ROOT, rel);
+    const canonicalContent = readFileSync(srcPath, 'utf8');
+    const mirrored = buildMirrorContent(canonicalContent, rel);
+
+    mkdirSync(dirname(destPath), { recursive: true });
+    writeFileSync(destPath, mirrored, 'utf8');
+
+    const rawBytes = readFileSync(destPath);
+    assertNoBom(rawBytes, destPath);
+    if (rel === 'SKILL.md' && !rawBytes.toString('utf8').startsWith('---\n')) {
+      throw new Error(`${destPath}: frontmatter is not the first line`);
+    }
+
+    console.log(`wrote ${destPath}`);
+    written.push(destPath);
+  }
+  return written;
+}
+
+if (isDirectlyInvoked(import.meta.url)) {
+  try {
+    syncAgentSkills();
+    console.log(
+      '\nThis is a per-machine step — CI cannot run it (the target lives in ' +
+        '$HOME and is absent on every fresh clone). Re-run `npm run skills:sync` ' +
+        'after any change under .claude/skills/pr-review-gate/.',
+    );
+  } catch (err) {
+    console.error(`skills:sync failed: ${err.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/tests/review-gate-mechanism.test.mjs
+++ b/scripts/tests/review-gate-mechanism.test.mjs
@@ -5,34 +5,32 @@
 // user-invocable only — `disable-model-invocation`), and nothing catches the
 // wiring rotting apart from prose review.
 //
-// Four assertions, each independently falsifiable:
-//   1. .claude/skills/pr-review-gate/SKILL.md exists and does NOT disable
-//      model invocation (the entire point of routing the gate through it).
-//   2. pr-review-gate/SKILL.md's frontmatter `name:` matches its directory
-//      basename (`pr-review-gate`) — the convention is that the directory is
-//      the skill's identifier and `name:` must agree with it. Assertion 1
-//      above only checks the path exists and reads its frontmatter for
-//      disable-model-invocation, so it stays green even if `name:` drifts to
-//      something else; assertion 1 catches half of the "stays resolvable"
-//      invariant (the path), this assertion catches the other half (the
-//      frontmatter agreeing with it).
-//   3. model-routing/SKILL.md's Mechanism bullet actually references
-//      pr-review-gate, rather than silently drifting back to naming
-//      code-review directly.
-//   4. CLAUDE.md's before-shipping step 10 references pr-review-gate too,
-//      so the checklist entry point agrees with the routing spec.
+// **Assertions are referred to elsewhere BY NAME, never by number.** This
+// header used to enumerate "four assertions" in an order that did not match
+// the order the test() calls appear in, so a plan saying "retarget assertion
+// 3" was ambiguous between two different tests. Do not reintroduce a numbered
+// list here — `git grep "^test(" scripts/tests/review-gate-mechanism.test.mjs`
+// is the authoritative inventory and cannot drift.
 //
-//   Assertions are referred to elsewhere BY NAME, never by number — this
-//   header and the test() order disagreed until 2026-08-13, and a plan that
-//   said "retarget assertion 3" was ambiguous between two different tests.
+// What this file locks, in themes rather than numbers:
+//   - the gate skill stays model-invocable and resolvable (path exists, no
+//     disable-model-invocation, frontmatter `name:` == directory basename);
+//   - pr-review-gate/SKILL.md — not model-routing — carries the dispatch
+//     mechanism and the effort ladder, and model-routing carries no second
+//     copy of the sections that moved out of it on 2026-08-13;
+//   - CLAUDE.md's before-shipping step 10 still names the skill;
+//   - both references/*.md exist AND are named by SKILL.md, so the dispatch
+//     prompt cannot point a reviewer at a file it never learns about;
+//   - every intra-repo .md link in the governance docs and skills resolves;
+//   - the cross-agent mirror matches what sync-agent-skills.mjs would write.
 //
-// Run via `npm run test:hooks` (node --test). All three source files are
-// `extraFiles` on the `test:hooks` step in scripts/verify-cache.mjs — none
-// of them sit under the step's existing globs (scripts/**, pinokio-scripts/**,
-// .github/**, .husky/**), so without those entries a diff touching only
-// .claude/skills/** or CLAUDE.md would print test:hooks [cached] and skip
-// the very guard that diff would break (the #1847 trap the comments there
-// document at length).
+// Run via `npm run test:hooks` (node --test). CLAUDE.md is an `extraFiles`
+// entry on the `test:hooks` step in scripts/verify-cache.mjs, and
+// `.claude/skills/**` is one of that step's globs (added 2026-08-13, replacing
+// three hand-listed literals that could not see a file which did not exist
+// yet). Without both, a diff touching only those paths would print
+// test:hooks [cached] and skip the very guard that diff would break — the
+// #1847 trap the comments there document at length.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';

--- a/scripts/tests/review-gate-mechanism.test.mjs
+++ b/scripts/tests/review-gate-mechanism.test.mjs
@@ -36,12 +36,12 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { readFileSync, existsSync, readdirSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { basename, dirname, join, resolve } from 'node:path';
-import { homedir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { readNormalized } from '../lib/read-normalized.mjs';
-import { buildMirrorContent } from '../sync-agent-skills.mjs';
+import { buildMirrorContent, syncOneFile } from '../sync-agent-skills.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(HERE, '..', '..');
@@ -155,30 +155,42 @@ test('pr-review-gate/SKILL.md names both reference files, and they exist', () =>
   }
 });
 
-// Markdown links of the form ](some/relative/path.md#anchor) — http(s) links
-// are skipped, and so are bare #anchor links (no file part to resolve).
-const INTRA_REPO_ANCHOR_LINK = /\]\((?!https?:)([^)#\s]+\.md)#([^)\s]+)\)/g;
+// Markdown links of the form ](some/relative/path.md) or
+// ](some/relative/path.md#anchor) — http(s) links are skipped, and so are
+// bare #anchor links (no file part to resolve). The anchor group is optional:
+// a plain .md link with no `#` still needs its target file checked for
+// existence, it just skips the heading check.
+const INTRA_REPO_MD_LINK = /\]\((?!https?:)([^)#\s]+\.md)(?:#([^)\s]+))?\)/g;
 
 /**
- * GitHub's heading-anchor slug: strip backticks, lowercase, drop everything
- * that is not a word char / space / hyphen, trim the ends, then replace each
- * REMAINING SPACE WITH ONE HYPHEN.
+ * GitHub's heading-anchor slug: lowercase, drop everything that is not a
+ * letter, digit, underscore, hyphen, or space — keeping letters/digits from
+ * ANY script, not just ASCII — then replace each REMAINING SPACE WITH ONE
+ * HYPHEN. Nothing is trimmed.
  *
- * The one-for-one replacement is the whole subtlety, and an earlier draft of
- * this helper got it wrong with `.replace(/ +/g, '-')`. GitHub does not
- * collapse runs of spaces: `### Scope discipline > merge magic` drops the `>`
- * and leaves TWO spaces, which slug to the DOUBLE hyphen in
- * CONTRIBUTING.md#scope-discipline--merge-magic. A collapsing version reports
- * that correct, live link as broken — a guard that fails on valid input, which
- * is worse than no guard: it trains its reader to "fix" correct documents.
- * The unit test below pins exactly that case GREEN.
+ * Two subtleties, both load-bearing:
+ *
+ * 1. The one-for-one space replacement, not a collapse. An earlier draft of
+ *    this helper got it wrong with `.replace(/ +/g, '-')`. GitHub does not
+ *    collapse runs of spaces: `### Scope discipline > merge magic` drops the
+ *    `>` and leaves TWO spaces, which slug to the DOUBLE hyphen in
+ *    CONTRIBUTING.md#scope-discipline--merge-magic. A collapsing version
+ *    reports that correct, live link as broken — a guard that fails on valid
+ *    input, which is worse than no guard: it trains its reader to "fix"
+ *    correct documents.
+ * 2. No trimming, and non-ASCII letters survive. A still-earlier draft used
+ *    `\w` (ASCII-only) and trimmed the ends, which mishandles both a leading
+ *    symbol (`✅ What is solid` should slug to `-what-is-solid` — the emoji
+ *    drops out, but the space after it survives untrimmed and becomes a
+ *    leading hyphen) and any non-ASCII letter (`Café & bar` should slug to
+ *    `café--bar`, keeping the `é`, not `caf--bar`).
+ *
+ * The unit test below pins all of these cases GREEN.
  */
 function githubAnchor(heading) {
   return heading
-    .replace(/`/g, '')
     .toLowerCase()
-    .replace(/[^\w\- ]+/g, '')
-    .replace(/^ +| +$/g, '')
+    .replace(/[^\p{L}\p{N}_ -]/gu, '')
     .replace(/ /g, '-');
 }
 
@@ -200,7 +212,13 @@ function stripFencedBlocks(text) {
 
 function headingAnchors(file) {
   const anchors = new Set();
-  for (const line of readNormalized(file).split('\n')) {
+  // stripFencedBlocks: a heading-shaped line inside a ```fence (e.g. the
+  // PR-comment template in pr-review-gate/SKILL.md, which contains literal
+  // "### Verdict" / "### Minor" lines as FORMAT to copy, not real headings)
+  // is not a real anchor. Without this, the SOURCE side of a link (which
+  // already strips fences before matching) and the TARGET side disagree, and
+  // the guard accepts a link that resolves only to a fenced example.
+  for (const line of stripFencedBlocks(readNormalized(file)).split('\n')) {
     const m = /^#{1,6} +(.+?)\s*$/.exec(line);
     if (m) anchors.add(githubAnchor(m[1]));
   }
@@ -222,7 +240,7 @@ function linkScanSet() {
   return [join(REPO_ROOT, 'CLAUDE.md'), join(REPO_ROOT, 'CONTRIBUTING.md'), ...skillDocs];
 }
 
-test('githubAnchor matches GitHub slugging, including runs of spaces', () => {
+test('githubAnchor matches GitHub slugging, including runs of spaces and non-ASCII', () => {
   // The green-on-awkward-input case. Without it, the collapsing bug that this
   // helper shipped with in draft is invisible: every OTHER assertion here is a
   // true-positive check, and a helper that over-reports passes all of them.
@@ -232,6 +250,10 @@ test('githubAnchor matches GitHub slugging, including runs of spaces', () => {
     githubAnchor('Incidental findings: report, fix, record'),
     'incidental-findings-report-fix-record',
   );
+  // Non-ASCII cases: a leading symbol drops but its trailing space survives
+  // untrimmed (leading hyphen), and a non-ASCII letter is kept, not stripped.
+  assert.equal(githubAnchor('✅ What is solid'), '-what-is-solid');
+  assert.equal(githubAnchor('Café & bar'), 'café--bar');
 });
 
 test('model-routing/SKILL.md no longer carries the moved PR-review sections', () => {
@@ -258,27 +280,49 @@ test('model-routing/SKILL.md no longer carries the moved PR-review sections', ()
   );
 });
 
-test('intra-repo anchor links in the governance docs and skills resolve to real headings', () => {
+test('headingAnchors ignores heading-shaped lines inside fenced code blocks', () => {
+  // pr-review-gate/SKILL.md's PR-comment template (a ```fence around lines
+  // like "### Verdict" / "### 🟡 Minor" / "### ✅ What is solid") is FORMAT to
+  // copy, not a real heading — GitHub does not render it as one, so no real
+  // link can legitimately target it. Without stripFencedBlocks on this
+  // (target) side, those lines register as anchors anyway: the guard fails
+  // open on the very file it ships, exactly as the source side already
+  // strips fences before matching link text.
+  const anchors = headingAnchors(GATE_SKILL_PATH);
+  for (const fake of ['verdict', 'minor', '-what-is-solid', 'blocking-claim', 'significant-claim']) {
+    assert.ok(
+      !anchors.has(fake),
+      `headingAnchors(pr-review-gate/SKILL.md) reports "${fake}" as a real anchor — ` +
+        'it only exists inside the ```fenced PR-comment template',
+    );
+  }
+});
+
+test('intra-repo .md links in the governance docs and skills resolve to real files and headings', () => {
   // CLAUDE.md:716 links model-routing/SKILL.md#mandatory-independent-review-prs.
   // Moving that section breaks the anchor while the existing string-match
   // assertion ("step 10 references pr-review-gate") stays GREEN — the guard
   // would certify the very line it broke. Presence of a word is not integrity
-  // of a link.
+  // of a link. A plain .md link with no `#` gets the same file-existence
+  // check, minus the heading lookup — CONTRIBUTING.md:414-415 link
+  // `superpowers/specs/...` and `features/archive/...` with no `docs/`
+  // prefix, which only a file-existence check (not the old anchor-only regex)
+  // catches, since neither link carries a `#`.
   const broken = [];
   for (const source of linkScanSet()) {
     const text = stripFencedBlocks(readNormalized(source));
-    for (const [, relPath, anchor] of text.matchAll(INTRA_REPO_ANCHOR_LINK)) {
+    for (const [, relPath, anchor] of text.matchAll(INTRA_REPO_MD_LINK)) {
       const target = resolve(dirname(source), relPath);
       if (!existsSync(target)) {
-        broken.push(`${basename(source)} -> ${relPath} (file does not exist)`);
+        broken.push(`${basename(source)} -> ${relPath}${anchor ? '#' + anchor : ''} (file does not exist)`);
         continue;
       }
-      if (!headingAnchors(target).has(anchor.toLowerCase())) {
+      if (anchor && !headingAnchors(target).has(anchor.toLowerCase())) {
         broken.push(`${basename(source)} -> ${relPath}#${anchor} (no such heading)`);
       }
     }
   }
-  assert.deepEqual(broken, [], `dangling intra-repo anchor links:\n  ${broken.join('\n  ')}`);
+  assert.deepEqual(broken, [], `dangling intra-repo .md links:\n  ${broken.join('\n  ')}`);
 });
 
 // The mirror lives OUTSIDE the repo, in the cross-agent store at
@@ -319,4 +363,69 @@ test('the agent-store mirror matches its canonical source, when it exists', () =
       `${rel} has drifted from its canonical copy — run npm run skills:sync`,
     );
   }
+});
+
+test('syncOneFile throws when the CANONICAL SOURCE has a UTF-8 BOM, and writes no mirror', () => {
+  // The BOM check must look at the source, not the written mirror: the
+  // mirror always begins with either '---' (frontmatter) or '<!--' (the
+  // provenance header on a non-frontmatter file), so a BOM landing on the
+  // canonical source would otherwise be silently relocated into the middle
+  // of the mirrored file rather than caught. This never touches the real
+  // $HOME mirror — both paths are fixtures under a throwaway tmpdir.
+  const tmpDir = mkdtempSync(join(tmpdir(), 'skills-sync-bom-'));
+  try {
+    const srcPath = join(tmpDir, 'SKILL.md');
+    const destPath = join(tmpDir, 'mirror', 'SKILL.md');
+    const bom = Buffer.from([0xef, 0xbb, 0xbf]);
+    const body = Buffer.from('---\nname: pr-review-gate\n---\nBody text.\n', 'utf8');
+    writeFileSync(srcPath, Buffer.concat([bom, body]));
+
+    assert.throws(
+      () => syncOneFile(srcPath, destPath, 'SKILL.md'),
+      /has a UTF-8 BOM/,
+      'syncOneFile did not throw for a BOM-poisoned canonical source',
+    );
+    assert.ok(
+      !existsSync(destPath),
+      'a BOM-poisoned canonical source must not produce a mirrored file at all',
+    );
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// buildMirrorContent is a pure function — it needs no filesystem and runs on
+// every machine, unlike the mirror-drift test above which fails open when
+// $HOME has no mirror. These assertions are its only coverage that isn't
+// conditional on that mirror existing.
+test('buildMirrorContent: frontmatter-bearing input keeps frontmatter as the literal first line', () => {
+  const input = '---\nname: pr-review-gate\n---\nBody text.\n';
+  const out = buildMirrorContent(input, 'SKILL.md');
+  assert.ok(out.startsWith('---\n'), `expected output to start with '---\\n', got: ${JSON.stringify(out.slice(0, 20))}`);
+});
+
+test('buildMirrorContent: the header is inserted exactly once, after the frontmatter close', () => {
+  const input = '---\nname: pr-review-gate\n---\nBody text.\n';
+  const out = buildMirrorContent(input, 'SKILL.md');
+  const marker = 'MIRRORED COPY — do not edit here.';
+  const firstIdx = out.indexOf(marker);
+  assert.notEqual(firstIdx, -1, 'header must be present');
+  assert.equal(out.indexOf(marker, firstIdx + 1), -1, 'header must appear exactly once');
+  const frontmatterEnd = out.indexOf('\n---\n', 4) + '\n---\n'.length;
+  assert.ok(firstIdx > frontmatterEnd, 'header must land after the closing frontmatter delimiter, not before/inside it');
+});
+
+test('buildMirrorContent: a non-frontmatter input gets the header at the top', () => {
+  const input = 'Just a plain reference doc, no frontmatter.\n';
+  const out = buildMirrorContent(input, 'references/reviewer-brief.md');
+  assert.ok(out.startsWith('<!-- MIRRORED COPY'), 'header must lead a file with no frontmatter block');
+});
+
+test('buildMirrorContent: the canonical body appears exactly once, not duplicated', () => {
+  const input = '---\nname: pr-review-gate\n---\nUnique body marker XYZZY appears here.\n';
+  const out = buildMirrorContent(input, 'SKILL.md');
+  const marker = 'Unique body marker XYZZY appears here.';
+  const firstIdx = out.indexOf(marker);
+  assert.notEqual(firstIdx, -1, 'canonical body text must be present');
+  assert.equal(out.indexOf(marker, firstIdx + 1), -1, 'canonical body text must not be duplicated');
 });

--- a/scripts/tests/review-gate-mechanism.test.mjs
+++ b/scripts/tests/review-gate-mechanism.test.mjs
@@ -232,6 +232,30 @@ test('githubAnchor matches GitHub slugging, including runs of spaces', () => {
   );
 });
 
+test('model-routing/SKILL.md no longer carries the moved PR-review sections', () => {
+  // The move exists to end a rule living in two places. Without this, a future
+  // edit can paste either section back and both files drift apart silently —
+  // the exact failure the move was meant to fix.
+  const src = readNormalized(ROUTING_SKILL_PATH);
+  assert.doesNotMatch(
+    src,
+    /^## Mandatory independent review \(PRs\)$/m,
+    'model-routing/SKILL.md still carries "## Mandatory independent review (PRs)" — ' +
+      'it moved to pr-review-gate/SKILL.md; two copies will drift',
+  );
+  assert.doesNotMatch(
+    src,
+    /^## PR-gate issue verification$/m,
+    'model-routing/SKILL.md still carries "## PR-gate issue verification" — ' +
+      'it moved to pr-review-gate/SKILL.md; two copies will drift',
+  );
+  assert.match(
+    src,
+    /pr-review-gate/,
+    'model-routing/SKILL.md must keep a pointer to where the PR sections went',
+  );
+});
+
 test('intra-repo anchor links in the governance docs and skills resolve to real headings', () => {
   // CLAUDE.md:716 links model-routing/SKILL.md#mandatory-independent-review-prs.
   // Moving that section breaks the anchor while the existing string-match

--- a/scripts/tests/review-gate-mechanism.test.mjs
+++ b/scripts/tests/review-gate-mechanism.test.mjs
@@ -39,7 +39,9 @@ import assert from 'node:assert/strict';
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { basename, dirname, join, resolve } from 'node:path';
+import { homedir } from 'node:os';
 import { readNormalized } from '../lib/read-normalized.mjs';
+import { buildMirrorContent } from '../sync-agent-skills.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(HERE, '..', '..');
@@ -277,4 +279,44 @@ test('intra-repo anchor links in the governance docs and skills resolve to real 
     }
   }
   assert.deepEqual(broken, [], `dangling intra-repo anchor links:\n  ${broken.join('\n  ')}`);
+});
+
+// The mirror lives OUTSIDE the repo, in the cross-agent store at
+// ~/.agents/skills/. Cline (and five other agents) read only that store —
+// verified 2026-08-13 by asking Cline in this workspace: it listed the 23
+// global skills and answered "pr-review-gate: NO".
+const AGENT_SKILL_STORE = join(homedir(), '.agents', 'skills');
+const MIRRORED_SKILL = 'pr-review-gate';
+
+test('the agent-store mirror matches its canonical source, when it exists', () => {
+  // FAILS OPEN BY CONSTRUCTION, and that is not an oversight. The target is
+  // in $HOME: absent on a fresh clone and in CI. Making this a hard failure
+  // would turn every never-synced machine red. The trade is deliberate — but
+  // it means a GREEN run here proves nothing about a machine that has not
+  // synced, so never report this as "the mirror is in sync".
+  const mirrorRoot = join(AGENT_SKILL_STORE, MIRRORED_SKILL);
+  if (!existsSync(mirrorRoot)) {
+    // Not skipped silently: say why, so a reader of CI output can tell the
+    // difference between "verified" and "not checked".
+    console.log(`[skip] no agent-store mirror at ${mirrorRoot} — run npm run skills:sync`);
+    return;
+  }
+  const canonicalRoot = join(REPO_ROOT, '.claude', 'skills', MIRRORED_SKILL);
+  for (const rel of ['SKILL.md', 'references/reviewer-brief.md', 'references/findings-triage.md']) {
+    const mirrored = join(mirrorRoot, rel);
+    assert.ok(existsSync(mirrored), `mirror is missing ${rel} — run npm run skills:sync`);
+    // Compare the whole mirrored file against what the sync script WOULD write
+    // for the current canonical source. Splitting on the provenance marker and
+    // comparing only the tail was the earlier approach, and it forced the
+    // script to duplicate SKILL.md's frontmatter block so that the tail would
+    // equal the canonical file exactly — a wart in the artifact a reviewing
+    // agent actually reads, to save this test one line. Comparing against the
+    // builder covers the header format as well as the body, and needs no
+    // magic delimiter.
+    assert.equal(
+      readNormalized(mirrored),
+      buildMirrorContent(readNormalized(join(canonicalRoot, rel)), rel),
+      `${rel} has drifted from its canonical copy — run npm run skills:sync`,
+    );
+  }
 });

--- a/scripts/tests/review-gate-mechanism.test.mjs
+++ b/scripts/tests/review-gate-mechanism.test.mjs
@@ -8,12 +8,7 @@
 // Four assertions, each independently falsifiable:
 //   1. .claude/skills/pr-review-gate/SKILL.md exists and does NOT disable
 //      model invocation (the entire point of routing the gate through it).
-//   2. model-routing/SKILL.md's Mechanism bullet actually references
-//      pr-review-gate, rather than silently drifting back to naming
-//      code-review directly.
-//   3. CLAUDE.md's before-shipping step 10 references pr-review-gate too,
-//      so the checklist entry point agrees with the routing spec.
-//   4. pr-review-gate/SKILL.md's frontmatter `name:` matches its directory
+//   2. pr-review-gate/SKILL.md's frontmatter `name:` matches its directory
 //      basename (`pr-review-gate`) — the convention is that the directory is
 //      the skill's identifier and `name:` must agree with it. Assertion 1
 //      above only checks the path exists and reads its frontmatter for
@@ -21,6 +16,15 @@
 //      something else; assertion 1 catches half of the "stays resolvable"
 //      invariant (the path), this assertion catches the other half (the
 //      frontmatter agreeing with it).
+//   3. model-routing/SKILL.md's Mechanism bullet actually references
+//      pr-review-gate, rather than silently drifting back to naming
+//      code-review directly.
+//   4. CLAUDE.md's before-shipping step 10 references pr-review-gate too,
+//      so the checklist entry point agrees with the routing spec.
+//
+//   Assertions are referred to elsewhere BY NAME, never by number — this
+//   header and the test() order disagreed until 2026-08-13, and a plan that
+//   said "retarget assertion 3" was ambiguous between two different tests.
 //
 // Run via `npm run test:hooks` (node --test). All three source files are
 // `extraFiles` on the `test:hooks` step in scripts/verify-cache.mjs — none
@@ -131,4 +135,25 @@ test("CLAUDE.md's before-shipping step 10 references pr-review-gate", () => {
     'before-shipping step 10 no longer references pr-review-gate — the entry ' +
       'point maintainers actually follow must name the model-invocable skill',
   );
+});
+
+test('pr-review-gate/SKILL.md names both reference files, and they exist', () => {
+  // The dispatch prompt points the reviewer at references/reviewer-brief.md BY
+  // PATH. This layout's new failure mode is that path not resolving: the
+  // reviewer is handed no rubric at all and reviews from generic instinct,
+  // silently. Checking existence alone is not enough — a file nobody names is
+  // just as unreachable as one that isn't there.
+  const src = readNormalized(GATE_SKILL_PATH);
+  const skillDir = dirname(GATE_SKILL_PATH);
+  for (const rel of ['references/reviewer-brief.md', 'references/findings-triage.md']) {
+    assert.ok(existsSync(join(skillDir, rel)), `missing ${rel} under ${skillDir}`);
+    const literal = rel.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&');
+    assert.match(
+      src,
+      new RegExp(literal),
+      `pr-review-gate/SKILL.md never names ${rel} — a reviewer would never be ` +
+        `told to read it, so the rubric reaches it only as well as the ` +
+        `dispatching session happens to retype it`,
+    );
+  }
 });

--- a/scripts/tests/review-gate-mechanism.test.mjs
+++ b/scripts/tests/review-gate-mechanism.test.mjs
@@ -442,10 +442,18 @@ test('syncOneFile throws when SKILL.md frontmatter is not the first line, and le
     const preExisting = '---\nname: pr-review-gate\n---\nA previously-good mirror.\n';
     writeFileSync(destPath, preExisting, 'utf8');
 
+    // Pinned to the CANONICAL SOURCE path specifically, not just the message
+    // text: the regex alone matches regardless of which path the error
+    // names, so reverting the srcPath->destPath identifier in
+    // sync-agent-skills.mjs (naming the mirrored destination instead of the
+    // canonical source that is actually malformed) would leave this green.
     assert.throws(
       () => syncOneFile(srcPath, destPath, 'SKILL.md'),
-      /frontmatter is not the first line/,
-      'syncOneFile did not throw for a canonical source missing frontmatter',
+      (err) =>
+        /frontmatter is not the first line/.test(err.message) &&
+        err.message.startsWith(`${srcPath}:`) &&
+        !err.message.includes(destPath),
+      'syncOneFile did not throw naming the canonical source path (srcPath), not the mirrored destination',
     );
     assert.equal(
       readFileSync(destPath, 'utf8'),

--- a/scripts/tests/review-gate-mechanism.test.mjs
+++ b/scripts/tests/review-gate-mechanism.test.mjs
@@ -89,36 +89,31 @@ test("pr-review-gate/SKILL.md's frontmatter name: matches its directory", () => 
   );
 });
 
-test("model-routing/SKILL.md's PR-review Mechanism bullet references pr-review-gate", () => {
-  // readNormalized: the section regex below requires a literal '\n## ',
-  // which misses on a CRLF checkout (#2291).
-  const src = readNormalized(ROUTING_SKILL_PATH);
-  // The file has TWO "- **Mechanism**:" bullets (the spec/plan review's
-  // assumption-checker one, and the PR review's one) — scope to the section
-  // heading first so a naive first-match regex can't silently grab the wrong
-  // one (it did, the first time this test was written: it matched the
-  // assumption-checker bullet and never actually exercised the PR-review
-  // wording this guard exists to check).
-  const sectionMatch = /## Mandatory independent review \(PRs\)\n([\s\S]*?)(?=\n## )/.exec(src);
-  assert.ok(
-    sectionMatch,
-    'could not find the "## Mandatory independent review (PRs)" section in ' +
-      'model-routing/SKILL.md — it may have been renamed or moved',
-  );
-  const mechanismMatch = /- \*\*Mechanism\*\*:[\s\S]*?(?=\n- \*\*[A-Z]|\n## )/.exec(
-    sectionMatch[1],
-  );
-  assert.ok(
-    mechanismMatch,
-    'could not find the "- **Mechanism**:" bullet under "Mandatory independent ' +
-      'review (PRs)" in model-routing/SKILL.md — it may have been reworded or moved',
-  );
+test('pr-review-gate/SKILL.md carries the dispatch mechanism and the effort ladder', () => {
+  // Retargeted 2026-08-13: this assertion used to read model-routing's
+  // "## Mandatory independent review (PRs)" section, which has moved into this
+  // skill. It must read the file that now OWNS the rule, or it certifies a
+  // section that no longer exists.
+  const src = readNormalized(GATE_SKILL_PATH);
+
+  const dispatch = /\n## Dispatch\n([\s\S]*?)(?=\n## )/.exec(src);
+  assert.ok(dispatch, 'pr-review-gate/SKILL.md has no "## Dispatch" section');
   assert.match(
-    mechanismMatch[0],
-    /pr-review-gate/,
-    'the Mechanism bullet no longer references pr-review-gate — the gate it ' +
-      'documents must be the one that is actually model-invocable',
+    dispatch[1],
+    /non-fork/,
+    'the Dispatch section no longer requires a non-fork reviewer — a fork ' +
+      'inherits the dispatching session, which is the opposite of independent review',
   );
+
+  const ladder = /\n## Effort level\n([\s\S]*?)(?=\n## )/.exec(src);
+  assert.ok(ladder, 'pr-review-gate/SKILL.md has no "## Effort level" section');
+  for (const level of ['low', 'medium', 'high']) {
+    assert.match(
+      ladder[1],
+      new RegExp('`' + level + '`'),
+      `the effort ladder no longer names \`${level}\``,
+    );
+  }
 });
 
 test("CLAUDE.md's before-shipping step 10 references pr-review-gate", () => {

--- a/scripts/tests/review-gate-mechanism.test.mjs
+++ b/scripts/tests/review-gate-mechanism.test.mjs
@@ -34,7 +34,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync, existsSync, readdirSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { readFileSync, existsSync, readdirSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { basename, dirname, join, resolve } from 'node:path';
 import { homedir, tmpdir } from 'node:os';
@@ -217,7 +217,14 @@ function headingAnchors(file) {
   // already strips fences before matching) and the TARGET side disagree, and
   // the guard accepts a link that resolves only to a fenced example.
   for (const line of stripFencedBlocks(readNormalized(file)).split('\n')) {
-    const m = /^#{1,6} +(.+?)\s*$/.exec(line);
+    // (?:\s+#+)? strips an optional closed-ATX closing sequence — GitHub
+    // renders `## Foo ##` as heading text "Foo", not "Foo ##". The stripped
+    // run must be whitespace-separated from the content: `## C#` keeps its
+    // trailing `#` (no preceding whitespace before it), only a *space-then-
+    // hashes* run at the line's end is a closing sequence. Latent today (zero
+    // closed-ATX headings in the current scan set) but a plain
+    // `(.+?)\s*$` would silently mis-anchor the first one that appears.
+    const m = /^#{1,6} +(.+?)(?:\s+#+)?\s*$/.exec(line);
     if (m) anchors.add(githubAnchor(m[1]));
   }
   return anchors;
@@ -293,6 +300,30 @@ test('headingAnchors ignores heading-shaped lines inside fenced code blocks', ()
       `headingAnchors(pr-review-gate/SKILL.md) reports "${fake}" as a real anchor — ` +
         'it only exists inside the ```fenced PR-comment template',
     );
+  }
+});
+
+test('headingAnchors strips a closed-ATX heading\'s trailing hashes', () => {
+  // GitHub renders `## Foo ##` (closed-ATX form) as heading text "Foo" — the
+  // trailing ` ##` is a closing sequence, not part of the text. Before the
+  // fix, the capturing regex kept it verbatim ("Foo ##"), which githubAnchor
+  // then slugs to "foo-" (trailing hyphen from the stripped-but-still-spaced
+  // hashes) instead of "foo" — a link to `#foo` would report as dangling
+  // against a heading that visibly renders as "Foo" on GitHub. Zero
+  // occurrences in today's scan set (this is latent, not live), so this unit
+  // assertion is the only thing pinning the regex.
+  const tmpDir = mkdtempSync(join(tmpdir(), 'heading-anchors-closed-atx-'));
+  try {
+    const file = join(tmpDir, 'doc.md');
+    writeFileSync(file, '## Foo ##\n', 'utf8');
+    const anchors = headingAnchors(file);
+    assert.ok(anchors.has('foo'), `expected anchors to contain "foo", got: ${JSON.stringify([...anchors])}`);
+    assert.ok(
+      !anchors.has('foo-'),
+      'closed-ATX trailing hashes leaked into the anchor as "foo-" instead of being stripped to "foo"',
+    );
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
@@ -386,6 +417,40 @@ test('syncOneFile throws when the CANONICAL SOURCE has a UTF-8 BOM, and writes n
     assert.ok(
       !existsSync(destPath),
       'a BOM-poisoned canonical source must not produce a mirrored file at all',
+    );
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('syncOneFile throws when SKILL.md frontmatter is not the first line, and leaves a pre-existing mirror untouched', () => {
+  // The frontmatter check must run BEFORE the write, like the BOM check
+  // above: it inspects `mirrored`, which already exists before writeFileSync
+  // is called, so nothing blocks hoisting it. Before the fix, the write ran
+  // first — a malformed canonical source clobbered a previously-GOOD mirror
+  // with an unusable one, and only then threw. This never touches the real
+  // $HOME mirror — both paths are fixtures under a throwaway tmpdir.
+  const tmpDir = mkdtempSync(join(tmpdir(), 'skills-sync-frontmatter-'));
+  try {
+    const srcPath = join(tmpDir, 'SKILL.md');
+    const destPath = join(tmpDir, 'mirror', 'SKILL.md');
+    // No leading '---\n': buildMirrorContent falls through to its
+    // no-frontmatter branch (header + body), so the mirrored output starts
+    // with '<!--', not '---\n' — the malformed-canonical-source case.
+    writeFileSync(srcPath, 'Just body text, no frontmatter block.\n', 'utf8');
+    mkdirSync(dirname(destPath), { recursive: true });
+    const preExisting = '---\nname: pr-review-gate\n---\nA previously-good mirror.\n';
+    writeFileSync(destPath, preExisting, 'utf8');
+
+    assert.throws(
+      () => syncOneFile(srcPath, destPath, 'SKILL.md'),
+      /frontmatter is not the first line/,
+      'syncOneFile did not throw for a canonical source missing frontmatter',
+    );
+    assert.equal(
+      readFileSync(destPath, 'utf8'),
+      preExisting,
+      'a malformed canonical source must not clobber a pre-existing good mirror',
     );
   } finally {
     rmSync(tmpDir, { recursive: true, force: true });

--- a/scripts/tests/review-gate-mechanism.test.mjs
+++ b/scripts/tests/review-gate-mechanism.test.mjs
@@ -36,9 +36,9 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { basename, dirname, join } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
 import { readNormalized } from '../lib/read-normalized.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -151,4 +151,106 @@ test('pr-review-gate/SKILL.md names both reference files, and they exist', () =>
         `dispatching session happens to retype it`,
     );
   }
+});
+
+// Markdown links of the form ](some/relative/path.md#anchor) — http(s) links
+// are skipped, and so are bare #anchor links (no file part to resolve).
+const INTRA_REPO_ANCHOR_LINK = /\]\((?!https?:)([^)#\s]+\.md)#([^)\s]+)\)/g;
+
+/**
+ * GitHub's heading-anchor slug: strip backticks, lowercase, drop everything
+ * that is not a word char / space / hyphen, trim the ends, then replace each
+ * REMAINING SPACE WITH ONE HYPHEN.
+ *
+ * The one-for-one replacement is the whole subtlety, and an earlier draft of
+ * this helper got it wrong with `.replace(/ +/g, '-')`. GitHub does not
+ * collapse runs of spaces: `### Scope discipline > merge magic` drops the `>`
+ * and leaves TWO spaces, which slug to the DOUBLE hyphen in
+ * CONTRIBUTING.md#scope-discipline--merge-magic. A collapsing version reports
+ * that correct, live link as broken — a guard that fails on valid input, which
+ * is worse than no guard: it trains its reader to "fix" correct documents.
+ * The unit test below pins exactly that case GREEN.
+ */
+function githubAnchor(heading) {
+  return heading
+    .replace(/`/g, '')
+    .toLowerCase()
+    .replace(/[^\w\- ]+/g, '')
+    .replace(/^ +| +$/g, '')
+    .replace(/ /g, '-');
+}
+
+/** Blank out fenced code blocks — a ```js sample containing a markdown-link
+ *  literal is not a link. Measured: without this, scanning this repo's own
+ *  plan docs reports their example snippets as dangling. */
+function stripFencedBlocks(text) {
+  const out = [];
+  let inFence = false;
+  for (const line of text.split('\n')) {
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    out.push(inFence ? '' : line);
+  }
+  return out.join('\n');
+}
+
+function headingAnchors(file) {
+  const anchors = new Set();
+  for (const line of readNormalized(file).split('\n')) {
+    const m = /^#{1,6} +(.+?)\s*$/.exec(line);
+    if (m) anchors.add(githubAnchor(m[1]));
+  }
+  return anchors;
+}
+
+/** The scan set is DERIVED, not hand-listed: the two root governance docs plus
+ *  every markdown file under .claude/skills/**. A hand-list would reproduce the
+ *  enumeration trap Task 4 exists to close — the next skill doc added would be
+ *  unprotected for exactly the same reason the three extraFiles literals were.
+ *  Historical plan docs under docs/ are deliberately OUT of scope: measured
+ *  2026-08-13, they carry 15 pre-existing dangling links (relative paths
+ *  written as if from the repo root), none of which this work touches. */
+function linkScanSet() {
+  const skillsRoot = join(REPO_ROOT, '.claude', 'skills');
+  const skillDocs = readdirSync(skillsRoot, { recursive: true, withFileTypes: true })
+    .filter((d) => d.isFile() && d.name.endsWith('.md'))
+    .map((d) => join(d.parentPath ?? d.path, d.name));
+  return [join(REPO_ROOT, 'CLAUDE.md'), join(REPO_ROOT, 'CONTRIBUTING.md'), ...skillDocs];
+}
+
+test('githubAnchor matches GitHub slugging, including runs of spaces', () => {
+  // The green-on-awkward-input case. Without it, the collapsing bug that this
+  // helper shipped with in draft is invisible: every OTHER assertion here is a
+  // true-positive check, and a helper that over-reports passes all of them.
+  assert.equal(githubAnchor('Scope discipline > merge magic'), 'scope-discipline--merge-magic');
+  assert.equal(githubAnchor('Mandatory independent review (PRs)'), 'mandatory-independent-review-prs');
+  assert.equal(
+    githubAnchor('Incidental findings: report, fix, record'),
+    'incidental-findings-report-fix-record',
+  );
+});
+
+test('intra-repo anchor links in the governance docs and skills resolve to real headings', () => {
+  // CLAUDE.md:716 links model-routing/SKILL.md#mandatory-independent-review-prs.
+  // Moving that section breaks the anchor while the existing string-match
+  // assertion ("step 10 references pr-review-gate") stays GREEN — the guard
+  // would certify the very line it broke. Presence of a word is not integrity
+  // of a link.
+  const broken = [];
+  for (const source of linkScanSet()) {
+    const text = stripFencedBlocks(readNormalized(source));
+    for (const [, relPath, anchor] of text.matchAll(INTRA_REPO_ANCHOR_LINK)) {
+      const target = resolve(dirname(source), relPath);
+      if (!existsSync(target)) {
+        broken.push(`${basename(source)} -> ${relPath} (file does not exist)`);
+        continue;
+      }
+      if (!headingAnchors(target).has(anchor.toLowerCase())) {
+        broken.push(`${basename(source)} -> ${relPath}#${anchor} (no such heading)`);
+      }
+    }
+  }
+  assert.deepEqual(broken, [], `dangling intra-repo anchor links:\n  ${broken.join('\n  ')}`);
 });

--- a/scripts/tests/verify-cache.test.mjs
+++ b/scripts/tests/verify-cache.test.mjs
@@ -444,6 +444,21 @@ test('stepTouchedByDiff: a hook-script diff matches test:hooks via extraFiles', 
   assert.equal(stepTouchedByDiff(stepByName['test:hooks'], diff), true);
 });
 
+test('stepTouchedByDiff: a pr-review-gate reference-file diff is in scope for test:hooks', () => {
+  // The three .claude/skills literals this replaced could not see a file that
+  // did not exist when they were written — defect shape "a guard that
+  // enumerates loses one spelling per round". A reference file added later
+  // would print test:hooks [cached] and leave review-gate-mechanism.test.mjs
+  // stale-green on exactly the diff that breaks it.
+  const diff = ['.claude/skills/pr-review-gate/references/reviewer-brief.md'];
+  assert.equal(stepTouchedByDiff(stepByName['test:hooks'], diff), true);
+});
+
+test('stepTouchedByDiff: a brand-new skill file is in scope for test:hooks', () => {
+  const diff = ['.claude/skills/pr-review-gate/references/some-future-file.md'];
+  assert.equal(stepTouchedByDiff(stepByName['test:hooks'], diff), true);
+});
+
 // PR #2007 review, Minor 9 — bump-version.test.mjs mirrors bump-version.mjs's
 // TEXT into a throwaway repo at RUNTIME (no module-graph edge), the same
 // #1847 trap release-notes-gate.mjs's own extraFiles entry already guards

--- a/scripts/verify-cache.mjs
+++ b/scripts/verify-cache.mjs
@@ -143,6 +143,14 @@ export const STEPS = [
            it does not read the file from disk (plan review round 2 named
            the wrong file/mechanism; M1, #2146 review). */
         '.husky/**',
+        /* .claude/skills/** is an input because review-gate-mechanism.test.mjs
+           reads those files as TEXT at RUNTIME. This was three literal paths
+           until 2026-08-13; a literal list cannot see a file that does not
+           exist yet, so every reference file added later would have needed
+           hand-registering here or its diff would print test:hooks [cached]
+           and leave the guard stale-green. Same #1847 trap as fixtures/**
+           above, with the enumeration failure mode on top. */
+        '.claude/skills/**',
       ],
       /* preflight-ffmpeg.cjs is an input because ffmpeg-version.test.mjs
          requires it — a diff that breaks the parser must run its own test.
@@ -234,19 +242,19 @@ export const STEPS = [
         // so the structural test never ran on the one diff shape it exists
         // to catch.
         'server/madge-cycles-allowlist.json',
-        // ops-55 (#2241): review-gate-mechanism.test.mjs reads all three of
-        // these as TEXT at RUNTIME (frontmatter + prose regex, not a
-        // module-graph edge) to assert the mandated PR-review-gate mechanism
-        // stays model-invocable and cross-referenced. None sits under this
-        // step's own globs above (.claude/skills/** and root CLAUDE.md are
-        // both outside scripts/**, pinokio-scripts/**, .github/**, .husky/**)
-        // — without these entries, a diff touching only .claude/skills/** or
-        // CLAUDE.md prints test:hooks [cached] locally and (ci-scope.mjs
-        // derives its scope from this same STEPS[] entry) skips the guard's
-        // CI leg too, on exactly the diff shape that would break it. Same
-        // #1847 runtime-read trap as fixtures/** above.
-        '.claude/skills/pr-review-gate/SKILL.md',
-        '.claude/skills/model-routing/SKILL.md',
+        // ops-55 (#2241): review-gate-mechanism.test.mjs reads CLAUDE.md as
+        // TEXT at RUNTIME (frontmatter + prose regex, not a module-graph
+        // edge) to assert the mandated PR-review-gate mechanism stays
+        // model-invocable and cross-referenced. CLAUDE.md sits at the repo
+        // root, outside this step's own globs above (scripts/**,
+        // pinokio-scripts/**, .github/**, .husky/**, .claude/skills/**) — so
+        // without this entry a CLAUDE.md-only diff prints test:hooks
+        // [cached] locally and (ci-scope.mjs derives its scope from this
+        // same STEPS[] entry) skips the guard's CI leg too, on exactly the
+        // diff shape that would break it. Same #1847 runtime-read trap as
+        // fixtures/** above. The equivalent reads under .claude/skills/**
+        // are covered by that tree's own glob above (2026-08-13) instead of
+        // being listed here as literals — see that glob's comment.
         'CLAUDE.md',
       ],
       includeLockfiles: ['root'],


### PR DESCRIPTION
## Summary

`.claude/skills/pr-review-gate/` said only *how to dispatch a reviewer*. It is now the single home for this repo's PR review process — the runbook, the rubric, the triage rules, and a durable per-pass record on the PR itself.

- **`SKILL.md`** — the shipping session's runbook: preconditions, docs-only exemption, effort ladder, dispatch, the pass comment, triage, re-review loop, issue verification. For gates CLAUDE.md already owns it *names and links* them rather than restating — a second copy of a rule is a rule that drifts.
- **`references/reviewer-brief.md`** — the rubric, read by the reviewer **by path** so it arrives verbatim: this repo's bookkeeping gates, plus ~10 recurring defect shapes each stated as *how it hides*.
- **`references/findings-triage.md`** — the fix-now bar, the defect/chore/taste seam, the void deferral reasons, the design-pass carve-out.
- **`model-routing/SKILL.md`** loses the two PR sections and keeps routing.

Two design decisions worth flagging for the reviewer:

**The reviewer posts its own comment.** An earlier draft had the shipping session relay it, justified by the reviewer having "no write access" — that justification was false. The `Agent` tool has no per-dispatch tool restriction, and even `Explore` keeps `Bash`. Routing the report through the session bought nothing but an unverified relay operated by the one party with a motive to soften findings. The reviewer's boundary is now stated as what it is — *modifies no tracked file* — and made checkable: the session diffs `git rev-parse HEAD` + `git status --porcelain` before and after, and any delta is a gate failure.

**The mirror guard fails open, deliberately.** Cline reads only `~/.agents/skills/`, outside the repo, so the drift guard skips when that path is absent (fresh clone, CI). That is defect shape #1 in this PR's own rubric; it is unavoidable here rather than accidental, it prints a visible skip line, and a green run must never be reported as "the mirror is in sync."

## Test plan

- [x] `npm run test:hooks` — 1372/1372
- [x] Every new assertion mutation-verified in both directions, including the anchor helper restored to its buggy form to confirm it goes red
- [x] Content-fidelity diff of the moved effort ladder against `origin/main`: `low`/`medium`/`high` criteria, multi-scope rule, mixed-type rule, `ultra` opt-in rule and docs-only file-set test all unchanged; the issue-verification section is byte-for-byte identical
- [x] `npm run skills:sync` → Cline lists `pr-review-gate`
- [ ] Reviewer: the fail-open mirror guard is the one place this PR knowingly accepts a weaker check — confirm the reasoning holds

**Release notes: not applicable** — process/tooling, no user- or operator-visible delta.
**On-box acceptance: not applicable** — no hardware-provable behaviour.
**Not docs-only** — touches `scripts/**`, so `verify.yml` runs in full and this gate applies to itself.

## Also fixed, found in passing

- **`.gitignore` blanket-ignored `.claude/`** — the two new reference files were invisible to `git add`, which skips ignored paths *silently*. The commit would have carried the guard asserting the files exist and not the files, passing locally and failing in CI. Fixed with `.claude/*` + `!.claude/skills/` rather than `git add -f`, which would re-arm the trap for every future file.
- **`CLAUDE.md:716`'s anchor died with the moved section** — and the existing guard, which only string-matches `pr-review-gate` on that line, would have stayed green while the link 404'd. A new link-integrity assertion now catches it. A mechanical sweep found **four** such links where a read had found one.
- **`CLAUDE.md:301-306`** pointed at model-routing for a ladder that no longer lives there.
- **`extraFiles` enumerated three literal paths** — a list that cannot see a file that does not exist yet. Replaced with a `.claude/skills/**` glob.
- **The guard file's header comment numbered its assertions in a different order than the tests appear**, making "assertion 3" ambiguous between two different tests.
- **The sync script duplicated `SKILL.md`'s frontmatter** into the mirrored copy purely so the guard could split on a marker — a repeated metadata block in the file a reviewing agent reads, to save the test one line.

Closes #2338
