### PR TITLE
docs(docs): design and plan the #2346 tag-clause colon rule

### DIFF
--- a/docs/superpowers/plans/2026-08-18-2346-colon-rule.md
+++ b/docs/superpowers/plans/2026-08-18-2346-colon-rule.md
@@ -18,10 +18,13 @@ instruments are `.mts` scripts run with `npx tsx`.
 
 **Spec:** [`docs/superpowers/specs/2026-08-18-tag-clause-name-shape-design.md`](../specs/2026-08-18-tag-clause-name-shape-design.md)
 
-**Worktree / branch:** `C:\Claude\Projects\wt-2346-tag-clause-name-shape`, on
-`docs/docs-2346-tag-clause-name-shape`. The branch name says `docs/` because it
-was cut for the design thread. **Task 1 step 1 renames it** — implementation
-commits must not land on a `docs/`-typed branch.
+**Worktree / branch:** cut a **fresh** one — `node scripts/wt-new.mjs
+fix/server-2346-colon-tag-clause` — off `main` **after** the design PR has
+merged. This plan and its spec live on `docs/docs-2346-tag-clause-name-shape`
+(worktree `C:\Claude\Projects\wt-2346-tag-clause-name-shape`), which ships as a
+docs-only PR of its own; that merge is what puts both documents on `main` where
+a cold implementation agent can read them. Do **not** implement on the design
+branch.
 
 ---
 
@@ -85,14 +88,32 @@ Copied verbatim from the spec. Every task's requirements include these.
   QuoteRun[], conv: LanguageConventions): boolean` — signature **unchanged**.
   Task 2's A/B reads the behaviour, not the symbol.
 
-- [ ] **Step 1: Rename the branch off `docs/`**
+- [ ] **Step 1: Cut the implementation worktree off `main`**
 
 ```bash
-git -C "C:/Claude/Projects/wt-2346-tag-clause-name-shape" branch -m fix/server-2346-colon-tag-clause
+git -C "C:/Claude/Projects/Audiobook-Generator" checkout main
+git -C "C:/Claude/Projects/Audiobook-Generator" pull
+node C:/Claude/Projects/Audiobook-Generator/scripts/wt-new.mjs fix/server-2346-colon-tag-clause
 ```
 
-`docs/`-typed branches are for the design thread; this one now carries runtime
-code. Nothing has been pushed yet, so no upstream fix-up is needed.
+`wt-new.mjs` does branch + worktree + non-clashing ports + both `npm install`s,
+and the root install activates husky via `prepare` — so the tree is gated from
+its first commit. A tool-created worktree is **not**: its hooks silently no-op,
+so an invalid commit message sails through and pre-push verify never fires. If
+you did not use `wt-new.mjs`, run `npx husky` and junction **both**
+`node_modules` and `server/node_modules` before doing anything else, then verify
+with `ls -d .husky/_ && git config core.hooksPath`.
+
+Confirm `main` actually carries this plan and its spec before starting — if the
+design PR has not merged, stop and merge it first rather than working from the
+design branch.
+
+Every later step writes the new worktree's absolute path as **`$WT`**. Set it
+once from `wt-new.mjs`'s printed path — e.g.
+`WT=C:/Claude/Projects/wt-2346-colon-tag-clause` — and note that
+`C:/Claude/Projects/Audiobook-Generator` always means the **primary checkout on
+`main`**, which Task 2 uses as the A/B's shipped arm. The two are never
+interchangeable there.
 
 - [ ] **Step 2: Write the failing test**
 
@@ -186,7 +207,7 @@ identical output and the suite cannot tell them apart.
 - [ ] **Step 3: Run it and confirm it fails for the right reason**
 
 ```bash
-npm --prefix "C:/Claude/Projects/wt-2346-tag-clause-name-shape/server" test -- src/analyzer/dialogue-structure/parser.test.ts -t "#2346 defect B"
+npm --prefix "$WT/server" test -- src/analyzer/dialogue-structure/parser.test.ts -t "#2346 defect B"
 ```
 
 Expected, per the measured table above: the **first three FAIL, the last two
@@ -246,7 +267,7 @@ immediately before the closing `*/`:
 - [ ] **Step 6: Run the test — green**
 
 ```bash
-npm --prefix "C:/Claude/Projects/wt-2346-tag-clause-name-shape/server" test -- src/analyzer/dialogue-structure/parser.test.ts -t "#2346 defect B"
+npm --prefix "$WT/server" test -- src/analyzer/dialogue-structure/parser.test.ts -t "#2346 defect B"
 ```
 
 Expected: 5 passed.
@@ -300,7 +321,7 @@ directly above the `it(` at `:367`:
 - [ ] **Step 10: Run the whole dialogue-structure suite**
 
 ```bash
-npm --prefix "C:/Claude/Projects/wt-2346-tag-clause-name-shape/server" test -- src/analyzer/dialogue-structure/
+npm --prefix "$WT/server" test -- src/analyzer/dialogue-structure/
 ```
 
 Expected: 14 files, **386 tests**, all green (381 before, +5 from step 2). The
@@ -313,8 +334,8 @@ adjusting the expectation.
 - [ ] **Step 11: Commit**
 
 ```bash
-git -C "C:/Claude/Projects/wt-2346-tag-clause-name-shape" add server/src/analyzer/dialogue-structure/parser.ts server/src/analyzer/dialogue-structure/parser.test.ts
-git -C "C:/Claude/Projects/wt-2346-tag-clause-name-shape" commit -m "fix(server): stop the tag-clause guard eating a colon-introduced turn (#2346)"
+git -C "$WT" add server/src/analyzer/dialogue-structure/parser.ts server/src/analyzer/dialogue-structure/parser.test.ts
+git -C "$WT" commit -m "fix(server): stop the tag-clause guard eating a colon-introduced turn (#2346)"
 ```
 
 ---
@@ -373,8 +394,8 @@ Create `C:\Claude\castwright-corpus\s2346\ab.mts`:
    two files, one diff.
 
    Usage:
-     CW_REPO=C:/Claude/Projects/Audiobook-Generator                 npx tsx s2346/ab.mts > s2346/shipped.txt
-     CW_REPO=C:/Claude/Projects/wt-2346-tag-clause-name-shape       npx tsx s2346/ab.mts > s2346/colon.txt
+     CW_REPO=<primary checkout, on main> npx tsx s2346/ab.mts > s2346/shipped.txt
+     CW_REPO=<the fix worktree>          npx tsx s2346/ab.mts > s2346/colon.txt
      diff s2346/shipped.txt s2346/colon.txt */
 import { pathToFileURL } from 'node:url';
 
@@ -410,7 +431,7 @@ do not report its output as evidence that no speaker moved.
 
 ```bash
 CW_REPO=C:/Claude/Projects/Audiobook-Generator npx tsx C:/Claude/castwright-corpus/s2346/ab.mts > C:/Claude/castwright-corpus/s2346/shipped.txt
-CW_REPO=C:/Claude/Projects/wt-2346-tag-clause-name-shape npx tsx C:/Claude/castwright-corpus/s2346/ab.mts > C:/Claude/castwright-corpus/s2346/colon.txt
+CW_REPO=$WT npx tsx C:/Claude/castwright-corpus/s2346/ab.mts > C:/Claude/castwright-corpus/s2346/colon.txt
 diff C:/Claude/castwright-corpus/s2346/shipped.txt C:/Claude/castwright-corpus/s2346/colon.txt
 ```
 
@@ -444,9 +465,9 @@ prose. From the worktree, add a temporary logger to `cutsATagClause` —
 clause slice — then:
 
 ```bash
-git -C "C:/Claude/Projects/wt-2346-tag-clause-name-shape" diff server/src/analyzer/dialogue-structure/parser.ts > C:/Claude/castwright-corpus/s2346/decline-log.patch
-git -C "C:/Claude/Projects/wt-2346-tag-clause-name-shape" checkout -- server/src/analyzer/dialogue-structure/parser.ts
-git -C "C:/Claude/Projects/wt-2346-tag-clause-name-shape" status --short
+git -C "$WT" diff server/src/analyzer/dialogue-structure/parser.ts > C:/Claude/castwright-corpus/s2346/decline-log.patch
+git -C "$WT" checkout -- server/src/analyzer/dialogue-structure/parser.ts
+git -C "$WT" status --short
 ```
 
 The `status --short` is the proof of revert, per the corpus README's own
@@ -511,8 +532,8 @@ agent from the spec alone after this step.
 - [ ] **Step 8: Commit the repo-side half**
 
 ```bash
-git -C "C:/Claude/Projects/wt-2346-tag-clause-name-shape" add docs/superpowers/specs/2026-08-18-tag-clause-name-shape-design.md
-git -C "C:/Claude/Projects/wt-2346-tag-clause-name-shape" commit -m "docs(docs): cite the preserved #2346 corpus instruments by path"
+git -C "$WT" add docs/superpowers/specs/2026-08-18-tag-clause-name-shape-design.md
+git -C "$WT" commit -m "docs(docs): cite the preserved #2346 corpus instruments by path"
 ```
 
 `C:\Claude\castwright-corpus\` is outside the repo by design (248 MB of
@@ -575,7 +596,7 @@ unreachable, and the one measured instance was a gain. Do not change any figure.
 - [ ] **Step 4: Confirm nothing changed colour**
 
 ```bash
-npm --prefix "C:/Claude/Projects/wt-2346-tag-clause-name-shape/server" test -- src/analyzer/dialogue-structure/
+npm --prefix "$WT/server" test -- src/analyzer/dialogue-structure/
 ```
 
 Expected: 386 passed, identical to Task 1 step 10. A comment-only task that
@@ -584,8 +605,8 @@ moves the count has edited something it should not have.
 - [ ] **Step 5: Commit**
 
 ```bash
-git -C "C:/Claude/Projects/wt-2346-tag-clause-name-shape" add server/src/analyzer/dialogue-structure/parser.test.ts server/src/analyzer/dialogue-structure/lang/de.ts
-git -C "C:/Claude/Projects/wt-2346-tag-clause-name-shape" commit -m "docs(server): correct guard prose the #2346 colon rule makes false"
+git -C "$WT" add server/src/analyzer/dialogue-structure/parser.test.ts server/src/analyzer/dialogue-structure/lang/de.ts
+git -C "$WT" commit -m "docs(server): correct guard prose the #2346 colon rule makes false"
 ```
 
 ---
@@ -694,12 +715,13 @@ either: this is a spec, not a feature plan.
 - [ ] **Step 4: Branch-scoped verify**
 
 ```bash
-npm --prefix "C:/Claude/Projects/wt-2346-tag-clause-name-shape" run verify:fast:branch
+npm --prefix "$WT" run verify:fast:branch
 ```
 
-Expected green. Confirm the worktree's hooks are real first
-(`ls -d .husky/_ && git config core.hooksPath`) — a tool-created worktree's hooks
-silently no-op, and this one was created by hand.
+Expected green. **Hook output is not proof of verification in a worktree** — it
+has been observed looking entirely genuine, real timings and real test counts,
+while gating nothing. Run this by hand regardless of what the pre-push hook
+printed.
 
 - [ ] **Step 5: Push and open the PR**
 

--- a/docs/superpowers/plans/2026-08-18-2346-colon-rule.md
+++ b/docs/superpowers/plans/2026-08-18-2346-colon-rule.md
@@ -1,0 +1,738 @@
+# The tag-clause colon rule (#2346 defect B) — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `cutsATagClause` from declining a genuine turn that a *leading*
+tag introduces with a colon, so the German sentence it currently deletes is
+spoken.
+
+**Architecture:** One early `return false` at the top of `cutsATagClause`
+(`parser.ts:439`), keyed on the character immediately before the candidate
+after trailing whitespace is stripped. Where it fires the guard is switched
+off entirely — that is the mechanism, and it is safe only because the real
+corpus contains exactly two paragraphs where it fires and both were read. No
+other function, table, or tier changes.
+
+**Tech Stack:** TypeScript, Node 20, Vitest (`server/` project). Corpus
+instruments are `.mts` scripts run with `npx tsx`.
+
+**Spec:** [`docs/superpowers/specs/2026-08-18-tag-clause-name-shape-design.md`](../specs/2026-08-18-tag-clause-name-shape-design.md)
+
+**Worktree / branch:** `C:\Claude\Projects\wt-2346-tag-clause-name-shape`, on
+`docs/docs-2346-tag-clause-name-shape`. The branch name says `docs/` because it
+was cut for the design thread. **Task 1 step 1 renames it** — implementation
+commits must not land on a `docs/`-typed branch.
+
+---
+
+## Global Constraints
+
+Copied verbatim from the spec. Every task's requirements include these.
+
+- **Defect A is out of scope in every form**, including the `out`-based repair.
+  Targeting it re-declines 5,892 genuine spans in `pg/zh/23835.txt`. The pinned
+  gap test at `parser.test.ts:1375` **stays**.
+- **Encodings 1–3 are falsified and must not be re-proposed**: per-language
+  `tagPrecedesTurn`, candidate-is-name-shaped, candidate-contains-a-roster-name.
+  Both dead encodings pick a property of the *candidate*; the distinction is a
+  property of the *separator*.
+- **`.replace(/\s+$/u, '')` is load-bearing, not tidying.** The raw
+  colon-adjacent count across the whole corpus is **zero** — without the strip
+  the change does nothing at all, silently.
+- **Make no attribution claim anywhere** — not in the PR body, the release
+  notes, a code comment, or a commit message. The 42-case family in
+  `reopen-sweep.test.ts` has **zero power** here (0 of its 42 case bodies
+  contain a colon, and it omits German). An attribution claim requires a
+  colon-bearing, German-inclusive family of **66 cases** with a firing control
+  that actually shows **32 lost**. Nothing in this plan builds one.
+- **This ships a segmentation fix, not an attribution fix.** The recovered
+  German turn carries `speaker: null`. Release-note wording must say so.
+- **Do not touch** the language tables, the primary tier, `scanQuoteRuns`, or
+  `crossExamine`'s `dialogueOpen` contract. Do not broaden the separator set to
+  `;` or `—`.
+- **A corpus replay is not clearance.** Two wrong diagnoses in this strand
+  passed a clean 0-of-747-chapter replay. Task 2 decides because its flip set is
+  *enumerated and read*, not because it is a corpus run.
+
+---
+
+## File Structure
+
+| file | responsibility | task |
+|---|---|---|
+| `server/src/analyzer/dialogue-structure/parser.ts` | the rule (`cutsATagClause`, `:439`) + its header doc (`:409-438`) | 1 |
+| `server/src/analyzer/dialogue-structure/parser.test.ts` | the real-paragraph regression test; the `:367-370` coincidence comment | 1 |
+| `server/src/analyzer/dialogue-structure/parser.test.ts` | `:1410` and `:459-465` prose the change makes false | 3 |
+| `server/src/analyzer/dialogue-structure/lang/de.ts` | `:64-66` arity claim contradicted by the lines it cites | 3 |
+| `C:\Claude\castwright-corpus\2288-corpus-lib.mts` | `CW_REPO` env override so both A/B arms are addressable | 2 |
+| `C:\Claude\castwright-corpus\s2346\` (new) | the A/B instrument, the decline-logger patch, its README | 2 |
+| `docs/superpowers/specs/2026-08-18-tag-clause-name-shape-design.md` | Instruments section → cite `s2346/` by absolute path | 2 |
+| `docs/release-notes-next.md`, `RELEASE_NOTES.md` | the shipped delta | 4 |
+
+---
+
+### Task 1: The colon rule, pinned by the real German paragraph
+
+**Files:**
+- Modify: `server/src/analyzer/dialogue-structure/parser.ts:409-464`
+- Modify: `server/src/analyzer/dialogue-structure/parser.test.ts` (new `describe`
+  after the `#2315 guard cutsATagClause` block ending near `:558`; comment at
+  `:361-370`)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `cutsATagClause(line: string, cand: QuoteRun, primaryRuns:
+  QuoteRun[], conv: LanguageConventions): boolean` — signature **unchanged**.
+  Task 2's A/B reads the behaviour, not the symbol.
+
+- [ ] **Step 1: Rename the branch off `docs/`**
+
+```bash
+git -C "C:/Claude/Projects/wt-2346-tag-clause-name-shape" branch -m fix/server-2346-colon-tag-clause
+```
+
+`docs/`-typed branches are for the design thread; this one now carries runtime
+code. Nothing has been pushed yet, so no upstream fix-up is needed.
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `server/src/analyzer/dialogue-structure/parser.test.ts`. The body is
+the **real paragraph** from `pg/de/63460.txt` (Gutenberg 63460, lines
+3814–3829, unwrapped) — acceptance item 2 forbids a reduced shape, because a
+reduced shape drops the unrelated `»Tick-Tack ... Tick-Tack«` clock run that is
+what sets `precededByPrimaryRun` in the first place.
+
+```ts
+/* #2346 defect B — the guard fires on a LEADING tag and deletes the turn it
+   introduces. A colon immediately before the candidate means the verb
+   INTRODUCES what follows (`sagte er …: «…»`, the Latin analogue of CJK's
+   `：`); the guard's remaining tests all assume the verb ATTRIBUTES something
+   already parsed.
+
+   The body is the REAL paragraph from Gutenberg 63460, not a reduced shape.
+   The reduction is what hides the bug: the trigger is the unrelated
+   `»Tick-Tack ... Tick-Tack«` clock earlier in the same paragraph, which sets
+   `precededByPrimaryRun` for a candidate it has nothing to do with. Shorten
+   the body and the test passes for the wrong reason.
+
+   This is a SEGMENTATION assertion, not an attribution one — the recovered
+   turn has no speaker, and this suite is documented as blind to attribution. */
+describe('parser — #2346 defect B: a colon-introduced turn is not eaten by the tag-clause guard', () => {
+  const spoken = (body: string, lang: string) =>
+    spansOf(parseChapterStructure(body, buildNameIndex([], conventionsFor(lang)!)))
+      .filter((s) => s.kind === 'speech')
+      .map((s) => body.slice(s.start, s.end));
+
+  const DE_63460 =
+    'Es war gruselig und dunkel auf der Stiege, aber dann zündete Ulebuhle sein Öllämpchen an, der Schlüssel ' +
+    'drehte sich kreischend im Schloß, und knarrend öffnete sich die Turmtür, um uns einzulassen in den ' +
+    'geheimnisvollen Raum. -- Da stand in der Mitte auf einer Säule ein großes Ding, wie eine Kanone, und so ' +
+    'dick, daß die dünnsten von uns wohl hätten durch das Rohr hindurchkriechen können. Es blinkte daran von ' +
+    'allerlei Schrauben und Griffen, von Stahl und Messing. Oben war ein großes Glas im Rohr, wohl wie ein ' +
+    'Teller, und unten ein ganz winziges, durch das man hindurchschauen mußte. Und dann tickte da noch eine ' +
+    'große Uhr in einem Glasgehäuse, mit einem langen Perpendikel, der mächtig vornehm und langsam hin und her ' +
+    'schwang und unablässig ganz bedächtig sein »Tick-Tack ... Tick-Tack« sagte. -- Da waren auch noch allerlei ' +
+    'Apparate in den Ecken und an den Wänden, und Bilder hingen da von Mond und Sternen, und dicke Bücher lagen ' +
+    'in den Fächern. Aber wenn wir Ulebuhle nach all dem fragten, dann sagte er nur in seiner knurrigen ' +
+    'Weise: «Schnickschnack und Finger davon! Das versteht ihr nicht!»';
+
+  it('de: the colon-introduced turn survives as its own speech span (real paragraph)', () => {
+    expect(spoken(DE_63460, 'de')).toEqual([
+      'Tick-Tack ... Tick-Tack',
+      'Schnickschnack und Finger davon! Das versteht ihr nicht!',
+    ]);
+  });
+
+  it('de: a colon-introduced turn with NO whitespace before the quote also survives', () => {
+    expect(spoken('„Guten Tag", sagte er. Dann sagte er:«Hallo».', 'de')).toEqual(['Guten Tag', 'Hallo']);
+  });
+
+  /* The full-width `：` arm must use a SECONDARY zh pair. `“…”` is a zh PRIMARY
+     pair, so `他说：“你好”。` never reaches the guard at all and already returns
+     `['你好']` on shipped code — measured. A test written on that shape cannot
+     fail, in either direction. `‘…’` is zh's secondary pair, and the leading
+     `“早安”` supplies the primary run the guard requires before it will act. */
+  it('zh: a full-width colon introduces the turn the same way', () => {
+    expect(spoken('“早安”，他说。然后他说：‘你好’。', 'zh')).toEqual(['早安', '你好']);
+  });
+
+  it('zh: the same shape WITHOUT the colon is still declined', () => {
+    expect(spoken('“早安”，他说。然后他说‘你好’。', 'zh')).toEqual(['早安']);
+  });
+
+  it('de: a TRAILING tag is still declined — the guard is not disabled generally', () => {
+    expect(spoken('„Guten Tag", sagte «Ulebuhle». Und dann ging er.', 'de')).toEqual(['Guten Tag']);
+  });
+});
+```
+
+**All five expectations are measured, not predicted** — probed against the real
+parser on 2026-08-18, both arms (shipped = primary checkout on `main`, +colon =
+this worktree with the rule applied and then reverted):
+
+| case | shipped | + colon rule |
+|---|---|---|
+| real `pg/de/63460` paragraph | `[Tick-Tack]` | `[Tick-Tack, Schnickschnack…]` |
+| `…sagte er:«Hallo».` (no space) | `[Guten Tag]` | `[Guten Tag, Hallo]` |
+| `…然后他说：‘你好’。` | `[早安]` | `[早安, 你好]` |
+| `…然后他说‘你好’。` (no colon) | `[早安]` | `[早安]` — control |
+| `…sagte «Ulebuhle».` (trailing tag) | `[Guten Tag]` | `[Guten Tag]` — control |
+
+The last two are the cases that fail if the rule is written too broadly. Each has
+a verb and a preceding primary run but **no colon**, so the guard must still
+decline — without them, "the rule fires" and "the guard was deleted" produce
+identical output and the suite cannot tell them apart.
+
+- [ ] **Step 3: Run it and confirm it fails for the right reason**
+
+```bash
+npm --prefix "C:/Claude/Projects/wt-2346-tag-clause-name-shape/server" test -- src/analyzer/dialogue-structure/parser.test.ts -t "#2346 defect B"
+```
+
+Expected, per the measured table above: the **first three FAIL, the last two
+PASS**. The first must fail showing exactly `[ 'Tick-Tack ... Tick-Tack' ]` — the
+German turn absent entirely, not merely mis-bounded. **If it fails some other
+way, stop and re-read the body**: a paste that lost a character silently changes
+what is being measured. The two controls passing while the rest are red is what
+proves the new cases are reachable and the controls are not vacuously green.
+
+- [ ] **Step 4: Implement the rule**
+
+In `server/src/analyzer/dialogue-structure/parser.ts`, insert at the top of
+`cutsATagClause` (currently `:439`), before the `primaryRuns` loop:
+
+```ts
+function cutsATagClause(line: string, cand: QuoteRun, primaryRuns: QuoteRun[], conv: LanguageConventions): boolean {
+  /* #2346 defect B. A colon immediately before the candidate means the verb
+     INTRODUCES what follows — `sagte er …: «…»`, the Latin analogue of CJK's
+     `：`. Every test below assumes the opposite (that the verb ATTRIBUTES a
+     turn already parsed), so none of them may run on a leading tag.
+
+     Where this fires the guard is switched OFF entirely — it is an early
+     `return false` ahead of every other test, not an extra condition. That is
+     safe here only because the real corpus contains exactly TWO paragraphs
+     where it fires and both were read (`pg/de/63460.txt`, `pg/zh/52200.txt`);
+     it is an empirical bound, not a structural one, and it must be re-measured
+     if the tables or the corpus change.
+
+     The trailing-whitespace strip is LOAD-BEARING, not tidying: the target
+     paragraph's colon is followed by a space, and the raw colon-adjacent count
+     across the whole corpus is ZERO. Remove the strip and this does nothing at
+     all, silently. */
+  const lastCh = line.slice(0, cand.start).replace(/\s+$/u, '').slice(-1);
+  if (lastCh === ':' || lastCh === '：') return false;
+
+  let from = 0;
+  // …existing body, unchanged…
+```
+
+- [ ] **Step 5: Update the guard's header doc**
+
+The header at `parser.ts:409-438` documents a two-test rule ("Once a primary run
+is confirmed, the discriminator is a SENTENCE BOUNDARY, not a verb alone"). It
+is now three tests, and the new one runs first. Append to that comment block,
+immediately before the closing `*/`:
+
+```
+    #2346 defect B added a THIRD test, and it runs FIRST: a colon immediately
+    before the candidate (whitespace stripped) means the verb introduces the
+    turn rather than attributing one, so the guard declines nothing at all
+    there. That is a switch-off, not a narrowing — see the note on the rule
+    itself. The proxy remains wrong in the other direction too (defect A: the
+    guard is inert where no primary run precedes the candidate), which is
+    accepted, priced at <=21 of 1,164, and pinned in `parser.test.ts`.
+```
+
+- [ ] **Step 6: Run the test — green**
+
+```bash
+npm --prefix "C:/Claude/Projects/wt-2346-tag-clause-name-shape/server" test -- src/analyzer/dialogue-structure/parser.test.ts -t "#2346 defect B"
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 7: Mutation receipt — mutant 1, delete the rule**
+
+Delete the two rule lines (keep the comment), re-run step 6, and **paste the
+actual failure text into the task report**. Expected RED on the first three
+cases, GREEN on the two controls. Restore.
+
+- [ ] **Step 8: Mutation receipt — mutant 2, the silent one**
+
+Restore the rule but delete only `.replace(/\s+$/u, '')`:
+
+```ts
+  const lastCh = line.slice(0, cand.start).slice(-1);
+```
+
+Re-run step 6 and **paste the actual failure text**. Expected RED on the **real
+German paragraph only** — its colon is the one followed by a space. The
+no-whitespace `de` case and the `zh` case (`说：‘你好’`, colon directly against the
+quote) both stay GREEN, which is precisely why this mutant is the dangerous one:
+four of five assertions still pass and only the real-corpus paragraph notices.
+Restore.
+
+> This is also the argument for keeping the real paragraph in the suite. Every
+> reduced shape a reviewer would naturally write has the colon flush against the
+> quote, and every one of them is blind to this mutant.
+
+> Both receipts are acceptance item 3 and the report is not complete without the
+> observed output. A receipt that says "confirmed red" without the text is not a
+> receipt.
+
+- [ ] **Step 9: Comment the fixture that survives by coincidence**
+
+`parser.test.ts:367-370` is the only shipped fixture that already puts a colon
+before a secondary candidate (`Das Schild dort: «Zu»`). It stays green — but
+only because `Das Schild dort` carries no verb stem, so `hasStem` returned
+`false` before this change and the colon rule returns `false` after it. Add
+directly above the `it(` at `:367`:
+
+```ts
+  // #2346: `dort: «Zu»` is the only shipped fixture with a colon before a
+  // secondary candidate, so it is the one place the new colon rule and the
+  // pre-existing `hasStem` test overlap. It was green before the rule and is
+  // green after it — but for DIFFERENT reasons (no verb stem, then the colon),
+  // which is a coincidence, not a guarantee. It cannot detect a regression in
+  // either mechanism; the `#2346 defect B` describe below is what pins the rule.
+```
+
+- [ ] **Step 10: Run the whole dialogue-structure suite**
+
+```bash
+npm --prefix "C:/Claude/Projects/wt-2346-tag-clause-name-shape/server" test -- src/analyzer/dialogue-structure/
+```
+
+Expected: 14 files, **386 tests**, all green (381 before, +5 from step 2). The
+381 baseline is measured: the whole directory was run on 2026-08-18 with the
+rule applied and no existing test changed colour.
+Necessary, never sufficient — this suite is documented as blind to attribution.
+If the count differs from 386, reconcile it before committing rather than
+adjusting the expectation.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git -C "C:/Claude/Projects/wt-2346-tag-clause-name-shape" add server/src/analyzer/dialogue-structure/parser.ts server/src/analyzer/dialogue-structure/parser.test.ts
+git -C "C:/Claude/Projects/wt-2346-tag-clause-name-shape" commit -m "fix(server): stop the tag-clause guard eating a colon-introduced turn (#2346)"
+```
+
+---
+
+### Task 2: The corpus A/B — the deciding acceptance item — and preserve the instruments
+
+The spec's own chore list says acceptance items 1 and 3 **cannot be executed by
+a cold agent** as written, because the measurement patch was reverted and never
+preserved. This task fixes that and runs the measurement.
+
+**Files:**
+- Modify: `C:\Claude\castwright-corpus\2288-corpus-lib.mts:23` (add the `CW_REPO`
+  env override)
+- Create: `C:\Claude\castwright-corpus\s2346\ab.mts`
+- Create: `C:\Claude\castwright-corpus\s2346\decline-log.patch`
+- Create: `C:\Claude\castwright-corpus\s2346\README.md`
+- Modify: `C:\Claude\castwright-corpus\README.md` (the known-good figures block)
+- Modify: `docs/superpowers/specs/2026-08-18-tag-clause-name-shape-design.md`
+  (Instruments section)
+
+**Interfaces:**
+- Consumes: Task 1's shipped rule, read through the **worktree path**, not a
+  port.
+- Produces: `s2346/ab.mts`, run as
+  `CW_REPO=<abs> npx tsx C:/Claude/castwright-corpus/s2346/ab.mts`, printing one
+  line per changed paragraph plus a `books touched:` summary.
+
+- [ ] **Step 1: Make both A/B arms addressable**
+
+`2288-corpus-lib.mts:23` hardcodes `const REPO = 'C:/Claude/Projects/Audiobook-Generator';`
+— the primary checkout, which is on `main`. That is the *shipped* arm. The
+worktree is the *+colon* arm. Both already exist on disk, so no parser patching
+is needed for the outcome A/B at all. Make the path selectable, keeping the
+current value as the default so every other script in the directory is
+unaffected:
+
+```ts
+const REPO = process.env.CW_REPO ?? 'C:/Claude/Projects/Audiobook-Generator';
+```
+
+This is strictly better than the env-gated parser patch the spec describes: it
+measures two real checkouts rather than one patched one, and it leaves nothing
+to revert.
+
+- [ ] **Step 2: Write the A/B instrument**
+
+Create `C:\Claude\castwright-corpus\s2346\ab.mts`:
+
+```ts
+/* #2346 — the deciding measurement. Parse the whole 331-book corpus through ONE
+   checkout and emit a per-paragraph span signature; run it twice (shipped arm =
+   primary checkout on main, +colon arm = the worktree) and diff the two files.
+
+   Why signatures and not an in-process A/B: `2288-corpus-lib.mts` resolves the
+   parser at module load, so one process can only ever hold one arm. Two runs,
+   two files, one diff.
+
+   Usage:
+     CW_REPO=C:/Claude/Projects/Audiobook-Generator                 npx tsx s2346/ab.mts > s2346/shipped.txt
+     CW_REPO=C:/Claude/Projects/wt-2346-tag-clause-name-shape       npx tsx s2346/ab.mts > s2346/colon.txt
+     diff s2346/shipped.txt s2346/colon.txt */
+import { pathToFileURL } from 'node:url';
+
+const LIB = 'C:/Claude/castwright-corpus/2288-corpus-lib.mts';
+const { loadGutenberg, loadStandardEbooks, parseChapterStructure, buildNameIndex, conventionsFor } =
+  await import(pathToFileURL(LIB).href);
+
+const LANGS = ['es', 'fr', 'ru', 'en', 'zh', 'ja', 'de'];
+const books = [...(await loadGutenberg(LANGS)), ...(await loadStandardEbooks())];
+
+let paragraphs = 0;
+for (const b of books) {
+  const conv = conventionsFor(b.lang);
+  if (!conv) continue;
+  const idx = buildNameIndex([], conv);
+  for (const [i, p] of b.paragraphs.entries()) {
+    paragraphs++;
+    const spans = parseChapterStructure(p, idx).flatMap((q: { spans: unknown[] }) => q.spans);
+    const sig = spans
+      .map((s: { kind: string; start: number; end: number }) => `${s.kind}:${s.start}-${s.end}`)
+      .join('|');
+    if (sig) console.log(`${b.id}\t${i}\t${sig}`);
+  }
+}
+console.error(`books ${books.length} · paragraphs ${paragraphs}`);
+```
+
+`buildNameIndex([], conv)` — an **empty roster**. This instrument is silent
+about attribution *by construction*. It bounds blast radius and nothing more;
+do not report its output as evidence that no speaker moved.
+
+- [ ] **Step 3: Run both arms and diff**
+
+```bash
+CW_REPO=C:/Claude/Projects/Audiobook-Generator npx tsx C:/Claude/castwright-corpus/s2346/ab.mts > C:/Claude/castwright-corpus/s2346/shipped.txt
+CW_REPO=C:/Claude/Projects/wt-2346-tag-clause-name-shape npx tsx C:/Claude/castwright-corpus/s2346/ab.mts > C:/Claude/castwright-corpus/s2346/colon.txt
+diff C:/Claude/castwright-corpus/s2346/shipped.txt C:/Claude/castwright-corpus/s2346/colon.txt
+```
+
+Run from a directory with `tsx` available (`C:/Claude/Projects/Audiobook-Generator/server`).
+
+**Expected — this is acceptance item 1, and it decides:**
+
+```
+books 331 · paragraphs 726385   (both arms, on stderr)
+2 changed paragraphs, in exactly 2 books:
+  pg/de/63460.txt   the target — the turn becomes its own speech span
+  pg/zh/52200.txt   a tag containing a nested turn splits into tag + speech + narration
+```
+
+**Fails if** the changed set differs in size or membership. A third book, or a
+different book, means the rule reaches further than it was cleared for — stop
+and report, do not adjudicate a new flip inside an implementation task. That is
+a design decision and belongs back in phase 1.
+
+Confirm the stderr paragraph count matches between arms before trusting the
+diff: an arm that loaded fewer books would produce a small diff for the wrong
+reason.
+
+- [ ] **Step 4: Preserve the decline-logger patch**
+
+The outcome A/B above needs no patch. The *decline count* (`102 → 100`) does,
+because a decline is internal to `cutsATagClause` and counting it any other way
+is a reimplementation-by-proxy. Capture it as an applicable patch rather than
+prose. From the worktree, add a temporary logger to `cutsATagClause` —
+`appendFileSync` on each `return true`, recording `lang`, the book id, and the
+clause slice — then:
+
+```bash
+git -C "C:/Claude/Projects/wt-2346-tag-clause-name-shape" diff server/src/analyzer/dialogue-structure/parser.ts > C:/Claude/castwright-corpus/s2346/decline-log.patch
+git -C "C:/Claude/Projects/wt-2346-tag-clause-name-shape" checkout -- server/src/analyzer/dialogue-structure/parser.ts
+git -C "C:/Claude/Projects/wt-2346-tag-clause-name-shape" status --short
+```
+
+The `status --short` is the proof of revert, per the corpus README's own
+pattern. **The working tree must be clean before the next step.** Vitest
+silences `console.log`, which is why the logger writes to a file.
+
+- [ ] **Step 5: Write `s2346/README.md`**
+
+```markdown
+# s2346 — the colon rule (#2346 defect B)
+
+`ab.mts` is the deciding instrument. Two arms, two files, one diff — see the
+header of `ab.mts` for the exact invocation. It needs `CW_REPO`, added to
+`2288-corpus-lib.mts` for this round; without it the loader always resolves the
+primary checkout and both arms are identical.
+
+`decline-log.patch` applies a temporary decline logger to `cutsATagClause`.
+Apply it, run the corpus, read the log, then `git checkout --` the file. Needed
+only for the `102 -> 100` decline figure; the paragraph-level A/B needs no patch.
+
+## Reference figures (2026-08-18, real parser, both arms on disk)
+
+    declines    shipped 102 -> +colon 100     (de 1, ja 1, zh 100)
+    paragraphs  changed 2 · speech +2 · tag 0 · narration +1
+    books       pg/de/63460.txt, pg/zh/52200.txt
+
+## What this directory canNOT tell you
+
+`ab.mts` runs `buildNameIndex([], conv)` — an EMPTY ROSTER. It is silent about
+attribution BY CONSTRUCTION, not by measurement. It bounds blast radius. Any
+speaker claim needs `s2315/attrib.mts`, rebuilt German-inclusive (66 cases) with
+a firing control that shows 32 lost — see the note added to the parent README.
+```
+
+- [ ] **Step 6: Correct the parent README's known-good figures**
+
+`C:\Claude\castwright-corpus\README.md`'s "Known-good reference figures" block
+still presents the 42-case attribution family as this strand's safety case. For
+the colon rule it has **no power at all**. Append to that block:
+
+```markdown
+> **The 42-case attribution family is powerless for #2346's colon rule.** Zero
+> of its 42 case bodies contain a colon — its separators are `, dijo `,
+> `, said ` and the CJK equivalents — so the rule's predicate cannot fire on a
+> single case, and a "shipped == +colon" result there is true BY CONSTRUCTION.
+> The family also hardcodes six languages and omits GERMAN, the language of the
+> target. The German-inclusive family is 66 cases with a firing control of 32
+> (`lang/de.ts:78-79`); rebuilt with a colon separator it loses 32 of 66 with
+> the rule live — i.e. where the rule fires, the guard is off. Add German before
+> using this family for anything.
+```
+
+- [ ] **Step 7: Point the spec at the preserved instruments**
+
+In `docs/superpowers/specs/2026-08-18-tag-clause-name-shape-design.md`, the
+Instruments section and the chore "Record the instruments actually used" both
+describe an unpreserved patch. Replace the chore bullet with a line recording
+`s2346/ab.mts` + `s2346/decline-log.patch` by absolute path, and add `s2346/` to
+the Instruments list. Acceptance items 1 and 3 must be executable by a cold
+agent from the spec alone after this step.
+
+- [ ] **Step 8: Commit the repo-side half**
+
+```bash
+git -C "C:/Claude/Projects/wt-2346-tag-clause-name-shape" add docs/superpowers/specs/2026-08-18-tag-clause-name-shape-design.md
+git -C "C:/Claude/Projects/wt-2346-tag-clause-name-shape" commit -m "docs(docs): cite the preserved #2346 corpus instruments by path"
+```
+
+`C:\Claude\castwright-corpus\` is outside the repo by design (248 MB of
+third-party text) and is not committed. Say so in the task report.
+
+---
+
+### Task 3: Prose the change makes false
+
+Three sentences in shipped files become wrong the moment Task 1 lands. Under
+CLAUDE.md's incidental-findings rule these are chores fixed in the same round,
+not filed. Grouped because a reviewer can accept or reject them as one docs-only
+unit.
+
+**Files:**
+- Modify: `server/src/analyzer/dialogue-structure/parser.test.ts:1410`
+- Modify: `server/src/analyzer/dialogue-structure/parser.test.ts:459-465`
+- Modify: `server/src/analyzer/dialogue-structure/lang/de.ts:64-66`
+
+**Interfaces:**
+- Consumes: Task 1's rule (these sentences describe it). No code changes; no
+  test may change colour.
+
+- [ ] **Step 1: Reword the pinned gap test's expectation**
+
+`parser.test.ts:1410` reads *"this test is expected to start FAILING the moment
+#2346 is fixed, at which point it should be deleted, not adjusted to pass
+again."* Task 1 fixes #2346's **defect B** and the test keeps passing, because it
+pins **defect A** — which is accepted and stays. Replace with:
+
+```
+     gap — this test pins DEFECT A (the guard is INERT where no primary run
+     precedes the candidate), which #2346's design accepted and priced rather
+     than fixed; it is expected to keep passing. #2346's shipped change is
+     defect B (the guard FIRING on a leading tag), a disjoint population
+     separated by `precededByPrimaryRun` — never average the two. Delete this
+     test only if defect A is itself fixed, not adjusted to pass again.
+```
+
+- [ ] **Step 2: Correct the guard describe header**
+
+`parser.test.ts:459-465` describes the guard as a two-part rule and no longer
+describes it. Append to that comment, before the closing `*/`:
+
+```
+   Since #2346 the guard also returns EARLY, declining nothing, when a colon
+   immediately precedes the candidate (whitespace stripped) — a leading tag
+   introduces its turn rather than attributing one. The cases in this block all
+   use trailing tags, so none of them exercise that path; `#2346 defect B` does.
+```
+
+- [ ] **Step 3: Correct the arity claim in `de.ts`**
+
+`lang/de.ts:64-66` says the Swiss entry is unreachable at two or more `«`, and
+the very lines it cites say otherwise: 16 changed paragraphs, "15 with exactly
+one `«`, 1 with two or more — a gain, not a collision instance". Reword the
+claim to match its own evidence: the entry is *degraded* at two or more, not
+unreachable, and the one measured instance was a gain. Do not change any figure.
+
+- [ ] **Step 4: Confirm nothing changed colour**
+
+```bash
+npm --prefix "C:/Claude/Projects/wt-2346-tag-clause-name-shape/server" test -- src/analyzer/dialogue-structure/
+```
+
+Expected: 386 passed, identical to Task 1 step 10. A comment-only task that
+moves the count has edited something it should not have.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "C:/Claude/Projects/wt-2346-tag-clause-name-shape" add server/src/analyzer/dialogue-structure/parser.test.ts server/src/analyzer/dialogue-structure/lang/de.ts
+git -C "C:/Claude/Projects/wt-2346-tag-clause-name-shape" commit -m "docs(server): correct guard prose the #2346 colon rule makes false"
+```
+
+---
+
+### Task 4: Ship
+
+**Files:**
+- Modify: `docs/release-notes-next.md`, `RELEASE_NOTES.md`
+- Modify: `docs/superpowers/specs/2026-08-18-tag-clause-name-shape-design.md`
+  (status → `stable`, Ship notes)
+
+**Interfaces:**
+- Consumes: Tasks 1–3 committed, Task 2's measured flip set.
+
+- [ ] **Step 1: File the issue defect B has to close**
+
+**This is a merge blocker, not bookkeeping.** #2346's title and body are
+entirely about defect A ("the tag-clause guard is inert for a paragraph typed
+wholly in a secondary-tier convention"); defect B was folded into it by a
+comment. Re-scoping #2346 to A alone leaves this PR with nothing to `Closes`,
+and `main`'s required `pr-issue-link` check rejects the merge. Per CLAUDE.md's
+PR-creation gate, file it without pausing to ask:
+
+Write the body to a file first — `gh issue create --body` with this much prose
+and these glyphs is fragile under MSYS path rewriting:
+
+```markdown
+`cutsATagClause` (`server/src/analyzer/dialogue-structure/parser.ts:439`) declines
+a secondary-tier quote-run whenever a primary run ends before it and the clause
+between carries a speech verb. That is the right test for a TRAILING tag. It is
+backwards for a LEADING one, where the verb introduces the turn instead of
+attributing an already-parsed one — and the guard then drops the entire spoken
+sentence.
+
+**Real case**, `pg/de/63460.txt` (Project Gutenberg 63460):
+
+> …dann **sagte** er nur in seiner knurrigen Weise**:** «Schnickschnack und
+> Finger davon! Das versteht ihr nicht!»
+
+An unrelated earlier primary run in the same paragraph — a clock going
+`»Tick-Tack ... Tick-Tack«` — sets `precededByPrimaryRun`; the clause carries
+`sagte`; the guard declines. The whole line is lost from the audiobook.
+
+**Measured**: 2 changed paragraphs in 726,385 across 331 books, in exactly two
+books (`pg/de/63460.txt`, `pg/zh/52200.txt`); both adjudicated in the design.
+
+**Segmentation, not attribution** — the recovered turn carries `speaker: null`.
+
+This is the mirror of #2346, which stays open: there the guard is INERT and a
+name is wrongly admitted. The two are disjoint populations separated by
+`precededByPrimaryRun` and must never be averaged.
+
+Design: `docs/superpowers/specs/2026-08-18-tag-clause-name-shape-design.md`
+```
+
+```bash
+gh issue create --repo dudarenok-maker/Castwright \
+  --title "The tag-clause guard (#2315) deletes a turn introduced by a leading tag" \
+  --label bug --label area:srv \
+  --body-file C:/Claude/castwright-corpus/s2346/issue-body.md
+```
+
+`bug` is a standalone label — no `type:`/`moscow:` pair, and no `docs/BACKLOG.md`
+row (bugs never render there). **Do not** describe it as an attribution bug.
+
+- [ ] **Step 2: Release notes, both files, in this PR**
+
+`docs/release-notes-next.md` — technical register, PR-refed:
+
+```markdown
+- **A German turn introduced by a leading tag is no longer deleted by the #2315
+  tag-clause guard** (#NN). `cutsATagClause` declined any secondary-tier
+  candidate preceded by a primary run and a speech verb, including
+  `sagte er …: «…»`, where the verb introduces the turn rather than attributing
+  one — dropping the entire spoken sentence. A colon immediately before the
+  candidate now short-circuits the guard. Segmentation only: the recovered turn
+  carries no speaker. Measured at 2 changed paragraphs in 726,385 across 331
+  books.
+```
+
+`RELEASE_NOTES.md` — user-facing, brand voice, into the **1.15.0** section at the
+top. Say a **line that was silently dropped is now spoken**; do not say anyone is
+attributed to it:
+
+```markdown
+- **A line of dialogue introduced with a colon is no longer silently dropped.**
+  In German a character often speaks after a colon — *…then he said in his gruff
+  way: «Nonsense and hands off!»* Castwright reads the words before a quote to
+  work out whether they introduce a line or attribute one, and for this shape it
+  got the answer backwards: it treated the whole spoken sentence as part of the
+  narration around it and left it out of the audiobook entirely. It now
+  recognises the colon for what it is, and the line gets read aloud.
+```
+
+- [ ] **Step 3: Ship the spec**
+
+Update the spec's `Status:` line: the design is shipped for **defect B**, with
+defect A explicitly still open. Add a Ship notes line carrying the date and Task
+1's commit SHA.
+
+**Do not move the file.** `docs/superpowers/specs/` has no `archive/`
+subdirectory — verified 2026-08-18 — unlike `docs/features/`, whose
+archive-on-ship rule does not apply here. `docs/features/INDEX.md` needs no entry
+either: this is a spec, not a feature plan.
+
+- [ ] **Step 4: Branch-scoped verify**
+
+```bash
+npm --prefix "C:/Claude/Projects/wt-2346-tag-clause-name-shape" run verify:fast:branch
+```
+
+Expected green. Confirm the worktree's hooks are real first
+(`ls -d .husky/_ && git config core.hooksPath`) — a tool-created worktree's hooks
+silently no-op, and this one was created by hand.
+
+- [ ] **Step 5: Push and open the PR**
+
+Title: `fix(server): stop the tag-clause guard eating a colon-introduced turn`
+
+Body must carry:
+- `Closes #NN` (step 1's new issue) and `Refs #2346` (defect A stays open).
+- The measured delta: 2 of 726,385 paragraphs, both books named and adjudicated.
+- **Both mutation receipts with their observed output**, including the silent
+  whitespace-strip mutant.
+- An explicit statement that **no attribution claim is made**, and why the
+  42-case family cannot support one here.
+- Under "Also fixed, found in passing": Task 3's three prose corrections.
+- **On-box acceptance: not applicable** — pure parser logic, no GPU, sidecar,
+  analyzer, or live book involved. Say this explicitly rather than omitting it.
+
+- [ ] **Step 6: The mandatory review gate**
+
+Run the `pr-review-gate` skill at **medium** depth (single-scope `fix`). Not a
+docs-only PR, so the exemption does not apply. Triage and fold findings before
+merge.
+
+---
+
+## The open question this plan does not answer
+
+Round 2's constructed case `“Hi”, he said: «Anton is here!»` moves `Hi` from
+`anton` to `null` under this rule. Whether that is a **regression or a
+correction is genuinely contested and is not settled** — `Anton` sits inside a
+*different turn*, not in the tag, so attributing `Hi` to it is arguably a false
+attribution the rule removes.
+
+It does **not** block either real-corpus flip, which are the whole shipping
+delta and are adjudicated. It is an owner-facing question that decides how the
+rule is *described* and whether a follow-up is owed. **Do not resolve it inside
+an implementation task.** If the reviewer raises it, point here.

--- a/docs/superpowers/specs/2026-08-18-tag-clause-name-shape-design.md
+++ b/docs/superpowers/specs/2026-08-18-tag-clause-name-shape-design.md
@@ -1,49 +1,24 @@
 # The tag-clause guard declines genuine turns — design
 
-Status: **active — owner decided 2026-08-18: fix defect B (the false positive), price defect A as an accepted residual. Encoding: a name-shape conjunct.** · Issue: [#2346](https://github.com/dudarenok-maker/Castwright/issues/2346) · Follows: [`2026-08-13-primary-pair-straddle-design.md`](2026-08-13-primary-pair-straddle-design.md) ([#2315](https://github.com/dudarenok-maker/Castwright/issues/2315), shipped PR [#2340](https://github.com/dudarenok-maker/Castwright/pull/2340)) · Strand: [#2288](https://github.com/dudarenok-maker/Castwright/issues/2288) M1/M2, [#2286](https://github.com/dudarenok-maker/Castwright/pull/2286)
+Status: **active — owner decided 2026-08-18: fix defect B (the false positive), price defect A as an accepted residual. Encoding: the colon separator rule (issue option 2), after two other encodings were built and falsified.** · Issue: [#2346](https://github.com/dudarenok-maker/Castwright/issues/2346) · Follows: [`2026-08-13-primary-pair-straddle-design.md`](2026-08-13-primary-pair-straddle-design.md) ([#2315](https://github.com/dudarenok-maker/Castwright/issues/2315), shipped PR [#2340](https://github.com/dudarenok-maker/Castwright/pull/2340)) · Strand: [#2288](https://github.com/dudarenok-maker/Castwright/issues/2288) M1/M2, [#2286](https://github.com/dudarenok-maker/Castwright/pull/2286)
 
 ---
 
 ## Summary
 
-`cutsATagClause` (`server/src/analyzer/dialogue-structure/parser.ts:439`) exists
-to stop a gained secondary-tier run from truncating a tag clause and stripping
-the neighbouring turn's speaker. It uses **"does a primary run end before this
-candidate?"** as its proxy for **"is this verb a trailing tag?"** That proxy is
-wrong in *both* directions, producing two mirror defects.
+`cutsATagClause` (`server/src/analyzer/dialogue-structure/parser.ts:439`) uses
+**"does a primary run end before this candidate?"** as its proxy for **"is this
+verb a trailing tag?"** The proxy is wrong in both directions:
 
-This design fixes one of them and prices the other. The two are not equally
-priced and not equally risky, and that asymmetry — not their raw counts — is
-what decided the scope.
+| | defect | measured, 331 books / 7 languages | a fix means |
+|---|---|---|---|
+| **A** | guard **inert** — no primary run precedes, so a name inside secondary quotes is admitted and the adjacent turn loses its speaker | **≤21** of 1,164 proxy firings | making the guard decline **more** |
+| **B** | guard **fires wrongly** — an unrelated earlier primary run makes the proxy true and a *leading* tag's genuine turn is dropped | **1** unambiguous case of 102 declines | making the guard decline **less** |
 
-| | defect | measured harm, 331 books / 7 languages | a fix means |
-|---|---|---:|---|
-| **A** | guard **inert** — the proxy is false when no primary run *precedes*, so a name inside secondary quotes is admitted as speech and the adjacent real turn loses its speaker | **≤21** of 1,164 proxy firings | making the guard decline **more** |
-| **B** | guard **fires wrongly** — an unrelated earlier primary run makes the proxy true, and a *leading* tag's genuine turn is silently dropped | **1** unambiguous case, of 102 total declines | making the guard decline **less** |
-
-**B ships. A is accepted and pinned.**
-
-## Why this split, and not "fix both"
-
-The issue asks for a single discriminator separating *"the verb belongs to the
-preceding turn's trailing tag"* (decline) from *"the verb introduces the
-following turn"* (admit). Both defects do resolve to that one question. But the
-two directions have opposite risk profiles:
-
-- **Fixing B is admit-only.** It can only move candidates *out* of the 102
-  declines, and all 102 are enumerated (`scratchpad/s2286/mc-cost-real.mts`).
-  The blast radius is bounded by a list we hold.
-- **Fixing A is decline-widening**, with no such bound. The obvious repair —
-  pass `out` (primary plus already-accepted secondary runs) instead of
-  `primaryRuns` — fixes A's three cases and **re-declines 5,892 genuine spans in
-  `pg/zh/23835.txt`**, reinstating PR #2340 round 1's MAJOR finding under a new
-  trigger, in the same book that finding was about.
-
-B is also the defect that **destroys a turn**, which the reading of record
-established for this strand — *"a rule must never destroy a turn; a spurious
-narration-read-as-speech span is a lesser harm"* (#2288 Task 0, decided
-2026-08-13) — refuses categorically rather than numerically. One instance in 331
-books does not make that principle inapplicable; it makes it cheap to honour.
+**B ships, via a colon rule. A is accepted and pinned.** Fixing A requires
+decline-widening — the move that re-declines 5,892 spans in `pg/zh/23835.txt`
+and reinstates PR #2340 round 1's MAJOR finding. Fixing B is admit-only and,
+measured, touches **2 of 102** declines.
 
 ### The case B is about
 
@@ -52,205 +27,198 @@ books does not make that principle inapplicable; it makes it cheap to honour.
 > …Aber wenn wir Ulebuhle nach all dem fragten, dann **sagte** er nur in seiner
 > knurrigen Weise**:** «Schnickschnack und Finger davon! Das versteht ihr nicht!»
 
-An unrelated primary-tier run earlier in the paragraph (`»Tick-Tack …
-Tick-Tack«`, a clock) sets `precededByPrimaryRun`; the clause back to the
-nearest sentence boundary contains `sagte`; the guard declines the candidate as
-a name inside a tag clause. It is not a name — it is the entire spoken
+An unrelated primary run earlier in the paragraph (`»Tick-Tack … Tick-Tack«`, a
+clock) sets `precededByPrimaryRun`; the clause carries `sagte`; the guard
+declines the candidate as a name inside a tag clause. It is the entire spoken
 sentence, and it is silently dropped.
 
-This also disposes of the issue's **option 1** (a per-language
-`tagPrecedesTurn` flag): German's dominant convention is verb-*after*-turn, yet
-here it is verb-before-turn via a colon. One flag per language cannot express a
-language that does both.
+## Three encodings were built and run. Two are dead.
+
+This section is the design's main content, because the two dead encodings are
+individually plausible and each was recommended before being falsified. Recording
+why they die is what stops them being re-proposed.
+
+| encoding | verdict | falsified by |
+|---|---|---|
+| **1. per-language `tagPrecedesTurn` flag** | dead | German uses **both** orders — trailing `, sagte er.` and leading `sagte er …: «…»`. One flag per language cannot express it. (#2346 comment, 2026-08-13) |
+| **2. candidate is NAME-SHAPED** (short, unpunctuated, ≤3 words / ≤5 CJK chars) | dead | A sentence-shaped candidate can **contain** a roster name. Probed on the real parser: `„Hallo“, sagte «Der Mann heisst Ulebuhle!»` keeps `speaker=ule` today because the guard fires; under this rule the candidate is admitted, the name is swallowed into a speech span, and the neighbouring turn loses its speaker. It **reintroduces defect 2** — the harm the guard exists for. |
+| **3. candidate contains a ROSTER NAME** | dead | Already evaluated and rejected by the #2315 design (`2026-08-13-primary-pair-straddle-design.md`, rejected-rules list): *"it fails on a turn that is a bare name (`«Антон!», сказала она.`)"*. Probed independently: it also breaks M2 residual 2 (`parser.test.ts`, `The sign said «Stop».`) and 4 `tier-sweep` cases — **5 failures**, because it neutralises the guard for every candidate that merely lacks a name. |
+| **4. COLON separator** (issue option 2) | **survives** | measured below |
+
+Encodings 2 and 3 fail from opposite sides and for the same underlying reason:
+each picks a property of the **candidate**, and the distinction being drawn is a
+property of the **separator** between the verb and the candidate.
 
 ## The rule
 
-One new conjunct, placed first so the guard's whole meaning stays readable in
-one function:
-
 ```ts
 function cutsATagClause(line: string, cand: QuoteRun, primaryRuns: QuoteRun[], conv: LanguageConventions): boolean {
-  /* #2346. This guard exists to stop a NAME-shaped run truncating a tag clause
-     and stripping the neighbouring turn's speaker. A candidate that cannot be a
-     name is never that harm, so it is never declined — which is what stopped a
-     genuine German turn (`sagte er …: «…»`) from being dropped. */
-  if (!isNameShaped(line.slice(cand.start + cand.openLen, cand.end - cand.closeLen))) return false;
+  /* #2346. A colon immediately before the candidate means the verb INTRODUCES
+     what follows — `sagte er …: «…»`, the Latin analogue of CJK's `：`. The
+     guard's remaining tests all assume the verb ATTRIBUTES something already
+     parsed, so they must not run on a leading tag. */
+  const lastCh = line.slice(0, cand.start).replace(/\s+$/u, '').slice(-1);
+  if (lastCh === ':' || lastCh === '：') return false;
   /* …existing precededByPrimaryRun / sentence-boundary / hasStem logic, unchanged… */
 }
 ```
 
-## Why this is safe by construction, not by measurement
+Three lines, no new plumbing, no signature change, no new dependency. It is
+**admit-only**: it can only remove candidates from the decline set.
 
-`cutsATagClause` has exactly one call site (`parser.ts:500`), in the form:
+**Admit-only is not the same as safe**, and this document does not claim it is.
+The guard's purpose is preventing *speaker loss on the adjacent turn*, not
+preventing run deletion; admitting more runs is one of the ways speaker loss is
+produced (`parser.ts:409-412`, and the #2315 design's correction to M2's residual
+pricing). Safety here rests on the attribution measurement below, not on the
+shape of the change.
 
-```ts
-if (cutsATagClause(line, c, primaryRuns, conv)) continue;
+## Measured
+
+All four measurements were run against the **real parser** in this worktree, not
+a port. Instruments and corpus are session `c1002188`'s scratchpad (331 books:
+`books/` 391 files, `epubs/en/` 100) — they exist and were re-run, not cited.
+
+### 1. Corpus decline delta — the blast radius
+
+Every decline the shipped guard makes across the 331-book corpus, tallied by the
+character preceding the candidate:
+
+```
+lang   declined   colon-preceded (WOULD FLIP)   name-shaped   colon & name-shaped
+de           1                            1              0                     0
+ja           1                            0              1                     0
+zh         100                            1             51                     0
+TOTAL      102                            2             52                     0
 ```
 
-It can only ever **decline** a candidate; it never accepts, creates, or moves
-one. Adding a conjunct can therefore only *shrink* the decline set. Three
-properties follow without needing a corpus run:
+**2 of 102 flip. Zero of them are name-shaped**, so the rule cannot cost a
+speaker by swallowing a name — the mechanism defect 2 is about is untouched by
+construction of the measurement, not by assumption.
 
-1. it cannot delete a primary run (it never sees the accept path for one);
-2. it cannot create a run that did not already exist as a candidate;
-3. it is a provable no-op on any language whose `secondaryQuotePairs` is empty,
-   because `findQuoteRuns` returns before the guard is reached
-   (`parser.ts:484`).
+The preceding-character histogram explains why the CJK exposure feared when this
+option was first raised does not materialise: `zh` declines sit after ordinary
+Han characters (`個` 10, `著` 8, `說` 7, `，` 6, `道` 3 …), because CJK leading
+tags are typed `高颎道：“…”` and `“…”` is a **primary** zh pair — those candidates
+never reach the guard at all.
 
-M1's never-delete invariant and the 270-test `dialogue-structure` suite hold by
-construction, in the same way M2's rule B held them. Measurement is still owed
-for *how much* moves — see Acceptance — but not for *whether the change is
-containable*.
+The two flips, in full:
 
-## The predicate
+| lang | book | candidate | status |
+|---|---|---|---|
+| `de` | `pg/de/63460.txt` | `Schnickschnack und Finger davon! Das versteht ihr nicht!` | **the target — the turn this design exists to save** |
+| `zh` | `pg/zh/52200.txt` | `我圖他潤肺。` | sentence-shaped, inside a nested-quote passage. **Not yet adjudicated in context — an acceptance item, not a cleared case.** |
 
-```ts
-/** #2346. The ticket's own NAME-shaped classifier, moved from the measurement
-    instrument into the parser so the guard and the published ≤21 harm figure
-    share ONE definition. */
-function isNameShaped(text: string): boolean {
-  const t = text.trim();
-  if (!t) return false;
-  if ([...t].some((ch) => SENTENCE_END_CHARS.has(ch))) return false;
-  return CJK_RE.test(t) ? [...t].length <= 5 : t.split(/\s+/).length <= 3;
-}
+### 2. Attribution — the instrument that carries the safety case
+
+#2315's design names the attribution-aware family as the instrument that decides
+safety, because every geometry instrument in this strand is blind to speaker loss
+by construction. Reproduced here against the real parser, all four arms in one
+process:
+
+```
+arm                                             cases  ATTRIBUTED  SPEAKER-LOST  TURN-LOST  EXTRA
+POSITIVE CONTROL (no secondary pair declared)      42          42             0          0      0
+FIRING CONTROL  (wide tables, guard OFF)           42          21            21          0     21
+wide tables, SHIPPED guard                         42          42             0          0      0
+wide tables, SHIPPED guard + COLON RULE            42          42             0          0      0
 ```
 
-Three deliberate choices:
+**Both required controls fire.** The positive control proves the metric can read
+a speaker at all; the firing control proves it can see the class (21 lost with
+the guard off). This independently reproduces #2315's published **21 → 0**. The
+colon rule moves nothing.
 
-- **Thresholds are the ticket's, not fresh ones.** ≤3 words / ≤5 CJK characters,
-  unpunctuated, is the exact classifier PR #2340 round 3 used to establish that
-  the raw 1,164 proxy overstated defect A's harm by ~100× and the real figure is
-  ≤21. Re-deriving a threshold here would mean the fix and the published number
-  no longer refer to the same thing — the recurring defect in this strand has
-  been a figure measured against one rule presented as evidence for another.
-- **"Unpunctuated" reuses `SENTENCE_END_CHARS`** (`parser.ts:374` — `.!?。！？`),
-  the constant the guard's own sentence-boundary walk already uses. Sentence
-  punctuation is exactly what separates a clause from a name.
-- **`[...t].length` counts code points, not UTF-16 units.** `name-matcher.ts:68`
-  already documents supplementary-plane Han (CJK Ext-B, U+20000+) as a real
-  case, where `.length` would double-count every glyph.
+### 3. Behavioural probes on the real parser
 
-### One bias inversion, named on purpose
+| case | shipped | + colon rule |
+|---|---|---|
+| `pg/de/63460` target shape | turn swallowed into the tag | **own speech span — turn saved** |
+| `„Hallo“, sagte «Der Mann heisst Ulebuhle!»` (encoding 2's counter-example) | `Hallo` speaker=`ule` | **unchanged** |
+| `“Hi”, he said. The sign said «Stop». “Bye”, she said.` (M2 residual 2) | `«Stop»` declined | **unchanged** |
+| `“Hi”, he said. Then she called: «Ulebuhle»` (encoding 3's bare-name failure) | declined | **admitted** |
 
-The classifier was built as a **generous upper bound on NAME-shaped**, so that
-defect A's harm figure could not be accused of under-counting. Reused as a
-runtime conjunct, that generosity inverts: *generous toward NAME-shaped* means
-*generous toward declining*, which is the direction of defect B — the very thing
-being fixed.
+### 4. Suite
 
-This is accepted deliberately, because the conservative direction here is the
-one that changes least: a stricter predicate would flip more of the 102 declines
-than the evidence supports. It is safe for the target case specifically —
-`«Schnickschnack und Finger davon! Das versteht ihr nicht!»` is two sentences
-carrying `!`, so it is sentence-shaped under any threshold in this family. The
-inversion is recorded here so that a future tightening is a deliberate act
-rather than a rediscovery.
-
-### Where `CJK_RE` comes from
-
-`CJK_RE` is currently module-local to `name-matcher.ts:54`. It must be
-**exported and imported**, not copied — a second regex defining "is this CJK"
-is precisely the duplicated-mechanism shape this codebase's conventions refuse
-(cf. "don't add a second id matcher" in CLAUDE.md).
-
-## What should move
-
-Predicted, **to be verified rather than assumed** — of the 102 corpus declines:
-
-| lang | declined today | name-shaped → still declined | sentence-shaped → now admitted |
-|---|---:|---:|---:|
-| `de` | 1 | 0 | **1** ← the target; turn saved |
-| `ja` | 1 | 1 | 0 |
-| `zh` | 100 | 51 | 49 |
-| `en`/`es`/`fr`/`ru` | 0 | 0 | 0 |
-| **total** | **102** | **52** | **50** |
-
-The 49 `zh` flips are almost entirely one messy plain-text edition
-(`pg/zh/24264.txt`, 紅樓夢) whose unbalanced quote punctuation sweeps narration
-into candidate spans. Read in context, most are not dialogue. Admitting them
-therefore buys nothing and costs narration-read-as-speech — **explicitly the
-lesser harm class** under the reading of record, and the price of a rule stated
-in terms of the guard's purpose rather than fitted to one book.
+`server/src/analyzer/dialogue-structure/` — **382 of 382 pass** with the rule
+applied (encoding 3, for contrast, produced 5 failures). This is **necessary and
+not sufficient**: the same suite is documented as blind to attribution, which is
+why measurement 2 exists.
 
 ## Acceptance
 
+Each item can fail, and the note says how. An item that cannot fail is not an
+acceptance criterion.
+
 1. **The German turn survives.** A regression test on the `pg/de/63460.txt`
-   shape: `sagte` + colon + a sentence-shaped secondary candidate yields the
-   speech span. Red before the change, green after.
-2. **Mutation receipt with observed output.** Remove the conjunct, re-run, and
-   report the actual failure text — not a claim that it fails.
-3. **Defect A is untouched.** The three pinned cases at `parser.test.ts:1420`,
-   `:1426`, `:1432` stay green *unchanged*. An admit-only rule cannot fix them,
-   so a flip there means the change is not admit-only.
-4. **Round 1's MAJOR finding does not return.** The zh leading-tag family
-   (`reopen-sweep.test.ts:405`) stays green, and `pg/zh/23835.txt` shows **no**
-   newly-declined spans.
-5. **Corpus movement matches the table above** — `mc-cost-real.mts` re-run:
-   102 → 52 declines, with **zero** name-shaped declines lost.
-6. **The 270-test `dialogue-structure` + `narrator-default` suite stays green.**
-7. **A corpus replay is not clearance.** Three diagnoses in this strand have
-   been wrong and two passed a clean 0-of-747-chapter replay. The corpus shows
-   safety, never sufficiency; item 1's generated shape is the instrument that
-   decides.
-
-### Expected, and requiring adjudication rather than silent repair
-
-The guard's own suite (`parser.test.ts:466`, "with real `secondaryQuotePairs`")
-was written when the guard had two conjuncts. Any case there whose candidate is
-sentence-shaped **will now be admitted**. Each such flip must be adjudicated
-individually and its expectation updated *with a comment saying why* — a test
-adjusted merely to pass again is how a guard silently loses its purpose.
+   shape. *Fails if* the rule is absent or mis-scoped — verified red-before /
+   green-after during design.
+2. **Mutation receipt with observed output.** Delete the two-line rule, re-run,
+   and paste the actual failure text.
+3. **M2 residual 2 stays declined** (`parser.test.ts`, `The sign said «Stop».`).
+   *Fails if* the rule over-admits — encoding 3 failed exactly here, so this is a
+   live check, not a formality.
+4. **The attribution family reports 42/42/0 with BOTH controls firing.** A run
+   whose firing control does not show 21 lost is void and must not be reported as
+   a pass.
+5. **The corpus decline delta is exactly the 2 rows above**, and
+   `colon & name-shaped` is **0**. *Fails if* the flip set differs in size or
+   membership.
+6. **The `zh` flip (`pg/zh/52200.txt`) is read in context and adjudicated** as
+   gain, neutral, or cost, and the verdict recorded. It is currently unread.
+7. **The 382-test suite stays green** — necessary, not sufficient (see above).
+8. **A corpus replay is not clearance.** Three diagnoses in this strand have been
+   wrong and two passed a clean 0-of-747-chapter replay. Items 1 and 4 decide.
 
 ## Residual: defect A, accepted and priced
 
-Defect A stays open, at a measured **≤21** of 1,164 proxy firings (2,202
-paragraphs exposed at paragraph level; 2,221 paragraphs / 8,802 runs at run
-level — the paragraph figure is a conservative under-count, not an over-count).
+Defect A stays open at **≤21** of 1,164 proxy firings (2,202 paragraphs exposed
+at paragraph level; 2,221 paragraphs / 8,802 runs at run level — the paragraph
+figure is a conservative under-count).
 
-**Do not target the raw 1,164.** It fires on an ordinary correctly-parsed
-two-turn paragraph as readily as on the harmful shape, and 94% of its mass is
-the former. A fix that drives it toward zero will very likely reinstate the
-5,892-span regression on `pg/zh/23835.txt`.
+**Do not target the raw 1,164.** It fires on ordinary correctly-parsed two-turn
+paragraphs as readily as on the harmful shape; ≥1,143 of 1,164 (98.2%) are
+sentence-shaped second turns, not names. Driving it toward zero will very likely
+reinstate the 5,892-span regression on `pg/zh/23835.txt`.
 
-The pinned gap test (`parser.test.ts:1375`) **stays**, because defect A remains
-real. Its comment does not: it currently reads *"this test is expected to start
-FAILING the moment #2346 is fixed, at which point it should be deleted"*. With B
-fixed and A priced, that sentence becomes false and must be corrected in the
-same diff.
+**A and B are disjoint populations, not two slices of one measurement.**
+`precededByPrimaryRun` separates them: A is measured where the guard is *inert*,
+B where the guard *declines*. Their language footprints barely overlap — A is
+`es`/`fr`/`zh`, B is `de`/`ja`/`zh`. Any future work must not average them.
+
+The pinned gap test (`parser.test.ts:1375`) **stays** — defect A remains real.
 
 ## Chores this change makes owed
 
-Each is fixed in this round, not filed (CLAUDE.md, *Incidental findings*):
-
-- `parser.test.ts:1410` — the "expected to start FAILING" comment, above.
-- `parser.ts:409-438` — the guard's header comment describes a two-conjunct
-  rule and must describe the third, including why it exists.
-- `#2346` — re-scoped to defect A alone, carrying the accepted price, so the
-  ticket stops claiming a decision is owed on B.
-- Both release-notes documents (`docs/release-notes-next.md` and
-  `RELEASE_NOTES.md`) — this is a user-visible attribution fix.
-- The issue's claim that it *"blocks full closure of #2286"* is restated: with
-  A priced, it does not.
+- `parser.test.ts:1410` — "expected to start FAILING the moment #2346 is fixed"
+  becomes false once B ships and A is priced. Reword to name **defect A**.
+- `parser.ts:409-438` — the guard's header documents a two-test rule; it must
+  document the colon test and why it comes first.
+- `parser.test.ts:459-465` — the describe header describes the guard as declining
+  "when a primary-tier turn precedes it **and** the clause carries a verb stem".
+  Now incomplete.
+- **#2346 re-scoped to defect A alone**, carrying its price, and its "blocks full
+  closure of #2286" line corrected — with A priced, it does not.
+- Both release-notes documents — this is a user-visible attribution fix.
+- **State the arity limit.** The German target is a `«…»` secondary run after a
+  `»…«` primary — the #2352 reversed-pair collision. `de.ts:63-71` records that a
+  **second** Swiss quote in the same paragraph seeds a primary run that swallows
+  the attribution anyway. So this fix saves the turn at **one** Swiss quote per
+  paragraph and is unreachable at two or more. That qualification belongs in the
+  test comment and the release note.
 
 ## Not in scope
 
-- **Defect A**, in any form — including the `out`-based repair, which is
-  rejected above with a measured reason.
-- **The colon/separator encoding** (the issue's option 2) and the
-  **roster-name encoding**. Both were considered and set aside on 2026-08-18;
-  recorded in this document's decision line so they are not re-litigated as
-  new ideas.
-- **#2352** (German `»…«` primary vs `«…»` secondary being exact reverses) — a
-  separate, still-open decision on a different mechanism.
-- Any change to `quotePairs` / `secondaryQuotePairs` tables.
-- Any change to the primary tier, `scanQuoteRuns`, or `crossExamine`'s
+- **Defect A** in any form, including the `out`-based repair.
+- **Encodings 1–3**, falsified above. Recorded so they are not re-proposed.
+- **#2352** — German's reversed primary/secondary pairs; a separate open decision.
+- Any change to the tables, the primary tier, `scanQuoteRuns`, or `crossExamine`'s
   `dialogueOpen` contract.
 
-## Instruments — do not rebuild
+## Instruments
 
-`scratchpad/s2286/mc-cost-real.mts` (the 102-decline inventory),
-`mc-de-sample-full.mts`, `remeasure-report.md`; `scratchpad/s2315/`'s
-`reprice-f2-exposed.mts`, `reprice-f2-classify.mts`, `reprice-f2-runlevel.mts`.
-The 331-book corpus is listed in
-[#2288 comment 5275015405](https://github.com/dudarenok-maker/Castwright/issues/2288#issuecomment-5275015405).
+Session `c1002188` scratchpad — `2288-corpus-lib.mts` (loader + the 331-book
+corpus), `s2286/mc-cost-real.mts` (the decline inventory), `s2315/attrib.mts`
+(the attribution family, whose four arms this design re-derives against the real
+parser). **These are in a Claude session temp directory, not the repository** —
+they are not repo-relative paths, and nothing in git preserves them.

--- a/docs/superpowers/specs/2026-08-18-tag-clause-name-shape-design.md
+++ b/docs/superpowers/specs/2026-08-18-tag-clause-name-shape-design.md
@@ -1,0 +1,256 @@
+# The tag-clause guard declines genuine turns — design
+
+Status: **active — owner decided 2026-08-18: fix defect B (the false positive), price defect A as an accepted residual. Encoding: a name-shape conjunct.** · Issue: [#2346](https://github.com/dudarenok-maker/Castwright/issues/2346) · Follows: [`2026-08-13-primary-pair-straddle-design.md`](2026-08-13-primary-pair-straddle-design.md) ([#2315](https://github.com/dudarenok-maker/Castwright/issues/2315), shipped PR [#2340](https://github.com/dudarenok-maker/Castwright/pull/2340)) · Strand: [#2288](https://github.com/dudarenok-maker/Castwright/issues/2288) M1/M2, [#2286](https://github.com/dudarenok-maker/Castwright/pull/2286)
+
+---
+
+## Summary
+
+`cutsATagClause` (`server/src/analyzer/dialogue-structure/parser.ts:439`) exists
+to stop a gained secondary-tier run from truncating a tag clause and stripping
+the neighbouring turn's speaker. It uses **"does a primary run end before this
+candidate?"** as its proxy for **"is this verb a trailing tag?"** That proxy is
+wrong in *both* directions, producing two mirror defects.
+
+This design fixes one of them and prices the other. The two are not equally
+priced and not equally risky, and that asymmetry — not their raw counts — is
+what decided the scope.
+
+| | defect | measured harm, 331 books / 7 languages | a fix means |
+|---|---|---:|---|
+| **A** | guard **inert** — the proxy is false when no primary run *precedes*, so a name inside secondary quotes is admitted as speech and the adjacent real turn loses its speaker | **≤21** of 1,164 proxy firings | making the guard decline **more** |
+| **B** | guard **fires wrongly** — an unrelated earlier primary run makes the proxy true, and a *leading* tag's genuine turn is silently dropped | **1** unambiguous case, of 102 total declines | making the guard decline **less** |
+
+**B ships. A is accepted and pinned.**
+
+## Why this split, and not "fix both"
+
+The issue asks for a single discriminator separating *"the verb belongs to the
+preceding turn's trailing tag"* (decline) from *"the verb introduces the
+following turn"* (admit). Both defects do resolve to that one question. But the
+two directions have opposite risk profiles:
+
+- **Fixing B is admit-only.** It can only move candidates *out* of the 102
+  declines, and all 102 are enumerated (`scratchpad/s2286/mc-cost-real.mts`).
+  The blast radius is bounded by a list we hold.
+- **Fixing A is decline-widening**, with no such bound. The obvious repair —
+  pass `out` (primary plus already-accepted secondary runs) instead of
+  `primaryRuns` — fixes A's three cases and **re-declines 5,892 genuine spans in
+  `pg/zh/23835.txt`**, reinstating PR #2340 round 1's MAJOR finding under a new
+  trigger, in the same book that finding was about.
+
+B is also the defect that **destroys a turn**, which the reading of record
+established for this strand — *"a rule must never destroy a turn; a spurious
+narration-read-as-speech span is a lesser harm"* (#2288 Task 0, decided
+2026-08-13) — refuses categorically rather than numerically. One instance in 331
+books does not make that principle inapplicable; it makes it cheap to honour.
+
+### The case B is about
+
+`pg/de/63460.txt`:
+
+> …Aber wenn wir Ulebuhle nach all dem fragten, dann **sagte** er nur in seiner
+> knurrigen Weise**:** «Schnickschnack und Finger davon! Das versteht ihr nicht!»
+
+An unrelated primary-tier run earlier in the paragraph (`»Tick-Tack …
+Tick-Tack«`, a clock) sets `precededByPrimaryRun`; the clause back to the
+nearest sentence boundary contains `sagte`; the guard declines the candidate as
+a name inside a tag clause. It is not a name — it is the entire spoken
+sentence, and it is silently dropped.
+
+This also disposes of the issue's **option 1** (a per-language
+`tagPrecedesTurn` flag): German's dominant convention is verb-*after*-turn, yet
+here it is verb-before-turn via a colon. One flag per language cannot express a
+language that does both.
+
+## The rule
+
+One new conjunct, placed first so the guard's whole meaning stays readable in
+one function:
+
+```ts
+function cutsATagClause(line: string, cand: QuoteRun, primaryRuns: QuoteRun[], conv: LanguageConventions): boolean {
+  /* #2346. This guard exists to stop a NAME-shaped run truncating a tag clause
+     and stripping the neighbouring turn's speaker. A candidate that cannot be a
+     name is never that harm, so it is never declined — which is what stopped a
+     genuine German turn (`sagte er …: «…»`) from being dropped. */
+  if (!isNameShaped(line.slice(cand.start + cand.openLen, cand.end - cand.closeLen))) return false;
+  /* …existing precededByPrimaryRun / sentence-boundary / hasStem logic, unchanged… */
+}
+```
+
+## Why this is safe by construction, not by measurement
+
+`cutsATagClause` has exactly one call site (`parser.ts:500`), in the form:
+
+```ts
+if (cutsATagClause(line, c, primaryRuns, conv)) continue;
+```
+
+It can only ever **decline** a candidate; it never accepts, creates, or moves
+one. Adding a conjunct can therefore only *shrink* the decline set. Three
+properties follow without needing a corpus run:
+
+1. it cannot delete a primary run (it never sees the accept path for one);
+2. it cannot create a run that did not already exist as a candidate;
+3. it is a provable no-op on any language whose `secondaryQuotePairs` is empty,
+   because `findQuoteRuns` returns before the guard is reached
+   (`parser.ts:484`).
+
+M1's never-delete invariant and the 270-test `dialogue-structure` suite hold by
+construction, in the same way M2's rule B held them. Measurement is still owed
+for *how much* moves — see Acceptance — but not for *whether the change is
+containable*.
+
+## The predicate
+
+```ts
+/** #2346. The ticket's own NAME-shaped classifier, moved from the measurement
+    instrument into the parser so the guard and the published ≤21 harm figure
+    share ONE definition. */
+function isNameShaped(text: string): boolean {
+  const t = text.trim();
+  if (!t) return false;
+  if ([...t].some((ch) => SENTENCE_END_CHARS.has(ch))) return false;
+  return CJK_RE.test(t) ? [...t].length <= 5 : t.split(/\s+/).length <= 3;
+}
+```
+
+Three deliberate choices:
+
+- **Thresholds are the ticket's, not fresh ones.** ≤3 words / ≤5 CJK characters,
+  unpunctuated, is the exact classifier PR #2340 round 3 used to establish that
+  the raw 1,164 proxy overstated defect A's harm by ~100× and the real figure is
+  ≤21. Re-deriving a threshold here would mean the fix and the published number
+  no longer refer to the same thing — the recurring defect in this strand has
+  been a figure measured against one rule presented as evidence for another.
+- **"Unpunctuated" reuses `SENTENCE_END_CHARS`** (`parser.ts:374` — `.!?。！？`),
+  the constant the guard's own sentence-boundary walk already uses. Sentence
+  punctuation is exactly what separates a clause from a name.
+- **`[...t].length` counts code points, not UTF-16 units.** `name-matcher.ts:68`
+  already documents supplementary-plane Han (CJK Ext-B, U+20000+) as a real
+  case, where `.length` would double-count every glyph.
+
+### One bias inversion, named on purpose
+
+The classifier was built as a **generous upper bound on NAME-shaped**, so that
+defect A's harm figure could not be accused of under-counting. Reused as a
+runtime conjunct, that generosity inverts: *generous toward NAME-shaped* means
+*generous toward declining*, which is the direction of defect B — the very thing
+being fixed.
+
+This is accepted deliberately, because the conservative direction here is the
+one that changes least: a stricter predicate would flip more of the 102 declines
+than the evidence supports. It is safe for the target case specifically —
+`«Schnickschnack und Finger davon! Das versteht ihr nicht!»` is two sentences
+carrying `!`, so it is sentence-shaped under any threshold in this family. The
+inversion is recorded here so that a future tightening is a deliberate act
+rather than a rediscovery.
+
+### Where `CJK_RE` comes from
+
+`CJK_RE` is currently module-local to `name-matcher.ts:54`. It must be
+**exported and imported**, not copied — a second regex defining "is this CJK"
+is precisely the duplicated-mechanism shape this codebase's conventions refuse
+(cf. "don't add a second id matcher" in CLAUDE.md).
+
+## What should move
+
+Predicted, **to be verified rather than assumed** — of the 102 corpus declines:
+
+| lang | declined today | name-shaped → still declined | sentence-shaped → now admitted |
+|---|---:|---:|---:|
+| `de` | 1 | 0 | **1** ← the target; turn saved |
+| `ja` | 1 | 1 | 0 |
+| `zh` | 100 | 51 | 49 |
+| `en`/`es`/`fr`/`ru` | 0 | 0 | 0 |
+| **total** | **102** | **52** | **50** |
+
+The 49 `zh` flips are almost entirely one messy plain-text edition
+(`pg/zh/24264.txt`, 紅樓夢) whose unbalanced quote punctuation sweeps narration
+into candidate spans. Read in context, most are not dialogue. Admitting them
+therefore buys nothing and costs narration-read-as-speech — **explicitly the
+lesser harm class** under the reading of record, and the price of a rule stated
+in terms of the guard's purpose rather than fitted to one book.
+
+## Acceptance
+
+1. **The German turn survives.** A regression test on the `pg/de/63460.txt`
+   shape: `sagte` + colon + a sentence-shaped secondary candidate yields the
+   speech span. Red before the change, green after.
+2. **Mutation receipt with observed output.** Remove the conjunct, re-run, and
+   report the actual failure text — not a claim that it fails.
+3. **Defect A is untouched.** The three pinned cases at `parser.test.ts:1420`,
+   `:1426`, `:1432` stay green *unchanged*. An admit-only rule cannot fix them,
+   so a flip there means the change is not admit-only.
+4. **Round 1's MAJOR finding does not return.** The zh leading-tag family
+   (`reopen-sweep.test.ts:405`) stays green, and `pg/zh/23835.txt` shows **no**
+   newly-declined spans.
+5. **Corpus movement matches the table above** — `mc-cost-real.mts` re-run:
+   102 → 52 declines, with **zero** name-shaped declines lost.
+6. **The 270-test `dialogue-structure` + `narrator-default` suite stays green.**
+7. **A corpus replay is not clearance.** Three diagnoses in this strand have
+   been wrong and two passed a clean 0-of-747-chapter replay. The corpus shows
+   safety, never sufficiency; item 1's generated shape is the instrument that
+   decides.
+
+### Expected, and requiring adjudication rather than silent repair
+
+The guard's own suite (`parser.test.ts:466`, "with real `secondaryQuotePairs`")
+was written when the guard had two conjuncts. Any case there whose candidate is
+sentence-shaped **will now be admitted**. Each such flip must be adjudicated
+individually and its expectation updated *with a comment saying why* — a test
+adjusted merely to pass again is how a guard silently loses its purpose.
+
+## Residual: defect A, accepted and priced
+
+Defect A stays open, at a measured **≤21** of 1,164 proxy firings (2,202
+paragraphs exposed at paragraph level; 2,221 paragraphs / 8,802 runs at run
+level — the paragraph figure is a conservative under-count, not an over-count).
+
+**Do not target the raw 1,164.** It fires on an ordinary correctly-parsed
+two-turn paragraph as readily as on the harmful shape, and 94% of its mass is
+the former. A fix that drives it toward zero will very likely reinstate the
+5,892-span regression on `pg/zh/23835.txt`.
+
+The pinned gap test (`parser.test.ts:1375`) **stays**, because defect A remains
+real. Its comment does not: it currently reads *"this test is expected to start
+FAILING the moment #2346 is fixed, at which point it should be deleted"*. With B
+fixed and A priced, that sentence becomes false and must be corrected in the
+same diff.
+
+## Chores this change makes owed
+
+Each is fixed in this round, not filed (CLAUDE.md, *Incidental findings*):
+
+- `parser.test.ts:1410` — the "expected to start FAILING" comment, above.
+- `parser.ts:409-438` — the guard's header comment describes a two-conjunct
+  rule and must describe the third, including why it exists.
+- `#2346` — re-scoped to defect A alone, carrying the accepted price, so the
+  ticket stops claiming a decision is owed on B.
+- Both release-notes documents (`docs/release-notes-next.md` and
+  `RELEASE_NOTES.md`) — this is a user-visible attribution fix.
+- The issue's claim that it *"blocks full closure of #2286"* is restated: with
+  A priced, it does not.
+
+## Not in scope
+
+- **Defect A**, in any form — including the `out`-based repair, which is
+  rejected above with a measured reason.
+- **The colon/separator encoding** (the issue's option 2) and the
+  **roster-name encoding**. Both were considered and set aside on 2026-08-18;
+  recorded in this document's decision line so they are not re-litigated as
+  new ideas.
+- **#2352** (German `»…«` primary vs `«…»` secondary being exact reverses) — a
+  separate, still-open decision on a different mechanism.
+- Any change to `quotePairs` / `secondaryQuotePairs` tables.
+- Any change to the primary tier, `scanQuoteRuns`, or `crossExamine`'s
+  `dialogueOpen` contract.
+
+## Instruments — do not rebuild
+
+`scratchpad/s2286/mc-cost-real.mts` (the 102-decline inventory),
+`mc-de-sample-full.mts`, `remeasure-report.md`; `scratchpad/s2315/`'s
+`reprice-f2-exposed.mts`, `reprice-f2-classify.mts`, `reprice-f2-runlevel.mts`.
+The 331-book corpus is listed in
+[#2288 comment 5275015405](https://github.com/dudarenok-maker/Castwright/issues/2288#issuecomment-5275015405).

--- a/docs/superpowers/specs/2026-08-18-tag-clause-name-shape-design.md
+++ b/docs/superpowers/specs/2026-08-18-tag-clause-name-shape-design.md
@@ -1,53 +1,49 @@
 # The tag-clause guard declines genuine turns — design
 
-Status: **active — owner decided 2026-08-18: fix defect B (the false positive), price defect A as an accepted residual. Encoding: the colon separator rule (issue option 2), after two other encodings were built and falsified.** · Issue: [#2346](https://github.com/dudarenok-maker/Castwright/issues/2346) · Follows: [`2026-08-13-primary-pair-straddle-design.md`](2026-08-13-primary-pair-straddle-design.md) ([#2315](https://github.com/dudarenok-maker/Castwright/issues/2315), shipped PR [#2340](https://github.com/dudarenok-maker/Castwright/pull/2340)) · Strand: [#2288](https://github.com/dudarenok-maker/Castwright/issues/2288) M1/M2, [#2286](https://github.com/dudarenok-maker/Castwright/pull/2286)
+Status: **active — owner decided 2026-08-18: fix defect B (the false positive), price defect A as an accepted residual. Encoding: the colon separator rule, after three others were built and falsified. Round-2 adversarial pass folded; one owner question re-opened (§ "The question this re-opens").** · Issue: [#2346](https://github.com/dudarenok-maker/Castwright/issues/2346) · Follows: [`2026-08-13-primary-pair-straddle-design.md`](2026-08-13-primary-pair-straddle-design.md) ([#2315](https://github.com/dudarenok-maker/Castwright/issues/2315), PR [#2340](https://github.com/dudarenok-maker/Castwright/pull/2340)) · Strand: [#2288](https://github.com/dudarenok-maker/Castwright/issues/2288) M1/M2, [#2286](https://github.com/dudarenok-maker/Castwright/pull/2286)
 
 ---
 
 ## Summary
 
-`cutsATagClause` (`server/src/analyzer/dialogue-structure/parser.ts:439`) uses
-**"does a primary run end before this candidate?"** as its proxy for **"is this
-verb a trailing tag?"** The proxy is wrong in both directions:
+`cutsATagClause` (`parser.ts:439`) uses **"does a primary run end before this
+candidate?"** as its proxy for **"is this verb a trailing tag?"** The proxy is
+wrong in both directions:
 
-| | defect | measured, 331 books / 7 languages | a fix means |
+| | defect | measured, 331 books | a fix means |
 |---|---|---|---|
-| **A** | guard **inert** — no primary run precedes, so a name inside secondary quotes is admitted and the adjacent turn loses its speaker | **≤21** of 1,164 proxy firings | making the guard decline **more** |
-| **B** | guard **fires wrongly** — an unrelated earlier primary run makes the proxy true and a *leading* tag's genuine turn is dropped | **1** unambiguous case of 102 declines | making the guard decline **less** |
+| **A** | guard **inert** — a name inside secondary quotes is admitted, the adjacent turn loses its speaker | **≤21** of 1,164 proxy firings | making the guard decline **more** |
+| **B** | guard **fires wrongly** — a *leading* tag's genuine turn is dropped | **1** unambiguous case of 102 declines | making the guard decline **less** |
 
-**B ships, via a colon rule. A is accepted and pinned.** Fixing A requires
-decline-widening — the move that re-declines 5,892 spans in `pg/zh/23835.txt`
-and reinstates PR #2340 round 1's MAJOR finding. Fixing B is admit-only and,
-measured, touches **2 of 102** declines.
+**B ships. A is accepted and pinned.** Fixing A requires decline-widening — the
+move that re-declines 5,892 spans in `pg/zh/23835.txt` and reinstates PR #2340
+round 1's MAJOR finding. Fixing B is admit-only and, measured end-to-end,
+changes **2 paragraphs in 726,385**.
 
 ### The case B is about
 
-`pg/de/63460.txt`:
+`pg/de/63460.txt`: `…dann` **`sagte`** `er nur in seiner knurrigen Weise`**`:`**
+`«Schnickschnack und Finger davon! Das versteht ihr nicht!»`
 
-> …Aber wenn wir Ulebuhle nach all dem fragten, dann **sagte** er nur in seiner
-> knurrigen Weise**:** «Schnickschnack und Finger davon! Das versteht ihr nicht!»
+An unrelated earlier primary run (`»Tick-Tack…«`, a clock) sets
+`precededByPrimaryRun`; the clause carries `sagte`; the guard declines the
+candidate as a name in a tag clause. It is the entire spoken sentence, dropped.
 
-An unrelated primary run earlier in the paragraph (`»Tick-Tack … Tick-Tack«`, a
-clock) sets `precededByPrimaryRun`; the clause carries `sagte`; the guard
-declines the candidate as a name inside a tag clause. It is the entire spoken
-sentence, and it is silently dropped.
+## Three encodings were built and falsified
 
-## Three encodings were built and run. Two are dead.
-
-This section is the design's main content, because the two dead encodings are
-individually plausible and each was recommended before being falsified. Recording
-why they die is what stops them being re-proposed.
+Recorded because each is individually plausible and two were recommended before
+being killed. This is the design's most durable content.
 
 | encoding | verdict | falsified by |
 |---|---|---|
-| **1. per-language `tagPrecedesTurn` flag** | dead | German uses **both** orders — trailing `, sagte er.` and leading `sagte er …: «…»`. One flag per language cannot express it. (#2346 comment, 2026-08-13) |
-| **2. candidate is NAME-SHAPED** (short, unpunctuated, ≤3 words / ≤5 CJK chars) | dead | A sentence-shaped candidate can **contain** a roster name. Probed on the real parser: `„Hallo“, sagte «Der Mann heisst Ulebuhle!»` keeps `speaker=ule` today because the guard fires; under this rule the candidate is admitted, the name is swallowed into a speech span, and the neighbouring turn loses its speaker. It **reintroduces defect 2** — the harm the guard exists for. |
-| **3. candidate contains a ROSTER NAME** | dead | Already evaluated and rejected by the #2315 design (`2026-08-13-primary-pair-straddle-design.md`, rejected-rules list): *"it fails on a turn that is a bare name (`«Антон!», сказала она.`)"*. Probed independently: it also breaks M2 residual 2 (`parser.test.ts`, `The sign said «Stop».`) and 4 `tier-sweep` cases — **5 failures**, because it neutralises the guard for every candidate that merely lacks a name. |
-| **4. COLON separator** (issue option 2) | **survives** | measured below |
+| **1.** per-language `tagPrecedesTurn` | dead | German uses **both** orders — trailing `, sagte er.` and leading `sagte er …: «…»` |
+| **2.** candidate is NAME-SHAPED | dead | a sentence-shaped candidate can **contain** a roster name. Probed: `„Hallo“, sagte «Der Mann heisst Ulebuhle!»` keeps `speaker=ule` today; the rule admits it and strips the speaker |
+| **3.** candidate contains a ROSTER NAME | dead | already rejected by #2315 (`2026-08-13-primary-pair-straddle-design.md:755-758`, *"fails on a turn that is a bare name"*). Probing also broke M2 residual 2 + 4 `tier-sweep` cases — **5 failures** |
+| **4.** COLON separator | **ships** | survives measurement 1; see the honest limits below |
 
-Encodings 2 and 3 fail from opposite sides and for the same underlying reason:
-each picks a property of the **candidate**, and the distinction being drawn is a
-property of the **separator** between the verb and the candidate.
+Encodings 2 and 3 fail from opposite sides for one reason: each picks a property
+of the **candidate**, while the distinction being drawn is a property of the
+**separator**.
 
 ## The rule
 
@@ -55,170 +51,221 @@ property of the **separator** between the verb and the candidate.
 function cutsATagClause(line: string, cand: QuoteRun, primaryRuns: QuoteRun[], conv: LanguageConventions): boolean {
   /* #2346. A colon immediately before the candidate means the verb INTRODUCES
      what follows — `sagte er …: «…»`, the Latin analogue of CJK's `：`. The
-     guard's remaining tests all assume the verb ATTRIBUTES something already
-     parsed, so they must not run on a leading tag. */
+     guard's remaining tests assume the verb ATTRIBUTES something already
+     parsed, so they must not run on a leading tag.
+
+     The trailing-whitespace strip is LOAD-BEARING, not tidying: the target
+     paragraph's colon is followed by a space, and the raw colon-adjacent count
+     across the whole corpus is ZERO. Remove the strip and the fix does nothing
+     at all, silently. */
   const lastCh = line.slice(0, cand.start).replace(/\s+$/u, '').slice(-1);
   if (lastCh === ':' || lastCh === '：') return false;
   /* …existing precededByPrimaryRun / sentence-boundary / hasStem logic, unchanged… */
 }
 ```
 
-Three lines, no new plumbing, no signature change, no new dependency. It is
-**admit-only**: it can only remove candidates from the decline set.
+## What this rule actually is
 
-**Admit-only is not the same as safe**, and this document does not claim it is.
-The guard's purpose is preventing *speaker loss on the adjacent turn*, not
-preventing run deletion; admitting more runs is one of the ways speaker loss is
-produced (`parser.ts:409-412`, and the #2315 design's correction to M2's residual
-pricing). Safety here rests on the attribution measurement below, not on the
-shape of the change.
+**Where it fires, the guard is switched off entirely.** It is an early
+`return false` ahead of every other test. That is the mechanism, stated plainly,
+because round 2 showed the previous draft obscured it behind an instrument that
+could not see it.
+
+It is safe **not** because of any general property, but because the real corpus
+contains only two paragraphs where it fires, and both were read. If colon-typeset
+tag clauses were common, this rule would remove the guard's protection for all of
+them. That is an empirical bound, not a structural one, and it must be restated
+if the tables or the corpus ever change.
 
 ## Measured
 
-All four measurements were run against the **real parser** in this worktree, not
-a port. Instruments and corpus are session `c1002188`'s scratchpad (331 books:
-`books/` 391 files, `epubs/en/` 100) — they exist and were re-run, not cited.
+Instruments and corpus: **`C:\Claude\castwright-corpus\`** (preserved 2026-08-18;
+see its `README.md`). All runs are against the **real parser**, not a port.
 
-### 1. Corpus decline delta — the blast radius
-
-Every decline the shipped guard makes across the 331-book corpus, tallied by the
-character preceding the candidate:
+### 1. Corpus delta — CONFIRMED, and the only instrument with power here
 
 ```
-lang   declined   colon-preceded (WOULD FLIP)   name-shaped   colon & name-shaped
-de           1                            1              0                     0
-ja           1                            0              1                     0
-zh         100                            1             51                     0
-TOTAL      102                            2             52                     0
+lang   declined   colon-preceded (WOULD FLIP)   name-shaped
+de           1                            1              0
+ja           1                            0              1
+zh         100                            1             51
+TOTAL      102                            2             52
 ```
 
-**2 of 102 flip. Zero of them are name-shaped**, so the rule cannot cost a
-speaker by swallowing a name — the mechanism defect 2 is about is untouched by
-construction of the measurement, not by assumption.
+Independently reproduced to the unit by the round-2 reviewer from a
+from-scratch instrument: 331 books, 726,385 paragraphs, 102 declines, same
+per-language split. The `name-shaped` column also reproduces the figures
+published independently in the #2346 issue comment.
 
-The preceding-character histogram explains why the CJK exposure feared when this
-option was first raised does not materialise: `zh` declines sit after ordinary
-Han characters (`個` 10, `著` 8, `說` 7, `，` 6, `道` 3 …), because CJK leading
-tags are typed `高颎道：“…”` and `“…”` is a **primary** zh pair — those candidates
-never reach the guard at all.
-
-The two flips, in full:
-
-| lang | book | candidate | status |
-|---|---|---|---|
-| `de` | `pg/de/63460.txt` | `Schnickschnack und Finger davon! Das versteht ihr nicht!` | **the target — the turn this design exists to save** |
-| `zh` | `pg/zh/52200.txt` | `我圖他潤肺。` | sentence-shaped, inside a nested-quote passage. **Not yet adjudicated in context — an acceptance item, not a cleared case.** |
-
-### 2. Attribution — the instrument that carries the safety case
-
-#2315's design names the attribution-aware family as the instrument that decides
-safety, because every geometry instrument in this strand is blind to speaker loss
-by construction. Reproduced here against the real parser, all four arms in one
-process:
+A full-parse A/B over the corpus closes the second-order question — whether an
+admitted run perturbs anything else in its paragraph:
 
 ```
-arm                                             cases  ATTRIBUTED  SPEAKER-LOST  TURN-LOST  EXTRA
-POSITIVE CONTROL (no secondary pair declared)      42          42             0          0      0
-FIRING CONTROL  (wide tables, guard OFF)           42          21            21          0     21
-wide tables, SHIPPED guard                         42          42             0          0      0
-wide tables, SHIPPED guard + COLON RULE            42          42             0          0      0
+declines   SHIPPED 102 → +COLON 100  (delta -2)
+paragraphs CHANGED 2 · speech +2 · tag 0 · narration +1
+books touched: pg/de/63460.txt (1), pg/zh/52200.txt (1)
 ```
 
-**Both required controls fire.** The positive control proves the metric can read
-a speaker at all; the firing control proves it can see the class (21 lost with
-the guard off). This independently reproduces #2315's published **21 → 0**. The
-colon rule moves nothing.
+Nothing outside the flip set moves, including through
+`parseQuoteParagraph:706-719`'s narration→tag reclassification.
 
-### 3. Behavioural probes on the real parser
+**Both flips are adjudicated:**
+
+| lang | book | verdict |
+|---|---|---|
+| `de` | `pg/de/63460.txt` | **the target.** The turn is recovered as its own speech span |
+| `zh` | `pg/zh/52200.txt` | **gain.** A tag containing a nested quoted turn splits into `tag` + `speech` + `narration`; a genuine turn is recovered and **no speaker changes** |
+
+The `zh` flip has one incidental effect worth recording: its residue demotes from
+`tag` to `narration`, because the **traditional** form of "said" is absent from
+`zh.speechVerbStems` (simplified-only). Pre-existing and unrelated to this rule —
+it is the source of the `narration +1` above.
+
+### 2. Attribution — RETRACTED as evidence for this rule
+
+An earlier draft reported the attribution family as certifying this change. **It
+does not, and the claim is withdrawn.**
+
+- **0 of the family's 42 case bodies contain a colon.** Its verb separators are
+  `, dijo `, `, said `, and the CJK equivalents. The rule's predicate cannot fire
+  on a single case, so the "shipped" and "+colon rule" rows were identical *by
+  construction*. Reading that identity as reassurance was the error.
+- **The denominator was also wrong.** The family hardcodes six languages and
+  omits **German** — the language of the target and of the only unambiguous flip.
+  The German-inclusive family is **66 cases with a firing control of 32**, which
+  `de.ts:78-79` already records: *"0 of 66 with the guard live vs 32 of 66 lost
+  without it."*
+- **Supplied by round 2, the missing arm:** the same family rebuilt with a colon
+  separator loses **32 of 66** speakers with the rule live — identical to the
+  guard-off control. Consistent with "where it fires, the guard is off".
+
+Correspondingly, the corpus measurement's `name-shaped` column does **not** prove
+harmlessness. It is computed with `buildNameIndex([], conv)` — an empty roster —
+which #2315's own instrument header calls *"silent about attribution BY
+CONSTRUCTION, not by measurement."* The earlier draft reused that phrase to mean
+the opposite of its source. The `name-shaped` column bounds **blast radius**, and
+nothing more.
+
+### 3. Behavioural probes (real parser)
 
 | case | shipped | + colon rule |
 |---|---|---|
-| `pg/de/63460` target shape | turn swallowed into the tag | **own speech span — turn saved** |
-| `„Hallo“, sagte «Der Mann heisst Ulebuhle!»` (encoding 2's counter-example) | `Hallo` speaker=`ule` | **unchanged** |
-| `“Hi”, he said. The sign said «Stop». “Bye”, she said.` (M2 residual 2) | `«Stop»` declined | **unchanged** |
-| `“Hi”, he said. Then she called: «Ulebuhle»` (encoding 3's bare-name failure) | declined | **admitted** |
+| `pg/de/63460` real paragraph | turn swallowed into the tag | **own speech span — turn saved**, `speaker: null` |
+| `„Hallo“, sagte «Der Mann heisst Ulebuhle!»` (encoding 2's counter-example) | `Hallo` = `ule` | unchanged (no colon) |
+| `“Hi”, he said. The sign said «Stop». “Bye”, she said.` (M2 residual 2) | declined | unchanged (no colon) |
+| `“Hi”, he said. Then she called: «Ulebuhle»` (encoding 3's failure) | declined | **admitted** |
+| `“Hi”, he said: «Anton is here!»` | `Hi` = `anton` | `Hi` = **null** — see below |
+
+**The target's recovered turn carries `speaker: null`**, and the neighbouring
+`Tick-Tack` turn is `null` in both arms. **This ships a segmentation fix, not an
+attribution fix** — a line that was silently dropped is now spoken. The
+release-note wording must say that.
 
 ### 4. Suite
 
-`server/src/analyzer/dialogue-structure/` — **382 of 382 pass** with the rule
-applied (encoding 3, for contrast, produced 5 failures). This is **necessary and
-not sufficient**: the same suite is documented as blind to attribution, which is
-why measurement 2 exists.
+`src/analyzer/dialogue-structure/` — **14 files, 381 tests, all green** with the
+rule applied. (An earlier draft said 382; that was the count with the new
+regression test already present. After acceptance item 2 lands, expect 382.)
+
+Only one shipped fixture puts a colon before a secondary candidate —
+`parser.test.ts:367-370` — and it stays green only because that clause carries no
+verb stem, so `hasStem` already returns false. **That is a coincidence, not a
+guarantee**, and it must be named in a comment so a future change cannot break it
+silently.
+
+## The question this re-opens
+
+Round 2's constructed case `“Hi”, he said: «Anton is here!»` moves `Hi` from
+`anton` to `null`. Whether that is a **regression or a correction is genuinely
+contested and is not settled here**: `Anton` appears inside a *different turn*,
+not in the tag, so attributing `Hi` to it is arguably a false attribution that
+the rule removes. The 32-of-66 colon-family figure inherits the same ambiguity.
+
+**This is an owner-facing question, not an implementation choice.** It does not
+block the two real-corpus flips, which are adjudicated above and are the whole
+shipping delta — but it decides how the rule is described, and whether a
+follow-up is owed. It is flagged rather than resolved.
 
 ## Acceptance
 
-Each item can fail, and the note says how. An item that cannot fail is not an
-acceptance criterion.
+Every item names how it can fail. An item that cannot fail is not a criterion —
+round 1 and round 2 each found several, so this list is deliberately shorter and
+blunter than its predecessors.
 
-1. **The German turn survives.** A regression test on the `pg/de/63460.txt`
-   shape. *Fails if* the rule is absent or mis-scoped — verified red-before /
-   green-after during design.
-2. **Mutation receipt with observed output.** Delete the two-line rule, re-run,
-   and paste the actual failure text.
-3. **M2 residual 2 stays declined** (`parser.test.ts`, `The sign said «Stop».`).
-   *Fails if* the rule over-admits — encoding 3 failed exactly here, so this is a
-   live check, not a formality.
-4. **The attribution family reports 42/42/0 with BOTH controls firing.** A run
-   whose firing control does not show 21 lost is void and must not be reported as
-   a pass.
-5. **The corpus decline delta is exactly the 2 rows above**, and
-   `colon & name-shaped` is **0**. *Fails if* the flip set differs in size or
-   membership.
-6. **The `zh` flip (`pg/zh/52200.txt`) is read in context and adjudicated** as
-   gain, neutral, or cost, and the verdict recorded. It is currently unread.
-7. **The 382-test suite stays green** — necessary, not sufficient (see above).
-8. **A corpus replay is not clearance.** Three diagnoses in this strand have been
-   wrong and two passed a clean 0-of-747-chapter replay. Items 1 and 4 decide.
+1. **The corpus delta is exactly the two adjudicated flips.** Re-run the
+   instrumented A/B: `102 → 100`, 2 paragraphs changed, touched books
+   `pg/de/63460.txt` and `pg/zh/52200.txt`. *Fails if* the flip set differs in
+   size or membership. **This is the deciding item** — the only measurement with
+   discriminating power over this change.
+2. **The German turn is recovered** on the real paragraph (not a reduced shape),
+   as its own speech span. *Fails if* the rule is absent, mis-scoped, or if the
+   whitespace strip is removed.
+3. **Mutation receipt with observed output, twice**: delete the rule, and
+   separately delete only `.replace(/\s+$/u, '')`. Both must go red; paste the
+   actual failure text. The second mutant is the silent one.
+4. **`parser.test.ts:367-370` stays green and gains a comment** explaining that it
+   survives on `hasStem`, not on the colon test.
+5. **The 381-test suite stays green** (382 once item 2's test lands) — necessary,
+   never sufficient; this suite is documented as blind to attribution.
+6. **No attribution claim is made without a colon-bearing, German-inclusive
+   family (66 cases) and a firing control that actually fires.** A run reporting
+   `0 lost` whose firing control did not show 32 is void.
+7. **A corpus replay is not clearance.** Two wrong diagnoses in this strand passed
+   a clean 0-of-747-chapter replay. Item 1 decides because its flip set is
+   *enumerated and read*, not because it is a corpus run.
 
 ## Residual: defect A, accepted and priced
 
-Defect A stays open at **≤21** of 1,164 proxy firings (2,202 paragraphs exposed
-at paragraph level; 2,221 paragraphs / 8,802 runs at run level — the paragraph
-figure is a conservative under-count).
+**≤21** of 1,164 proxy firings. **Do not target the raw 1,164** — ≥1,143 (98.2%)
+are sentence-shaped second turns, not names, and driving it to zero reinstates the
+5,892-span regression on `pg/zh/23835.txt`.
 
-**Do not target the raw 1,164.** It fires on ordinary correctly-parsed two-turn
-paragraphs as readily as on the harmful shape; ≥1,143 of 1,164 (98.2%) are
-sentence-shaped second turns, not names. Driving it toward zero will very likely
-reinstate the 5,892-span regression on `pg/zh/23835.txt`.
+**A and B are disjoint populations**, separated by `precededByPrimaryRun`: A is
+measured where the guard is *inert*, B where it *declines*. Footprints barely
+overlap (A: `es`/`fr`/`zh`; B: `de`/`ja`/`zh`). Never average them.
 
-**A and B are disjoint populations, not two slices of one measurement.**
-`precededByPrimaryRun` separates them: A is measured where the guard is *inert*,
-B where the guard *declines*. Their language footprints barely overlap — A is
-`es`/`fr`/`zh`, B is `de`/`ja`/`zh`. Any future work must not average them.
-
-The pinned gap test (`parser.test.ts:1375`) **stays** — defect A remains real.
+The pinned gap test (`parser.test.ts:1375`) **stays** — A remains real.
 
 ## Chores this change makes owed
 
+- **Defect B needs an issue to close.** #2346's title and body are entirely about
+  defect A; B was folded in by the 2026-08-13 comment explicitly to avoid a second
+  ticket. Re-scoping #2346 to A alone leaves the PR with nothing to `Closes`, and
+  `main`'s required `pr-issue-link` check makes that a **merge blocker**. Either
+  file a `bug` issue for B and `Closes` it, or keep #2346 open and use `Refs`.
+- **Record the instruments actually used.** Measurements 1 and 3 need a
+  `parser.ts` patch (a decline logger, and an env-gated rule) that was reverted and
+  not preserved. As written, acceptance items 1 and 3 cannot be executed by a cold
+  agent. Preserve the patch and the scripts under `C:\Claude\castwright-corpus\`
+  and cite them by absolute path.
+- `parser.ts:409-438` — the guard's header documents a two-test rule; document the
+  colon test, why it runs first, and that it disables the guard where it fires.
 - `parser.test.ts:1410` — "expected to start FAILING the moment #2346 is fixed"
-  becomes false once B ships and A is priced. Reword to name **defect A**.
-- `parser.ts:409-438` — the guard's header documents a two-test rule; it must
-  document the colon test and why it comes first.
-- `parser.test.ts:459-465` — the describe header describes the guard as declining
-  "when a primary-tier turn precedes it **and** the clause carries a verb stem".
-  Now incomplete.
-- **#2346 re-scoped to defect A alone**, carrying its price, and its "blocks full
-  closure of #2286" line corrected — with A priced, it does not.
-- Both release-notes documents — this is a user-visible attribution fix.
-- **State the arity limit.** The German target is a `«…»` secondary run after a
-  `»…«` primary — the #2352 reversed-pair collision. `de.ts:63-71` records that a
-  **second** Swiss quote in the same paragraph seeds a primary run that swallows
-  the attribution anyway. So this fix saves the turn at **one** Swiss quote per
-  paragraph and is unreachable at two or more. That qualification belongs in the
-  test comment and the release note.
+  becomes false. Reword to name **defect A**.
+- `parser.test.ts:459-465` — describe header no longer describes the guard.
+- **Release notes: describe a segmentation fix**, not an attribution fix — a line
+  that was silently dropped is now spoken. The recovered turn has no speaker.
+- **Correct the arity claim.** `de.ts:64-66` records that the Swiss entry changes
+  the parse in **16 of 63,941** German paragraphs — 15 with exactly one `«` and
+  **1 with two or more, a gain**. "Unreachable at two or more" is contradicted by
+  the lines it cites.
 
 ## Not in scope
 
 - **Defect A** in any form, including the `out`-based repair.
-- **Encodings 1–3**, falsified above. Recorded so they are not re-proposed.
+- **Encodings 1–3**, falsified above and recorded so they are not re-proposed.
 - **#2352** — German's reversed primary/secondary pairs; a separate open decision.
+- Broadening the separator set to `;` or `—` (the rule is narrower than its own
+  rationale; deliberately, pending evidence).
 - Any change to the tables, the primary tier, `scanQuoteRuns`, or `crossExamine`'s
   `dialogueOpen` contract.
 
 ## Instruments
 
-Session `c1002188` scratchpad — `2288-corpus-lib.mts` (loader + the 331-book
-corpus), `s2286/mc-cost-real.mts` (the decline inventory), `s2315/attrib.mts`
-(the attribution family, whose four arms this design re-derives against the real
-parser). **These are in a Claude session temp directory, not the repository** —
-they are not repo-relative paths, and nothing in git preserves them.
+**`C:\Claude\castwright-corpus\`** — preserved 2026-08-18 out of session temp,
+where it was one cleanup from being lost. `2288-corpus-lib.mts` (loader;
+`loadGutenberg` over 7 languages = 231 books, `loadStandardEbooks` = 100, the
+**331** every figure cites — out of 491 files total across 11 languages),
+`s2286/mc-cost-real.mts` (the decline inventory), `s2315/attrib.mts` (the
+attribution family — **six languages only; add German before using it**). Its
+`README.md` carries the rewiring notes and the known-good reference figures.


### PR DESCRIPTION
## Summary

Phase 1 (design) for #2346. **No runtime code** — the spec and the implementation
plan, so a cold implementation thread can execute from `main`.

Three encodings were built and falsified before the shipping one survived, and
that graveyard is the most durable content here:

| encoding | falsified by |
|---|---|
| per-language `tagPrecedesTurn` | German uses **both** orders — trailing `, sagte er.` and leading `sagte er …: «…»` |
| candidate is NAME-SHAPED | a sentence-shaped candidate can *contain* a roster name; probing showed the rule strips a speaker that survives today |
| candidate contains a ROSTER NAME | already rejected by #2315; probing broke 5 shipped tests |
| **COLON separator** | **ships** — each dead encoding picks a property of the *candidate*; the distinction is a property of the *separator* |

The scope call is **fix defect B, price defect A** — on risk asymmetry, not on
counts. B is admit-only and bounded by an enumerated list of 102 declines; A
needs decline-widening, the move that re-declines 5,892 spans in
`pg/zh/23835.txt` and reinstates PR #2340 round 1's MAJOR finding.

**An earlier draft's attribution claim is retracted in full.** The 42-case
family it cited has zero power here — 0 of its 42 case bodies contain a colon,
so "shipped == +colon" was true *by construction*, and its denominator omits
German, the language of the target. This ships a **segmentation** fix: the
recovered turn carries `speaker: null`.

## Test plan

Docs-only — no tests change. Every expectation the plan hands the implementer is
**measured against the real parser**, both arms on disk, not predicted:

| case | shipped | + colon rule |
|---|---|---|
| real `pg/de/63460` paragraph | turn deleted | turn recovered as its own speech span |
| `…sagte er:«Hallo».` | `[Guten Tag]` | `[Guten Tag, Hallo]` |
| `…然后他说：‘你好’。` | `[早安]` | `[早安, 你好]` |
| `…然后他说‘你好’。` (no colon) | `[早安]` | `[早安]` — control |
| `…sagte «Ulebuhle».` (trailing tag) | `[Guten Tag]` | `[Guten Tag]` — control |

Writing this plan killed a test that could not fail: the full-width-colon case
was first drafted as `他说：“你好”。`, but `“…”` is a zh **primary** pair, so that
candidate never reaches the guard and the assertion already passes on `main`. It
was replaced with the secondary-pair shape above, which does flip.

The corpus A/B and the 381-test directory run were both re-run with the rule
temporarily applied and then reverted (`git status` clean, 0 markers).

Refs #2346

🤖 Generated with [Claude Code](https://claude.com/claude-code)
