### PR TITLE
docs(docs): tell Cline the commit gate takes minutes and its 30s cap cannot clear it

### DIFF
--- a/.claude/skills/pr-review-gate/SKILL.md
+++ b/.claude/skills/pr-review-gate/SKILL.md
@@ -44,12 +44,16 @@ rather than a new classification:
 
 - **`low`** — single-scope `chore`, `test`, `build`, `ci`, or `docs`
   (mechanical, no user-facing behavior change). `docs` sits here because it
-  ships no runtime surface — but note that "docs-type commit" and "docs-only
-  **file set**" are different tests, and only the second one
-  [exempts](#exemption) a PR from the gate entirely. A `docs(...)` PR touching
-  `.clinerules/` or `.claude/skills/` is reviewed at `low`, not skipped; that
-  gap was found the hard way on PR #2385, whose depth had to be argued by
-  analogy because `docs` appeared in no tier.
+  ships no *product* behavior — **not** because it is inert: a `docs(...)`
+  commit can change instructions agents follow literally (`.clinerules/`,
+  `.claude/skills/`, `AGENTS.md`), and a wrong instruction there is a
+  correctness bug with a blast radius, which is why it is reviewed rather than
+  waved through. Note also that "docs-type commit" and "docs-only **file
+  set**" are different tests, and only the second one [exempts](#exemption) a
+  PR from the gate entirely. PR #2385 was exactly this case — a `docs(...)` PR
+  touching `.clinerules/`, whose depth had to be argued by analogy because
+  `docs` appeared in no tier, and whose review then found six correctness bugs
+  in the instructions themselves.
 - **`medium`** — single-scope `feat` or `fix`.
 - **`high`** — `refactor`, `perf`, or any multi-scope PR (CONTRIBUTING.md's
   own "use sparingly" multi-scope guidance already flags these as

--- a/.claude/skills/pr-review-gate/SKILL.md
+++ b/.claude/skills/pr-review-gate/SKILL.md
@@ -42,18 +42,19 @@ For every non-exempt PR, **review depth** scales with the PR's commit
 type/scope, reusing CONTRIBUTING.md's existing commit-convention vocabulary
 rather than a new classification:
 
-- **`low`** — single-scope `chore`, `test`, `build`, `ci`, or `docs`
-  (mechanical, no user-facing behavior change). `docs` sits here because it
-  ships no *product* behavior — **not** because it is inert: a `docs(...)`
-  commit can change instructions agents follow literally (`.clinerules/`,
-  `.claude/skills/`, `AGENTS.md`), and a wrong instruction there is a
-  correctness bug with a blast radius, which is why it is reviewed rather than
-  waved through. Note also that "docs-type commit" and "docs-only **file
-  set**" are different tests, and only the second one [exempts](#exemption) a
-  PR from the gate entirely. PR #2385 was exactly this case — a `docs(...)` PR
-  touching `.clinerules/`, whose depth had to be argued by analogy because
-  `docs` appeared in no tier, and whose review then found six correctness bugs
-  in the instructions themselves.
+- **`low`** — single-scope `chore`, `test`, `build`, `ci`, or `docs`. Usually
+  mechanical with no user-facing behavior change; `docs` earns the tier by
+  shipping no *product* behavior, **not** by being inert. A `docs(...)` commit
+  can change instructions agents follow literally (`.clinerules/`,
+  `.claude/skills/`, `AGENTS.md`), where a wrong instruction is a correctness
+  bug with a blast radius — so that subclass is reviewed rather than waved
+  through, and `low` buys it a narrower scope, not a lighter standard. Note
+  also that "docs-type commit" and "docs-only **file set**" are different
+  tests, and only the second one [exempts](#exemption) a PR from the gate
+  entirely. PR #2385 was exactly this case — a `docs(...)` PR touching
+  `.clinerules/`, whose depth had to be argued by analogy because `docs`
+  appeared in no tier, and whose three review passes then found **nine**
+  correctness bugs in the instructions themselves.
 - **`medium`** — single-scope `feat` or `fix`.
 - **`high`** — `refactor`, `perf`, or any multi-scope PR (CONTRIBUTING.md's
   own "use sparingly" multi-scope guidance already flags these as

--- a/.claude/skills/pr-review-gate/SKILL.md
+++ b/.claude/skills/pr-review-gate/SKILL.md
@@ -42,8 +42,14 @@ For every non-exempt PR, **review depth** scales with the PR's commit
 type/scope, reusing CONTRIBUTING.md's existing commit-convention vocabulary
 rather than a new classification:
 
-- **`low`** — single-scope `chore`, `test`, `build`, or `ci` (mechanical, no
-  user-facing behavior change).
+- **`low`** — single-scope `chore`, `test`, `build`, `ci`, or `docs`
+  (mechanical, no user-facing behavior change). `docs` sits here because it
+  ships no runtime surface — but note that "docs-type commit" and "docs-only
+  **file set**" are different tests, and only the second one
+  [exempts](#exemption) a PR from the gate entirely. A `docs(...)` PR touching
+  `.clinerules/` or `.claude/skills/` is reviewed at `low`, not skipped; that
+  gap was found the hard way on PR #2385, whose depth had to be argued by
+  analogy because `docs` appeared in no tier.
 - **`medium`** — single-scope `feat` or `fix`.
 - **`high`** — `refactor`, `perf`, or any multi-scope PR (CONTRIBUTING.md's
   own "use sparingly" multi-scope guidance already flags these as

--- a/.clinerules/cline.md
+++ b/.clinerules/cline.md
@@ -131,29 +131,29 @@ any test step in scope takes minutes. So a foreground `git commit` cannot
 finish, and retrying it never will.** The cap is internal to Cline -- there is
 no CLI flag (`-t/--timeout` is the whole-run timeout, not the per-command one).
 
-**What is actually in scope** is decided per step by `STEPS[]` in
-`scripts/verify-cache.mjs` -- that file is the source of truth, not a path
-prefix. Pre-commit runs `verify:fast:scoped` over
-`test:hooks,check:budget-poll,test,test:server`, and a step runs when the
-staged diff matches its own `globs` **or** any of its `extraFiles`. So:
+**So commit detached ALWAYS -- do not try to work out whether this diff is one
+of the slow ones.** That prediction is the bug. Three successive revisions of
+this very paragraph tried to enumerate what puts a step in scope, and all three
+were wrong in the same direction: they under-listed, so an agent read its own
+change as exempt and took the foreground path into the 30-second kill. Detached
+costs nothing when the commit is fast -- the first poll returns immediately --
+and it is the only correct route when it is slow. There is no case where
+predicting first helps.
 
-- a `src/**` edit runs `test` -- not only "server" changes are slow;
-- a `server/src/**` edit runs `test:server`;
-- **`openapi.yaml` alone runs both**, while matching no `server/` path at all;
-- **`RELEASE_NOTES.md` and `docs/release-notes-next.md` are `extraFiles` of
-  `test:hooks`** -- and that pair is exactly what CLAUDE.md's before-shipping
-  step 5 makes nearly every PR touch. So "it's only docs" is **not** a reason
-  to expect a fast commit: `test:hooks` is recorded at 41-58 s, over the cap on
-  its own. `test:hooks` also globs `scripts/**`, `.github/workflows/**`,
-  `.github/actions/**`, `.husky/**`, `pinokio-scripts/**` and
-  `docs/testing/**`;
-- a root `package.json` or lockfile edit is `computeShared` -- it busts **every**
-  leg at once, ~12 minutes, and matches no step's globs, so reading only the
-  globs would tell you nothing runs;
-- a diff touching none of the above skips every leg and commits in seconds.
-  That is a real case, but check it rather than assume it -- the honest test is
-  "does this diff match any step's globs, `extraFiles`, or `computeShared`",
-  not "is this a docs change".
+If you do want to know, `STEPS[]` in `scripts/verify-cache.mjs` is the source
+of truth and the only one; pre-commit runs `verify:fast:scoped` over
+`test:hooks,check:budget-poll,test,test:server`, and a step runs when the staged
+diff matches its `globs`, any of its `extraFiles`, or `computeShared`. Read it
+there rather than trusting a summary -- including this one. What makes a
+summary untrustworthy here is that the surprising members are the whole point:
+`test:hooks` alone reaches `.claude/skills/**`, `.claude/agents/**`,
+`CLAUDE.md`, `CONTRIBUTING.md`, and the `RELEASE_NOTES.md` /
+`docs/release-notes-next.md` pair that CLAUDE.md's before-shipping step 5 makes
+nearly every PR touch -- so editing the very skill files this document tells you
+to edit costs 41-58 s, and "it's only docs" predicts nothing. `openapi.yaml`
+runs both `test` and `test:server` while matching no `server/` path. A root
+`package.json` or lockfile edit is `computeShared` and busts every leg at once,
+~12 minutes, while matching no step's globs at all.
 
 **Budget 10-15 minutes when a test step is in scope, and do not call it hung
 before 20.** Recorded on this repo: `test:server` **518.8 s** and `test`
@@ -227,9 +227,12 @@ elseif ($done)       { Get-Content "$T\commit.log" -Tail 40 }
 else                 { "child gone with no EXIT= -- check whether HEAD moved before assuming nothing happened" }
 ```
 
-**`alive` outranks `done`.** If the process is still up, any sentinel you can
-see belongs to an earlier attempt -- that combination is a stale read, not a
-result.
+**While it is alive, a sentinel you can see is from an earlier attempt** -- keep
+polling rather than reading it as this run's result. Once the process is gone
+the sentinel is yours. The one thing that settles any disagreement is the repo
+itself: `git -C $W log --oneline -1`. Check that before acting on a surprising
+verdict, because a pid can be reused and a log line can be stale, while a
+commit either exists or does not.
 
 `EXIT=0` means the hook passed; confirm with `git -C $W log --oneline -1`.
 Anything else is a real failure in the log and is yours to fix.

--- a/.clinerules/cline.md
+++ b/.clinerules/cline.md
@@ -140,7 +140,20 @@ staged diff matches its own `globs` **or** any of its `extraFiles`. So:
 - a `src/**` edit runs `test` -- not only "server" changes are slow;
 - a `server/src/**` edit runs `test:server`;
 - **`openapi.yaml` alone runs both**, while matching no `server/` path at all;
-- a docs-only diff matches nothing and commits in seconds, every leg `[skip]`ped.
+- **`RELEASE_NOTES.md` and `docs/release-notes-next.md` are `extraFiles` of
+  `test:hooks`** -- and that pair is exactly what CLAUDE.md's before-shipping
+  step 5 makes nearly every PR touch. So "it's only docs" is **not** a reason
+  to expect a fast commit: `test:hooks` is recorded at 41-58 s, over the cap on
+  its own. `test:hooks` also globs `scripts/**`, `.github/workflows/**`,
+  `.github/actions/**`, `.husky/**`, `pinokio-scripts/**` and
+  `docs/testing/**`;
+- a root `package.json` or lockfile edit is `computeShared` -- it busts **every**
+  leg at once, ~12 minutes, and matches no step's globs, so reading only the
+  globs would tell you nothing runs;
+- a diff touching none of the above skips every leg and commits in seconds.
+  That is a real case, but check it rather than assume it -- the honest test is
+  "does this diff match any step's globs, `extraFiles`, or `computeShared`",
+  not "is this a docs change".
 
 **Budget 10-15 minutes when a test step is in scope, and do not call it hung
 before 20.** Recorded on this repo: `test:server` **518.8 s** and `test`
@@ -188,6 +201,11 @@ created and a naive poll waits forever. Same family as the `.ps1` traps under
 "Never do these".
 
 ```powershell
+# Clear the log FIRST. Start-Process returns before the child truncates it, so
+# on a RETRY inside the same $T the very first poll reads the PREVIOUS
+# attempt's sentinel and reports a verdict for a run that is still going.
+Remove-Item "$T\commit.log" -ErrorAction SilentlyContinue
+
 # Quote each path argument: -ArgumentList does NOT quote its elements.
 $p = Start-Process powershell -WindowStyle Hidden -PassThru -ArgumentList @(
   '-NoProfile','-ExecutionPolicy','Bypass','-File',"`"$T\commit.ps1`"",
@@ -204,12 +222,25 @@ $id    = Get-Content "$T\commit.pid"
 $alive = [bool](Get-Process -Id $id -ErrorAction SilentlyContinue)
 $done  = (Test-Path "$T\commit.log") -and (Select-String -Path "$T\commit.log" -Pattern '^EXIT=' -Quiet)
 "alive=$alive done=$done"
-if ($done)                    { Get-Content "$T\commit.log" -Tail 40 }
-elseif (-not $alive)          { "child exited without writing EXIT= -- it died before the commit ran" }
+if ($alive)          { 'still running -- keep polling, and IGNORE any EXIT= you can see' }
+elseif ($done)       { Get-Content "$T\commit.log" -Tail 40 }
+else                 { "child gone with no EXIT= -- check whether HEAD moved before assuming nothing happened" }
 ```
+
+**`alive` outranks `done`.** If the process is still up, any sentinel you can
+see belongs to an earlier attempt -- that combination is a stale read, not a
+result.
 
 `EXIT=0` means the hook passed; confirm with `git -C $W log --oneline -1`.
 Anything else is a real failure in the log and is yours to fix.
+
+**Two ways the log misleads on the way out.** The child redirects with `*>&1`,
+so a *successful* run's tail can still be full of `NativeCommandError` and
+`CategoryInfo` -- that is PowerShell rendering git's stderr progress chatter,
+not a failure; read `EXIT=` and `git log`, not the shape of the text. And if
+the child vanished without a sentinel, **check `git -C $W log --oneline -1`
+before concluding it never ran**: it may have been killed after the commit
+landed, which is exactly what happened on #2382.
 
 **Do not end your turn while it runs.** Polling is active waiting and is
 correct; ending the run is not -- you are headless and nothing will wake you.

--- a/.clinerules/cline.md
+++ b/.clinerules/cline.md
@@ -120,6 +120,38 @@ this file gets fixed. Anything of general value belongs in `CLAUDE.md` instead.
 - **Git-ignored artifacts (`brand/`, `mockups/`, marketing captures) are
   produced in the primary checkout**, never in a worktree: they do not travel
   with the branch and worktree teardown destroys them.
+- **A commit here takes 5-7 minutes, and your runtime kills a command at 30
+  seconds -- so a foreground `git commit` on a `server/**` change can never
+  succeed, however many times you retry.** Pre-commit runs
+  `verify:fast:scoped`, and any staged file under `server/` puts the whole
+  server suite in scope: ~163 s for `test:server` alone. That is the gate
+  working, not a hang. The 30 s cap is internal to the Cline runtime -- there
+  is no CLI flag for it (`--timeout` is the whole-run timeout, not the
+  per-command one) -- and no amount of shrinking the change gets under it,
+  because even a bare `npm run lint` over the repo exceeds it. **Launch the
+  commit detached and poll**; each poll returns instantly, so the cap stops
+  mattering:
+
+  ```powershell
+  $T = $env:TEMP
+  Set-Content "$T\msg.txt" -Encoding utf8 -Value 'fix(scope): subject line'
+  @'
+  git -C <worktree> commit -F "$env:TEMP\msg.txt" *>&1 |
+    Out-File -FilePath "$env:TEMP\commit.log" -Encoding utf8
+  "EXIT=$LASTEXITCODE" | Out-File -FilePath "$env:TEMP\commit.log" -Append -Encoding utf8
+  '@ | Set-Content "$T\commit.ps1" -Encoding utf8
+  $p = Start-Process powershell -ArgumentList '-NoProfile','-ExecutionPolicy','Bypass','-File',"$T\commit.ps1" -WindowStyle Hidden -PassThru
+  $p.Id | Set-Content "$T\commit.pid"
+  # then poll (expect 15-20 polls) until EXIT= appears:
+  (Test-Path "$T\commit.log") -and (Select-String -Path "$T\commit.log" -Pattern '^EXIT=' -Quiet)
+  ```
+
+  The message goes in a file so no argument quoting can bite, and the
+  `EXIT=` sentinel is how you read the result once the shell that launched it
+  is gone. `EXIT=0` means the hook passed; anything else is a real failure in
+  the log and is yours to fix. **Never `--no-verify`.** This cost six identical
+  claim-and-fail cycles and twelve commit attempts on #2382 before anyone
+  noticed the cap was the whole story.
 
 ## Findings are fixed, not filed
 

--- a/.clinerules/cline.md
+++ b/.clinerules/cline.md
@@ -120,38 +120,106 @@ this file gets fixed. Anything of general value belongs in `CLAUDE.md` instead.
 - **Git-ignored artifacts (`brand/`, `mockups/`, marketing captures) are
   produced in the primary checkout**, never in a worktree: they do not travel
   with the branch and worktree teardown destroys them.
-- **A commit here takes 5-7 minutes, and your runtime kills a command at 30
-  seconds -- so a foreground `git commit` on a `server/**` change can never
-  succeed, however many times you retry.** Pre-commit runs
-  `verify:fast:scoped`, and any staged file under `server/` puts the whole
-  server suite in scope: ~163 s for `test:server` alone. That is the gate
-  working, not a hang. The 30 s cap is internal to the Cline runtime -- there
-  is no CLI flag for it (`--timeout` is the whole-run timeout, not the
-  per-command one) -- and no amount of shrinking the change gets under it,
-  because even a bare `npm run lint` over the repo exceeds it. **Launch the
-  commit detached and poll**; each poll returns instantly, so the cap stops
-  mattering:
+- **A commit can take longer than your 30-second command cap, so `git commit`
+  has to be run detached.** Not a silent trap -- the timeout is loud -- but the
+  loop it produces is not. See "Committing when a step is in scope" below.
 
-  ```powershell
-  $T = $env:TEMP
-  Set-Content "$T\msg.txt" -Encoding utf8 -Value 'fix(scope): subject line'
-  @'
-  git -C <worktree> commit -F "$env:TEMP\msg.txt" *>&1 |
-    Out-File -FilePath "$env:TEMP\commit.log" -Encoding utf8
-  "EXIT=$LASTEXITCODE" | Out-File -FilePath "$env:TEMP\commit.log" -Append -Encoding utf8
-  '@ | Set-Content "$T\commit.ps1" -Encoding utf8
-  $p = Start-Process powershell -ArgumentList '-NoProfile','-ExecutionPolicy','Bypass','-File',"$T\commit.ps1" -WindowStyle Hidden -PassThru
-  $p.Id | Set-Content "$T\commit.pid"
-  # then poll (expect 15-20 polls) until EXIT= appears:
-  (Test-Path "$T\commit.log") -and (Select-String -Path "$T\commit.log" -Pattern '^EXIT=' -Quiet)
-  ```
+## Committing when a step is in scope
 
-  The message goes in a file so no argument quoting can bite, and the
-  `EXIT=` sentinel is how you read the result once the shell that launched it
-  is gone. `EXIT=0` means the hook passed; anything else is a real failure in
-  the log and is yours to fix. **Never `--no-verify`.** This cost six identical
-  claim-and-fail cycles and twelve commit attempts on #2382 before anyone
-  noticed the cap was the whole story.
+**Your runtime kills a single command at 30 seconds. A pre-commit run that has
+any test step in scope takes minutes. So a foreground `git commit` cannot
+finish, and retrying it never will.** The cap is internal to Cline -- there is
+no CLI flag (`-t/--timeout` is the whole-run timeout, not the per-command one).
+
+**What is actually in scope** is decided per step by `STEPS[]` in
+`scripts/verify-cache.mjs` -- that file is the source of truth, not a path
+prefix. Pre-commit runs `verify:fast:scoped` over
+`test:hooks,check:budget-poll,test,test:server`, and a step runs when the
+staged diff matches its own `globs` **or** any of its `extraFiles`. So:
+
+- a `src/**` edit runs `test` -- not only "server" changes are slow;
+- a `server/src/**` edit runs `test:server`;
+- **`openapi.yaml` alone runs both**, while matching no `server/` path at all;
+- a docs-only diff matches nothing and commits in seconds, every leg `[skip]`ped.
+
+**Budget 10-15 minutes when a test step is in scope, and do not call it hung
+before 20.** Recorded on this repo: `test:server` **518.8 s** and `test`
+**153.3 s** in the last green `.verify-cache.json`; a contended red run of
+`test:server` took **746.6 s** (`docs/testing/flaky-register.md`). A single
+vitest run can report far less wall-clock on an idle box, so treat these as the
+range, not a constant.
+
+Launch it detached and poll. Each poll returns instantly, so the cap stops
+mattering:
+
+```powershell
+# Per-run directory. A FIXED log path is read by the next poll as the PREVIOUS
+# run's result: Start-Process returns before the child truncates the file, so a
+# stale EXIT=0 reports success for a commit that is still running.
+$run = Get-Date -Format 'yyyyMMdd-HHmmss'
+$T   = Join-Path $env:TEMP "cw-commit-$run"
+$W   = 'C:\Claude\Projects\wt-<your-worktree>'
+New-Item -ItemType Directory -Path $T -Force | Out-Null
+
+# NO BOM. PS 5.1's `Set-Content -Encoding utf8` writes one, `git commit -F` does
+# NOT strip it, and scripts/validate-commit-msg.mjs then rejects the subject --
+# AFTER you have paid the whole battery, with an error echoing a subject that
+# looks perfectly valid because the BOM is invisible.
+[IO.File]::WriteAllText("$T\msg.txt", 'fix(scope): subject line', (New-Object System.Text.UTF8Encoding $false))
+```
+
+The child script takes its paths as parameters, so nothing has to be
+interpolated into the here-string and `$LASTEXITCODE` resolves in the child:
+
+```powershell
+@'
+param([string]$Dir, [string]$Worktree)
+$ErrorActionPreference = 'Continue'
+git -C $Worktree commit -F (Join-Path $Dir 'msg.txt') *>&1 |
+  Out-File -FilePath (Join-Path $Dir 'commit.log') -Encoding utf8
+"EXIT=$LASTEXITCODE" | Out-File -FilePath (Join-Path $Dir 'commit.log') -Append -Encoding utf8
+'@ | Set-Content "$T\commit.ps1" -Encoding utf8
+```
+
+**That closing `'@` must be at column zero** -- indent it (as happens
+automatically inside a markdown list item) and PS 5.1 fails with
+`WhitespaceBeforeHereStringFooter` before running anything, so no log is ever
+created and a naive poll waits forever. Same family as the `.ps1` traps under
+"Never do these".
+
+```powershell
+# Quote each path argument: -ArgumentList does NOT quote its elements.
+$p = Start-Process powershell -WindowStyle Hidden -PassThru -ArgumentList @(
+  '-NoProfile','-ExecutionPolicy','Bypass','-File',"`"$T\commit.ps1`"",
+  '-Dir',"`"$T`"",'-Worktree',"`"$W`"")
+$p.Id | Set-Content "$T\commit.pid"
+```
+
+Then poll until it resolves. **Check the process as well as the sentinel** --
+those two disagreeing is how you learn the child died at parse time instead of
+waiting on it forever:
+
+```powershell
+$id    = Get-Content "$T\commit.pid"
+$alive = [bool](Get-Process -Id $id -ErrorAction SilentlyContinue)
+$done  = (Test-Path "$T\commit.log") -and (Select-String -Path "$T\commit.log" -Pattern '^EXIT=' -Quiet)
+"alive=$alive done=$done"
+if ($done)                    { Get-Content "$T\commit.log" -Tail 40 }
+elseif (-not $alive)          { "child exited without writing EXIT= -- it died before the commit ran" }
+```
+
+`EXIT=0` means the hook passed; confirm with `git -C $W log --oneline -1`.
+Anything else is a real failure in the log and is yours to fix.
+
+**Do not end your turn while it runs.** Polling is active waiting and is
+correct; ending the run is not -- you are headless and nothing will wake you.
+If it genuinely cannot be delivered from your lane, say so once with the exact
+command and the cap.
+
+**Never `--no-verify`** (the two documented exceptions are under "Never do
+these" and neither is "the hook is slow"). This cost six identical
+claim-and-fail cycles and twelve commit attempts on #2382 before the cap was
+recognised as the whole story.
 
 ## Findings are fixed, not filed
 


### PR DESCRIPTION
## Summary

Records in `.clinerules/cline.md` that a commit in this repo can take **10-15 minutes** whenever a test step is in scope, and that the Cline runtime's **30-second per-command cap can never clear it** — so a foreground `git commit` cannot finish, and retrying it never will. The cap is internal to Cline; `-t/--timeout` is the whole-run timeout, not a per-command one.

**What is in scope is decided by `STEPS[]` in `scripts/verify-cache.mjs`**, not by a path prefix — a `src/**` edit runs `test`, a `server/src/**` edit runs `test:server`, and **`openapi.yaml` alone runs both while matching no `server/` path at all**. A docs-only diff matches nothing and commits in seconds.

The entry carries a **detached-and-poll recipe**: launch the commit detached, poll instantly-returning commands until an `EXIT=` sentinel appears, and check the child process as well as the sentinel so a child that dies at parse time is reported rather than waited on forever.

`.clinerules/cline.md` is the right home rather than `CLAUDE.md`: per this repo's own `AGENTS.md`, Cline loads `AGENTS.md` and `.clinerules/*.md` and **neither `CLAUDE.md` nor `CONTRIBUTING.md`**. So this reaches every Cline session in the repo, not just the one that hit the wall.

**Found the expensive way.** #2382 burned six identical claim-and-fail cycles and twelve commit attempts — each correctly re-deriving the same one-line `prefer-const` fix, then dying in the pre-commit hook — before the cap was recognised as the whole story. `--no-verify` was correctly refused every time.

**Also fixed, found in passing:** the `pr-review-gate` depth ladder listed no tier for `docs`, so a `docs(...)` PR's review depth had to be argued by analogy each time. It now sits at `low`, with the distinction between a docs-*type* commit and a docs-only *file set* spelled out — only the second exempts a PR from the gate.

## Test plan

Docs-only in effect; no runtime surface, so no automated test is owed and none was added.

**Release notes: not applicable** — no user- or operator-visible behaviour change (agent-instruction files only), so per CLAUDE.md before-shipping step 5 both release-notes documents are deliberately untouched.

Every claim in the recipe was reproduced under **real Windows PowerShell 5.1** (`5.1.26100.9022`), which is what `Start-Process powershell` launches — not under pwsh 7, where two of these bugs are invisible:

- **BOM, both directions.** 5.1 `Set-Content -Encoding utf8` → first bytes `239,187,191`; `[IO.File]::WriteAllText(..., UTF8Encoding $false)` → `102,105,120`. Against a throwaway repo with a BOM-rejecting `commit-msg` hook: the BOM message is **rejected `EXIT=1`**, the fixed one **commits `EXIT=0`** with `COMMIT_EDITMSG` starting `102,105,120`.
- **The whole recipe, extracted from the file rather than retyped**, run against a repo with a 40-second `pre-commit`: poll #1 reported `alive=True done=False`, the final poll `alive=False done=True` with `EXIT=0`, and the commit landed.
- **Scope and duration figures** read from the repo: `.verify-cache.json` last-green `test:server` **518,751 ms** and `test` **153,320 ms`; `docs/testing/flaky-register.md` records a contended `test:server` at **746.6 s**; `STEPS[]` globs confirm `openapi.yaml` is an `extraFiles` entry for both `test` and `test:server`.
- **The pre-commit hook on this branch's own commits** exercised the scoping from the other side: `[pass] test:hooks` then `[skip]` for the other three legs.

Closes #2384
