### PR TITLE
docs(docs): point the D13 re-gate verdict at its decision issue

### DIFF
--- a/docs/superpowers/plans/2026-08-13-attribution-collapse-visibility-wave1.md
+++ b/docs/superpowers/plans/2026-08-13-attribution-collapse-visibility-wave1.md
@@ -963,8 +963,9 @@ merge; filled 2026-08-14 alongside the D13 re-gate.
 re-gate this wave was required to run has now run, and its verdict is *drop
 the `drifted` state* — see spec §D13 re-gated → *Re-gate outcome* and
 [the run sheet §5](../../testing/attribution-collapse-visibility-onbox-acceptance.md).
-That is an owner confirmation, not a settled fact, so this plan stays out of
-`archive/` until Wave 2's surface is decided.
+That is an owner confirmation, not a settled fact — tracked as
+[#2357](https://github.com/dudarenok-maker/Castwright/issues/2357) — so this
+plan stays out of `archive/` until Wave 2's surface is decided.
 
 **Acceptance still owed** (register row E11, which stays open): the
 dash-stripped re-run invariance check, and re-analysing one book post-D18 to

--- a/docs/superpowers/specs/2026-08-06-attribution-collapse-visibility-design.md
+++ b/docs/superpowers/specs/2026-08-06-attribution-collapse-visibility-design.md
@@ -1572,7 +1572,10 @@ be cleared. This section's own bar — *"if the bimodality does not survive the
 re-basing, D13 is dropped rather than shipped with a threshold picked off a
 book"* — is therefore met on the drop side.
 
-**Owner confirmation owed — this fires §Open questions' question-2 caveat**
+**Owner confirmation owed — tracked as
+[#2357](https://github.com/dudarenok-maker/Castwright/issues/2357), which
+carries the options and this evidence in decision form. It fires §Open
+questions' question-2 caveat**
 (*"Wave 1 must re-measure D13 under the current unit; if the gap does not
 survive, D13 is dropped despite this answer"*), rather than opening a new
 question. It is a confirmation and not an automatic application because the
@@ -2979,7 +2982,10 @@ if the gap does not survive, D13 is dropped despite this answer.
 > agreed the conditional here — but the condition's evaluation is not the
 > clean yes/no it was written for (the gap *did* survive; only its
 > non-fixture half did not), so it is worth confirming rather than applying
-> silently. Question 2's banner-scope answer is not reopened: if D13 goes,
+> silently. **The decision is tracked as
+> [#2357](https://github.com/dudarenok-maker/Castwright/issues/2357)** —
+> #1984 itself closed when Wave 1 shipped, so it is not the home for this.
+> Question 2's banner-scope answer is not reopened: if D13 goes,
 > the cache-sourced banner tier goes with it and `alsoCollapsed`, the fifth
 > library state and `attributionVerdictKey` are not built.
 

--- a/docs/testing/attribution-collapse-visibility-onbox-acceptance.md
+++ b/docs/testing/attribution-collapse-visibility-onbox-acceptance.md
@@ -308,8 +308,9 @@ surfaced on its first real run. The finding is about the fifth *state*, not
 the column.
 
 **This is an owner decision, and it is recorded in the spec** (§D13 re-gated
-→ *Re-gate outcome*) rather than settled here. The options and the
-recommendation live there.
+→ *Re-gate outcome*) and tracked as
+[#2357](https://github.com/dudarenok-maker/Castwright/issues/2357) rather
+than settled here. The options and the recommendation live in both.
 
 ### 5f · Reproducing this
 


### PR DESCRIPTION
## Summary

Follow-up to #2356. That PR recorded the D13 re-gate's verdict as *"owner confirmation owed"* but had no ticket to confirm on — **#1984 closed when Wave 1 shipped**, so it is not the home for a Wave 2 decision.

Filed #2357 (the options, the evidence, and the acceptance in decision form) and linked it from all three places that name the decision:

- the spec's `§D13 re-gated → Re-gate outcome` **and** its `§Open questions` question-2 caveat;
- the run sheet's §5e verdict;
- the Wave 1 plan's Ship notes, which explain why the plan is deliberately unarchived.

Traceability only — no measurement, no verdict, and no number changes.

## Test plan

Docs-only; no paired test owed. Neither the register nor the live view is touched, so the owed total stays **72** and no republish is needed.

Refs #2357