### PR TITLE
chore(ops): ignore the token-saver skill's .token-saver/ scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,12 @@ server/src/__wire-fixtures__/
 # reports, mockups). Local scratch output, never committed.
 artifacts/
 
+# Accepted-result scratch written by the token-saver skill, which saves the
+# current result under `.token-saver/` in whatever project it is run from —
+# including any worktree cut from this repo. Model output written without
+# review; never committed.
+.token-saver/
+
 # Local clone of the separate Castwright.wiki.git repo, used by
 # scripts/sync-wiki.mjs as its push staging area. Recreated fresh on every
 # `npm run wiki:sync` run; never committed.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -51,6 +51,11 @@ export default tseslint.config(
       // Ad-hoc, local-only repro/bisect scripts (e.g. server/repro-attribution.mts).
       // Throwaway debugging probes — git-ignored and not held to the lint bar.
       'server/repro-*.mts',
+      // Accepted-result scratch written by the token-saver skill (see the
+      // matching .gitignore entry). Unreviewed model output that can land on a
+      // linted extension, and the skill writes it under whatever root it is
+      // pointed at — so match at any depth, not just the repo root.
+      '**/.token-saver/',
     ],
   },
 


### PR DESCRIPTION
## Summary

Stops the `token-saver` skill's scratch directory from reaching git or lint.

The skill saves accepted results under `.token-saver/` in whatever project it
runs from. Nothing ignored it, so the directory showed up in `git status` and
could be committed by accident — the contents are model output written without
review. Open Engine worktrees multiply the surface, since each one gets its own
untracked copy.

Two entries, because ignoring it in git alone left it linted:

- **`.gitignore`** — placed next to the existing agent-scratch ignores
  (`artifacts/`, `.superpowers/`, `.wiki-sync-cache/`,
  `server/src/__wire-fixtures__/`) on the same "defense in depth against an
  accidental commit" reasoning those entries already record.
- **`eslint.config.mjs`** — ESLint flat config traverses dot-directories, which
  is why `.claude/`, `.worktrees/` and `server/repro-*.mts` are listed by hand.
  `.token-saver/` is the first of these scratch dirs whose contents can land on
  a linted extension, so unreviewed model output would fail `npm run lint`
  locally. Matched at any depth (`**/`), not root-anchored — the skill writes
  the directory under whatever root it is pointed at.

## Test plan

No automated test is owed: the change adds no runtime code or behaviour that
could regress, and the only seam a test could reach is the config files' own
bytes. Both entries were instead verified live on the branch, each with a
control proving the check could fail.

**`.gitignore`**
- `git check-ignore -v .token-saver/` → `.gitignore:177`. Also resolves for
  `server/.token-saver/` and `src/lib/.token-saver/current.md`, confirming the
  unanchored spelling is the one the skill needs.
- A real file at `.token-saver/current.md` produced **no** `git status
  --porcelain` entry.
- Control: `.claude/skills/token-saver/SKILL.md` is **not** ignored, so
  mirroring the skill into the tracked `.claude/skills/` still works.

**`eslint.config.mjs`** — with probe files at `.token-saver/probe.ts` **and**
`server/.token-saver/probe.ts`:
- Without the entry: `npm run lint` exits **1**, `2 problems`.
- With the entry: `npm run lint` exits **0**.
- The two-warning control confirms both depths were genuinely reachable by
  ESLint, which is what justifies `**/` over a root anchor.

## Notes

- **Release notes skipped deliberately** — internal repo hygiene with no user-
  or operator-visible delta, per the Before-shipping checklist's "no shippable
  delta" carve-out.
- Work was done in a dedicated worktree (`C:\Claude\Projects\wt-token-saver-ignore`),
  with the primary checkout left clean on `main`.

Closes #2380
