### PR TITLE
fix(frontend): surface model-manager Load/Stop failures (#2349)

### DIFF
--- a/src/views/model-manager.test.tsx
+++ b/src/views/model-manager.test.tsx
@@ -10,6 +10,7 @@ import { accountSlice, type AccountState } from '../store/account-slice';
 import { uiSlice } from '../store/ui-slice';
 import { settingsSlice } from '../store/settings-slice';
 import { upgradeSlice } from '../store/upgrade-slice';
+import { notificationsSlice } from '../store/notifications-slice';
 import { ModelManagerView } from './model-manager';
 import { api, type ModelControlResult, type ModelInventoryResponse } from '../lib/api';
 import type { UserSettings } from '../lib/types';
@@ -179,6 +180,7 @@ function renderManager(initial: Partial<UserSettings> = {}) {
       ui: uiSlice.reducer,
       settings: settingsSlice.reducer,
       upgrade: upgradeSlice.reducer,
+      notifications: notificationsSlice.reducer,
     },
     preloadedState: { account: preloaded },
   });
@@ -398,6 +400,71 @@ describe('ModelManagerView — qwen-base17 row', () => {
     const qwen = await screen.findByTestId('model-row-qwen-base');
     within(qwen).getByRole('button', { name: /load model/i }).click();
     await waitFor(() => expect(mockLoad).toHaveBeenCalledWith({ engine: 'qwen' }));
+  });
+});
+
+describe('ModelManagerView — load/stop failure surfacing (#2349)', () => {
+  const QWEN_BASE17_ITEM = {
+    id: 'qwen-base17' as const,
+    kind: 'tts' as const,
+    label: 'Qwen3-TTS Base (1.7B)',
+    present: true,
+    sizeBytes: 2_000_000_000,
+    diskPath: 'hub/models--Qwen--Qwen3-TTS-12Hz-1.7B-Base',
+    loaded: false,
+    installState: 'ready' as const,
+    isDefaultEngine: false,
+    isFallbackEngine: false,
+    removable: true,
+    updatable: true,
+  };
+
+  beforeEach(() => {
+    mockInventory.mockResolvedValue({
+      ...INVENTORY,
+      items: [...INVENTORY.items, QWEN_BASE17_ITEM],
+    });
+  });
+
+  it('surfaces a status:"error" result from a Load as an error toast', async () => {
+    vi.mocked(api.loadSidecar).mockResolvedValue({ status: 'error', error: 'OOM on GPU' });
+    const { store } = renderManager();
+    const row = await screen.findByTestId('model-row-qwen-base17');
+    within(row).getByRole('button', { name: /load model/i }).click();
+
+    await waitFor(() => expect(api.loadSidecar).toHaveBeenCalledWith({ engine: 'qwen', model: '1.7b' }));
+    await waitFor(() =>
+      expect(store.getState().notifications.toasts.some((t) => t.message.includes('OOM on GPU'))).toBe(true),
+    );
+  });
+
+  it('surfaces a thrown (network) failure from a Stop as an error toast', async () => {
+    vi.mocked(api.unloadSidecar).mockRejectedValue(new Error('sidecar went away'));
+    mockInventory.mockResolvedValue({
+      ...INVENTORY,
+      items: [...INVENTORY.items, { ...QWEN_BASE17_ITEM, loaded: true }],
+    });
+    const { store } = renderManager();
+    const row = await screen.findByTestId('model-row-qwen-base17');
+    within(row).getByRole('button', { name: /stop/i }).click();
+
+    await waitFor(() => expect(api.unloadSidecar).toHaveBeenCalledWith({ engine: 'qwen', model: '1.7b' }));
+    await waitFor(() =>
+      expect(store.getState().notifications.toasts.some((t) => t.message.includes('sidecar went away'))).toBe(true),
+    );
+  });
+
+  it('a failed Load does not trigger a refetch (nothing changed on disk/VRAM)', async () => {
+    vi.mocked(api.loadSidecar).mockResolvedValue({ status: 'error', error: 'OOM' });
+    const callsBefore = vi.mocked(api.getModelInventory).mock.calls.length;
+    renderManager();
+    const row = await screen.findByTestId('model-row-qwen-base17');
+    within(row).getByRole('button', { name: /load model/i }).click();
+
+    await waitFor(() => expect(api.loadSidecar).toHaveBeenCalled());
+    /* The initial-mount fetch already happened before the click; a failed action
+       must NOT add another inventory poll. */
+    expect(vi.mocked(api.getModelInventory).mock.calls.length).toBe(callsBefore + 1);
   });
 });
 

--- a/src/views/model-manager.test.tsx
+++ b/src/views/model-manager.test.tsx
@@ -450,7 +450,13 @@ describe('ModelManagerView — load/stop failure surfacing (#2349)', () => {
 
     await waitFor(() => expect(api.unloadSidecar).toHaveBeenCalledWith({ engine: 'qwen', model: '1.7b' }));
     await waitFor(() =>
-      expect(store.getState().notifications.toasts.some((t) => t.message.includes('sidecar went away'))).toBe(true),
+      expect(
+        store
+          .getState()
+          .notifications.toasts.some(
+            (t) => t.message.includes('sidecar went away') && t.message.includes(`Stop ${QWEN_BASE17_ITEM.label} failed:`),
+          ),
+      ).toBe(true),
     );
   });
 

--- a/src/views/model-manager.tsx
+++ b/src/views/model-manager.tsx
@@ -13,6 +13,7 @@ import { DevicePanel } from '../components/device-panel';
 import { useAppDispatch, useAppSelector } from '../store';
 import { uiActions } from '../store/ui-slice';
 import { saveAccountSettings } from '../store/account-slice';
+import { notificationsActions } from '../store/notifications-slice';
 import {
   ModelControlPill,
   type ModelControlState,
@@ -21,6 +22,7 @@ import {
 import {
   api,
   type EngineHealthState,
+  type ModelControlResult,
   type ModelInventoryItem,
   type ModelInventoryResponse,
   type ModelsStatus,
@@ -154,6 +156,7 @@ export function ModelManagerView() {
 }
 
 function ModelInventory({ keepAliveMap }: { keepAliveMap: Record<string, number> }) {
+  const dispatch = useAppDispatch();
   const [inv, setInv] = useState<ModelInventoryResponse | null>(null);
   const [modelsStatus, setModelsStatus] = useState<ModelsStatus | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -250,9 +253,34 @@ function ModelInventory({ keepAliveMap }: { keepAliveMap: Record<string, number>
           busyKind: busyAction?.id === item.id ? busyAction.kind : null,
           onAction: async (action: () => Promise<unknown>, kind: 'load' | 'stop') => {
             setBusyAction({ id: item.id, kind });
+            const verb = kind === 'load' ? 'Load' : 'Stop';
             try {
-              await action();
+              /* #2349 — a background Load/Stop that fails must surface *somewhere*.
+                 Previously this shared handler (used by EVERY row — TTS + analyzer
+                 + ASR, and both the load and stop pills) ran `await action()`
+                 inside try/finally and ignored the result, so a `status:'error'`
+                 body or a thrown fetch error was silently swallowed and the pill
+                 just flipped back with zero indication. Since every pill funnels
+                 here, surfacing in this one place is systemic coverage for all of
+                 them (this is intentionally NOT a per-call-site patch). */
+              const result = (await action()) as ModelControlResult | undefined;
+              if (result?.status === 'error') {
+                dispatch(
+                  notificationsActions.pushToast({
+                    kind: 'error',
+                    message: result.error || `${verb} ${item.label} failed`,
+                  }),
+                );
+                return; // nothing changed on disk/VRAM — don't refetch
+              }
               await refetch();
+            } catch (e) {
+              dispatch(
+                notificationsActions.pushToast({
+                  kind: 'error',
+                  message: e instanceof Error ? e.message : `${verb} ${item.label} failed`,
+                }),
+              );
             } finally {
               setBusyAction(null);
             }

--- a/src/views/model-manager.tsx
+++ b/src/views/model-manager.tsx
@@ -271,14 +271,18 @@ function ModelInventory({ keepAliveMap }: { keepAliveMap: Record<string, number>
                     message: result.error || `${verb} ${item.label} failed`,
                   }),
                 );
-                return; // nothing changed on disk/VRAM — don't refetch
+                return; // assume nothing changed on disk/VRAM — don't refetch
               }
               await refetch();
             } catch (e) {
               dispatch(
                 notificationsActions.pushToast({
                   kind: 'error',
-                  message: e instanceof Error ? e.message : `${verb} ${item.label} failed`,
+                  /* Prefix a transport-level (thrown) failure with the op + model so
+                     the toast isn't an ambiguous bare "Failed to fetch". */
+                  message: e instanceof Error
+                    ? `${verb} ${item.label} failed: ${e.message}`
+                    : `${verb} ${item.label} failed`,
                 }),
               );
             } finally {


### PR DESCRIPTION
﻿## Summary

The Model Manager's background Load/Stop actions swallowed every failure silently. The shared `onAction` handler ran the sidecar/ollama load/unload inside try/finally and ignored the returned `ModelControlResult`, so a `status:'error'` body or a thrown fetch error flipped the pill back with zero user-visible indication. Because every row (TTS voice engines, analyzer/Ollama rows, ASR) and both Load and Stop pills funnel through that one handler, this was systemic — not a single-line spot fix.

This surfaces failures through the app's global toast surface (`notificationsActions.pushToast` → `<ToastStack>`): the handler now inspects `action()`'s result and toasts the server's `error` text (or a `{Load|Stop} <label> failed` fallback), and catches the thrown-network path that the previous `finally` otherwise papered over. A failed action no longer triggers a pointless inventory refetch.

Closes #2349

## Test plan

- [x] Pre-commit `verify:fast:scoped` — frontend suite green (335 files / 4776 tests), `test:server` skipped as out-of-scope
- [x] Pre-push / `verify:fast:branch` — lint, typecheck, build all pass; remaining steps scope-skipped; re-run fully cached
- [x] Transient warnings ("Selector unknown…") are pre-existing (baseline emits 51), not introduced by this change
