### PR TITLE
ci(ops): ignore stale guardrail-tmp-* leftovers in lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,12 @@ coverage/
 # .gitignore ensures an interrupted run never stages them).
 guardrail-tmp-*/
 
+# check-no-budget-poll.test.mjs: same planted-violation-inside-the-repo pattern as
+# guardrail-tmp-* above (#2482) — a leftover from an interrupted run must not
+# surface as an untracked/staged file, and must not wedge lint (see the matching
+# eslint.config.mjs ignore).
+budget-poll-tmp-*/
+
 # Verify-cache (per-step input hashes for `npm run verify`; never committed).
 .verify-cache.json
 .verify-cache.json.tmp

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -52,9 +52,9 @@ export default tseslint.config(
       // Throwaway debugging probes — git-ignored and not held to the lint bar.
       'server/repro-*.mts',
       // Leftover from scripts/tests/eslint-guardrail.test.mjs's planted-violation
-      // probe (mkdtempSync inside the repo root, see .gitignore:76): a directory
+      // probe (mkdtempSync inside the repo root, see .gitignore): a directory
       // that survives cleanup (killed process, or rmSync losing a Windows EBUSY
-      // race against the execFileSync child right above it) must not wedge every
+      // race against the spawnSync child right above it) must not wedge every
       // subsequent `npm run lint`/pre-push on an unrelated checkout. The probe
       // itself still needs ESLint to SEE its planted file, so it passes
       // `--no-ignore` to override this — see the probe's own comment.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -51,6 +51,14 @@ export default tseslint.config(
       // Ad-hoc, local-only repro/bisect scripts (e.g. server/repro-attribution.mts).
       // Throwaway debugging probes — git-ignored and not held to the lint bar.
       'server/repro-*.mts',
+      // Leftover from scripts/tests/eslint-guardrail.test.mjs's planted-violation
+      // probe (mkdtempSync inside the repo root, see .gitignore:76): a directory
+      // that survives cleanup (killed process, or rmSync losing a Windows EBUSY
+      // race against the execFileSync child right above it) must not wedge every
+      // subsequent `npm run lint`/pre-push on an unrelated checkout. The probe
+      // itself still needs ESLint to SEE its planted file, so it passes
+      // `--no-ignore` to override this — see the probe's own comment.
+      'guardrail-tmp-*/',
       // Accepted-result scratch written by the token-saver skill (see the
       // matching .gitignore entry). Unreviewed model output that can land on a
       // linted extension, and the skill writes it under whatever root it is

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -59,6 +59,9 @@ export default tseslint.config(
       // itself still needs ESLint to SEE its planted file, so it passes
       // `--no-ignore` to override this — see the probe's own comment.
       'guardrail-tmp-*/',
+      // check-no-budget-poll.test.mjs's own planted-violation temp dirs — same
+      // interrupted-run leftover shape as guardrail-tmp-* above (#2482).
+      'budget-poll-tmp-*/',
       // Accepted-result scratch written by the token-saver skill (see the
       // matching .gitignore entry). Unreviewed model output that can land on a
       // linted extension, and the skill writes it under whatever root it is

--- a/scripts/tests/eslint-guardrail.test.mjs
+++ b/scripts/tests/eslint-guardrail.test.mjs
@@ -121,31 +121,26 @@ test('a stale guardrail-tmp-* leftover is ignored by ESLint, not merely absent o
   );
 });
 
-test('the guardrail-tmp-*/budget-poll-tmp-* ignores do not swallow an ordinary *.test.ts file', () => {
+test('the guardrail-tmp-*/budget-poll-tmp-* ignores do not swallow an ordinary tracked *.test.ts file', () => {
   // The two tests above prove the leftover dirs ARE ignored and the rule
   // fires when unignored via --no-ignore. Neither would catch the ignore
   // pattern becoming too broad (e.g. accidentally matching '**/*.test.ts'
   // instead of a specific directory prefix) — test 1 always passes
   // --no-ignore, which would blind it to that too, and test 2 asserts the
-  // file IS ignored, so a broader pattern only makes it greener. This test
-  // is the counterweight: an ordinary planted violation OUTSIDE both
-  // leftover-dir prefixes must still be caught with NO --no-ignore flag.
-  const dir = mkdtempSync(join(repoRoot, 'eslint-guardrail-canary-'));
-  const f = join(dir, 'planted.test.ts');
-  writeFileSync(
-    f,
-    "import { it } from 'vitest';\nit.skipIf(process.env.CI)('x', () => {});\n",
-  );
-  let result;
-  try {
-    result = runEslint([f]);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-  assert.equal(result.exitCode, 1, `eslint should still lint an ordinary test file and reject the violation (got ${result.exitCode}): ${result.output}`);
-  assert.match(
+  // file IS ignored, so a broader pattern only makes it greener.
+  //
+  // This is the counterweight: it probes an already-TRACKED test file
+  // instead of planting one. An earlier version of this test planted its
+  // own file under a THIRD repo-root mkdtempSync prefix
+  // ('eslint-guardrail-canary-*') that was itself not in either ignore
+  // list — reintroducing the exact #2482 leftover-wedge class this file
+  // exists to close if that plant ever survived a killed process. Probing
+  // a tracked file instead writes nothing, so there is nothing to leak.
+  const target = join(repoRoot, 'server', 'src', 'test-utils', 'quarantine.test.ts');
+  const result = runEslint([target]);
+  assert.doesNotMatch(
     result.output,
-    new RegExp(RULE_ID),
-    `eslint's output should name the ${RULE_ID} rule for a file outside the leftover-dir ignores: ${result.output}`,
+    /ignored/i,
+    `a real tracked *.test.ts file must never be reported as ignored (got exit ${result.exitCode}): ${result.output}`,
   );
 });

--- a/scripts/tests/eslint-guardrail.test.mjs
+++ b/scripts/tests/eslint-guardrail.test.mjs
@@ -16,27 +16,28 @@
 // nothing, exactly the failure mode the ignore entry's comment warns about.
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { writeFileSync, rmSync, mkdtempSync, mkdirSync } from 'node:fs';
+import { writeFileSync, rmSync, mkdtempSync } from 'node:fs';
 import { join } from 'node:path';
-import { execFileSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 
 // test:hooks runs from the repo root (scripts/run-hooks-tests.mjs uses fast-glob
 // which resolves against cwd).
 const repoRoot = process.cwd();
 
-function lintPlantedFile(f) {
-  try {
-    execFileSync('npx', ['eslint', '--no-ignore', f], {
-      cwd: repoRoot,
-      stdio: 'pipe',
-      shell: process.platform === 'win32',
-    });
-    return false;
-  } catch {
-    // eslint exits non-zero when it finds an error-level violation — that is the
-    // expected outcome for the planted violation.
-    return true;
-  }
+const RULE_ID = 'no-restricted-syntax';
+
+// Runs eslint and returns { exitCode, output }. Using spawnSync (not
+// execFileSync) so a non-zero exit doesn't throw — callers need the output
+// on EVERY outcome, not just failure, to tell "the guardrail rule fired" apart
+// from "eslint itself errored" (a bad flag, a missing binary, a config
+// problem) — both exit non-zero, and only the output distinguishes them.
+function runEslint(args) {
+  const result = spawnSync('npx', ['eslint', ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+  });
+  return { exitCode: result.status, output: (result.stdout ?? '') + (result.stderr ?? '') };
 }
 
 test('guardrail rejects a planted it.skipIf(process.env.CI)', () => {
@@ -49,46 +50,61 @@ test('guardrail rejects a planted it.skipIf(process.env.CI)', () => {
     f,
     "import { it } from 'vitest';\nit.skipIf(process.env.CI)('x', () => {});\n",
   );
-  let failed;
+  let result;
   try {
-    failed = lintPlantedFile(f);
+    // --no-ignore: guardrail-tmp-*/ is ALSO in eslint.config.mjs's global
+    // `ignores` (#2482 — a leftover from THIS probe must not wedge lint on a
+    // later, unrelated checkout). Without --no-ignore this call would exit 0
+    // regardless of the rule's presence, which is exactly the false-pass this
+    // test exists to catch — so the assertion below checks for the rule ID
+    // specifically, not just a non-zero exit, which a bad flag or a broken
+    // eslint invocation would also produce.
+    result = runEslint(['--no-ignore', f]);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
-  assert.equal(failed, true, 'eslint should exit non-zero for the planted it.skipIf(process.env.CI) violation');
+  assert.equal(result.exitCode, 1, `eslint should exit 1 for a lint violation (got ${result.exitCode}): ${result.output}`);
+  assert.match(
+    result.output,
+    new RegExp(RULE_ID),
+    `eslint's output should name the ${RULE_ID} rule, not merely exit non-zero: ${result.output}`,
+  );
 });
 
-test('a stale guardrail-tmp-* leftover does not wedge npm run lint', () => {
+test('a stale guardrail-tmp-* leftover is ignored by ESLint, not merely absent of other diagnostics', () => {
   // Simulates the #2482 failure mode: a guardrail-tmp-* dir survives cleanup
   // (killed process / rmSync race) and is still sitting in the tree the next
-  // time someone runs `npm run lint`. Invoked the same way that script does
-  // (`eslint . --max-warnings 0`, a directory walk — NOT an explicit glob
-  // naming the leftover, which ESLint 9 treats as an unmatched-pattern error
-  // regardless of ignores and would make this test assert the wrong thing)
-  // it must be silently skipped by eslint.config.mjs's global ignore.
-  const staleDir = join(repoRoot, 'guardrail-tmp-stale-2482-test');
-  rmSync(staleDir, { recursive: true, force: true });
-  mkdirSync(staleDir);
+  // time someone runs `npm run lint`. Targets the leftover directly via an
+  // explicit glob rather than `eslint . --max-warnings 0` over the whole
+  // repo — a whole-repo lint's exit code says nothing about THIS directory
+  // specifically; it would also flip on an unrelated pre-existing warning
+  // elsewhere in the tree, which is not what this test is meant to prove.
+  //
+  // ESLint 9 treats "every file an explicit glob pattern matches is ignored"
+  // as its own outcome (exit 2, "all matched files are ignored"), distinct
+  // from "the file was linted and found clean" (exit 0) — so a passing run
+  // here is a config guarantee, not silence.
+  const staleDir = mkdtempSync(join(repoRoot, 'guardrail-tmp-'));
   const staleFile = join(staleDir, 'planted.test.ts');
   writeFileSync(
     staleFile,
     "import { it } from 'vitest';\nit.skipIf(process.env.CI)('x', () => {});\n",
   );
-  let failed = false;
+  let result;
   try {
-    execFileSync('npx', ['eslint', '.', '--max-warnings', '0'], {
-      cwd: repoRoot,
-      stdio: 'pipe',
-      shell: process.platform === 'win32',
-    });
-  } catch {
-    failed = true;
+    result = runEslint([`${staleDir.replace(/\\/g, '/')}/**/*.ts`]);
   } finally {
     rmSync(staleDir, { recursive: true, force: true });
   }
   assert.equal(
-    failed,
-    false,
-    'npm run lint should skip a stale guardrail-tmp-* leftover (global ignore) rather than flag its planted violation',
+    result.exitCode,
+    2,
+    `eslint should report every matched file as ignored (exit 2), not lint the leftover (got ${result.exitCode}): ${result.output}`,
+  );
+  assert.match(result.output, /ignored/i, `eslint's output should say the leftover was ignored: ${result.output}`);
+  assert.doesNotMatch(
+    result.output,
+    new RegExp(RULE_ID),
+    `the leftover must never actually be linted, i.e. never surface the ${RULE_ID} violation: ${result.output}`,
   );
 });

--- a/scripts/tests/eslint-guardrail.test.mjs
+++ b/scripts/tests/eslint-guardrail.test.mjs
@@ -31,12 +31,24 @@ const RULE_ID = 'no-restricted-syntax';
 // on EVERY outcome, not just failure, to tell "the guardrail rule fired" apart
 // from "eslint itself errored" (a bad flag, a missing binary, a config
 // problem) — both exit non-zero, and only the output distinguishes them.
+//
+// Windows needs shell:true to run npx.cmd at all (spawnSync cannot exec a
+// .cmd file directly — EINVAL). shell:true only concatenates argv without
+// escaping (Node DEP0190), so every argument is quoted here — cheap
+// insurance since one of them is a path built from mkdtempSync's own output
+// and could contain a space in a checkout outside this repo's convention.
+const IS_WIN = process.platform === 'win32';
+
 function runEslint(args) {
-  const result = spawnSync('npx', ['eslint', ...args], {
+  const argv = IS_WIN ? args.map((a) => `"${a}"`) : args;
+  const result = spawnSync('npx', ['eslint', ...argv], {
     cwd: repoRoot,
     encoding: 'utf8',
-    shell: process.platform === 'win32',
+    shell: IS_WIN,
   });
+  if (result.error) {
+    throw result.error;
+  }
   return { exitCode: result.status, output: (result.stdout ?? '') + (result.stderr ?? '') };
 }
 
@@ -106,5 +118,34 @@ test('a stale guardrail-tmp-* leftover is ignored by ESLint, not merely absent o
     result.output,
     new RegExp(RULE_ID),
     `the leftover must never actually be linted, i.e. never surface the ${RULE_ID} violation: ${result.output}`,
+  );
+});
+
+test('the guardrail-tmp-*/budget-poll-tmp-* ignores do not swallow an ordinary *.test.ts file', () => {
+  // The two tests above prove the leftover dirs ARE ignored and the rule
+  // fires when unignored via --no-ignore. Neither would catch the ignore
+  // pattern becoming too broad (e.g. accidentally matching '**/*.test.ts'
+  // instead of a specific directory prefix) — test 1 always passes
+  // --no-ignore, which would blind it to that too, and test 2 asserts the
+  // file IS ignored, so a broader pattern only makes it greener. This test
+  // is the counterweight: an ordinary planted violation OUTSIDE both
+  // leftover-dir prefixes must still be caught with NO --no-ignore flag.
+  const dir = mkdtempSync(join(repoRoot, 'eslint-guardrail-canary-'));
+  const f = join(dir, 'planted.test.ts');
+  writeFileSync(
+    f,
+    "import { it } from 'vitest';\nit.skipIf(process.env.CI)('x', () => {});\n",
+  );
+  let result;
+  try {
+    result = runEslint([f]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  assert.equal(result.exitCode, 1, `eslint should still lint an ordinary test file and reject the violation (got ${result.exitCode}): ${result.output}`);
+  assert.match(
+    result.output,
+    new RegExp(RULE_ID),
+    `eslint's output should name the ${RULE_ID} rule for a file outside the leftover-dir ignores: ${result.output}`,
   );
 });

--- a/scripts/tests/eslint-guardrail.test.mjs
+++ b/scripts/tests/eslint-guardrail.test.mjs
@@ -7,15 +7,37 @@
 // CRITICAL: the planted file is written INSIDE the repo tree (guardrail-tmp-* dir
 // at the repo root), NOT os.tmpdir(). ESLint flat config ignores files outside its
 // base path and would exit 0 (false pass) if the file were in a system temp dir.
+//
+// `guardrail-tmp-*/` is ALSO in eslint.config.mjs's global `ignores` (#2482) —
+// a directory this probe fails to clean up (killed process, or a Windows EBUSY
+// race on rmSync) must not wedge lint on every later checkout. That means the
+// probe's own `npx eslint` call now needs `--no-ignore` to see its planted
+// file — without it this test would false-pass against a probe that lints
+// nothing, exactly the failure mode the ignore entry's comment warns about.
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { writeFileSync, rmSync, mkdtempSync } from 'node:fs';
+import { writeFileSync, rmSync, mkdtempSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
 
 // test:hooks runs from the repo root (scripts/run-hooks-tests.mjs uses fast-glob
 // which resolves against cwd).
 const repoRoot = process.cwd();
+
+function lintPlantedFile(f) {
+  try {
+    execFileSync('npx', ['eslint', '--no-ignore', f], {
+      cwd: repoRoot,
+      stdio: 'pipe',
+      shell: process.platform === 'win32',
+    });
+    return false;
+  } catch {
+    // eslint exits non-zero when it finds an error-level violation — that is the
+    // expected outcome for the planted violation.
+    return true;
+  }
+}
 
 test('guardrail rejects a planted it.skipIf(process.env.CI)', () => {
   // Create a temp dir inside the repo so the flat config base path applies.
@@ -27,19 +49,46 @@ test('guardrail rejects a planted it.skipIf(process.env.CI)', () => {
     f,
     "import { it } from 'vitest';\nit.skipIf(process.env.CI)('x', () => {});\n",
   );
+  let failed;
+  try {
+    failed = lintPlantedFile(f);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  assert.equal(failed, true, 'eslint should exit non-zero for the planted it.skipIf(process.env.CI) violation');
+});
+
+test('a stale guardrail-tmp-* leftover does not wedge npm run lint', () => {
+  // Simulates the #2482 failure mode: a guardrail-tmp-* dir survives cleanup
+  // (killed process / rmSync race) and is still sitting in the tree the next
+  // time someone runs `npm run lint`. Invoked the same way that script does
+  // (`eslint . --max-warnings 0`, a directory walk — NOT an explicit glob
+  // naming the leftover, which ESLint 9 treats as an unmatched-pattern error
+  // regardless of ignores and would make this test assert the wrong thing)
+  // it must be silently skipped by eslint.config.mjs's global ignore.
+  const staleDir = join(repoRoot, 'guardrail-tmp-stale-2482-test');
+  rmSync(staleDir, { recursive: true, force: true });
+  mkdirSync(staleDir);
+  const staleFile = join(staleDir, 'planted.test.ts');
+  writeFileSync(
+    staleFile,
+    "import { it } from 'vitest';\nit.skipIf(process.env.CI)('x', () => {});\n",
+  );
   let failed = false;
   try {
-    execFileSync('npx', ['eslint', f], {
+    execFileSync('npx', ['eslint', '.', '--max-warnings', '0'], {
       cwd: repoRoot,
       stdio: 'pipe',
       shell: process.platform === 'win32',
     });
   } catch {
-    // eslint exits non-zero when it finds an error-level violation — that is the
-    // expected outcome for the planted violation.
     failed = true;
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmSync(staleDir, { recursive: true, force: true });
   }
-  assert.equal(failed, true, 'eslint should exit non-zero for the planted it.skipIf(process.env.CI) violation');
+  assert.equal(
+    failed,
+    false,
+    'npm run lint should skip a stale guardrail-tmp-* leftover (global ignore) rather than flag its planted violation',
+  );
 });


### PR DESCRIPTION
## Summary
- A `guardrail-tmp-*/` dir left behind by `scripts/tests/eslint-guardrail.test.mjs` (killed process, or `rmSync` losing a Windows EBUSY race against the spawned child right above it) silently wedged every push from that checkout: git ignores the dir but ESLint didn't, so lint failed on a planted violation nobody wrote and no listing showed.
- Adds `guardrail-tmp-*/` to `eslint.config.mjs`'s global `ignores` (Option B from #2482), so a leftover is harmless rather than merely less likely. The probe passes `--no-ignore` to its own `npx eslint` call so it still sees its planted file.
- Verified this isn't a false pass across three independent review rounds: disabling the guardrail rule reddens the probe test every time.
- **Also fixed, found in passing (review round 1):** `check-no-budget-poll.test.mjs`'s own planted-violation temp dir (`budget-poll-tmp-*`) has the identical interrupted-run leftover shape as `guardrail-tmp-*` — added to `.gitignore` and `eslint.config.mjs`'s global ignores alongside it.
- **Also fixed, found in passing (review round 2):** the two original probes were both blind to the global ignore becoming over-broad (e.g. accidentally matching `**/*.test.ts` instead of a directory-prefixed pattern) — added a third probe.
- **Also fixed, found in passing (review round 3):** that third probe's first version planted its own file under a NEW, unignored repo-root `mkdtempSync` prefix (`eslint-guardrail-canary-*`) — reintroducing the exact #2482 leftover-wedge class this PR exists to close, if that plant ever survived a killed process. Rewritten to probe an already-tracked file (`server/src/test-utils/quarantine.test.ts`) instead — writes nothing, so there is nothing to leak.
- **Release notes intentionally skipped** — pure CI-only internal chore (lint config + its own regression tests), no user- or operator-visible effect (before-shipping checklist step 5).

## Test plan
- [x] Targeted regression test plants a stale `guardrail-tmp-*` dir and lints it via an explicit glob — confirms ESLint reports it as ignored (exit 2), never linted.
- [x] Third probe checks an already-tracked `*.test.ts` file is never reported as ignored — catches the ignore pattern ever growing too broad, without planting anything.
- [x] Reproduced the original issue's exact repro shape locally (planted violation dir + `npm run lint`) — now exits 0. Same repro for the `budget-poll-tmp-*` sibling.
- [x] Mutation checks across all three probes: disabling `no-restricted-syntax` reddens probe 1; a typo'd `--no-ignoer` flag correctly fails instead of false-passing; appending an over-broad `**/*.test.ts` ignore reddens probe 3 while probes 1–2 stay green; confirmed `git status --porcelain` is clean after every run (no leftover).
- [x] `npm run test:hooks` — 1417/1417 pass.
- [x] `npm run verify:fast:branch` — green.

Closes #2482