### PR TITLE
fix(ci): persist winget ffmpeg PATH fix past the install step

### DIFF
--- a/.github/workflows/cross-os.yml
+++ b/.github/workflows/cross-os.yml
@@ -118,26 +118,32 @@ jobs:
                 # `npm run verify:quick` runs `pretest`'s ffmpeg preflight
                 # (observed 2026-08-19, cross-os run 32209846581).
                 # $GITHUB_PATH is the documented mechanism for a step to
-                # prepend a directory onto PATH for the rest of the job. A
-                # per-user winget install (no admin elevation, the case on
-                # GitHub-hosted runners) always lands under this WinGet
-                # Links dir. Deliberately its OWN try/catch, outside the one
-                # above: a failure persisting this bookkeeping entry must
-                # never retract an ffmpeg install that actually verified
-                # working, nor fail the whole install silently -- it can
-                # only warn. Guarded on both $env:GITHUB_PATH and
-                # $env:LOCALAPPDATA being set: this step only runs on
-                # windows-latest, where both are always present for a real
-                # job, but scripts/tests/cross-os-ffmpeg-install.test.mjs
-                # executes this same script directly via pwsh (including on
-                # ubuntu-latest, where LOCALAPPDATA is never set) to pin its
-                # control flow against stubbed choco/winget/ffmpeg.
+                # prepend a directory onto PATH for the rest of the job.
+                # winget's Gyan.FFmpeg package places its shim here -- the
+                # exact path observed in the real CI failure this fixes
+                # (cross-os run 32209846581,
+                # C:\Users\runneradmin\AppData\Local\Microsoft\WinGet\Links\ffmpeg.exe).
+                # Deliberately its OWN try/catch, outside the one above: a
+                # failure persisting this bookkeeping entry must never
+                # retract an ffmpeg install that actually verified working,
+                # nor fail the whole install silently -- it can only warn.
+                # `-ErrorAction Stop` forces Add-Content's own failures to be
+                # catchable here (its default is a non-terminating error,
+                # which a bare try/catch does not observe at all). Guarded
+                # on both $env:GITHUB_PATH and $env:LOCALAPPDATA being set:
+                # this step only runs on windows-latest, where both are
+                # always present for a real job, but
+                # scripts/tests/cross-os-ffmpeg-install.test.mjs executes
+                # this same script directly via pwsh -- including with
+                # LOCALAPPDATA deliberately absent, to pin the guard against
+                # exactly the crash that broke PR #2479's first attempt at
+                # this fix (`Join-Path $null ...`).
                 if ($ffmpegOk -and $env:GITHUB_PATH -and $env:LOCALAPPDATA) {
                   try {
                     $ffmpegDir = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Links'
-                    Add-Content -Path $env:GITHUB_PATH -Value $ffmpegDir
+                    Add-Content -Path $env:GITHUB_PATH -Value $ffmpegDir -ErrorAction Stop
                   } catch {
-                    Write-Host "warning: failed to persist ffmpeg's install directory to `$GITHUB_PATH for later steps: $_"
+                    Write-Host "::warning::failed to persist ffmpeg's install directory to `$GITHUB_PATH for later steps -- later steps in this job may not find ffmpeg on PATH: $_"
                   }
                 }
               } else {

--- a/.github/workflows/cross-os.yml
+++ b/.github/workflows/cross-os.yml
@@ -105,31 +105,40 @@ jobs:
                   $env:Path = [System.Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' + [System.Environment]::GetEnvironmentVariable('Path', 'User')
                   & ffmpeg -version | Out-Null
                   $ffmpegOk = ($LASTEXITCODE -eq 0)
-                  if ($ffmpegOk -and $env:GITHUB_PATH) {
-                    # The re-read above only fixes PATH for *this* step's
-                    # process. Every later step (Verify, Build, ...) is a
-                    # fresh process spawned by the runner service, which
-                    # still carries the PATH it had at job start -- so
-                    # without this, ffmpeg resolves here but goes missing
-                    # again by the time `npm run verify:quick` runs
-                    # `pretest`'s ffmpeg preflight (observed 2026-08-19,
-                    # cross-os run 32209846581). $GITHUB_PATH is the
-                    # documented mechanism for a step to prepend a
-                    # directory onto PATH for the rest of the job. A
-                    # per-user winget install (no admin elevation, the case
-                    # on GitHub-hosted runners) always lands under this
-                    # WinGet Links dir -- that observed CI path is more
-                    # reliable here than `Get-Command ffmpeg`, which
-                    # resolves to a shim with no real `.Source` in some
-                    # shells. Guarded on $env:GITHUB_PATH being set at all,
-                    # since it's a GitHub Actions-only mechanism -- absent
-                    # in a local shell or this step's own regression test.
-                    $ffmpegDir = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Links'
-                    Add-Content -Path $env:GITHUB_PATH -Value $ffmpegDir
-                  }
                 } catch {
                   Write-Host "winget fallback unavailable: $_"
                   $ffmpegOk = $false
+                }
+
+                # The re-read above only fixes PATH for *this* step's
+                # process. Every later step (Verify, Build, ...) is a fresh
+                # process spawned by the runner service, which still
+                # carries the PATH it had at job start -- so without this,
+                # ffmpeg resolves here but goes missing again by the time
+                # `npm run verify:quick` runs `pretest`'s ffmpeg preflight
+                # (observed 2026-08-19, cross-os run 32209846581).
+                # $GITHUB_PATH is the documented mechanism for a step to
+                # prepend a directory onto PATH for the rest of the job. A
+                # per-user winget install (no admin elevation, the case on
+                # GitHub-hosted runners) always lands under this WinGet
+                # Links dir. Deliberately its OWN try/catch, outside the one
+                # above: a failure persisting this bookkeeping entry must
+                # never retract an ffmpeg install that actually verified
+                # working, nor fail the whole install silently -- it can
+                # only warn. Guarded on both $env:GITHUB_PATH and
+                # $env:LOCALAPPDATA being set: this step only runs on
+                # windows-latest, where both are always present for a real
+                # job, but scripts/tests/cross-os-ffmpeg-install.test.mjs
+                # executes this same script directly via pwsh (including on
+                # ubuntu-latest, where LOCALAPPDATA is never set) to pin its
+                # control flow against stubbed choco/winget/ffmpeg.
+                if ($ffmpegOk -and $env:GITHUB_PATH -and $env:LOCALAPPDATA) {
+                  try {
+                    $ffmpegDir = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Links'
+                    Add-Content -Path $env:GITHUB_PATH -Value $ffmpegDir
+                  } catch {
+                    Write-Host "warning: failed to persist ffmpeg's install directory to `$GITHUB_PATH for later steps: $_"
+                  }
                 }
               } else {
                 Write-Host "winget fallback unavailable: no winget command on this runner."

--- a/.github/workflows/cross-os.yml
+++ b/.github/workflows/cross-os.yml
@@ -105,6 +105,28 @@ jobs:
                   $env:Path = [System.Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' + [System.Environment]::GetEnvironmentVariable('Path', 'User')
                   & ffmpeg -version | Out-Null
                   $ffmpegOk = ($LASTEXITCODE -eq 0)
+                  if ($ffmpegOk -and $env:GITHUB_PATH) {
+                    # The re-read above only fixes PATH for *this* step's
+                    # process. Every later step (Verify, Build, ...) is a
+                    # fresh process spawned by the runner service, which
+                    # still carries the PATH it had at job start -- so
+                    # without this, ffmpeg resolves here but goes missing
+                    # again by the time `npm run verify:quick` runs
+                    # `pretest`'s ffmpeg preflight (observed 2026-08-19,
+                    # cross-os run 32209846581). $GITHUB_PATH is the
+                    # documented mechanism for a step to prepend a
+                    # directory onto PATH for the rest of the job. A
+                    # per-user winget install (no admin elevation, the case
+                    # on GitHub-hosted runners) always lands under this
+                    # WinGet Links dir -- that observed CI path is more
+                    # reliable here than `Get-Command ffmpeg`, which
+                    # resolves to a shim with no real `.Source` in some
+                    # shells. Guarded on $env:GITHUB_PATH being set at all,
+                    # since it's a GitHub Actions-only mechanism -- absent
+                    # in a local shell or this step's own regression test.
+                    $ffmpegDir = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Links'
+                    Add-Content -Path $env:GITHUB_PATH -Value $ffmpegDir
+                  }
                 } catch {
                   Write-Host "winget fallback unavailable: $_"
                   $ffmpegOk = $false

--- a/.github/workflows/cross-os.yml
+++ b/.github/workflows/cross-os.yml
@@ -129,21 +129,29 @@ jobs:
                 # nor fail the whole install silently -- it can only warn.
                 # `-ErrorAction Stop` forces Add-Content's own failures to be
                 # catchable here (its default is a non-terminating error,
-                # which a bare try/catch does not observe at all). Guarded
-                # on both $env:GITHUB_PATH and $env:LOCALAPPDATA being set:
-                # this step only runs on windows-latest, where both are
-                # always present for a real job, but
-                # scripts/tests/cross-os-ffmpeg-install.test.mjs executes
-                # this same script directly via pwsh -- including with
-                # LOCALAPPDATA deliberately absent, to pin the guard against
-                # exactly the crash that broke PR #2479's first attempt at
-                # this fix (`Join-Path $null ...`).
-                if ($ffmpegOk -and $env:GITHUB_PATH -and $env:LOCALAPPDATA) {
-                  try {
-                    $ffmpegDir = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Links'
-                    Add-Content -Path $env:GITHUB_PATH -Value $ffmpegDir -ErrorAction Stop
-                  } catch {
-                    Write-Host "::warning::failed to persist ffmpeg's install directory to `$GITHUB_PATH for later steps -- later steps in this job may not find ffmpeg on PATH: $_"
+                # which a bare try/catch does not observe at all). Gated on
+                # $env:GITHUB_PATH: absent outside GitHub Actions (a local
+                # shell, or scripts/tests/cross-os-ffmpeg-install.test.mjs's
+                # parser/parse-only checks), where there is nothing to
+                # persist to. $env:LOCALAPPDATA is checked separately, NOT
+                # folded into this same condition -- this step only runs on
+                # windows-latest, where it is always present for a real job,
+                # but a silent skip on the rare box where it genuinely isn't
+                # would recreate #2478 downstream with zero signal. The
+                # regression test deliberately unsets LOCALAPPDATA (mirrors
+                # ubuntu-latest's Hooks-tests leg, which also executes this
+                # script) specifically to pin that the missing case warns
+                # rather than skips quietly.
+                if ($ffmpegOk -and $env:GITHUB_PATH) {
+                  if ($env:LOCALAPPDATA) {
+                    try {
+                      $ffmpegDir = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Links'
+                      Add-Content -Path $env:GITHUB_PATH -Value $ffmpegDir -ErrorAction Stop
+                    } catch {
+                      Write-Host "::warning::failed to persist ffmpeg's install directory to `$GITHUB_PATH for later steps -- later steps in this job may not find ffmpeg on PATH: $_"
+                    }
+                  } else {
+                    Write-Host "::warning::LOCALAPPDATA is not set -- cannot determine the winget-installed ffmpeg directory to persist to `$GITHUB_PATH; later steps in this job may not find ffmpeg on PATH."
                   }
                 }
               } else {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,26 +155,31 @@ jobs:
                 # (observed 2026-08-19, cross-os run 32209846581, same step
                 # shape as this file's). $GITHUB_PATH is the documented
                 # mechanism for a step to prepend a directory onto PATH for
-                # the rest of the job. A per-user winget install (no admin
-                # elevation, the case on GitHub-hosted runners) always
-                # lands under this WinGet Links dir. Deliberately its OWN
-                # try/catch, outside the one above: a failure persisting
-                # this bookkeeping entry must never retract an ffmpeg
-                # install that actually verified working, nor fail the
-                # whole install silently -- it can only warn. Guarded on
-                # both $env:GITHUB_PATH and $env:LOCALAPPDATA being set:
-                # this step only runs on windows-latest, where both are
-                # always present for a real job, but
+                # the rest of the job. winget's Gyan.FFmpeg package places
+                # its shim here -- the exact path observed in the real CI
+                # failure this fixes (cross-os run 32209846581,
+                # C:\Users\runneradmin\AppData\Local\Microsoft\WinGet\Links\ffmpeg.exe).
+                # Deliberately its OWN try/catch, outside the one above: a
+                # failure persisting this bookkeeping entry must never
+                # retract an ffmpeg install that actually verified working,
+                # nor fail the whole install silently -- it can only warn.
+                # `-ErrorAction Stop` forces Add-Content's own failures to
+                # be catchable here (its default is a non-terminating
+                # error, which a bare try/catch does not observe at all).
+                # Guarded on both $env:GITHUB_PATH and $env:LOCALAPPDATA
+                # being set: this step only runs on windows-latest, where
+                # both are always present for a real job, but
                 # scripts/tests/cross-os-ffmpeg-install.test.mjs executes
-                # this same script directly via pwsh (including on
-                # ubuntu-latest, where LOCALAPPDATA is never set) to pin its
-                # control flow against stubbed choco/winget/ffmpeg.
+                # this same script directly via pwsh -- including with
+                # LOCALAPPDATA deliberately absent, to pin the guard
+                # against exactly the crash that broke PR #2479's first
+                # attempt at this fix (`Join-Path $null ...`).
                 if ($ffmpegOk -and $env:GITHUB_PATH -and $env:LOCALAPPDATA) {
                   try {
                     $ffmpegDir = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Links'
-                    Add-Content -Path $env:GITHUB_PATH -Value $ffmpegDir
+                    Add-Content -Path $env:GITHUB_PATH -Value $ffmpegDir -ErrorAction Stop
                   } catch {
-                    Write-Host "warning: failed to persist ffmpeg's install directory to `$GITHUB_PATH for later steps: $_"
+                    Write-Host "::warning::failed to persist ffmpeg's install directory to `$GITHUB_PATH for later steps -- later steps in this job may not find ffmpeg on PATH: $_"
                   }
                 }
               } else {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,20 +166,29 @@ jobs:
                 # `-ErrorAction Stop` forces Add-Content's own failures to
                 # be catchable here (its default is a non-terminating
                 # error, which a bare try/catch does not observe at all).
-                # Guarded on both $env:GITHUB_PATH and $env:LOCALAPPDATA
-                # being set: this step only runs on windows-latest, where
-                # both are always present for a real job, but
-                # scripts/tests/cross-os-ffmpeg-install.test.mjs executes
-                # this same script directly via pwsh -- including with
-                # LOCALAPPDATA deliberately absent, to pin the guard
-                # against exactly the crash that broke PR #2479's first
-                # attempt at this fix (`Join-Path $null ...`).
-                if ($ffmpegOk -and $env:GITHUB_PATH -and $env:LOCALAPPDATA) {
-                  try {
-                    $ffmpegDir = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Links'
-                    Add-Content -Path $env:GITHUB_PATH -Value $ffmpegDir -ErrorAction Stop
-                  } catch {
-                    Write-Host "::warning::failed to persist ffmpeg's install directory to `$GITHUB_PATH for later steps -- later steps in this job may not find ffmpeg on PATH: $_"
+                # Gated on $env:GITHUB_PATH: absent outside GitHub Actions
+                # (a local shell, or
+                # scripts/tests/cross-os-ffmpeg-install.test.mjs's
+                # parser/parse-only checks), where there is nothing to
+                # persist to. $env:LOCALAPPDATA is checked separately, NOT
+                # folded into this same condition -- this step only runs on
+                # windows-latest, where it is always present for a real
+                # job, but a silent skip on the rare box where it genuinely
+                # isn't would recreate #2478 downstream with zero signal.
+                # The regression test deliberately unsets LOCALAPPDATA
+                # (mirrors ubuntu-latest's Hooks-tests leg, which also
+                # executes this script) specifically to pin that the
+                # missing case warns rather than skips quietly.
+                if ($ffmpegOk -and $env:GITHUB_PATH) {
+                  if ($env:LOCALAPPDATA) {
+                    try {
+                      $ffmpegDir = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Links'
+                      Add-Content -Path $env:GITHUB_PATH -Value $ffmpegDir -ErrorAction Stop
+                    } catch {
+                      Write-Host "::warning::failed to persist ffmpeg's install directory to `$GITHUB_PATH for later steps -- later steps in this job may not find ffmpeg on PATH: $_"
+                    }
+                  } else {
+                    Write-Host "::warning::LOCALAPPDATA is not set -- cannot determine the winget-installed ffmpeg directory to persist to `$GITHUB_PATH; later steps in this job may not find ffmpeg on PATH."
                   }
                 }
               } else {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,29 @@ jobs:
                   $env:Path = [System.Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' + [System.Environment]::GetEnvironmentVariable('Path', 'User')
                   & ffmpeg -version | Out-Null
                   $ffmpegOk = ($LASTEXITCODE -eq 0)
+                  if ($ffmpegOk -and $env:GITHUB_PATH) {
+                    # The re-read above only fixes PATH for *this* step's
+                    # process. Every later step (Verify, Build, ...) is a
+                    # fresh process spawned by the runner service, which
+                    # still carries the PATH it had at job start -- so
+                    # without this, ffmpeg resolves here but goes missing
+                    # again by the time `npm run verify:quick` runs
+                    # `pretest`'s ffmpeg preflight (observed 2026-08-19,
+                    # cross-os run 32209846581, same step shape as this
+                    # file's). $GITHUB_PATH is the documented mechanism for
+                    # a step to prepend a directory onto PATH for the rest
+                    # of the job. A per-user winget install (no admin
+                    # elevation, the case on GitHub-hosted runners) always
+                    # lands under this WinGet Links dir -- that observed CI
+                    # path is more reliable here than `Get-Command ffmpeg`,
+                    # which resolves to a shim with no real `.Source` in
+                    # some shells. Guarded on $env:GITHUB_PATH being set at
+                    # all, since it's a GitHub Actions-only mechanism --
+                    # absent in a local shell or this step's own regression
+                    # test.
+                    $ffmpegDir = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Links'
+                    Add-Content -Path $env:GITHUB_PATH -Value $ffmpegDir
+                  }
                 } catch {
                   Write-Host "winget fallback unavailable: $_"
                   $ffmpegOk = $false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,32 +141,41 @@ jobs:
                   $env:Path = [System.Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' + [System.Environment]::GetEnvironmentVariable('Path', 'User')
                   & ffmpeg -version | Out-Null
                   $ffmpegOk = ($LASTEXITCODE -eq 0)
-                  if ($ffmpegOk -and $env:GITHUB_PATH) {
-                    # The re-read above only fixes PATH for *this* step's
-                    # process. Every later step (Verify, Build, ...) is a
-                    # fresh process spawned by the runner service, which
-                    # still carries the PATH it had at job start -- so
-                    # without this, ffmpeg resolves here but goes missing
-                    # again by the time `npm run verify:quick` runs
-                    # `pretest`'s ffmpeg preflight (observed 2026-08-19,
-                    # cross-os run 32209846581, same step shape as this
-                    # file's). $GITHUB_PATH is the documented mechanism for
-                    # a step to prepend a directory onto PATH for the rest
-                    # of the job. A per-user winget install (no admin
-                    # elevation, the case on GitHub-hosted runners) always
-                    # lands under this WinGet Links dir -- that observed CI
-                    # path is more reliable here than `Get-Command ffmpeg`,
-                    # which resolves to a shim with no real `.Source` in
-                    # some shells. Guarded on $env:GITHUB_PATH being set at
-                    # all, since it's a GitHub Actions-only mechanism --
-                    # absent in a local shell or this step's own regression
-                    # test.
-                    $ffmpegDir = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Links'
-                    Add-Content -Path $env:GITHUB_PATH -Value $ffmpegDir
-                  }
                 } catch {
                   Write-Host "winget fallback unavailable: $_"
                   $ffmpegOk = $false
+                }
+
+                # The re-read above only fixes PATH for *this* step's
+                # process. Every later step (Verify, Build, ...) is a fresh
+                # process spawned by the runner service, which still
+                # carries the PATH it had at job start -- so without this,
+                # ffmpeg resolves here but goes missing again by the time
+                # `npm run verify:quick` runs `pretest`'s ffmpeg preflight
+                # (observed 2026-08-19, cross-os run 32209846581, same step
+                # shape as this file's). $GITHUB_PATH is the documented
+                # mechanism for a step to prepend a directory onto PATH for
+                # the rest of the job. A per-user winget install (no admin
+                # elevation, the case on GitHub-hosted runners) always
+                # lands under this WinGet Links dir. Deliberately its OWN
+                # try/catch, outside the one above: a failure persisting
+                # this bookkeeping entry must never retract an ffmpeg
+                # install that actually verified working, nor fail the
+                # whole install silently -- it can only warn. Guarded on
+                # both $env:GITHUB_PATH and $env:LOCALAPPDATA being set:
+                # this step only runs on windows-latest, where both are
+                # always present for a real job, but
+                # scripts/tests/cross-os-ffmpeg-install.test.mjs executes
+                # this same script directly via pwsh (including on
+                # ubuntu-latest, where LOCALAPPDATA is never set) to pin its
+                # control flow against stubbed choco/winget/ffmpeg.
+                if ($ffmpegOk -and $env:GITHUB_PATH -and $env:LOCALAPPDATA) {
+                  try {
+                    $ffmpegDir = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Links'
+                    Add-Content -Path $env:GITHUB_PATH -Value $ffmpegDir
+                  } catch {
+                    Write-Host "warning: failed to persist ffmpeg's install directory to `$GITHUB_PATH for later steps: $_"
+                  }
                 }
               } else {
                 Write-Host "winget fallback unavailable: no winget command on this runner."

--- a/scripts/tests/cross-os-ffmpeg-install.test.mjs
+++ b/scripts/tests/cross-os-ffmpeg-install.test.mjs
@@ -50,7 +50,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { resolve, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import { readNormalized } from '../lib/read-normalized.mjs';
@@ -171,11 +171,11 @@ const PWSH_SKIP_REASON = PWSH_EXE
       ...PWSH_DISCOVERY.attempts.map((a) => `  - ${a}`),
     ].join('\n');
 
-function runPowerShellFile(scriptPath, extraArgs = []) {
+function runPowerShellFile(scriptPath, extraArgs = [], envOverrides = {}) {
   const args = ['-NoProfile', '-NonInteractive'];
   if (process.platform === 'win32') args.push('-ExecutionPolicy', 'Bypass');
   args.push('-File', scriptPath, ...extraArgs);
-  return spawnSync(PWSH_EXE, args, { encoding: 'utf8' });
+  return spawnSync(PWSH_EXE, args, { encoding: 'utf8', env: { ...process.env, ...envOverrides } });
 }
 
 // Uses PowerShell's OWN parser — System.Management.Automation.Language.Parser
@@ -242,12 +242,35 @@ function parsePowerShellSyntaxErrors(scriptText) {
 // and leaves a marker behind — proving the delay actually fires, without
 // the test paying the 15s wall-clock cost and without changing a single
 // character of the shipped script.
+// GITHUB_PATH and LOCALAPPDATA are real, live environment variables when
+// this test itself runs inside GitHub Actions (test:hooks is scoped in by
+// this diff on every OS, including ubuntu-latest, where LOCALAPPDATA is
+// never set). Without isolating them, the stubbed script under test would
+// either crash (Join-Path against a null LOCALAPPDATA) or, worse, silently
+// append a test-only path to the CI job's OWN $GITHUB_PATH file, corrupting
+// PATH for every later step of the real job the test is running inside.
+// Each invocation gets its own throwaway GITHUB_PATH file and LOCALAPPDATA
+// directory so the script's real control flow can be observed without
+// touching (or depending on) the host job's actual environment.
 function runStubbedFfmpegScript(scriptBody, stubPreamble) {
   const dir = mkdtempSync(join(tmpdir(), 'pwsh-behave-'));
   const scriptPath = join(dir, 'scenario.ps1');
   writeFileSync(scriptPath, `${stubPreamble}\n${scriptBody}\n`, 'utf8');
+  const githubPathFile = join(dir, 'github_path.txt');
+  const localAppDataDir = join(dir, 'LocalAppData');
   try {
-    return runPowerShellFile(scriptPath);
+    const proc = runPowerShellFile(scriptPath, [], {
+      GITHUB_PATH: githubPathFile,
+      LOCALAPPDATA: localAppDataDir,
+    });
+    let githubPathContents = '';
+    try {
+      githubPathContents = readFileSync(githubPathFile, 'utf8');
+    } catch {
+      // Never written -- valid when the script never reached the
+      // PATH-persist branch (e.g. the choco-works-first-try path).
+    }
+    return { ...proc, githubPathContents, localAppDataDir };
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -407,6 +430,26 @@ for (const path of WORKFLOWS) {
       proc.stdout,
       /ffmpeg verified working \(attempt 1\/3\)\./,
       'expected the post-winget ffmpeg re-check to succeed',
+    );
+    // Pins the #2478 fix itself: the step must persist the ffmpeg install
+    // directory to $GITHUB_PATH so LATER steps in the job (Verify, Build,
+    // ...) — fresh processes that never re-read the registry PATH this
+    // step patched in-process — can still find it. Isolated GITHUB_PATH /
+    // LOCALAPPDATA (see runStubbedFfmpegScript) means this exercises the
+    // real branch rather than skipping it, which is what let the original
+    // #2478 fix ship with this exact defect (Join-Path against a null
+    // LOCALAPPDATA crashes; the crash was masked locally because
+    // GITHUB_PATH is unset outside CI, so the guard never entered the
+    // branch at all).
+    assert.equal(proc.status, 0, `did not expect the PATH-persist step to fail the job; stderr:\n${proc.stderr}`);
+    assert.match(
+      proc.githubPathContents,
+      /Microsoft[\\/]WinGet[\\/]Links/,
+      `expected the ffmpeg install directory to be appended to $GITHUB_PATH; got:\n${JSON.stringify(proc.githubPathContents)}`,
+    );
+    assert.ok(
+      proc.githubPathContents.includes(join(proc.localAppDataDir, 'Microsoft', 'WinGet', 'Links')),
+      `expected the persisted directory to be rooted under this run's LOCALAPPDATA; got:\n${JSON.stringify(proc.githubPathContents)}`,
     );
   });
 

--- a/scripts/tests/cross-os-ffmpeg-install.test.mjs
+++ b/scripts/tests/cross-os-ffmpeg-install.test.mjs
@@ -171,11 +171,11 @@ const PWSH_SKIP_REASON = PWSH_EXE
       ...PWSH_DISCOVERY.attempts.map((a) => `  - ${a}`),
     ].join('\n');
 
-function runPowerShellFile(scriptPath, extraArgs = [], envOverrides = {}) {
+function runPowerShellFile(scriptPath, extraArgs = [], env = process.env) {
   const args = ['-NoProfile', '-NonInteractive'];
   if (process.platform === 'win32') args.push('-ExecutionPolicy', 'Bypass');
   args.push('-File', scriptPath, ...extraArgs);
-  return spawnSync(PWSH_EXE, args, { encoding: 'utf8', env: { ...process.env, ...envOverrides } });
+  return spawnSync(PWSH_EXE, args, { encoding: 'utf8', env });
 }
 
 // Uses PowerShell's OWN parser — System.Management.Automation.Language.Parser
@@ -249,20 +249,27 @@ function parsePowerShellSyntaxErrors(scriptText) {
 // either crash (Join-Path against a null LOCALAPPDATA) or, worse, silently
 // append a test-only path to the CI job's OWN $GITHUB_PATH file, corrupting
 // PATH for every later step of the real job the test is running inside.
-// Each invocation gets its own throwaway GITHUB_PATH file and LOCALAPPDATA
-// directory so the script's real control flow can be observed without
-// touching (or depending on) the host job's actual environment.
-function runStubbedFfmpegScript(scriptBody, stubPreamble) {
+// Each invocation gets its own throwaway GITHUB_PATH file and, by default,
+// its own LOCALAPPDATA directory, so the script's real control flow can be
+// observed without touching (or depending on) the host job's actual
+// environment. `withLocalAppData: false` deliberately UNSETS it (deleted
+// from the child's env entirely, not set to '') to reproduce the shape that
+// actually broke #2478's first fix attempt: GITHUB_PATH present,
+// LOCALAPPDATA absent -- exactly ubuntu-latest's Hooks-tests leg.
+function runStubbedFfmpegScript(scriptBody, stubPreamble, { withLocalAppData = true } = {}) {
   const dir = mkdtempSync(join(tmpdir(), 'pwsh-behave-'));
   const scriptPath = join(dir, 'scenario.ps1');
   writeFileSync(scriptPath, `${stubPreamble}\n${scriptBody}\n`, 'utf8');
   const githubPathFile = join(dir, 'github_path.txt');
-  const localAppDataDir = join(dir, 'LocalAppData');
+  const localAppDataDir = withLocalAppData ? join(dir, 'LocalAppData') : null;
+  const env = { ...process.env, GITHUB_PATH: githubPathFile };
+  if (withLocalAppData) {
+    env.LOCALAPPDATA = localAppDataDir;
+  } else {
+    delete env.LOCALAPPDATA;
+  }
   try {
-    const proc = runPowerShellFile(scriptPath, [], {
-      GITHUB_PATH: githubPathFile,
-      LOCALAPPDATA: localAppDataDir,
-    });
+    const proc = runPowerShellFile(scriptPath, [], env);
     let githubPathContents = '';
     try {
       githubPathContents = readFileSync(githubPathFile, 'utf8');
@@ -412,6 +419,12 @@ for (const path of WORKFLOWS) {
     const proc = runStubbedFfmpegScript(scriptBody, STUB_CHOCO_WORKS_FIRST_TRY);
     assert.equal(proc.status, 0, `expected exit 0; stdout:\n${proc.stdout}\nstderr:\n${proc.stderr}`);
     assert.match(proc.stdout, /ffmpeg verified working \(attempt 1\/3\)\./);
+    // The PATH-persist branch lives inside the winget-fallback path only --
+    // choco succeeding on the first try must never touch $GITHUB_PATH. A
+    // guard that dropped its `$ffmpegOk` (or its winget-only scoping) would
+    // still pass every other assertion in this file; this is the one that
+    // would catch it.
+    assert.equal(proc.githubPathContents, '', 'expected $GITHUB_PATH untouched on the choco-succeeds path');
   });
 
   test(`${rel}: Windows ffmpeg install behaviour -- choco fails, winget rescues it`, {
@@ -441,7 +454,6 @@ for (const path of WORKFLOWS) {
     // LOCALAPPDATA crashes; the crash was masked locally because
     // GITHUB_PATH is unset outside CI, so the guard never entered the
     // branch at all).
-    assert.equal(proc.status, 0, `did not expect the PATH-persist step to fail the job; stderr:\n${proc.stderr}`);
     assert.match(
       proc.githubPathContents,
       /Microsoft[\\/]WinGet[\\/]Links/,
@@ -453,6 +465,40 @@ for (const path of WORKFLOWS) {
     );
   });
 
+  // Mutation-differentiating: this is the exact shape (GITHUB_PATH present,
+  // LOCALAPPDATA absent) that ubuntu-latest's Hooks-tests leg hits, and that
+  // broke the #2478 fix's first attempt (PR #2479 review pass 1) -- the
+  // pre-fix guard (`if ($ffmpegOk -and $env:GITHUB_PATH)`, no LOCALAPPDATA
+  // check) crashes `Join-Path $null ...`, gets swallowed by the surrounding
+  // try/catch, and the whole install verdict flips to failed. Running this
+  // scenario against that pre-fix script body reproduces exactly that:
+  // `winget fallback unavailable: Cannot bind argument to parameter 'Path'
+  // because it is null` and a fallthrough to a second attempt. This test
+  // fails on that code and passes on the current guard
+  // (`... -and $env:LOCALAPPDATA`), which is the property worth pinning --
+  // not just "the happy path with LOCALAPPDATA set still works".
+  test(`${rel}: Windows ffmpeg install behaviour -- choco fails, winget rescues it, but LOCALAPPDATA is unset (ubuntu-latest's Hooks-tests leg)`, {
+    skip: PWSH_SKIP_REASON ?? false,
+  }, () => {
+    const source = readNormalized(path);
+    const scriptBody = windowsFfmpegScriptBody(windowsFfmpegStepBlock(source));
+    const proc = runStubbedFfmpegScript(scriptBody, STUB_CHOCO_FAILS_WINGET_RESCUES, { withLocalAppData: false });
+    assert.equal(proc.status, 0, `expected exit 0; stdout:\n${proc.stdout}\nstderr:\n${proc.stderr}`);
+    assert.match(
+      proc.stdout,
+      /ffmpeg verified working \(attempt 1\/3\)\./,
+      'expected the winget-rescued ffmpeg install to still be reported successful with LOCALAPPDATA absent',
+    );
+    // The PATH-persist branch must be SKIPPED, not crash and not fall
+    // through to a later attempt -- with no LOCALAPPDATA there is nowhere
+    // correct to derive a WinGet Links directory from.
+    assert.equal(
+      proc.githubPathContents,
+      '',
+      `expected $GITHUB_PATH untouched when LOCALAPPDATA is absent; got:\n${JSON.stringify(proc.githubPathContents)}`,
+    );
+  });
+
   test(`${rel}: Windows ffmpeg install behaviour -- both choco and winget fail all 3 attempts -> exit 1 with the CI message, retrying with a real delay`, {
     skip: PWSH_SKIP_REASON ?? false,
   }, () => {
@@ -460,6 +506,14 @@ for (const path of WORKFLOWS) {
     const scriptBody = windowsFfmpegScriptBody(windowsFfmpegStepBlock(source));
     const proc = runStubbedFfmpegScript(scriptBody, STUB_BOTH_FAIL_ALL_ATTEMPTS);
     assert.equal(proc.status, 1, `expected exit 1; stdout:\n${proc.stdout}\nstderr:\n${proc.stderr}`);
+    // Guards against a mutated condition that drops `$ffmpegOk` from the
+    // PATH-persist gate: ffmpeg never actually installed here, so nothing
+    // should be written to $GITHUB_PATH across any of the 3 attempts.
+    assert.equal(
+      proc.githubPathContents,
+      '',
+      `expected $GITHUB_PATH untouched when ffmpeg never verified working; got:\n${JSON.stringify(proc.githubPathContents)}`,
+    );
     assert.match(
       proc.stderr,
       /CI: ffmpeg install failed after 3 attempts/,

--- a/scripts/tests/cross-os-ffmpeg-install.test.mjs
+++ b/scripts/tests/cross-os-ffmpeg-install.test.mjs
@@ -465,18 +465,21 @@ for (const path of WORKFLOWS) {
     );
   });
 
-  // Mutation-differentiating: this is the exact shape (GITHUB_PATH present,
-  // LOCALAPPDATA absent) that ubuntu-latest's Hooks-tests leg hits, and that
-  // broke the #2478 fix's first attempt (PR #2479 review pass 1) -- the
-  // pre-fix guard (`if ($ffmpegOk -and $env:GITHUB_PATH)`, no LOCALAPPDATA
-  // check) crashes `Join-Path $null ...`, gets swallowed by the surrounding
-  // try/catch, and the whole install verdict flips to failed. Running this
-  // scenario against that pre-fix script body reproduces exactly that:
-  // `winget fallback unavailable: Cannot bind argument to parameter 'Path'
-  // because it is null` and a fallthrough to a second attempt. This test
-  // fails on that code and passes on the current guard
-  // (`... -and $env:LOCALAPPDATA`), which is the property worth pinning --
-  // not just "the happy path with LOCALAPPDATA set still works".
+  // This is the exact shape (GITHUB_PATH present, LOCALAPPDATA absent) that
+  // ubuntu-latest's Hooks-tests leg hits, and that broke the #2478 fix's
+  // first attempt (PR #2479 review pass 1) -- the pass-1 script had no
+  // dedicated try/catch around the PATH-persist logic at all, so
+  // `Join-Path $null ...` crashed straight into the winget-install
+  // try/catch, which flipped the whole install verdict to failed (attempt
+  // 2/3, not 1/3). Round 2 fixed the CRASH by giving the persist logic its
+  // own try/catch -- which the `attempt 1/3` + empty-$GITHUB_PATH
+  // assertions below pin -- but that alone still let a real box missing
+  // LOCALAPPDATA skip the persist with zero signal. This test's final
+  // assertion (the explicit `::warning::` line) is what actually pins the
+  // LOCALAPPDATA-specific guard: round-3 review proved that folding
+  // `$env:LOCALAPPDATA` back into the single outer condition (undoing the
+  // nested if/else) leaves every OTHER assertion in this test green, since
+  // the crash containment alone already accounts for them.
   test(`${rel}: Windows ffmpeg install behaviour -- choco fails, winget rescues it, but LOCALAPPDATA is unset (ubuntu-latest's Hooks-tests leg)`, {
     skip: PWSH_SKIP_REASON ?? false,
   }, () => {
@@ -496,6 +499,17 @@ for (const path of WORKFLOWS) {
       proc.githubPathContents,
       '',
       `expected $GITHUB_PATH untouched when LOCALAPPDATA is absent; got:\n${JSON.stringify(proc.githubPathContents)}`,
+    );
+    // The skip must be LOUD (round-2 review, PR #2479): folding
+    // `$env:LOCALAPPDATA` back into the single outer `if` condition
+    // (instead of the nested if/else this pins) makes the exact same three
+    // assertions above pass -- ffmpeg still verifies working, PATH still
+    // stays untouched -- while silently dropping this warning, which is
+    // the only signal a real box missing LOCALAPPDATA would ever produce.
+    assert.match(
+      proc.stdout,
+      /::warning::LOCALAPPDATA is not set/,
+      'expected an explicit warning when LOCALAPPDATA is absent, not a silent skip',
     );
   });
 


### PR DESCRIPTION
## Summary
- The scheduled Cross-OS Verify run on 2026-08-19 (run 32209846581) failed on `Verify (windows-latest)`: the winget ffmpeg fallback re-reads PATH from the registry so `ffmpeg -version` resolves *within that step's own process*, but every later step is a fresh process that still carries the job's original PATH — so `npm run verify:quick`'s `test:server` `pretest` failed with "ffmpeg not on this shell's PATH".
- Fix: append the resolved WinGet Links directory to `$GITHUB_PATH` so it carries into every subsequent step in the job. `release.yml` carries an identical step, so it gets the identical fix.
- Three review rounds (full detail in PR comments): round 1 found the PATH-persist logic crashed under the exact env shape this diff's own `test:hooks` leg hits on `ubuntu-latest` (GITHUB_PATH set, LOCALAPPDATA unset), and that the test harness was mutating the real job's own `$GITHUB_PATH` file. Round 2 found `Add-Content`'s own failure wasn't actually catchable (non-terminating error under the default preference) and that the new tests were placebos that passed against the pre-fix code too. Round 3 (final allowed round) found the LOCALAPPDATA check was folded into a single conjunct that would skip the persist step silently on a real box missing it, with a test that passed for the wrong reason. All fixed and independently verified against the actual pre-fix / mutated script bodies, not just re-read.
- Filed #2480 for the flagged duplication between the two workflow files, with the decision it owes named explicitly.

## Test plan
- [x] `scripts/tests/cross-os-ffmpeg-install.test.mjs` — 14 tests (12 original + 2 added across this PR's rounds), all green, including a scenario that deliberately unsets `LOCALAPPDATA` (mirrors ubuntu-latest's Hooks-tests leg), asserts the explicit warning it now produces, and negative assertions that `$GITHUB_PATH` stays untouched on the choco-succeeds and both-fail paths.
- [x] `npm run test:hooks` full suite green (1415/1415).
- [x] PowerShell parser check on the modified blocks reports zero syntax errors.
- [x] Manually reproduced the exact CI failure this PR fixes, and each round's flagged regression, by running the pre-fix/mutated script bodies directly through pwsh with the relevant env shape, confirming each new assertion actually fails against the code it's meant to catch.
- [ ] On-box: the real winget-fallback path (choco actually failing on a live Windows runner) can only be proven by a live Cross-OS Verify run that hits it — not owed acceptance, just not independently re-triggerable from here; the next scheduled run (or one hitting the winget fallback) will confirm.
- N/A: release notes — this is a CI-only fix with no shippable product-facing delta (CLAUDE.md before-shipping step 5's explicit skip carve-out).

Closes #2478