### PR TITLE
docs(docs): tell Copilot about the 30s cap and the detached-commit pattern

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -89,7 +89,14 @@ Design notes Copilot should know:
 - Type generation: run npm run openapi:types after changing openapi.yaml; prefer the generated src/lib/api-types.ts.
 - Mock flag: VITE_USE_MOCKS toggles mock vs real API. Use it when running e2e vs unit tests as intended.
 - Precommit & prepush lifecycle:
-  - prepare runs husky; pre-commit runs verify:fast:scoped; pre-push runs full verify.
+  - prepare runs husky; pre-commit runs verify:fast:scoped; pre-push runs verify:fast:branch (branch-diff-scoped, not the full verify battery), and is skipped entirely for a docs-only push. Cloud verify.yml is the enforcing gate.
+- **Committing: launch it detached and poll. Always.**
+  - A commit here takes 5–7 minutes: pre-commit runs verify:fast:scoped, and any staged file under `server/` puts the whole server suite in scope. A push costs the same again through pre-push.
+  - **The Copilot CLI kills a single command at 30 seconds.** So a foreground `git commit` or `git push` on a server change cannot finish here, and retrying it never will — the cap has nothing to do with the size of your change. A foreground attempt is not slow, it is killed.
+  - **Launch the command detached**, redirect its output to a file under `%TEMP%`, and poll with short commands until the process exits; then read that file for the result. Each poll returns instantly, so the cap stops mattering. Polling is active waiting and is correct — what is wrong is ending your turn while it runs.
+  - **Do this always — do not try to predict whether this particular diff is one of the slow ones.** That prediction is the bug: it under-lists what is in scope, you read your own change as exempt, and you take the foreground path into the kill. Detached costs nothing when the commit is fast, because the first poll returns immediately.
+  - **Never `--no-verify`.** This is the exact failure that tempts it, and reaching for it is the tell: it means you have diagnosed a *slow* command when what you actually have is a *capped* one. It also does not save you — it makes the commit instant while the push still runs a hook and still dies at 30s. On 2026-08-19 an agent did precisely this and produced correct, well-tested code that never left the box.
+  - The full recipe, with argument-quoting and the sentinel rationale, is in `.clinerules/cline.md` under "Committing when a step is in scope". It is written for Cline, but the cap and the pattern are identical here.
 - Tests organization:
   - Frontend vitest next to code. Server vitest under server/. Sidecar pytest under server/tts-sidecar. Scripts Pester tests under scripts/tests.
 


### PR DESCRIPTION
## Summary

`.github/copilot-instructions.md` is auto-loaded by the Copilot CLI inside this repo — the direct analogue of `.clinerules/cline.md` for Cline. It carried **no** warning about the runtime's 30-second per-command cap and no detached-commit recipe, because until 2026-08-19 no Copilot lane had ever run here, so nobody had hit the wall from one.

Observed on #2474: a Copilot-CLI agent ran `git commit` in the foreground and was killed at exactly 30s (pre-commit runs the whole server suite on a `server/**` change), used `--no-verify` to make it instant, and then had its `git push` killed at 30s the same way. Correct code with two-sided paired tests, commit gate defeated, nothing delivered.

**The fix is that it is stated unconditionally.** The guidance already existed in three places and none of them reached that agent:

- `.clinerules/cline.md` is Cline-only;
- the ticket brief scoped it *"If you're cline: launch `git commit` detached…"* — the agent was not cline;
- the runner prompt made it conditional (`IF YOUR RUNTIME CAPS A SINGLE COMMAND`) and its very next step said to run long commands in the foreground and wait.

An instruction scoped "if you're X" reads as an **exemption** to every agent that isn't X — and the agent that most needs the rule is the one that reads the condition, finds it doesn't name them, and walks into the wall.

It also now says to commit detached **always**, rather than inviting the agent to work out whether this particular diff is one of the slow ones. That prediction is the bug: it under-lists what is in scope, the agent reads its own change as exempt, and takes the foreground path into the kill. Detached costs nothing when the commit is fast — the first poll returns immediately.

**Also fixed, found in passing:** the same bullet claimed *"pre-push runs full verify"*. That has been wrong since the CI rebalance — pre-push runs `verify:fast:branch` (branch-diff-scoped), and is skipped entirely for a docs-only push. Cloud `verify.yml` is the enforcing gate.

## Test plan

Instructions-only; there is no code path to test.

- `.github/copilot-instructions.md` matches the doc-glob fast path (`.github/*.md`), so pre-push skipped the battery by design and every `verify.yml` leg's scope condition is false.
- Verified the claim it now makes is true rather than inherited: the cap was measured at exactly 30s on two separate commands in the #2474 lane log, and the stale pre-push line was checked against `scripts/verify-cache.mjs` and `.husky/pre-push`.

**Regression plan:** none owed here — the enforcing guard lives in the private `open-engine` repo (`tests/foreground-commit-guard.tests.ps1`), which pins the prohibition in the runner prompt and asserts every lane context file carries the section, enumerating them **from disk** so a newly added lane cannot ship without it. That is where the drift can actually be caught; this file is the product-repo half.

**Release notes:** skipped deliberately — agent instructions have no user- or operator-visible delta.

**Review gate:** docs-only PR, exempt per the `pr-review-gate` skill's file-set test.

Closes #2475
