### PR TITLE
chore: add AGENTS.md and .clinerules for Cline compatibility

### DIFF
--- a/.clinerules/cline.md
+++ b/.clinerules/cline.md
@@ -1,57 +1,124 @@
 # Cline project rules (Castwright / Audiobook-Generator)
 
-Loaded by Cline each session. The full project context is in the root
-`CLAUDE.md` (Cline reads it too) -- these are Cline-specific operational
-prefs layered on top. Keep this minimal; move anything of general value into
-`CLAUDE.md` instead.
+Loaded by Cline each session. The canonical context is the root `CLAUDE.md`
+and `CONTRIBUTING.md` -- Cline reads both, so nothing here restates them. This
+file carries only two kinds of rule: ones that are **Cline-specific**, and ones
+that are **costly if missed** and easy to lose in 140 KB of prose. Keep it that
+way -- anything of general value belongs in `CLAUDE.md` instead.
 
-## Commits (Conventional Commits, enforced by hooks)
-- Subject format: `<type>(<scope>): <subject>`.
-  - Types: `feat | fix | refactor | perf | test | docs | build | ci | chore`
-  - Scopes (required except for `chore`): `frontend | server | sidecar | app |
-    scripts | e2e | mocks | openapi | docs | deps | ci | ops`
-  - Subject <= 100 chars. Breaking change = `!` before the colon
-    (e.g. `feat(server)!: drop legacy field`).
-  - Multi-line commit bodies end with a `Co-Authored-By:` trailer naming the
-    agent (e.g. `Co-Authored-By: Cline <...>`).
-- The `commit-msg` hook rejects malformed subjects; `pre-push` re-checks them,
-  refuses force-push/deletion of `main`, and runs `verify:fast:branch`.
+## Cline-specific
 
-## Verify before commit / push
-- `pre-commit` runs `npm run verify:fast:scoped` (scoped to STAGED files). Run
-  it before staging so hooks pass on the first try.
-- The fast local gate before pushing is `npm run verify:fast:branch`.
-- Never bypass hooks with `--no-verify` for dev work -- it is reserved for
-  CI-generated commits only (e.g. `.github/workflows/regen-visual-baselines.yml`).
-- Cloud `verify.yml` is a required status check on `main` -- the real gate.
+- **Skills resolve from `~/.agents/skills/` only.** Cline does not read a
+  workspace `.claude/skills/` (probed 2026-08-13,
+  `docs/testing/agent-skill-resolution-probe.md`). Re-run `npm run skills:sync`
+  after any change under `.claude/skills/pr-review-gate/`. It is a per-machine
+  step: the target is under `$HOME`, so CI cannot run it and a fresh clone has
+  no mirror.
+- **Model tiers are not selectable.** Subagents run on the configured session
+  model, so CLAUDE.md's "Model routing" table (Haiku / Sonnet / Opus / Fable)
+  and its `.claude/worktrees` + `claude/wt-*` branch choreography are
+  Claude-Code mechanics I cannot reproduce verbatim. Follow the INTENT -- fresh
+  cold subagents per task, per-task review, review-gated ships -- and where a
+  tier choice would genuinely change the outcome, say so and hand the decision
+  to the user.
+- **This is a Windows box running PowerShell 5.1.** No `&&` / `||` chaining
+  (use `;` or `if ($?) { ... }`), no ternary / `??` / `?.`. `head`, `tail`,
+  `which`, and `touch` do not exist -- use `Get-Content -TotalCount N` /
+  `-Tail N` and `(Get-Command x).Source`. A here-string's closing `'@` must sit
+  at column 0, and an em dash inside a `.ps1` is a parse terminator.
 
-## Testing discipline (required, per CLAUDE.md)
-- New behaviour ships a paired automated test. Bug fixes ship a regression test
-  that fails before the fix and passes after. Never delete or `.skip` a test
-  without an explicit replacement. UI cross-seam changes should land an e2e test.
+## Never do these
 
-## Execution model (sub-agent delivery — CLAUDE.md doctrine)
-- All NON-TRIVIAL work is sub-agent-executed: the main thread coordinates,
-  curates context, and judges; it does NOT produce hand-written task code.
-  Only work clearing CLAUDE.md's trivial bar (nothing can break, nothing needs
-  review) stays inline, plus validation (which is the main thread's job).
-- Dispatch FRESH cold subagents per task (spawn_agent / team tools), briefed
-  from the ticket/plan doc as the sole source of requirements — not forks that
-  inherit session context.
-- Per task: an implementer subagent, then a task-review subagent (spec + quality).
-- Non-trivial specs/plans get an adversarial `assumption-checker` pass before
-  the user approves; present its actual tagged output, not a paraphrase.
-- Ship through the `pr-review-gate` / code-review pass; the PR needs
-  `Closes #NN` / `Refs #NN`.
-- CAPABILITY NOTE (honest, Cline-specific): Cline cannot select model tiers for
-  subagents — they run on the configured session model. The repo's
-  Haiku/Sonnet/Opus/`Fable` routing table (CLAUDE.md "Model routing") and its
-  `.claude/worktrees` + `claude/wt-*` branch choreography are Claude-Code
-  mechanics I can't reproduce verbatim. I follow the INTENT (fresh subagent
-  execution + per-task review + review-gated ships), not those letter-level
-  mechanics. Where tier choice would matter, say so and hand the decision to
-  the user.
+- **Never commit to `main`.** Every change -- including a one-line doc fix --
+  reaches `main` through a branch and a PR; `main`'s required status checks
+  reject anything else. Branches are `<type>/<scope>-<slug>`.
+- **Never hand-edit a generated file:** `src/lib/api-types.ts` (regenerate via
+  `npm run openapi:types`), `docs/BACKLOG.md` (`npm run backlog:sync`),
+  `server/.env.example` (`npm run config:sync`).
+- **Never bypass a hook with `--no-verify`.** Triage instead: caused by my
+  change -> fix it in the same commit; pre-existing (the same test fails on
+  `main`) -> surface it to the user and do NOT fold the fix in; suspected flake
+  -> re-run that test alone once and name it. `--no-verify` is reserved for
+  CI-generated commits (`.github/workflows/regen-visual-baselines.yml`).
+- **Never treat hook output in a fresh worktree as proof of verification** --
+  see the first trap below.
+
+## Traps that fail silently
+
+- **A fresh worktree's git hooks do nothing, and say nothing.**
+  `core.hooksPath` is inherited but resolves per-worktree, and `.husky/_` is
+  git-ignored, so a new checkout gives git no hook to run: commit-msg
+  validation and the whole pre-push battery vanish, silently. Fix it before the
+  first commit with `npx husky`, then junction BOTH `node_modules` and
+  `server/node_modules` from the primary checkout (missing the second fails the
+  server legs with "vitest not found"). Simplest path is
+  `node scripts/wt-new.mjs <type>/<scope>-<slug>`, which does all of it plus
+  non-clashing ports.
+- **`.claude/` is git-ignored wholesale** -- `.gitignore` has `.claude/*` with
+  only `!.claude/skills/` re-included -- so a new file under it is silently
+  skipped by `git add` and never reaches the PR. Confirm with
+  `git status --short` after adding one.
+- **Git-ignored artifacts (`brand/`, `mockups/`, marketing captures) are
+  produced in the primary checkout**, never in a worktree: they do not travel
+  with the branch and worktree teardown destroys them.
+
+## Findings are fixed, not filed
+
+A defect or chore surfaced in passing is fixed in the same round, with its
+paired test, and declared in the PR body ("Also fixed, found in passing: ...").
+Filing an issue records the fix; it never substitutes for it. The one thing
+that defers a finding is a genuine design pass -- the fix has more than one
+defensible outcome and something has to choose between them -- and then the
+issue names the decision that is owed. "It would expand this PR", "it's
+pre-existing", "it needs its own test", and "it's only a chore" are all void.
+See CLAUDE.md "Incidental findings: report, fix, record".
+
+## Gates a PR must clear
+
+- Commit subjects follow Conventional Commits. The exact type and scope
+  vocabulary lives in CONTRIBUTING.md "Allowed types" / "Allowed scopes" and is
+  enforced by `scripts/validate-commit-msg.mjs` -- read it there rather than
+  copying the lists around, because they change.
+- `commit-msg` validates the subject. `pre-push` refuses force-push or deletion
+  of `main`, re-validates every pushed subject (so bypassing `commit-msg` buys
+  nothing), then runs `npm run verify:fast:branch` unless the push is
+  docs-only.
+- Run `npm run verify:fast:scoped` before staging and `npm run
+  verify:fast:branch` before pushing, so the hooks pass on the first try.
+- The **PR title** must itself match the commit-subject format
+  (`pr-title-lint.yml`), and the **PR body** must carry a literal `Closes #NN`
+  or `Refs #NN` (`pr-issue-link.yml`). Both are required status checks -- a
+  missing issue link blocks merge outright. File the issue if none exists.
+- A non-trivial spec or plan takes an adversarial `assumption-checker` pass
+  before the user is asked to approve it; present its actual output, not a
+  paraphrase.
+- Cloud `verify.yml` is the real enforcement gate. Every PR that is not
+  docs-only also takes the `pr-review-gate` pass before merge.
+
+## Every change owes
+
+- **A paired automated test.** New behaviour -> a new test. Bug fix -> a
+  regression test that fails before the fix and passes after. Never delete or
+  `.skip` a test without a named replacement. UI changes crossing
+  router/redux/layout seams land a Playwright spec under `e2e/`.
+- **Both release-notes files, in the same PR:** an entry in
+  `docs/release-notes-next.md` and a matching user-facing, brand-voice line in
+  the in-progress section at the top of `RELEASE_NOTES.md`. Skip only when the
+  change has no shippable delta, and say so explicitly rather than omitting it
+  silently.
+- **An on-box acceptance row** when it ships behaviour only real hardware can
+  prove (a live GPU, a real sidecar, a real analyzer, a real book). Recording
+  blocks the merge; running does not. All three surfaces move together -- see
+  CLAUDE.md "Before-shipping checklist" step 3.
 
 ## Working style
-- Surgical changes: fix what's broken, don't restyle what works. Match existing
-  conventions. Keep edits minimal (see CLAUDE.md "Simplicity first").
+
+- Surgical changes: fix what's broken, don't restyle what works. Match the
+  surrounding conventions even where you would write it differently. The seam
+  is defect / chore / taste -- the first two get fixed, the third is never
+  touched.
+- Simplicity first: the minimum code that solves the problem. No speculative
+  abstractions, no unrequested configurability.
+- All non-trivial work is sub-agent-executed: the main thread coordinates,
+  curates context, and judges. Trivial means nothing can break and nothing
+  needs review -- if you would want a review pass on it, it is not trivial.

--- a/.clinerules/cline.md
+++ b/.clinerules/cline.md
@@ -14,12 +14,12 @@ contains zero `CLAUDE` byte sequences under a binary-safe grep, against
 positive controls that do find `clinerules` and `AGENTS.md`; and a live
 `cline -p` probe in this workspace reported only `Workspace AGENTS.md` +
 `.clinerules/cline.md` in context. One caveat, so nobody re-derives this and
-thinks the note is wrong: `cli-windows-x64/bin/cline.exe` does carry a
-`CLAUDE.md` literal and a `claudeMd` / `claudeMdExcludes` **managed-policy**
-schema. That is enterprise-policy plumbing, not the workspace rule loader, and
-it changed nothing on this box -- but a managed config is the one thing that
-could make this stale. Re-probe rather than assume if you are on a managed
-install.
+thinks the note is wrong: `cli-windows-x64/bin/cline.exe` does carry
+`CLAUDE.md` literals, in a `claudeMd` / `claudeMdExcludes` settings schema
+belonging to the **bundled Claude Agent SDK** that Cline vendors -- not to its
+own rule loader. A vendored schema is not a loader, so those strings do not
+indicate `CLAUDE.md` support and no setting flips them into it. Re-verify if
+Cline's rule loader itself changes.
 
 This file is a summary, not a substitute. It deliberately restates almost
 nothing from them, carrying only rules that are **Cline-specific** or that
@@ -28,12 +28,17 @@ this file gets fixed. Anything of general value belongs in `CLAUDE.md` instead.
 
 ## Cline-specific
 
-- **Skills resolve from `~/.agents/skills/` only.** Cline does not read a
-  workspace `.claude/skills/` (probed 2026-08-13,
-  `docs/testing/agent-skill-resolution-probe.md`). Re-run `npm run skills:sync`
-  after any change under `.claude/skills/pr-review-gate/`. It is a per-machine
-  step: the target is under `$HOME`, so CI cannot run it and a fresh clone has
-  no mirror.
+- **Skills resolve from `~/.agents/skills/`; a workspace `.claude/skills/` is
+  not read.** Both proven by probe (2026-08-13,
+  `docs/testing/agent-skill-resolution-probe.md`), as is `~/.cline/skills`
+  being dead. So re-run `npm run skills:sync` after any change under
+  `.claude/skills/pr-review-gate/` -- a per-machine step, since the target is
+  under `$HOME`, so CI cannot run it and a fresh clone has no mirror. Do not
+  read that as an exhaustive list: the loader composes skill roots from its
+  rule directories (`skillsPath: join(<ruleDir>, "skills")`), so workspace
+  roots may also work. They are untested, and presence in the code is not
+  proof -- `~/.cline/skills` sits in that same list and is dead. Treat anything
+  beyond the two probed answers as unverified (#2368).
 - **Model tiers are not selectable, so a Cline review pass does NOT discharge
   the merge gate.** The probe above recorded `CLINE_TIER_SELECTABLE: no`,
   observing a subagent backed by `deepseek-v4-flash`; subagents do start cold
@@ -70,10 +75,13 @@ this file gets fixed. Anything of general value belongs in `CLAUDE.md` instead.
   fails on `main`) -> surface it to the user and do NOT fold the fix in;
   suspected flake -> re-run that test alone once and name it. CLAUDE.md
   "Working practice" states the rule flatly: do not use `--no-verify` to
-  bypass. The single documented exception is a `git commit --no-verify` in a
-  genuine emergency, and that commit still needs fixing before review
-  (CONTRIBUTING.md "Enforcement"). **"I already ran the tests" is not a
-  reason to skip pre-push**: that hook also runs `guard-protected-push` and
+  bypass. Two narrow exceptions are documented, neither of them "the hook is
+  red": a `git commit --no-verify` in a genuine emergency, where the commit
+  still needs fixing before review (CONTRIBUTING.md "Enforcement"), and a
+  `git push --no-verify` when the force-push or branch deletion
+  `guard-protected-push` is refusing is the thing you actually intend
+  (CLAUDE.md "Commit gate", `.husky/pre-push`). **"I already ran the tests" is
+  not a third**: that hook also runs `guard-protected-push` and
   `guard-commit-subjects`, and `verify:fast:branch` runs neither, so bypassing
   drops the backstop that catches a malformed subject when `commit-msg` did
   not fire -- exactly the fresh-worktree case below, and the leak that shipped

--- a/.clinerules/cline.md
+++ b/.clinerules/cline.md
@@ -1,10 +1,19 @@
 # Cline project rules (Castwright / Audiobook-Generator)
 
-Loaded by Cline each session. The canonical context is the root `CLAUDE.md`
-and `CONTRIBUTING.md` -- Cline reads both, so nothing here restates them. This
-file carries only two kinds of rule: ones that are **Cline-specific**, and ones
-that are **costly if missed** and easy to lose in 140 KB of prose. Keep it that
-way -- anything of general value belongs in `CLAUDE.md` instead.
+## Read these first -- they are NOT loaded for you
+
+The canonical rules are the root **`CLAUDE.md`** and **`CONTRIBUTING.md`**.
+Cline loads neither: its rule loader reads this file, `.clinerules/*.md`, and
+workspace/global `AGENTS.md`, and nothing else (verified 2026-08-14 against the
+installed `@cline/core` loader and a live `cline -p` probe). **Read both files
+before your first edit** -- `CLAUDE.md` for the working principles, execution
+model and conventions, `CONTRIBUTING.md` for the commit / branch / PR / issue /
+release-notes specs.
+
+This file is a summary, not a substitute. It deliberately restates almost
+nothing from them, carrying only rules that are **Cline-specific** or that
+**fail silently**. Where the two disagree, they win -- and tell the user, so
+this file gets fixed. Anything of general value belongs in `CLAUDE.md` instead.
 
 ## Cline-specific
 
@@ -14,13 +23,19 @@ way -- anything of general value belongs in `CLAUDE.md` instead.
   after any change under `.claude/skills/pr-review-gate/`. It is a per-machine
   step: the target is under `$HOME`, so CI cannot run it and a fresh clone has
   no mirror.
-- **Model tiers are not selectable.** Subagents run on the configured session
-  model, so CLAUDE.md's "Model routing" table (Haiku / Sonnet / Opus / Fable)
-  and its `.claude/worktrees` + `claude/wt-*` branch choreography are
-  Claude-Code mechanics I cannot reproduce verbatim. Follow the INTENT -- fresh
-  cold subagents per task, per-task review, review-gated ships -- and where a
-  tier choice would genuinely change the outcome, say so and hand the decision
-  to the user.
+- **Model tiers are not selectable, so a Cline review pass does NOT discharge
+  the merge gate.** The probe above recorded `CLINE_TIER_SELECTABLE: no`,
+  observing a subagent backed by `deepseek-v4-flash`; subagents do start cold
+  (`CLINE_SUBAGENT_COLD: yes`, self-reported, not independently reproduced).
+  Independence is the property people check and it is the one Cline has -- the
+  tier is the one it lacks. So CLAUDE.md's "Model routing" table (Haiku /
+  Sonnet / Opus / Fable) and its `.claude/worktrees` + `claude/wt-*` branch
+  choreography are Claude-Code mechanics I cannot reproduce. Follow the INTENT
+  -- fresh cold subagents per task, per-task review, review-gated ships -- but
+  record a Cline pass as a **flash-tier independent pass, never as the
+  `pr-review-gate` gate itself**, and hand any decision that turns on tier
+  choice to the user. Calling it "the review gate" is a false completion
+  claim.
 - **This is a Windows box running PowerShell 5.1.** No `&&` / `||` chaining
   (use `;` or `if ($?) { ... }`), no ternary / `??` / `?.`. `head`, `tail`,
   `which`, and `touch` do not exist -- use `Get-Content -TotalCount N` /
@@ -33,13 +48,21 @@ way -- anything of general value belongs in `CLAUDE.md` instead.
   reaches `main` through a branch and a PR; `main`'s required status checks
   reject anything else. Branches are `<type>/<scope>-<slug>`.
 - **Never hand-edit a generated file:** `src/lib/api-types.ts` (regenerate via
-  `npm run openapi:types`), `docs/BACKLOG.md` (`npm run backlog:sync`),
-  `server/.env.example` (`npm run config:sync`).
-- **Never bypass a hook with `--no-verify`.** Triage instead: caused by my
-  change -> fix it in the same commit; pre-existing (the same test fails on
-  `main`) -> surface it to the user and do NOT fold the fix in; suspected flake
-  -> re-run that test alone once and name it. `--no-verify` is reserved for
-  CI-generated commits (`.github/workflows/regen-visual-baselines.yml`).
+  `npm run openapi:types`) and `docs/BACKLOG.md` (`npm run backlog:sync`) are
+  generated whole. `server/.env.example` is only PARTLY generated -- the block
+  between the `BEGIN`/`END generated config knobs` markers is owned by
+  `npm run config:sync`, and the ~460 lines outside it (including
+  `GEMINI_API_KEY=`) are hand-authored and safe to edit. `config:check` never
+  looks outside the block, so it will not catch a mistake there.
+- **Never bypass a hook with `--no-verify` to get unstuck.** Triage instead:
+  caused by my change -> fix it in the same commit; pre-existing (the same test
+  fails on `main`) -> surface it to the user and do NOT fold the fix in;
+  suspected flake -> re-run that test alone once and name it. Bypassing is
+  legitimate in two narrow cases only: a genuine emergency, where the commit
+  still needs fixing before review (CONTRIBUTING.md "Enforcement"), and
+  deliberately skipping the pre-push hook on a push whose gate you have already
+  satisfied (CLAUDE.md "Commit gate"). Never on a red hook you have not
+  diagnosed.
 - **Never treat hook output in a fresh worktree as proof of verification** --
   see the first trap below.
 
@@ -54,6 +77,16 @@ way -- anything of general value belongs in `CLAUDE.md` instead.
   server legs with "vitest not found"). Simplest path is
   `node scripts/wt-new.mjs <type>/<scope>-<slug>`, which does all of it plus
   non-clashing ports.
+- **Tearing that worktree down in the wrong order destroys the primary
+  checkout.** `git worktree remove` (and `Remove-Item -Recurse`) will follow a
+  junction and delete the REAL `node_modules` it points at, taking husky
+  activation with it. Drop the junctions first -- `(Get-Item $j -Force).Delete()`
+  removes the link only -- gating on
+  `$i.Attributes -band [IO.FileAttributes]::ReparsePoint`, never on
+  `.LinkTarget`, which reads empty on PowerShell 5.1 even for a real junction
+  and so silently skips the delete. `cmd /c rmdir` no-ops and still returns 0,
+  so confirm with `Test-Path` rather than an exit code. Full recipe: CLAUDE.md
+  "Worktree teardown".
 - **`.claude/` is git-ignored wholesale** -- `.gitignore` has `.claude/*` with
   only `!.claude/skills/` re-included -- so a new file under it is silently
   skipped by `git add` and never reaches the PR. Confirm with
@@ -83,8 +116,12 @@ See CLAUDE.md "Incidental findings: report, fix, record".
   of `main`, re-validates every pushed subject (so bypassing `commit-msg` buys
   nothing), then runs `npm run verify:fast:branch` unless the push is
   docs-only.
-- Run `npm run verify:fast:scoped` before staging and `npm run
-  verify:fast:branch` before pushing, so the hooks pass on the first try.
+- Run `npm run verify:fast:branch` before pushing, so the hooks pass on the
+  first try. Do NOT rely on `verify:fast:scoped` as a pre-flight: it scopes to
+  the STAGED diff, so on an empty or unrelated index every leg reports
+  `(out of scope)` and it exits 0 having run no tests at all. A green from it
+  proves nothing until the change is staged -- and even then only for the legs
+  whose input globs the diff actually touches.
 - The **PR title** must itself match the commit-subject format
   (`pr-title-lint.yml`), and the **PR body** must carry a literal `Closes #NN`
   or `Refs #NN` (`pr-issue-link.yml`). Both are required status checks -- a

--- a/.clinerules/cline.md
+++ b/.clinerules/cline.md
@@ -1,0 +1,57 @@
+# Cline project rules (Castwright / Audiobook-Generator)
+
+Loaded by Cline each session. The full project context is in the root
+`CLAUDE.md` (Cline reads it too) -- these are Cline-specific operational
+prefs layered on top. Keep this minimal; move anything of general value into
+`CLAUDE.md` instead.
+
+## Commits (Conventional Commits, enforced by hooks)
+- Subject format: `<type>(<scope>): <subject>`.
+  - Types: `feat | fix | refactor | perf | test | docs | build | ci | chore`
+  - Scopes (required except for `chore`): `frontend | server | sidecar | app |
+    scripts | e2e | mocks | openapi | docs | deps | ci | ops`
+  - Subject <= 100 chars. Breaking change = `!` before the colon
+    (e.g. `feat(server)!: drop legacy field`).
+  - Multi-line commit bodies end with a `Co-Authored-By:` trailer naming the
+    agent (e.g. `Co-Authored-By: Cline <...>`).
+- The `commit-msg` hook rejects malformed subjects; `pre-push` re-checks them,
+  refuses force-push/deletion of `main`, and runs `verify:fast:branch`.
+
+## Verify before commit / push
+- `pre-commit` runs `npm run verify:fast:scoped` (scoped to STAGED files). Run
+  it before staging so hooks pass on the first try.
+- The fast local gate before pushing is `npm run verify:fast:branch`.
+- Never bypass hooks with `--no-verify` for dev work -- it is reserved for
+  CI-generated commits only (e.g. `.github/workflows/regen-visual-baselines.yml`).
+- Cloud `verify.yml` is a required status check on `main` -- the real gate.
+
+## Testing discipline (required, per CLAUDE.md)
+- New behaviour ships a paired automated test. Bug fixes ship a regression test
+  that fails before the fix and passes after. Never delete or `.skip` a test
+  without an explicit replacement. UI cross-seam changes should land an e2e test.
+
+## Execution model (sub-agent delivery — CLAUDE.md doctrine)
+- All NON-TRIVIAL work is sub-agent-executed: the main thread coordinates,
+  curates context, and judges; it does NOT produce hand-written task code.
+  Only work clearing CLAUDE.md's trivial bar (nothing can break, nothing needs
+  review) stays inline, plus validation (which is the main thread's job).
+- Dispatch FRESH cold subagents per task (spawn_agent / team tools), briefed
+  from the ticket/plan doc as the sole source of requirements — not forks that
+  inherit session context.
+- Per task: an implementer subagent, then a task-review subagent (spec + quality).
+- Non-trivial specs/plans get an adversarial `assumption-checker` pass before
+  the user approves; present its actual tagged output, not a paraphrase.
+- Ship through the `pr-review-gate` / code-review pass; the PR needs
+  `Closes #NN` / `Refs #NN`.
+- CAPABILITY NOTE (honest, Cline-specific): Cline cannot select model tiers for
+  subagents — they run on the configured session model. The repo's
+  Haiku/Sonnet/Opus/`Fable` routing table (CLAUDE.md "Model routing") and its
+  `.claude/worktrees` + `claude/wt-*` branch choreography are Claude-Code
+  mechanics I can't reproduce verbatim. I follow the INTENT (fresh subagent
+  execution + per-task review + review-gated ships), not those letter-level
+  mechanics. Where tier choice would matter, say so and hand the decision to
+  the user.
+
+## Working style
+- Surgical changes: fix what's broken, don't restyle what works. Match existing
+  conventions. Keep edits minimal (see CLAUDE.md "Simplicity first").

--- a/.clinerules/cline.md
+++ b/.clinerules/cline.md
@@ -3,12 +3,23 @@
 ## Read these first -- they are NOT loaded for you
 
 The canonical rules are the root **`CLAUDE.md`** and **`CONTRIBUTING.md`**.
-Cline loads neither: its rule loader reads this file, `.clinerules/*.md`, and
-workspace/global `AGENTS.md`, and nothing else (verified 2026-08-14 against the
-installed `@cline/core` loader and a live `cline -p` probe). **Read both files
-before your first edit** -- `CLAUDE.md` for the working principles, execution
-model and conventions, `CONTRIBUTING.md` for the commit / branch / PR / issue /
-release-notes specs.
+Cline loads neither. Its rule loader reads `.clinerules` (a directory or a bare
+file), `.cline/`, and workspace/global `AGENTS.md`, taking `.md` / `.markdown`
+/ `.txt`. **Read both canonical files before your first edit** -- `CLAUDE.md`
+for the working principles, execution model and conventions,
+`CONTRIBUTING.md` for the commit / branch / PR / issue / release-notes specs.
+
+Verified 2026-08-14, two ways: `@cline/core` (the package holding the loader)
+contains zero `CLAUDE` byte sequences under a binary-safe grep, against
+positive controls that do find `clinerules` and `AGENTS.md`; and a live
+`cline -p` probe in this workspace reported only `Workspace AGENTS.md` +
+`.clinerules/cline.md` in context. One caveat, so nobody re-derives this and
+thinks the note is wrong: `cli-windows-x64/bin/cline.exe` does carry a
+`CLAUDE.md` literal and a `claudeMd` / `claudeMdExcludes` **managed-policy**
+schema. That is enterprise-policy plumbing, not the workspace rule loader, and
+it changed nothing on this box -- but a managed config is the one thing that
+could make this stale. Re-probe rather than assume if you are on a managed
+install.
 
 This file is a summary, not a substitute. It deliberately restates almost
 nothing from them, carrying only rules that are **Cline-specific** or that
@@ -57,12 +68,16 @@ this file gets fixed. Anything of general value belongs in `CLAUDE.md` instead.
 - **Never bypass a hook with `--no-verify` to get unstuck.** Triage instead:
   caused by my change -> fix it in the same commit; pre-existing (the same test
   fails on `main`) -> surface it to the user and do NOT fold the fix in;
-  suspected flake -> re-run that test alone once and name it. Bypassing is
-  legitimate in two narrow cases only: a genuine emergency, where the commit
-  still needs fixing before review (CONTRIBUTING.md "Enforcement"), and
-  deliberately skipping the pre-push hook on a push whose gate you have already
-  satisfied (CLAUDE.md "Commit gate"). Never on a red hook you have not
-  diagnosed.
+  suspected flake -> re-run that test alone once and name it. CLAUDE.md
+  "Working practice" states the rule flatly: do not use `--no-verify` to
+  bypass. The single documented exception is a `git commit --no-verify` in a
+  genuine emergency, and that commit still needs fixing before review
+  (CONTRIBUTING.md "Enforcement"). **"I already ran the tests" is not a
+  reason to skip pre-push**: that hook also runs `guard-protected-push` and
+  `guard-commit-subjects`, and `verify:fast:branch` runs neither, so bypassing
+  drops the backstop that catches a malformed subject when `commit-msg` did
+  not fire -- exactly the fresh-worktree case below, and the leak that shipped
+  on #856.
 - **Never treat hook output in a fresh worktree as proof of verification** --
   see the first trap below.
 
@@ -77,10 +92,13 @@ this file gets fixed. Anything of general value belongs in `CLAUDE.md` instead.
   server legs with "vitest not found"). Simplest path is
   `node scripts/wt-new.mjs <type>/<scope>-<slug>`, which does all of it plus
   non-clashing ports.
-- **Tearing that worktree down in the wrong order destroys the primary
-  checkout.** `git worktree remove` (and `Remove-Item -Recurse`) will follow a
-  junction and delete the REAL `node_modules` it points at, taking husky
-  activation with it. Drop the junctions first -- `(Get-Item $j -Force).Delete()`
+- **Tearing that worktree down in the wrong order guts the primary checkout.**
+  `git worktree remove` (and `Remove-Item -Recurse`) will follow a junction and
+  delete the REAL `node_modules` it points at, so every npm script in the
+  primary checkout breaks until you reinstall. (Hooks themselves survive --
+  `.husky/_` is a real repo-root directory, not a link -- so they keep firing
+  and fail loudly; it is the *ordering* requirement and the two checks below
+  that are silent.) Drop the junctions first -- `(Get-Item $j -Force).Delete()`
   removes the link only -- gating on
   `$i.Attributes -band [IO.FileAttributes]::ReparsePoint`, never on
   `.LinkTarget`, which reads empty on PowerShell 5.1 even for a real junction

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,17 @@
 # Agent context
 
 This repository's full project context for AI coding agents lives in
-`CLAUDE.md` at the repo root. Claude Code and Cline both load it at the start
-of each session, so it is the single source of truth -- do not duplicate its
-rules here.
+`CLAUDE.md` at the repo root, with the branching / commit / PR / issue /
+release-notes specs alongside it in `CONTRIBUTING.md`. Those two are the single
+source of truth -- do not duplicate their rules here.
 
-@CLAUDE.md
-
-- **Claude Code:** `CLAUDE.md` is native.
-- **Cline:** reads `CLAUDE.md` + every `.clinerules/*.md`. Cline-specific
-  operational prefs live in `.clinerules/cline.md`.
-- **Other tools:** read `CLAUDE.md` directly (or import it here) for the same
-  canonical context.
+- **Claude Code:** `CLAUDE.md` is native; read `CONTRIBUTING.md` before opening
+  a branch or a PR.
+- **Cline:** reads `CLAUDE.md` and `CONTRIBUTING.md`, plus every
+  `.clinerules/*.md`. Cline-specific operational prefs live in
+  `.clinerules/cline.md`.
+- **Other tools:** read both files directly for the same canonical context. A
+  tool that reads *this* file but not `CLAUDE.md` should import it explicitly
+  (`@CLAUDE.md`, or whatever your include syntax is). Do not add that import
+  here unconditionally: any tool that already loads `CLAUDE.md` natively would
+  then pull the same ~90 KB into context twice.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,23 @@
 # Agent context
 
-This repository's full project context for AI coding agents lives in
-`CLAUDE.md` at the repo root, with the branching / commit / PR / issue /
-release-notes specs alongside it in `CONTRIBUTING.md`. Those two are the single
-source of truth -- do not duplicate their rules here.
+This repository's canonical context for AI coding agents is `CLAUDE.md` at the
+repo root, with the branching / commit / PR / issue / release-notes specs
+alongside it in `CONTRIBUTING.md`. Those two are the single source of truth --
+do not duplicate their rules here.
 
-- **Claude Code:** `CLAUDE.md` is native; read `CONTRIBUTING.md` before opening
+**Most tools do not load them automatically. Read both before your first edit.**
+
+- **Claude Code:** `CLAUDE.md` is native. Read `CONTRIBUTING.md` before opening
   a branch or a PR.
-- **Cline:** reads `CLAUDE.md` and `CONTRIBUTING.md`, plus every
-  `.clinerules/*.md`. Cline-specific operational prefs live in
-  `.clinerules/cline.md`.
-- **Other tools:** read both files directly for the same canonical context. A
-  tool that reads *this* file but not `CLAUDE.md` should import it explicitly
-  (`@CLAUDE.md`, or whatever your include syntax is). Do not add that import
-  here unconditionally: any tool that already loads `CLAUDE.md` natively would
-  then pull the same ~90 KB into context twice.
+- **Cline:** loads this file and every `.clinerules/*.md`, and **neither
+  `CLAUDE.md` nor `CONTRIBUTING.md`** -- verified 2026-08-14 against the
+  installed `@cline/core` rule loader (which knows `AGENTS.md` and
+  `.clinerules` and contains no `CLAUDE.md` literal) and a live `cline -p`
+  probe. So reading them is an explicit first step, not something already done
+  for you. Cline-specific operational prefs are in `.clinerules/cline.md`,
+  which is a summary and not a substitute.
+- **Other tools:** read both files directly. If your tool supports file
+  includes and you want them loaded unconditionally, add the import in your own
+  tool-specific config rather than here -- an unconditional `@CLAUDE.md` in
+  this file would pull the same ~90 KB in twice for any tool that already loads
+  `CLAUDE.md` natively.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Agent context
+
+This repository's full project context for AI coding agents lives in
+`CLAUDE.md` at the repo root. Claude Code and Cline both load it at the start
+of each session, so it is the single source of truth -- do not duplicate its
+rules here.
+
+@CLAUDE.md
+
+- **Claude Code:** `CLAUDE.md` is native.
+- **Cline:** reads `CLAUDE.md` + every `.clinerules/*.md`. Cline-specific
+  operational prefs live in `.clinerules/cline.md`.
+- **Other tools:** read `CLAUDE.md` directly (or import it here) for the same
+  canonical context.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -422,9 +422,15 @@ Design rationale:
   (git-ignored). Pure helpers unit-tested in `scripts/tests/build-companion-apk.test.mjs`.
 - `npm run openapi:types` — regenerate `src/lib/api-types.ts` from `openapi.yaml`.
 - `npm run skills:sync` — mirror `.claude/skills/pr-review-gate/` into
-  `~/.agents/skills/`, the only skill store Cline (and the five other agents
-  sharing it) resolves — it does **not** read a workspace `.claude/skills/`
-  (probed 2026-08-13, `docs/testing/agent-skill-resolution-probe.md`). A
+  `~/.agents/skills/`, the skill store Cline (and the five other agents sharing
+  it) is known to resolve — it does **not** read a workspace `.claude/skills/`
+  (probed 2026-08-13, `docs/testing/agent-skill-resolution-probe.md`). "The
+  ONLY store it resolves" overstated that probe, which tested two paths, not
+  the loader's whole search list: it composes skill roots from its rule
+  directories (`skillsPath: join(<ruleDir>, "skills")`), so workspace roots may
+  work too and would make this per-machine step avoidable. Untested, and code
+  presence is not proof — `~/.cline/skills` is in that same list and was proven
+  dead — so it stays unverified pending #2368. A
   **per-machine** step: the target is under `$HOME`, so CI cannot run it and a
   fresh clone has no mirror. Re-run after any change under that directory; the
   drift guard in `scripts/tests/review-gate-mechanism.test.mjs` catches a stale


### PR DESCRIPTION
## Summary

Adds cross-tool agent configuration so Claude Code, Cline, and other tools reach the same canonical project context.

- **`AGENTS.md`** — thin cross-tool hub. Names `CLAUDE.md` and `CONTRIBUTING.md` as the source of truth (the branching / commit / PR / issue / release-notes specs live in the latter, not the former) and states, per tool, whether they are loaded automatically or have to be read.
- **`.clinerules/cline.md`** — Cline session rules. Opens by telling the session that **`CLAUDE.md` and `CONTRIBUTING.md` are not loaded for it** and must be read first. Beyond that it carries only rules that are **Cline-specific** (where skills actually resolve from; model tiers not being selectable, and the `pr-review-gate` consequence; the PowerShell 5.1 shell) or that **fail silently** (a fresh worktree's hooks doing nothing while looking normal; worktree teardown order; `.claude/` being git-ignored wholesale; git-ignored artifacts belonging to the primary checkout), plus the gates a PR must clear and what every change owes.

Also corrects the same over-claim at its source in **`CLAUDE.md`** (the `skills:sync` bullet) — see pass 3 below.

Closes dudarenok-maker/Castwright#2363
Refs dudarenok-maker/open-engine#50

## The premise this PR was written on was wrong

The first version of both files asserted that **Cline reads `CLAUDE.md` and `CONTRIBUTING.md`**, and was designed around it — `.clinerules/cline.md` deliberately restated nothing, and `AGENTS.md`'s `@CLAUDE.md` import was removed as redundant.

**It does not read either.** Verified two ways, twice, independently: `@cline/core` (the package holding the rule loader) contains **zero** `CLAUDE` byte sequences under a binary-safe grep, against positive controls that do find `clinerules` and `AGENTS.md`; `CONTRIBUTING` appears nowhere in `@cline/*` outside a vendored `vercel/ai` README link; and a live `cline -p` probe in this workspace reported only `Workspace AGENTS.md` + `.clinerules/cline.md` in context.

So both files were telling a Cline session its canonical context was already loaded — guaranteeing it would never go read it. That is the one defect class a rules file can have that actually matters.

**Fix:** an explicit read-these-first instruction in both files, with the verification method and date recorded so the claim is auditable rather than asserted. Chosen over restoring an `@CLAUDE.md` import (~90 KB in every session, and it is unverified that Cline expands `@`-includes at all) and over making `.clinerules` self-sufficient (which would reintroduce the untested duplication that the pass-1 review removed). One caveat is recorded in the file itself, so nobody re-derives this and concludes the note is wrong: `cline.exe` does carry `CLAUDE.md` literals, in a `claudeMd` / `claudeMdExcludes` settings schema belonging to the **bundled Claude Agent SDK** that Cline vendors — not to its own rule loader. A vendored schema is not a loader, so no setting flips those strings into `CLAUDE.md` support. (Pass 3 corrected an earlier version of this sentence that called the schema enterprise policy and named a managed config as a staleness mechanism — it is neither.)

## Review record

Three rounds, each folded rather than deferred.

**Pass 1** (head `4ff5f44d`) — 1 blocking, 3 significant, 3 minor. Fixed in `f764e4ff`:

1. 🔴 the Cline premise above.
2. 🟠 `server/.env.example` is only **partly** generated — `config:sync` owns the `BEGIN`/`END` block (453–695 of 706 lines), so ~460 lines including `GEMINI_API_KEY=` at line 39 are hand-authored, and `config:check` never looks outside the block. "Never hand-edit" was false for most of the file.
3. 🟠 dropped "run `verify:fast:scoped` before staging" — it scopes to the **staged** diff, so on an empty index all four legs report `(out of scope)` and it exits 0 having run nothing. Advice to run a guaranteed-vacuous check.
4. 🟠 added the worktree-teardown warning — `git worktree remove` follows a junction and deletes the primary checkout's real `node_modules`. Load-bearing here precisely *because* the blocking finding means Cline never sees CLAUDE.md's copy.
5. 🟡 `--no-verify` "reserved for CI-generated commits" contradicted CONTRIBUTING.md and CLAUDE.md.
6. 🟡 model-tier text asserted a mechanism instead of reporting what the probe measured.
7. 🟡 dudarenok-maker/Castwright#2363 carried only `area:ops`, so it rendered in neither board view — now `type:chore` too.

**Pass 2** (head `f764e4ff`) — confirmed 5 of 7 resolved, and caught two of the fixes being wrong. Fixed in `cf43b275`:

8. 🟠 the `--no-verify` carve-out from fix 5 was **not in its cited source**. `CLAUDE.md:1182` states the rule flatly; the `:871` parenthetical it was read out of is scoped to deliberately bypassing `guard-protected-push` for an intended force-push, not to skipping the verify battery. Now names the single documented exception and spells out why "I already ran the tests" is not a second one — pre-push also runs `guard-protected-push` and `guard-commit-subjects`, and `verify:fast:branch` runs neither.
9. 🟡 fix 4's "taking husky activation with it" was false — `.husky/_` is a real repo-root directory, so hooks keep firing and fail **loudly**. Reframed around what is actually silent.
10. 🟡 "and nothing else" overstated the loader — it also reads a bare `.clinerules` file and `.cline/`, and takes `.markdown` / `.txt`.
11. 🟠 this PR body still carried the disproved premise. Fixed here.

**Pass 3** (head `cf43b275`) — **approve**, all four pass-2 findings verified resolved. Three cleanup findings, fixed in `fcc53b0f` rather than deferred:

12. 🟡 "the single documented exception" for `--no-verify` missed a second one — `CLAUDE.md` "Commit gate" and `.husky/pre-push:3` both document a deliberate `git push --no-verify` for an intended force-push/deletion. Third round this paragraph landed off its sources, so it now cites all three.
13. 🟡 the `cline.exe` caveat mis-attributed its own evidence. `claudeMd` / `claudeMdExcludes` are not enterprise policy — `claudeMdExcludes`' own description scopes it to User/Project/Local memory, and both keys belong to the bundled **Claude Agent SDK** settings schema Cline vendors. So "a managed config could make this stale" named a mechanism that cannot happen. Reworded to what the evidence supports.
14. 🟡 **"Skills resolve from `~/.agents/skills/` only" was an exhaustive claim the probe never established** — it tested two paths, while the loader composes skill roots from its rule directories (`skillsPath: join(<ruleDir>, "skills")`), so workspace roots may work too. Corrected in **both** files: `.clinerules/cline.md` inherited the sentence from `CLAUDE.md:425`, which is where the over-claim actually lives, so fixing only the copy would have left the source to re-propagate it. Neither now asserts an exhaustive list in either direction — code presence is not proof (`~/.cline/skills` is in that same list and was proven dead) — and dudarenok-maker/open-engine#50 is filed for the probe. This matters beyond accuracy: if a workspace root resolves, the per-machine `skills:sync` step becomes avoidable.

Gate discharged: approve verdict, and 🟡 findings do not re-trigger a round.

## Not applicable

- **Paired test** — no runtime surface, and nothing reads either file at runtime, so there is no assertion to add. That absence is itself why finding 2 of pass 1 removed the duplicated commit-type/scope lists instead of adding a drift guard: `scripts/verify-cache.mjs` lists `CLAUDE.md` in `test:hooks`'s `extraFiles` only because a test reads it, and registering these two paths would point at a guard that does not exist. `CLAUDE.md` is different — it *is* covered, which is why this PR's final commit ran the suite.
- **Release notes** — pure process/tooling change, no user- or operator-visible delta, per CLAUDE.md before-shipping step 5.
- **On-box acceptance** — no behaviour requiring real hardware.

## Test plan

- [x] Pre-commit `verify:fast:scoped` — every leg `(out of scope)`; green. Noted above that this is a vacuous green for this diff, so it is recorded as *ran*, not as *evidence*.
- [x] Pre-push `verify:fast:branch` — every leg `(out of scope)`; green. Same caveat.
- [x] `pr-title-lint` / `pr-issue-link` / CLA — green.
- [x] `test:hooks` — **ran for real** at `fcc53b0f` (the `CLAUDE.md` edit busts its cache, unlike the two earlier commits): 41 pass / 0 fail and 1402 pass / 0 fail, including `review-gate-mechanism.test.mjs`, which reads `CLAUDE.md` prose.
- [x] `pr-review-gate` — 3 passes, verdict **approve** at pass 3. Not docs-only, so the exemption never applied.
- [ ] CI `verify.yml` — aggregator green at `fcc53b0f`.
