### PR TITLE
docs(docs): turn the 74 owed on-box rows into 2-3 hour sitting packs

### DIFF
--- a/docs/testing/onbox-sitting-blocked-prerequisites.md
+++ b/docs/testing/onbox-sitting-blocked-prerequisites.md
@@ -1,0 +1,248 @@
+# Blocked-on-acquisition — on-box acceptance run sheet
+
+> **This is a working document.** Fill in the `Result:` lines AS you run this
+> on the box, once the prerequisite each row is blocked on has actually been
+> obtained. Do not pre-fill them.
+>
+> Plan of record: [`onbox-sitting-plan.md`](onbox-sitting-plan.md) §2.3, §5
+> Register rows: [`onbox-acceptance-register.md`](onbox-acceptance-register.md)
+> F1 (Group F), H1 and H2 (Group H), D3 (Group D)
+> Audit input: [`onbox-acceptance-staleness-audit.md`](onbox-acceptance-staleness-audit.md)
+
+---
+
+## 1. Purpose & scope
+
+This sitting covers the four register rows blocked on something that must be
+**obtained**, not on time or a free GPU slot: **F1** needs a real Android
+device (and, for one item, a CarPlay/Android Auto head unit); **H1**, **H2**
+and **D3** need a real CJK manuscript this repo's corpus does not currently
+have available. Unlike every other sitting in this wave, this pack cannot be
+scheduled today — it exists so the procedure is ready the moment each
+prerequisite lands.
+
+**Running time total (this sitting, once unblocked):** H1 (15 min) + H2
+(15 min) + D3 (20 min) = **50 minutes** for the three CJK-manuscript rows,
+run together once one or both manuscripts are in hand. **F1 is excluded from
+that total** — its own plan does not estimate it, and it is "an entire
+untested axis," not batchable with any other row in this register (see
+`onbox-sitting-plan.md` §7). F1 gets its own dedicated block whenever a
+device and (for app-9) a head unit are available; it does not ride the same
+sitting as H1/H2/D3, since neither shares hardware, engine residency or
+fixtures with the other.
+
+**Card / box:** H1 and H2 need no GPU, sidecar, or analyzer — pure functions
+over chapter text, runnable on any machine. D3 needs a working TTS engine
+(Kokoro, Coqui or Qwen — any one) to render a chapter, so a single card is
+enough; no VRAM contention concern. F1 needs the operator's GPU server
+reachable over LAN from the phone, not a dedicated card session on its own.
+
+## 2. Re-resolution — re-checked live, not taken from the audit
+
+Per `onbox-sitting-plan.md` §6 (the A2 false-grep incident), every row below
+was re-resolved against its own citations rather than trusted from the
+staleness audit.
+
+- **F1** (`docs/features/188-android-companion-app.md`): line 24 still reads
+  "all built, tested, and merged... The only thing left is the batched
+  live-device acceptance pass" verbatim, confirmed live in this worktree.
+  `app-3` through `app-8`/`app-13`/`app-14` all still carry "**Live device
+  acceptance owed**" against every entry (checked `app-3`–`app-5` directly;
+  matches the audit's citation). No file under `docs/testing/` records a
+  live-device run. **Audit verdict (STILL OWED) confirmed.**
+- **H1 / H2** (`server/src/tts/prose-units.ts`, #2256):
+  `gh api repos/dudarenok-maker/Castwright/issues/2256` →
+  `{"state":"closed","closed_at":"2026-08-14T11:17:46Z"}` — the *bug-fix*
+  issue is closed and merged, exactly as the register already accounts for;
+  closure does not discharge the on-box row, which is about the fix's real-
+  scale acceptance, not its existence. `ls
+  C:\AudiobookWorkspace\books\Castwright\Standalones\` lists the same seven
+  Coalfall Commission translations the audit found: two real CJK samples
+  (`煤落的委托` — zh, `コールフォールの依頼` — ja **mixed** kanji+kana), no
+  all-kana Japanese text and no full-length Han book. **Audit verdict (STILL
+  OWED, both rows) confirmed** — no new manuscript has arrived since the
+  audit ran.
+- **D3** (`server/src/analyzer/dialogue-structure/parser.ts`, #2315):
+  `gh api repos/dudarenok-maker/Castwright/issues/2315` →
+  `{"state":"closed","closed_at":"2026-08-13T21:32:45Z"}` — matches the
+  audit's citation exactly. **One re-resolution finding beyond what the
+  audit recorded:** the register's own D3 text (and the design doc's "What
+  it fixes, on real books" section) point at real corpus books —
+  `pg/zh/23835.txt` and others — as already read by "this PR's own
+  instruments," which reads as though a usable manuscript already exists.
+  It does not, on this box: those files were read from
+  `scratchpad/s2315/…`, a throwaway analysis directory this worktree does
+  not contain (`find … -iname s2315` returns nothing), and no copy of
+  `pg/zh/23835.txt` or the corpus it belongs to exists under
+  `C:\AudiobookWorkspace` or the primary checkout either. The "already in
+  the corpus" framing describes a one-time analysis fetch, not a persistent
+  asset — so **D3 is correctly binned as blocked-on-acquisition**, same as
+  H1/H2, and the audit's "real CJK manuscript" hardware field is accurate in
+  effect even though the register's own wording could be read as implying
+  otherwise. No file under `docs/testing/` mentions #2315 or
+  "primary-pair-straddle," confirmed. **Audit verdict (STILL OWED)
+  confirmed.**
+
+No row is excluded on re-resolution — all four remain genuinely blocked.
+
+## 3. Preconditions
+
+Stated once for the sitting; check off only what applies to the rows you are
+actually running (H1/H2/D3 share a session, F1 is its own).
+
+**For H1 / H2 / D3 (CJK manuscript rows):**
+
+- [ ] A real, legally usable **all-kana (no kanji) Japanese manuscript** —
+      the realistic shape is a children's book or early-reader text with no
+      kanji at all — for H1.
+- [ ] A real, legally usable **full-length Han (Chinese) manuscript** — book
+      scale, not an excerpt — for H2. (H1 and H2 need two *different* texts;
+      neither of this repo's existing Coalfall samples satisfies either,
+      per §2 above.)
+- [ ] For **D3**, no new manuscript is strictly required if either the H1 or
+      H2 manuscript (or this repo's existing `コールフォールの依頼` / `煤落的委托`
+      samples) contains a continuation paragraph of the shape the design doc
+      describes (an opening quote delimiter with no closer, itself containing
+      a quoted turn) — check for one before importing anything extra. If none
+      of the available texts contains that shape, D3 needs its own zh or ja
+      manuscript with at least one such paragraph.
+- [ ] A working TTS engine available (Kokoro, Coqui or Qwen — any one; D3
+      only, H1/H2 need no engine at all).
+- [ ] Repo checked out at this worktree/branch, `cd server && npm run
+      build` current (H1/H2 call `detectManuscriptLanguageFromChapters`
+      directly; D3's render goes through the normal import → chapter
+      generation path).
+- [ ] One shell is enough for all three rows.
+
+**For F1 (Android live-device rows):**
+
+- [ ] A real Android phone — the plan names a **Pixel 10 Pro**
+      (`docs/features/188-android-companion-app.md`).
+- [ ] The operator's GPU server reachable on the **same LAN/Wi-Fi** as the
+      phone.
+- [ ] For **app-9** only: a real **Android Auto / CarPlay head unit** (or a
+      head-unit emulator Google/Apple ship, if the plan later names one —
+      not confirmed present as of this pack).
+- [ ] At least 2 books available on the server library to exercise the
+      dual-book download/resume scenario.
+- [ ] A chapter the operator can regenerate mid-session, to exercise the
+      targeted re-sync + in-car position push-back step.
+
+## 4. Procedure
+
+### 4.1 H1 — kana-trigram richness gate at real-book scale (all-kana Japanese)
+
+*Blocked pending corpus.* Once an all-kana manuscript is in hand:
+
+1. Import the manuscript (or run its chapters directly through
+   `detectManuscriptLanguageFromChapters`, e.g. via `npx tsx` — see
+   `server/src/tts/detect-language.test.ts`'s `finding 3(b)` fixture for the
+   call shape this exercises) and observe the result.
+   **Result:** _(fill in: `{ language, supported, fallback }`)_
+2. Separately call `guiraudR` on the same (deduped, per `dedupeProseUnits`)
+   winning sample and record the actual value against
+   `LEXICAL_RICHNESS_FLOOR` (3) — see `server/src/tts/prose-units.ts`'s own
+   finding-3(b) block for what "winning sample" means here.
+   **Result:** _(fill in: observed R)_
+3. If the manuscript has multiple chapters, note the total combined
+   character count the richness gate actually saw (no length cap applies —
+   `prose-units.ts`'s finding-3(a) retraction).
+   **Result:** _(fill in: combined character count, and whether the margin
+   at that scale still clears the floor)_
+
+### 4.2 H2 — lexical-richness floor at full-length real Han-book scale
+
+*Blocked pending corpus.* Once a full-length Chinese manuscript is in hand:
+
+1. Import it (or run `detectManuscriptLanguageFromChapters` over its
+   chapters directly) and record the result.
+   **Result:** _(fill in: `{ language, supported, fallback }`, expected `zh`)_
+2. Record the combined character count of the joined winning sample the
+   gates actually saw (every winning chapter's `prepareSample` output, each
+   capped at 20,000 chars, joined) and the observed `guiraudR` against
+   `LEXICAL_RICHNESS_FLOOR` (3).
+   **Result:** _(fill in: N, and observed R)_
+3. Record the distinct-Han-character count at that scale — the `V` in
+   `V / sqrt(N)`. At N ≈ 400,000, R clears the floor only if V is above
+   ~1,900; this is the number that answers the row.
+   **Result:** _(fill in: distinct-Han-character count V)_
+
+### 4.3 D3 — the recovered turn actually sounds right when voiced
+
+*Blocked pending corpus* (see §2's re-resolution finding — the design doc's
+cited corpus books are not present on this box; D3 needs the same kind of
+acquisition as H1/H2 unless one of their manuscripts happens to contain a
+qualifying paragraph). Once a qualifying zh or ja manuscript is available:
+
+1. Import a `zh` or `ja` book containing a continuation paragraph of the
+   shape `docs/superpowers/specs/2026-08-13-primary-pair-straddle-design.md`
+   § "What it fixes, on real books" describes — an opening quote delimiter
+   with no closer of its own, itself containing a quoted turn (that section
+   quotes a worked `zh` example: `…眾鬼嘩然並出，曰：「爾恃符咒拘遣我...」聚而攢擊。…`
+   recovering as two runs rather than one merged run). If H1's all-kana or
+   H2's Han manuscript already contains such a paragraph, reuse it here
+   rather than importing a third text.
+2. Generate that chapter with a working TTS engine (any of Kokoro/Coqui/
+   Qwen — engine choice is not the variable under test).
+3. Listen to the rendered continuation paragraph. Confirm the previously-
+   swallowed inner turn now renders as its **own** speech turn, in the
+   character's own cast voice, rather than merged into the narration/tag
+   reading of the turn before it.
+   **Result:** _(fill in: pass/fail — own voice, correctly separated?)_
+4. Confirm the recovered boundary does not land mid-word and does not drop
+   a syllable, listening across the cut point specifically.
+   **Result:** _(fill in: pass/fail — clean boundary?)_
+5. **Optional, lower priority per the row's own text:** if a `ru` or `de`
+   chapter is convenient from the same import, spot-check one of its
+   affected continuation paragraphs the same way. Not required for this row
+   to clear.
+   **Result:** _(fill in: run? pass/fail if yes)_
+
+### 4.4 F1 — Android companion app, v1 live-device acceptance
+
+*Blocked pending device (and, for app-9, a head unit).* An entire untested
+axis — every module (`app-3` through `app-14`) is unit/widget-tested and CI-
+green, but **zero of it has been proven on a physical phone.** Once a Pixel
+10 Pro (or equivalent) and LAN access to the server are available, the full
+plan-188 live-device pass is three scenarios; write the procedure now so no
+decision is needed once the device lands, but do not attempt any of it
+without the device in hand:
+
+1. **v1 core, single end-to-end scenario** (`docs/features/
+   188-android-companion-app.md:622-630` has the full script): pair the
+   phone to the server via QR (token + CA fingerprint auto-verified, no OS
+   cert install) → browse the library by author/series/book → download 2
+   books → play offline with background, lock-screen and Bluetooth controls
+   plus a sleep timer → switch between the 2 books, confirming each resumes
+   at its own position → regenerate one chapter of book A on the server →
+   return to home Wi-Fi → confirm the app auto-syncs only that chapter and
+   pushes the in-car listening position back to the server.
+   **Result:** _(fill in: pass/fail per sub-step, per `:622-630`)_
+2. **app-9, head unit:** Android Auto / CarPlay media-browse tree
+   navigation and playback from a real head unit. Requires the head unit
+   separately from the phone.
+   **Result:** _(fill in: pass/fail)_
+3. **app-10, stream over LAN** (`docs/features/
+   188-android-companion-app.md:504-508`): an undownloaded chapter with
+   "Stream over LAN" on starts instantly, mid-chapter seek works,
+   lock-screen transport works, it survives backgrounding, and no OS
+   cert-install prompt appears; with streaming off or off-Wi-Fi, confirm a
+   "download to play" message appears rather than a stall.
+   **Result:** _(fill in: pass/fail per sub-check)_
+
+## 5. Teardown
+
+- **H1/H2:** no engine or process was started — nothing to unload. Discard
+  any manuscript-import artifacts created only for the test if they should
+  not remain in the library.
+- **D3:** stop/close the render session; evict the TTS engine used if it
+  should not stay warm for whatever sitting runs next; close the book if it
+  was imported solely for this row.
+- **F1:** unpair the phone from the server, stop any active playback,
+  disconnect the head unit if one was used, and confirm the server-side
+  library returns to its pre-sitting state (no stray test-only downloads
+  left counted against library storage).
+
+_(Once each row is actually run and recorded, mark it discharged in
+`onbox-acceptance-register.md` with a summary of this result — that edit is
+out of scope for this pack and belongs to whoever runs the sitting.)_

--- a/docs/testing/onbox-sitting-cloning-identity.md
+++ b/docs/testing/onbox-sitting-cloning-identity.md
@@ -1,0 +1,343 @@
+# On-box sitting pack — cloning + character-identity (A24, A26, A31, A32, A44, A45, A46, A47)
+
+> **Sitting pack** for wave 2 of `#2435`, step 6 of the `#2453` chain. Covers
+> register rows **A24, A26, A31, A32, A44, A45, A46, A47** — clone-derive,
+> clone-readiness, `characterId` drift and resolution, Russian XTTS quality,
+> entity decode, and the audition-centroid fix. Follows the shared format
+> fixed by [`onbox-sitting-plan.md`](onbox-sitting-plan.md) §5; the
+> re-resolution rule of §6 was applied to every row (see
+> [`## Excluded on re-resolution`](#excluded-on-re-resolution) — nothing was
+> excluded).
+>
+> **Box/card target:** the operator's GPU box, **single 8 GB card**, pinned
+> via `CUDA_VISIBLE_DEVICES=0`.
+>
+> **Running time total (recomputed 2026-08-20):** **170 minutes** — A24 ≈ 30,
+> A26 ≈ 15, A31 ≈ 30, A32 ≈ 20, A44 ≈ 20, A45 ≈ 20, A46 ≈ 10, A47 ≈ 25. Sum =
+> 170, matching the plan of record's stated total for this pack
+> ([`onbox-sitting-plan.md`](onbox-sitting-plan.md) §2.1) exactly — all eight
+> rows re-resolved as still owed, so nothing changed the arithmetic.
+
+## Preconditions
+
+Stated once for the sitting; do not repeat per row.
+
+- [ ] **Single 8 GB card.** `CUDA_VISIBLE_DEVICES=0`.
+- [ ] **A real cloned voice, ingested WITHOUT a transcript**
+      (`master.transcript === ''`) — A31's gate needs it in this state at the
+      start of the sitting; A31 §4 fills the transcript in, and every later
+      row that wants "a cloneable voice" (A24, A47) reuses the now-transcribed
+      clone rather than a second ingest.
+- [ ] **A non-English book** (A24, A45) — cast the clone above onto a
+      character with dialogue in it. `ASR_DEVICE` and `ASR_COMPUTE_TYPE` must
+      agree (a `cpu` device with a pinned `int8_float16` makes every
+      `/transcribe` 500 — A24 needs a working `/transcribe`).
+- [ ] **The real, already-affected workspace book for A32** —
+      *Playing with Fire* (Derek Landy, Skulduggery Pleasant) at
+      `C:\AudiobookWorkspace\books\Derek Landy\Skulduggery Pleasant\Playing with Fire`.
+      Present and untouched — do not run the Wave-3 repair script or any cast
+      edit against it before A32's section runs.
+      **Back up `16-chapter-twelve-barfight.segments.json`,
+      `19-chapter-fifteen-point-blank.segments.json`, and their `.mp3`s**
+      before re-rendering, so a bad run can be reverted without re-importing.
+- [ ] **An EPUB carrying named HTML entities** in its first-chapter heading
+      and/or body (A45) — reuse the non-English book above if it qualifies,
+      otherwise hand-substitute `&mdash;`/an accented named entity into a real
+      chapter. Confirm one exists in the on-box corpus before the sitting.
+- [ ] **A Russian book or line on the stock catalogue Coqui voice
+      `Damien Black`** (A44) — no clone needed, every #2026 defect reproduces
+      on it.
+- [ ] **A genuinely static-FFmpeg box** for A26 — `ffmpeg` on PATH, no hot-
+      patched FFmpeg DLLs inside `site-packages/torchcodec/` (confirm
+      `import torchcodec` still fails; if it succeeds, the box has drifted
+      back to hot-patched and A26 needs re-checking against register.md
+      §A26 item 1's three verified preconditions before trusting the result).
+- [ ] **A live sidecar and a book mid-render, plus OS-level process-kill
+      access** (A46) — `taskkill`/Task Manager, ability to bind a foreign
+      listener on `:9000`, ability to start a fresh sidecar manually, and
+      ability to set `SIDECAR_NEVER_ADOPT` on the server process.
+- [ ] SHA and a clean tree recorded below.
+
+SHA: `____________`  Clean tree: ☐  Date: `__________`  Run by: `__________`
+
+## Procedure
+
+Ordered so the Qwen-resident rows run first (A31 fixes the clone's transcript
+that A24 and A47 then reuse), the same non-English book and cast id-drift work
+ride the same Qwen residency, the engine swaps once into Coqui/XTTS for the
+two Russian/Coqui-derive rows, and the disruptive sidecar-kill row (A46) runs
+last, alone, since it deliberately crashes the sidecar twice.
+
+### A31 · Cast-time clone-readiness gate — the fixes actually fix ([#1980](https://github.com/dudarenok-maker/Castwright/issues/1980), plan [276](../features/archive/276-cast-time-derivability-warning.md))
+
+> **Criteria source:** [`clone-readiness-gate-onbox-acceptance.md`](clone-readiness-gate-onbox-acceptance.md)
+> §§3–6 — cited, not restated. Re-resolved 2026-08-20: `gh issue view 1980` →
+> closed 2026-08-01T04:11:06Z, matches. Plan 276 frontmatter `status: stable`.
+> Run sheet's every `Result:` line (§§3–6) is still an unfilled blank, SHA/
+> date/run-by line unfilled — no on-box run recorded. STILL OWED. Run **§4
+> first** — it is the load-bearing section per the run sheet's own §1 note —
+> and its "Add transcript" step is why this row runs before A24/A47: it
+> converts the sitting's transcript-less clone into one with a real
+> transcript, which those rows then use.
+
+1. Run [`clone-readiness-gate-onbox-acceptance.md`](clone-readiness-gate-onbox-acceptance.md)
+   §3 (the gate fires at cast time — Coqui assign, switch to Qwen, Approve
+   cast, expect the gate).
+   - Result:
+2. Run §4 (Add transcript → gate clears → render a chapter → confirm the
+   cloned voice actually speaks on Qwen, resolved voice key + by-ear listen).
+   - Result:
+3. Run §5 (force a genuine `derive-failed` slot, confirm **Retry derive**,
+   confirm the predicate re-evaluates to the underlying cause rather than
+   clearing to healthy).
+   - Result:
+4. Run §6 (control — switch back to Coqui, confirm **no gate** fires).
+   - Result:
+
+### A24 · A cloned voice renders a non-English book in the book's language (plan [275](../features/275-clone-voice-language.md), [#1951](https://github.com/dudarenok-maker/Castwright/issues/1951))
+
+> **Criteria source:** `onbox-acceptance-register.md` A24 (plan 275
+> §"On-box acceptance"). Re-resolved 2026-08-20: `gh issue view 1951` →
+> closed 2026-07-30T04:26:44Z; `gh issue view 1972` → closed
+> 2026-07-31T09:45:45Z (fixed by PR #1992, "refuse a splice when the render
+> and analysis disagree on a segment's owner"); `gh issue view 1969` → closed
+> 2026-08-16T03:56:07Z (fixed by PR #2402, "rebuild the audition centroid
+> when a character's voice is reassigned"). Both blockers the row's own
+> 2026-07-31 correction named are now resolved in code, but plan 275's own
+> Ship notes still record Step 2 (self-heal → restart → identical) and
+> Step 3/C-17 as **NOT RUN**, and no later run sheet or register annotation
+> records a rerun of the chapter-level criterion, the restart check, or the
+> QA `voice-mismatch` sub-check since #1972 and #1969 landed. STILL OWED.
+
+5. **Chapter-level criterion.** Render one chapter of the non-English book
+   (Preconditions) on the now-transcribed clone from A31. Transcribe the
+   output through the sidecar's `/transcribe` with Whisper **auto-detect**
+   (no `x-language`). **Pass = detected language is the book's, and
+   `avg_logprob` is better than ≈ −0.5.** Reference points from the row's own
+   prior measurements: pre-fix `en`/**−1.303**, with language corrected
+   `de`/**−0.366**, a natively-designed German control **−0.201**.
+   - Result (detected language / avg_logprob):
+6. **Title beat.** Confirm the chapter title's `/synthesize` call (the one
+   call in an otherwise batched chapter) also renders correctly — a
+   regression here hides behind correct-sounding body audio.
+   - Result:
+7. **`resolvedVoiceName` never substitutes.** Confirm
+   `characterSnapshots.<id>.resolvedVoiceName` is still the clone's storage
+   key throughout.
+   - Result:
+8. **Self-heal / restart identical (Step 2, still NOT RUN per plan 275).**
+   Render with a designed self-healed voice, restart the sidecar, render
+   again. Confirm the two renders are audibly identical.
+   - Result:
+9. **QA `voice-mismatch` check, opportunistic (Step 3/C-17).** Open the
+   chapter's QA report; confirm the cloned character has no `voice-mismatch`
+   rows. Only reachable with a character thin enough on in-book anchors to
+   trigger the audition fallback — treat as opportunistic within this same
+   render, not something to engineer.
+   - Result:
+
+### A47 · Reassigning a character's voice no longer scores it against the old speaker's persisted audition centroid ([#1969](https://github.com/dudarenok-maker/Castwright/issues/1969), PR #2402)
+
+> **Criteria source:** `onbox-acceptance-register.md` A47. Re-resolved
+> 2026-08-20: `gh pr view 2402` → merged 2026-08-16T03:56:05Z, title matches.
+> Only mock/unit coverage exists (`aggregate-audition-voice-reassign.test.ts`)
+> — no run sheet under `docs/testing/`. STILL OWED. Records A24's final
+> sub-check ("no `voice-mismatch` rows") for a **reassignment**, not the
+> first-assignment case A24 §9 covers — run here, still Qwen-resident, using
+> the same non-English book's cast.
+
+10. Assign a character thin enough on in-book anchors to take the
+    audition-reference path to one voice; render once so
+    `render-integrity.centroids.json` persists an `audition` row.
+    - Result:
+11. Reassign the character to a clearly different, cloned voice (the A31/A24
+    clone works); re-render.
+    - Result:
+12. Confirm the new voice's lines are **not** flagged `voice-mismatch`/
+    `severe` — the persisted centroid was rebuilt for the new voice, not
+    reused against the old speaker's.
+    - Result:
+
+### A32 · Cast/analysis `characterId` drift — Wave 1 resolver ([#2040](https://github.com/dudarenok-maker/Castwright/issues/2040))
+
+> **Criteria source:** [`cast-id-drift-onbox-acceptance.md`](cast-id-drift-onbox-acceptance.md)
+> §§3–5 — cited, not restated. Re-resolved 2026-08-20: `gh issue view 2040` →
+> closed 2026-08-04T17:40:01Z, matches. The run sheet's §§3–6 `Result:` lines
+> are all still unfilled blanks. §9 of that same run sheet (dated
+> 2026-08-11) re-rendered a **different** book (*Заказ Коалфолла*, for the
+> since-discharged A45 audio-currency row) — it does not touch *Playing with
+> Fire* ch19/ch16, the fixture this row names. STILL OWED. No clone needed —
+> switch the cast target to the *Playing with Fire* workspace book
+> (Preconditions) while Qwen stays resident.
+
+13. Run [`cast-id-drift-onbox-acceptance.md`](cast-id-drift-onbox-acceptance.md)
+    §3 (re-render chapter 19 — `the-torment` recovery, `characterSnapshots`
+    check, by-ear distinct-voice listen).
+    - Result:
+14. Run §4 (re-render chapter 16 — `lightning-dave` recovery **and**
+    `pool-player-2` negative control in the same chapter).
+    - Result:
+15. Run §5 (Cast-screen banner cross-check — `the-torment`/`lightning-dave`
+    no longer named; `pool-player-2` still named).
+    - Result:
+
+### A45 · Named-entity decode reaches the TTS engine on a real EPUB ([#2310](https://github.com/dudarenok-maker/Castwright/issues/2310), PR #2316)
+
+> **Criteria source:** `onbox-acceptance-register.md` A45. Re-resolved
+> 2026-08-20: `gh issue view 2310` → closed 2026-08-13T04:25:10Z; `gh pr view
+> 2316` → merged 2026-08-13T04:43:29Z, title matches ("widen named-entity
+> decode to the full HTML5 set"). Every layer proved only by unit/e2e tests
+> fixing the sentence text explicitly — no run sheet or dated result under
+> `docs/testing/` for a real EPUB. STILL OWED. Rides on the non-English book/
+> EPUB staged in Preconditions — still the same Qwen/book residency as A24.
+
+16. **Chapter-title beat (design spec Finding 0 — the one criterion no model
+    behaviour can mask).** On the EPUB whose first chapter heading carries
+    named entities (e.g. `<h1>L&rsquo;&Eacute;t&eacute;</h1>`), confirm the
+    spoken title beat says "L'Été" cleanly — no "ampersand … semicolon", no
+    gibberish.
+    - Result:
+17. **Body-line entity, secondary.** On the same or a second es/fr/ru EPUB
+    with named entities in body text, confirm a dash-opened dialogue line
+    renders with a pause (not "ampersand n dash semicolon" spoken aloud),
+    accented words render as the correct letters, and the manuscript view
+    shows real glyphs. Record whether this symptom reproduced at all
+    pre-fix — per the design spec, that is new information about the
+    analyzer chain, not a gate on this fix.
+    - Result:
+
+### A44 · Russian XTTS quality — leading-dash pause by ear, Coqui degeneracy guard live, neuter -ее invariant ([#2026](https://github.com/dudarenok-maker/Castwright/issues/2026), PR #2050)
+
+> **Criteria source:** [`fs38-wave3-onbox-acceptance.md`](fs38-wave3-onbox-acceptance.md)
+> `#2026 — additional acceptance criteria: Russian XTTS quality` section
+> (`:2657-2667`) — cited, not restated. Re-resolved 2026-08-20: `gh issue view
+> 2026` → still **OPEN**; `gh pr view 2050` → merged 2026-08-01T03:16:56Z,
+> title matches ("pause on a leading dash, add coqui degeneracy guard"); `gh
+> issue view 2057` → closed 2026-08-11T02:48:19Z (that issue only tracked
+> reconciling the register with this row, not running the acceptance). The
+> cited run sheet section's `Result:` line is still the unchecked
+> `☐ P ☐ F ☐ B ☐ N/A` template. STILL OWED. **First row in this sitting that
+> wants Coqui/XTTS resident instead of Qwen — the one engine swap in this
+> pack.** No clone needed; switch to the stock catalogue voice `Damien Black`.
+
+18. Run the cited section's item 1 (leading em-dash pause, by ear — compare
+    against no-leading-punctuation and interior-dash controls; reference
+    points +0.14 s / +1.53 s).
+    - Result:
+19. Run item 2 (`tts.coqui.degenGuard` live — confirm no false-positive on
+    ordinary short Russian lines; if a live collapse can be captured, confirm
+    whether the retry recovers it — a negative on the recovery half may be
+    correct behaviour per the guard's own docstring, not a failure).
+    - Result:
+20. Run item 3 (neuter `-ее` standing invariant — confirm it still
+    reproduces on `main`; this is a baseline record, not a sign-off).
+    - Result:
+
+### A26 · Cloned-voice derive on Coqui no longer needs torchcodec ([#1967](https://github.com/dudarenok-maker/Castwright/issues/1967))
+
+> **Criteria source:** `docs/superpowers/specs/2026-07-31-xtts-clone-torchcodec-ffmpeg-design.md`
+> §12; `onbox-acceptance-register.md` A26 items 1–4. Re-resolved 2026-08-20:
+> `gh issue view 1967` → closed 2026-07-31T06:06:03Z, matches. Items 1 and 3
+> are already DISCHARGED (register.md:1152-1184, pasted command output) —
+> **not re-run here.** Item 2's audible half and item 4 remain STILL OWED.
+> **Item 4 (Pinokio `import torchcodec` check) is explicitly batched with row
+> E1 in `onbox-sitting-device-browser.md`, which already owns the Pinokio
+> box — not run in this sitting.** Only item 2 runs here, on the same
+> static-FFmpeg box confirmed in Preconditions, same Coqui residency as A44.
+
+21. **Item 2 — latent equivalence, audible half.** Decode equivalence was
+    already measured bit-identical (max difference 0.0) during PR #1978's
+    review — not re-run. Derive the same cloned voice with and without the
+    `patched_xtts_load_audio()` wrap, on this genuinely shared-FFmpeg box,
+    and confirm the rendered output is equivalent by ear.
+    - Result:
+
+### A46 · Respawn budget deadline and exhaustion under sustained refusal ([#2106](https://github.com/dudarenok-maker/Castwright/issues/2106), PR #2398)
+
+> **Criteria source:** `onbox-acceptance-register.md` A46 — full scenario
+> text already spelled out there (`:2473-2496`), cited not restated except
+> for the exact commands below. Re-resolved 2026-08-20: `gh issue view 2106`
+> → closed 2026-08-16T03:05:14Z; `gh pr view 2398` → merged
+> 2026-08-16T03:05:13Z, title matches ("bound the sidecar respawn budget on
+> the refusal path"). Unit tests fully verify the accounting logic but
+> cannot reach the real race — no run sheet under `docs/testing/` covers
+> #2106/PR #2398 at all. STILL OWED. **Run last, alone** — both scenarios
+> deliberately kill the sidecar process, which would otherwise disrupt every
+> row above that depends on a stable warm engine.
+
+22. **Scenario 1 — supervisor crash-loop cap.** With a chapter actively
+    rendering, kill the sidecar's OS process directly (`taskkill /PID <pid>
+    /T /F` against `.run/tts.pid`, or Task Manager — **not**
+    `POST /api/sidecar/restart`). Immediately start a foreign, non-HTTP-
+    conformant listener on `:9000` (e.g. `nc -l 9000`). Grep the server log
+    for the supervisor's refusal counter advancing monotonically (1, 2, 3,
+    4, 5) across the `[sidecar] supervisor: spawn refused: ...` lines, then
+    for the exhaustion log `[sidecar] supervisor: <N> rapid spawn refusals
+    ... — giving up respawn.` once exhausted.
+    - Result (counter advanced 1→5, no reset):
+    - Result (exhaustion log seen):
+23. **Scenario 1 recovery.** Stop the foreign listener, then
+    `POST /api/sidecar/restart`; confirm the sidecar respawns and surfaces
+    ready on `GET /api/setup/models-status`.
+    - Result:
+24. **Scenario 2 — deadline timer for a hung PID probe.** Set
+    `SIDECAR_NEVER_ADOPT=1`, start a fresh sidecar manually
+    (`cd server/tts-sidecar && python main.py`) so the server doesn't own
+    its PID, then start the server with a chapter rendering. Grep the log
+    for the `UNFIT sidecar on :9000 ... replacing it` message and confirm
+    the PID lookup completes well under the 5000 ms deadline (no
+    deadline-timeout message on a responsive box). Confirm the new sidecar
+    becomes owned (`.run/tts.pid`) and surfaces ready.
+    - Result:
+25. **Scenario 2 cleanup.** Unset `SIDECAR_NEVER_ADOPT` (or set back to its
+    prior value) and restart the server so the next sitting adopts a
+    healthy pre-existing sidecar normally.
+    - Result:
+
+## Excluded on re-resolution
+
+None excluded. All eight rows were re-resolved against live repo/issue/PR
+state and the plan-of-record/run-sheet files themselves on 2026-08-20 and
+remain owed:
+
+- **A24** — `gh issue view 1951/1972/1969` all closed as the row describes;
+  plan 275 Ship notes still record Step 2 and Step 3/C-17 as NOT RUN, no
+  rerun since #1972/#1969 landed. STILL OWED.
+- **A26** — `gh issue view 1967` closed, matches. Items 1/3 already
+  DISCHARGED in the register text (not re-litigated); item 2's audible half
+  and item 4 (batched with E1) remain unrun. STILL OWED.
+- **A31** — `gh issue view 1980` closed, matches; plan 276 `status: stable`.
+  Run sheet's every `Result:` line still blank. STILL OWED.
+- **A32** — `gh issue view 2040` closed, matches. Run sheet §§3-6 blank; §9's
+  2026-08-11 run covers a different book for a different (discharged) row.
+  STILL OWED.
+- **A44** — `gh issue view 2026` still **OPEN**; `gh pr view 2050` merged,
+  matches; `gh issue view 2057` closed but only reconciled the register, not
+  the acceptance. Cited run-sheet section's Result line still the unchecked
+  template. STILL OWED.
+- **A45** — `gh issue view 2310` closed; `gh pr view 2316` merged, matches.
+  No run sheet or dated result anywhere for a real EPUB. STILL OWED.
+- **A46** — `gh issue view 2106` closed; `gh pr view 2398` merged, matches.
+  No run sheet under `docs/testing/` at all. STILL OWED.
+- **A47** — `gh pr view 2402` merged, matches. Only mock/unit coverage
+  exists; no run sheet. STILL OWED.
+
+None of the eight rows is AMBIGUOUS (that is A2/A16/A22's queue, not this
+pack's) — every cited plan/issue/PR agrees with its own row text, unlike
+A16's genuine frontmatter-vs-body contradiction handled in
+`onbox-sitting-vram-contention.md`.
+
+## Teardown
+
+- [ ] Evict Qwen (Base + VoiceDesign) and Coqui/XTTS so the next sitting
+      starts cold.
+- [ ] Confirm `SIDECAR_NEVER_ADOPT` is unset (A46 Scenario 2 cleanup) and the
+      server has been restarted at least once since.
+- [ ] Confirm no foreign listener is still bound on `:9000` (A46 Scenario 1).
+- [ ] Restore the *Playing with Fire* workspace book from the backups taken
+      in Preconditions if either re-render (A32 §§13-14) needs reverting, or
+      confirm the new state is intentionally kept.
+- [ ] Confirm any A26 static-FFmpeg-box changes (env vars, PATH) are left as
+      found.
+- [ ] Confirm the card returns to baseline (`nvidia-smi` ≈ idle) before
+      ending the sitting.

--- a/docs/testing/onbox-sitting-device-browser.md
+++ b/docs/testing/onbox-sitting-device-browser.md
@@ -1,0 +1,268 @@
+# Device & browser sitting — on-box acceptance run sheet
+
+> **This is a working document.** Fill in the `Result:` lines AS you run this
+> on the box. Do not pre-fill them.
+>
+> Plan of record: [`docs/testing/onbox-sitting-plan.md`](onbox-sitting-plan.md)
+> §5 (pack format), §4.7 (this sitting's place in the order).
+> Register rows: [`onbox-acceptance-register.md`](onbox-acceptance-register.md)
+> E1, E2, E3, E5, E6, E9, E10.
+> Feature plans: [`218-pinokio-installer.md`](../features/218-pinokio-installer.md) (E1),
+> [`250-lan-https-default.md`](../features/250-lan-https-default.md) (E2),
+> [`256-lan-pair-from-friendly-hostname.md`](../features/256-lan-pair-from-friendly-hostname.md) (E3),
+> [#1795](https://github.com/dudarenok-maker/Castwright/pull/1795) (E5),
+> [`269-ffmpeg-version-floor.md`](../features/269-ffmpeg-version-floor.md) (E6),
+> [`282-ort-pip-consistency-marker.md`](../features/282-ort-pip-consistency-marker.md) (E9),
+> [`225-lan-browser-device-auth.md`](../features/225-lan-browser-device-auth.md) (E10).
+>
+> **Running time total (recomputed):** E1 30 + E2 20 + E3 15 + E5 5 + E6 30 +
+> E9 30 + E10 20 = **150 minutes** — matches the plan of record's estimate.
+
+---
+
+## 1. Purpose & scope
+
+None of these seven rows need the operator's GPU. They need Pinokio, a real
+phone/browser on the LAN, and a swappable ffmpeg build — hardware the
+two-card/VRAM sittings don't touch. This sitting has two independent halves
+that can run in either order or on separate days:
+
+- **Pinokio half — E1, E9, E6.** Pinokio install/update on Windows (and, for
+  E1 only, a separate macOS machine), grouped because E9 and E6 each name
+  themselves "grouped with E1" and share its Pinokio setup.
+- **LAN/browser half — E2, E3, E10, E5.** One phone-pairing session on the
+  LAN-HTTPS server, because the audit records E3 as running in the same
+  session as E2, and E10 as sharing that whole setup. E5 is a DevTools
+  smoke-check with no server dependency and can be slotted into either half's
+  spare minutes, but is grouped here since it is browser-shaped like the rest
+  of this half.
+
+**Re-resolution note:** every row below was independently re-checked against
+live `gh issue`/`gh pr` state and the current source tree while writing this
+pack (2026-08-20). All seven remain accurately STILL OWED as the staleness
+audit describes; no citation had drifted, and nothing here is discharged or
+self-contradictory. **One UI label has drifted** since the register row was
+written — see E5's step, which names the corrected control name.
+
+## 2. Preconditions
+
+**Pinokio half:**
+
+- [ ] A Windows machine with Pinokio installed, and a **separate** clean
+      macOS machine with Pinokio installed (E1's macOS axis has had zero
+      on-box exercise — it cannot be satisfied by the Windows machine).
+- [ ] On the Windows machine, an **existing pre-fix Pinokio install** (i.e.
+      not a fresh Install) so an Update actually exercises the `reqHash`
+      branch E9 needs — see
+      [`ort-marker-onbox-acceptance.md`](ort-marker-onbox-acceptance.md) §6
+      preconditions for the exact prior-state requirement.
+- [ ] The Windows machine's card set to the **nvidia profile** for the E9
+      Update/Install pass.
+- [ ] ffmpeg swappable between a real **< 4.4** build and a real **≥ 6.0**
+      build on one machine (a 22.04 container with archive ffmpeg 4.4 is the
+      cheapest route per the register; any machine, no GPU needed for E6
+      itself — it only needs to be reachable from the same Pinokio conda env
+      for the `"ffmpeg>=6"` constraint half).
+
+**LAN/browser half:**
+
+- [ ] Server running with `LAN_HTTPS=1` (the default) so it boots HTTPS on
+      `:8443`.
+- [ ] A real phone on the same Wi-Fi as the server, with the Castwright
+      Companion app installed, free to: install a root CA, scan a pairing QR,
+      and be revoked.
+- [ ] A desktop browser open to the app for the DevTools smoke-check (E5) —
+      any machine, no server dependency.
+- [ ] A second shell/terminal free to issue a direct `DELETE
+      /api/devices/<id>` call for E10's forwarder-boundary check.
+
+## 3. Procedure — Pinokio half (E1, E9, E6)
+
+Ordered to seat the Windows Pinokio state once and reuse it across E1's
+Windows checks, E9's Update pass, and E6's Pinokio constraint check, then do
+E1's macOS axis as an independent block.
+
+1. **(E1, Windows — pinned Node)** From a fresh Install on the Windows
+   machine, open a `shell.run` step (or the Pinokio terminal, once the conda
+   env is active) and run `node --version`.
+   **Observe:** reports **24.x**, not whatever Pinokio's bundled kernel ships.
+   Then confirm Install → Start completes end to end with no solve/channel
+   error from the added conda package.
+   `Result:` _(fill in — node --version output, Install→Start outcome)_
+
+2. **(E1, Windows — mid-life upgrade path)** Take a **separate** install from
+   a pre-pin release. Run Update once and check `node --version`.
+   **Observe:** reporting the **bundled** version here is the documented,
+   correct result (the old `update.js` ran, no pin step) — not a failure. Run
+   Update a **second** time and check `node --version` again.
+   **Observe:** now reports **24.x** (the pin took effect from this Update).
+   Confirm `node_modules` still works after the Node-major swap (app starts,
+   no native-module load error).
+   `Result:` _(fill in — first Update version, second Update version,
+   node_modules outcome)_
+
+3. **(E1, Windows — native Stop)** From a running install, use Pinokio's
+   native Stop control.
+   **Observe:** the TTS sidecar process is actually reaped (not left
+   orphaned) — check the process list before and after Stop.
+   `Result:` _(fill in — sidecar PID before/after Stop)_
+
+4. **(E9 — ORT marker, Pinokio update path)** On the Windows machine's
+   existing pre-fix install (step 1's precondition), run
+   [`ort-marker-onbox-acceptance.md`](ort-marker-onbox-acceptance.md) §6.2–6.3
+   in full: run Update on the nvidia profile, confirm the `noop`/
+   `pip-in-place` branch behaves as documented (including the self-heal at
+   next server boot if `noop`), confirm Qwen3 installs with no `WinError 5`,
+   then in the same session run a fresh `install.js` pass and confirm the
+   same outcome. Fill in that run sheet's own §6.3 `Result:` fields — do not
+   duplicate them here.
+   `Result:` _(fill in here only: confirmed run against §6.3 of the cited
+   sheet, yes/no, and today's date)_
+
+5. **(E6 — ffmpeg floor, six-step walkthrough)** On the ffmpeg-swappable
+   machine, with ffmpeg **4.4** on PATH:
+   a. `npm run test:server` — **observe** preflight exits **1**, printing
+      "ffmpeg 4.4 is older than Castwright supports" with the host OS's
+      upgrade command.
+   b. Start the server, open the Setup Wizard's ffmpeg step — **observe** the
+      **amber outdated** card (`data-testid="step-ffmpeg-outdated"`), not the
+      "isn't installed yet" card; the wizard still **advances**; `GET
+      /api/setup/readiness` reports `ready: true` with
+      `blockers.ffmpeg.status === 'warn'`.
+   c. Admin → diagnostics — **observe** the ffmpeg row at status `warn` with
+      the version in its detail, **and** the top-bar Admin health dot goes
+      amber and stays amber on every screen (no dismiss).
+   d. Upgrade ffmpeg to **≥ 6.0**, click **Re-check without restarting the
+      server** — **observe** the card flips to green ready state.
+   e. Confirm the upgrade advice text itself is what actually cleared the
+      card (not a stale cache) — re-run diagnostics and confirm the health
+      dot returns to its normal state.
+   `Result:` _(fill in — each of a–e, pass/fail and any deviation)_
+
+6. **(E6 — Pinokio constraint, grouped with E1)** In the same Pinokio conda
+   env used above, confirm the `"ffmpeg>=6"` constraint is actually enforced
+   on a real conda solve (not just declared) — attempt a solve that would
+   pull ffmpeg <6 and confirm it's rejected or upgraded.
+   `Result:` _(fill in)_
+
+7. **(E1, macOS — independent block)** On the clean macOS machine, from a
+   fresh Pinokio Install:
+   a. **Observe** the install completes (first-ever macOS exercise of this
+      axis).
+   b. **Observe** the venv-from-conda step succeeds.
+   c. **Observe** the app's API spelling/calls work identically to Windows
+      (spot-check one render).
+   `Result:` _(fill in — install outcome, venv outcome, API spot-check
+   outcome)_
+
+## 4. Procedure — LAN/browser half (E2, E3, E10, E5)
+
+Ordered so the phone-pairing session happens once and every row that reads
+its state rides the same pairing.
+
+1. **(E2 — fresh boot)** Fresh install (Pinokio or native/manual
+   `start:prod`) with `LAN_HTTPS=1`.
+   **Observe:** server comes up HTTPS on `:8443`, `[cert] LAN certs
+   provisioned` is logged, `server/.env` gains a `LAN_AUTH_TOKEN`. Open the
+   desktop Open-Web-UI tab at `https://localhost:8443` — **observe** it loads
+   with no certificate warning.
+   `Result:` _(fill in)_
+
+2. **(E2 — real phone pairing)** On the phone, install the mkcert root CA
+   once (via the pairing QR / fingerprint pin), then browse
+   `https://castwright.local:8443` and complete pairing.
+   **Observe:** pairing completes with no cert warning on the phone.
+   `Result:` _(fill in)_
+
+3. **(E3 — friendly-hostname authorize + name-first pairing, same session)**
+   From the Listen tab's **"Pair a device"** banner (`companion-app-banner.tsx`),
+   open the pairing modal — its first step names the device (**"Name this
+   device… then generate a code"**, `aria-label="Device name"`) before
+   minting a session. Enter a name, generate the code, and complete pairing
+   from `https://castwright.local/#/admin`.
+   **Observe:** no 403 during authorization; in Admin → LAN access, the
+   device appears under the **chosen name**, not a generic "Device" label.
+   `Result:` _(fill in)_
+
+4. **(E3 — bare-LAN-IP guard)** From the phone (or another LAN client),
+   request the server by its bare LAN IP instead of `castwright.local`.
+   **Observe:** the loopback-only 403 guidance, not a raw failure.
+   `Result:` _(fill in)_
+
+5. **(E2 — degrade path)** Force `LAN_HTTPS=0` (or delete the certs) and
+   restart.
+   **Observe:** the server degrades to loopback HTTP on `:8080` with no
+   crash — a missing-cert warning is acceptable, a crash is not.
+   `Result:` _(fill in)_ Restore `LAN_HTTPS=1` and the certs before
+   continuing to E10.
+
+6. **(E10 — direct-port revoke, non-default port)** Set `LAN_HTTPS_PORT` to a
+   **non-default** value and bind the `:443` forwarder. From
+   `https://localhost:<port>` (direct, not through the forwarder), revoke one
+   of the paired test devices from Admin → LAN access (`lan-access-card.tsx`'s
+   **Revoke** button, only rendered when `isLoopbackHost()`).
+   **Observe:** revoke succeeds.
+   `Result:` _(fill in)_
+
+7. **(E10 — forwarder boundary)** From `https://localhost/` (through the
+   `:443` forwarder), attempt the same revoke.
+   **Observe:** the Revoke button renders, but the action returns **403**
+   with the actionable direct-port sentence (`revokeLoopbackOnlyHint` in
+   `lan-access-card.tsx`) — not a raw "revoke failed (403)".
+   `Result:` _(fill in — exact 403 message shown)_
+
+8. **(E10 — paired-phone view)** From the paired phone on `castwright.local`
+   (with **at least 3** devices paired in the list, per the row's own
+   caveat), open the LAN access list.
+   **Observe:** no Revoke control renders on **any** row, and the explanation
+   sentence appears **once**, below the whole list — not repeated per row.
+   `Result:` _(fill in)_
+
+9. **(E10 — direct DELETE from a paired LAN device)** From a second shell on
+   the paired phone's network (or curl from the phone itself if tooling
+   allows), issue `DELETE /api/devices/<host id>` directly, bypassing the UI.
+   **Observe:** 403, and the host's own device record is still present
+   afterward (survived, not silently revoked).
+   `Result:` _(fill in — response body, record presence after)_
+
+10. **(E5 — DevTools touch press-feedback smoke-check)** On the desktop
+    browser, open DevTools → toggle device emulation with touch enabled
+    (Chrome: **Ctrl+Shift+M** device-toolbar toggle, any touch-capable device
+    preset — this turns on `:active`/pointer-coarse styling instead of
+    `:hover`-only). Tap-and-hold, then release, each of the four controls
+    below and **observe** the press state visibly persists briefly on
+    tap/release, matching the existing `:hover` treatment (a flash that
+    disappears instantly, or no visible change at all, is a fail):
+    - Continue-listening rail **play badge**
+      (`src/components/library/continue-listening-rail.tsx:111`,
+      `group-active:bg-white/35`).
+    - The library's **"Add another book"** tile
+      (`src/components/library/library-grid.tsx:551-569`,
+      `data-tour-id="new-book-btn"`, `group-active:bg-peach` on its icon
+      circle). **Note:** the register row names this the "Add book" tile;
+      the control's current visible copy is **"Add another book"** — verified
+      against source while writing this pack, since Wave 1's whole finding
+      was that written-down control names drift.
+    - Setup Wizard **"Review ›"** chip on an amber/red diagnostics row
+      (`src/components/setup/setup-wizard.tsx:465-477`,
+      `group-active:text-magenta`).
+    - Voice-library card **drag icon**
+      (`src/components/voice-library-panel.tsx:563-564`, `IconDrag`,
+      `group-active:text-ink/60`).
+    `Result:` _(fill in — pass/fail per control)_
+
+## 5. Teardown
+
+- Stop the server; unset `LAN_HTTPS_PORT` and restore the default
+  `LAN_HTTPS=1`.
+- Un-pair every test device added during this sitting from Admin → LAN
+  access.
+- Turn off DevTools device/touch emulation.
+- Restore ffmpeg on PATH to the machine's normal (≥ 6.0) build.
+- Revert the Windows machine's Pinokio card selection away from the
+  nvidia-profile-only state if it differs from normal use.
+- Leave the macOS Pinokio install in place or remove it, operator's choice —
+  not required for any other sitting in this plan.
+
+_(Once run, mark register rows E1, E2, E3, E5, E6, E9, E10 discharged with a
+summary of these results and remove them from the "owed" count.)_

--- a/docs/testing/onbox-sitting-fs38-wave3.md
+++ b/docs/testing/onbox-sitting-fs38-wave3.md
@@ -1,0 +1,576 @@
+# fs-38 Wave 3 — on-box sitting pack (register row A1)
+
+> Sitting pack, not a rewrite. This is a **scheduling document over**
+> [`fs38-wave3-onbox-acceptance.md`](fs38-wave3-onbox-acceptance.md) (the
+> 3,264-line run sheet, read-only — this pack cites its section/test-ID numbers
+> and never copies its criteria). Fill the run sheet's own `Result:` lines when
+> you actually run each test; this pack's own `Result:` lines below are a
+> per-step completion record only.
+>
+> Register row: [`onbox-acceptance-register.md` A1](onbox-acceptance-register.md)
+> (search `### A1`). Plan of record: [`onbox-sitting-plan.md`](onbox-sitting-plan.md)
+> §2.1, §4 step 8, §5 (pack format), §6 (re-resolution rule).
+> Plans: `docs/features/267-fs38-wave3-voice-clone.md`,
+> `docs/features/268-fs38-wave3b2-resolver.md`,
+> `docs/features/271-fs38-wave3c-xtts.md` (all `status: active`).
+> Tracking issue: [#624](https://github.com/dudarenok-maker/Castwright/issues/624).
+>
+> **Running time: multi-hour, several sittings** — the row's own unchanged
+> estimate (`onbox-sitting-plan.md` §7), not a single number. This pack breaks
+> it into **4 sittings**, each targeted at 2.5–3.5 hours, totalling roughly
+> 11–11.5 hours of box time (~150 + ~170 + ~170 + ~190 minutes — see each
+> sitting's header). **Box/card:** the dual-GPU dev box, single 8 GB `cuda:0`
+> (RTX 4070) for every sitting in this pack — none of the still-owed sub-tests
+> below need the 2-card eGPU boot, so run this pack with the eGPU **unplugged**
+> (that rig is reserved for `onbox-sitting-two-card-boot.md`).
+
+---
+
+## 0. Re-resolution — what was checked before writing this pack
+
+Per `onbox-sitting-plan.md` §6, the audit is a lead, not a fact. Re-checked
+live, not taken on the row's or the audit's word:
+
+- **`gh issue view` / `gh pr view`, re-run against `dudarenok-maker/Castwright`
+  on 2026-08-20**, for every issue/PR the row's still-owed section depends on:
+
+  | # | State (re-checked) | Matches row's claim? |
+  |---|---|---|
+  | Issue #1972 (stale-attribution bug — invalidated the 3 run-2 retractions) | `CLOSED`, closed 2026-07-31 | Yes — row already treats this as fixed |
+  | Issue #1969 (voice-mismatch stale reference, A24-adjacent) | `CLOSED`, closed 2026-08-16 | Yes, and now has a merged fix (PR #2402, merged 2026-08-16) — newer than the row's text, not a contradiction |
+  | Issue #1944 (Coqui won't load after `/embed`) | `CLOSED`, closed 2026-07-30 | Yes |
+  | Issue #1967 (torchcodec/FFmpeg, blocked Section E on a stock box) | `CLOSED`, closed 2026-07-31 | Yes |
+  | PR #1978 (fixes #1967) | `MERGED` 2026-07-31 | Yes |
+  | Issue #2017 (spacy missing, E-04's `ImportError`) | `CLOSED`, closed 2026-08-01 | Yes |
+  | PR #2039 (fixes #2017) | `MERGED` 2026-08-01 | Yes — confirms the row's own caveat that E-04's `F` "stands until the exact reproduction is re-run" is still the correct read: the **fix** is merged, the **re-run** is not done |
+  | Issue #2026 (Russian XTTS quality, register row A44 — not this row) | `OPEN` | Yes, correctly left open |
+  | Issue #1998 (XTTS cross-language identity loss, feeds E-01's by-ear finding) | `OPEN` | Yes |
+  | Issue #399 (`side-11`, the host-memory-leak *investigation* tracking issue) | `CLOSED`, closed 2026-07-06 | **Needs its own note — see below** |
+
+- **The `side-11` closure does NOT discharge C-02/D-02's blocker.** #399 was
+  closed 2026-07-06 — three weeks *before* both fs-38 Wave 3 runs (2026-07-29,
+  2026-07-31) independently hit the leak (sidecar recycled 3×, committed
+  memory peaked at 29,395 MB — run sheet §7.2, "Pre-existing, not caused by
+  this wave"). Reading why #399 could close while the leak still fires: its
+  final fix, plan `243-side25-qwen-codec-gpu.md` (`status: stable`, `shipped:
+  2026-07-06`), ships the Code2Wav-codec-on-GPU mitigation **inert by default**
+  (`QWEN_CODEC_DEVICE=cpu`) — its own Benefit/Rationale section says the
+  payoff "only lands once an operator opts a box in **after** the on-box
+  acceptance run" it names as its own separate owed item. So on a default
+  config — which is what both fs-38 runs used, and what this pack's sittings
+  use — the leak is unmitigated. **C-02, D-02, and D-04's full-book variant
+  stay excluded from every sitting below**, exactly as the register and the
+  run sheet's own §7.4 state; the closed tracking issue is not a
+  re-resolution finding, it's confirmation that the block is real and
+  independent of that issue's lifecycle. (`D-04`'s *splice*-based repro does
+  **not** need a full-chapter render, so it is not blocked by this — see
+  Sitting 2.)
+
+- **Re-ran the run sheet's own §7.1 totals arithmetic** rather than trusting
+  the register's "20 of 60 run … ~40 still owed … 3 retracted" headline: the
+  run sheet's own "Corrected totals — Run 2" table (§7.1, after the #1972
+  root cause was found) shows **20 P (one partial) + 0 F + 8 B + 1 N/A + 31 not
+  reached = 60**. That reconciles with the register's rounding ("~40 owed" ≈
+  31 not-reached + 8 blocked, since a Blocked result is also not a discharge).
+  No contradiction found — see §7 below for exactly which of the 31
+  not-reached and how many of the 8 blocked this pack covers.
+
+- **No item in the "still owed" set was found already discharged, or
+  self-contradictory, on inspection of the run sheet's own §7.1 result
+  table.** Checked every ID this pack schedules (A-13, A-07/08/09, B-02,
+  B-03, B-05, B-08…B-13, C-01, C-03…C-09, C-12…C-18, C-20, C-21, D-01, D-04,
+  E-03, E-04, E-06, E-07) against its §7.1 row: all blank/**B**, none show a
+  **P** that would make scheduling it redundant. C-19, D-03, B-01, B-04, B-06,
+  B-07, C-10, C-11, E-01, E-02, E-05, E-08, E-09, and all of Section A except
+  A-07/08/09/A-13 are already **P**/discharged/retired and are correctly
+  **not** in this pack.
+
+**No exclusions were needed** — see `## Excluded on re-resolution` below,
+which is consequently empty of pack-relevant items.
+
+## Excluded on re-resolution
+
+Nothing excluded. Every still-owed sub-test this pack schedules was
+independently re-confirmed still-owed against the run sheet's own §7.1 table
+and the live `gh` state of its blocking issues (§0 above). The one item that
+looked at first glance like it might have changed status — `side-11`/#399
+being `CLOSED` — was investigated and found **not** to discharge C-02/D-02;
+see §0's dedicated note. C-02, D-02, and D-04's full-chapter variant remain
+excluded from every sitting for the reason already given in the run sheet and
+register, not a new finding of this pack.
+
+---
+
+## 1. What this pack does NOT schedule
+
+So the coverage arithmetic in §7 is checkable: this pack schedules **31** of
+the run sheet's 60 sub-tests (all still-owed and un-blocked). It excludes:
+
+- **20 already `P`/discharged**, **1 `N/A`** (B-06, retired in favour of an
+  automated test) — no on-box run is owed.
+- **1 `P` (incidental)** — D-03, proven while isolating #1941; not re-run.
+- **8 `B` (blocked)**: A-07/A-08/A-09/B-02 need a real browser+mic — **this
+  pack DOES schedule these four**, because the operator's box has both (this
+  row was binned to the operator-sittings set in `onbox-sitting-plan.md` §2.1,
+  not to `onbox-sitting-blocked-prerequisites.md`); their `B` marking in the
+  run sheet reflects the *previous* runs being agent-driven with no mic
+  access, not a hardware gap on this box. B-05 needs a way to fail `/embed`
+  transiently — scheduled (Sitting 3). **C-02 and D-02 stay excluded** — blocked
+  by the side-11 leak, confirmed still live in §0.
+
+That leaves the 31 scheduled below, split across 4 sittings.
+
+---
+
+## 2. Sitting 1 — Browser/mic path, and cross-book identity (≈150 min)
+
+**Covers:** A-13, A-07, A-08, A-09, B-02, B-03, B-08, D-01 (run sheet §5,
+Sections A/B/D).
+
+### 2.1 Preconditions
+
+- [ ] Single 8 GB card only (`CUDA_VISIBLE_DEVICES=0`), eGPU unplugged.
+- [ ] `npm start` — full stack (frontend + server + sidecar), **not**
+      `npm run dev:mock`. Confirm real backend per run sheet §2.1's warning.
+- [ ] A real desktop browser with a working, permission-grantable microphone
+      on this box (Chrome recommended — the in-app recorder targets
+      `audio/webm`, run sheet fixture F-7).
+- [ ] Qwen weights present (P-13), session engine picker = Qwen (P-23).
+- [ ] The Coalfall EN book (`server/src/__fixtures__/the-coalfall-commission.md`)
+      imported, analysed, and already carrying the healthy cloned voice `$U`
+      from the prior run's B-01/B-07 (confirm it is still assigned to its
+      Section B character — redo the `POST /assign` from run sheet B-07 if the
+      workspace was reset since the last session).
+- [ ] A **second** Qwen-routed book imported for D-01 — a second import of the
+      same Coalfall EN fixture under a different book id is sufficient; both
+      books must resolve to the Qwen engine (no engine override).
+- [ ] One extra shell free for `curl`/PowerShell probes alongside the browser.
+
+### 2.2 Procedure
+
+Ordered browser-driven wizard steps first (one continuous UI session), then
+the cross-book check, so the microphone permission prompt is granted once.
+
+1. **A-13** — confirm the voice library is unconditionally available even with
+   a stale `"voices.library.enabled": false` override hand-added to
+   `~/.castwright/user-settings.json`. Do: apply the override, restart the
+   server, hit the routes and open `#/voices` + a cast profile drawer per run
+   sheet A-13. Observe: neither route 404s, My-voices/clone CTA present, no
+   "Voice library" group in Advanced settings. **Result:** _____________
+2. **A-07** — run the browser recorder (webm/opus) end to end per run sheet
+   A-07. Observe: the exact ingest/transcript flow A-01 already proved, now
+   via the recorder — compare against A-01's recorded 202/transcript shape.
+   **Result:** _____________
+3. **A-08** — deny mic permission, confirm fallback to Upload per run sheet
+   A-08. Observe: no dead-end, Upload tab remains reachable. **Result:** _____________
+4. **A-09** — confirm Continue is gated on consent per run sheet A-09.
+   **Result:** _____________
+5. **B-02** — full wizard happy path via **Record** (run sheet B-02, steps =
+   B-01's steps 2-9 substituting Record for Upload). Record the second `$U`
+   — you need it for D-01 below. Observe: `candidate.json.captureMethod` and
+   the persisted entry's `master.captureMethod` both read `"record"`.
+   **Result:** _____________ **Second $U:** _____________
+6. **B-03** — the by-ear identity check (run sheet B-03). Play F-1, then the
+   wizard audition, then a **fresh** `/sample` synth (not the wizard's
+   in-memory preview). Judgement is against F-1 directly, not a vibe: same
+   speaker / arguably same / clearly different, circled per the run sheet's
+   own verdict line. Get a second listener if one is on hand. **Result:** _____________
+7. **B-08** — cast-view Play on the Section-B character (run sheet B-08).
+   Observe: unmistakably the cloned speaker (same bar as B-03), and a new
+   `qwen-<uuid>-<modelKey>-<hash>.mp3` appears under `server\audio\voices\`;
+   a second Play is served `cached: true`. **Result:** _____________
+8. **D-01** — assign the *first* `$U` to a character in book A (already true
+   from B-07) and the *second* `$U` (from step 5) to a character in book B.
+   Start a render in book A, then start book B's render while A is still in
+   flight (run sheet D-01 steps 2-5). Observe: both complete, each renders
+   its own cloned identity with no cross-book bleed, and `voices\qwen\` holds
+   exactly one `.pt` per uuid — no duplicate/competing files. **Result:** _____________
+
+### 2.3 Teardown
+
+- [ ] Remove the hand-added `"voices.library.enabled": false` override from
+      `~/.castwright/user-settings.json`, restart the server (A-13's cleanup,
+      run sheet §7.3 checklist).
+- [ ] Leave both `$U` values recorded for later sittings — do not revoke
+      either yet (Sitting 2 needs the first `$U` healthy).
+- [ ] Confirm no chapter render is still in flight before closing the browser.
+
+---
+
+## 3. Sitting 2 — Qwen resolver classification & lifecycle (≈170 min)
+
+**Covers:** C-01 ⭐, C-03, C-04, C-05a, C-05b, C-06, C-07, C-08 ⭐, C-09, C-12,
+C-18, D-04 (run sheet §5, Section C + D-04). Same card and engine as Sitting
+1 — no swap. This sitting is the deliberate-kill / manifest-editing family;
+group it apart from the UI-facing checks in Sitting 3 so PowerShell-driven
+scripted work doesn't keep alternating with browser observation.
+
+### 3.1 Preconditions
+
+- [ ] Same box/card as Sitting 1 (`cuda:0`, eGPU still unplugged) — no
+      re-plug needed.
+- [ ] Qwen resident, session engine = Qwen.
+- [ ] The first `$U` from Sitting 1, healthy, assigned to a character (`$K`
+      = its Qwen storage key) in the Coalfall EN book, in a chapter where it
+      speaks **≥6 lines** and is **not** the narrator (needed for C-03/C-04's
+      contrast case).
+- [ ] A second character in the same book with **its own** cloned or designed
+      voice, for C-03's "unrelated broken voice doesn't fail the chapter" case
+      — the second `$U` from Sitting 1 works.
+- [ ] A chapter with a **narrated title** (for C-04) and, separately, one with
+      **no** narrated title (for C-05a/C-05b) — confirm both exist in the
+      fixture book per run sheet §4.1's checklist.
+- [ ] `cast.json` backed up before starting (`Copy-Item cast.json
+      cast.json.bak`) — C-05a/C-05b hand-edit it to create an orphaned
+      `characterId`.
+- [ ] Ability to hard-kill the sidecar process (`Stop-Process -Name python
+      -Force`, verified against the PID in `logs\tts.log`, not a guess) for
+      C-08 and C-12.
+- [ ] Two shells: one to tail `logs\tts.log`, one to fire pre-staged
+      PowerShell commands (revoke, kill) at a precise moment for C-01/C-12.
+
+### 3.2 Procedure
+
+Ordered so the manifest returns to a known-healthy state between tests, and
+the two timing-sensitive tests (C-01, C-12) — which may need 3-5 attempts
+each per the run sheet's own budget — are run while attention is freshest.
+
+1. **C-01** ⭐ — force Repairable (delete `$K.pt`), start the chapter render,
+   fire a pre-staged revoke in the window before `Cloned + cached Qwen voice`
+   appears in `tts.log` (run sheet C-01). Observe, all three must hold:
+   `revokedAt` survives; the chapter fails `cloned-voice-broken`/`revoked`;
+   no `.pt`/`.json`/`__1.7b.pt`/entry-dir `master.wav` survives. Budget 3-5
+   attempts. **Result:** _____________ **Attempts:** ____
+2. Re-clone (or restore) `$U` to healthy before continuing — C-01 leaves it
+   revoked by design.
+3. **C-08** ⭐ — force Repairable again, **stop the sidecar** (leave server
+   up; disable `autoStartSidecar` first if it would respawn), generate the
+   chapter, immediately read `engines.qwen.status` (run sheet C-08). Observe:
+   the chapter fails, but status is **not** `'failed'`; restart the sidecar
+   and re-run the same chapter — it now completes with no manual repair.
+   **Result:** _____________ **Status after failed run:** _____________
+4. **C-09** — corrupt the entry (`master.transcript = ''`), force Repairable,
+   generate (run sheet C-09). Observe: fails `derive-failed`; status **is**
+   `'failed'` this time (contrast with C-08); restart + re-run fails again
+   immediately with no derive attempted (terminal). Restore the transcript
+   afterward. **Result:** _____________
+5. **C-12** — record the good `.pt`'s hash/size, trigger a rewrite (C-07's
+   method 2: bump `baseModel`, then render), hard-kill the sidecar the
+   instant the derive begins per run sheet C-12. Observe: the live `.pt` is
+   either byte-identical to the pre-kill hash or a complete new file — never
+   truncated; any leftover temp file is the `.tmp`-suffixed shape, which is
+   acceptable. Repeat a few times to actually land inside the write window.
+   **Result:** _____________ **Attempts:** ____ **Truncated `.pt` ever seen?** ☐ no ☐ yes
+6. **C-06** — delete only `$K.pt` (leave manifest/master alone), generate,
+   observe the self-heal per run sheet C-06: chapter completes, exactly one
+   `Cloned + cached Qwen voice` log line, `.pt` reappears with a fresh
+   timestamp, a second chapter afterward fires no further derive.
+   **Result:** _____________
+7. **C-07** — simulate a stale `baseModel` (edit `voice.json` per run sheet
+   C-07 option 2, noting in the notes field that it's simulated not a real
+   model bump), generate. Observe: exactly one re-derive despite the `.pt`
+   already existing; `baseModel` afterward matches the sidecar's current
+   value. **Result:** _____________ **Method used:** simulated
+8. **C-18** — with the `.pt` present, set a bogus `baseModel` on a
+   **designed** voice (not `$U`'s cloned one — use a second, designed
+   library entry), generate. Observe: **no** re-derive fires, `.pt`'s
+   `LastWriteTime`/hash unchanged — contrast against C-06/C-07's cloned-voice
+   behaviour (run sheet C-18). **Result:** _____________
+9. **C-03** — assign `$U` (speaks) and the second character's voice (silent
+   in this chapter — verify!) into the same chapter, revoke the second voice,
+   generate (run sheet C-03). Observe: chapter completes normally, `$U`
+   renders as itself; then generate a chapter where the second character
+   *does* speak and confirm that one fails naming it. **Result:** _____________
+10. **C-04** — assign `$U` to the **narrator**, with chapter-title narration
+    on and a narrated title; revoke `$U`; generate (run sheet C-04). Observe:
+    fails `cloned-voice-broken` naming the narrator, no title audio produced
+    — confirms the title-beat union into the readiness set. Re-clone/restore
+    `$U` afterward. **Result:** _____________
+11. **C-05a** — snapshot `cast.json`, remove a non-narrator character object
+    so its sentences become orphaned; assign the narrator a **healthy**
+    cloned voice (contrast with the original C-05, which used revoked); turn
+    off chapter-title narration; generate (run sheet C-05, the "C-05a" note
+    under C-05). Observe (post-#2023-fix expectation): the chapter now fails
+    `cloned-voice-broken` naming the narrator — a healthy cloned voice must
+    never render another character's orphaned line either.
+    **Result (C-05a):** _____________
+12. **C-05b** — repeat with a **designed** (non-cloned) narrator instead.
+    Observe: the chapter completes, AND the rendered segment carries
+    `renderedFallbackCharacterId` naming the narrator, `GET
+    /api/books/:id/state`'s `orphanedCharacterFallbacks` map names the
+    orphan, and the Cast view shows the amber advisory banner. Restore
+    `cast.json` from the backup when done. **Result (C-05b):** _____________
+13. **D-04** — with a **revoked** cloned voice assigned to a speaking
+    character (reuse `$U` post-C-01, or revoke it fresh), trigger a chapter
+    **splice** on that chapter, then an **audio-QA repair** (run sheet D-04).
+    Observe (verify-as-expected per run sheet §6 KL-i, not a defect if seen):
+    both fail with the plain `UnresolvableClonedVoiceError.message` naming
+    the voice and reason, but **no** `cloned-voice-broken` toast/help
+    link/`generationErrorCode` on these two paths — contrast against C-01/C-15's
+    generation-route failure. **Result:** _____________
+
+### 3.3 Teardown
+
+- [ ] Restore `$U` to healthy (re-clone if C-01/C-04 left it revoked and you
+      need it again in Sitting 3 — B-11/B-12/C-13/C-14/C-16/C-17 all want a
+      healthy or freshly-broken clone, not a leftover revoked one).
+- [ ] Restore `cast.json` from `cast.json.bak`; delete the backup once
+      confirmed restored.
+- [ ] Re-enable `autoStartSidecar` if you disabled it for C-08.
+- [ ] Restore the corrupted transcript from C-09.
+- [ ] Confirm the sidecar is up and `/health` answers before ending.
+
+---
+
+## 4. Sitting 3 — Diagnostics, capacity, UI surfacing & designed self-heal (≈170 min)
+
+**Covers:** C-13, C-14, C-15, C-16, C-17 ⭐, C-20, C-21, B-05, B-09, B-10,
+B-11, B-12, B-13 (run sheet §5, Sections B + C). Same card/engine as
+Sittings 1-2 — no swap; this is the third and last Qwen-only sitting before
+Sitting 4 moves to Coqui.
+
+### 4.1 Preconditions
+
+- [ ] Same box/card, eGPU still unplugged.
+- [ ] A healthy `$U` assigned to a character that speaks **≥6 lines** across
+      **2 chapters** (for B-09/B-10's consistency checks).
+- [ ] `SEG_CAPACITY_ADMISSION` confirmed `1` (or unset) in `server/.env`
+      before starting (B-12 needs it ON first, then toggles it).
+- [ ] The generation view open and visible in the browser for C-15 (toast
+      timing) — same browser session as Sitting 1 is fine to reopen.
+- [ ] A way to hold an exclusive file handle on a `.pt` from a second
+      PowerShell session (`[System.IO.File]::Open(..., 'None')`) for C-21.
+- [ ] A **designed** (not cloned) voice created fresh on this branch, with
+      its retained `qwen-<uuid>__master.wav` confirmed present — required for
+      C-17; a voice designed before this branch cannot self-heal and is not a
+      valid fixture for this test.
+- [ ] The Kokoro engine available as a picker option (for C-13/C-14's
+      wrong-engine cases).
+
+### 4.2 Procedure
+
+1. **B-09** — generate the chapter with `$U` speaking ≥6 lines (run sheet
+   B-09). Observe: completes, every line of `$U`'s character is the same
+   voice with no drift or fallback, no `Cloned + cached Qwen voice` line in
+   the log (healthy voice, no re-derive). **Result:** _____________
+2. **B-10** — generate the second chapter `$U` speaks in, A/B a line from
+   each chapter (run sheet B-10). Observe: indistinguishable identity across
+   chapters, `baseModel` unchanged from B-01. **Result:** _____________
+3. **B-05** — make `/embed` fail transiently without touching
+   `/qwen/clone-voice` (run sheet B-05 lists the practical options), clone.
+   Observe: the clone still completes (`.pt` written) despite the fidelity
+   check failing — advisory, not fatal. **Result:** _____________
+4. **B-11** — edit a throwaway clone's manifest per run sheet B-11's
+   PowerShell snippet to force each of cases (i)/(ii)/(iii), attempting the
+   assign each time. Observe the three distinct outcomes: (i) 409 naming
+   Coqui XTTS v2, (ii) 409 naming Qwen, (iii) 200 with a `warning` field
+   naming Qwen and a chapter that still renders on Coqui. Also confirm the
+   separate revoked-entry 409. Restore the manifest afterward.
+   **Result:** _____________
+5. **B-12** — confirm admission ON, clone (record which device the
+   reservation landed on), then force the no-capacity branch by occupying
+   the target card, clone again (run sheet B-12). Observe: step 2 clone
+   succeeds naming a concrete device; step 3 clone gets a 503
+   `{noCapacity:true,...}` with **no orphan `.pt`/entry dir** left behind.
+   Optionally A/B with admission OFF, then **restore to `1`**.
+   **Result:** _____________ **Device:** _____ **`neededMb` on 503:** _____
+6. **B-13** — stop the sidecar, run the wizard to Save, confirm the 503 (not
+   a fake success, nothing persisted), restart the sidecar, provoke a
+   sidecar-side 4xx via the direct curl in run sheet B-13. Observe: the 4xx
+   surfaces through `POST /api/voice-library/clone` as **502**, not the raw
+   4xx. **Result:** _____________
+7. **C-13** — with `$U` assigned and Qwen healthy, switch the session engine
+   to **Kokoro**, generate (run sheet C-13). Observe: fails naming
+   `(wrong-engine)`, remedy says "switch the book to Qwen", **not** "Qwen is
+   unavailable". Contrast: switch back to Qwen, stop the sidecar, generate —
+   now `(engine-unavailable)` with a different remedy. Record both exact
+   messages. **Result:** _____________
+8. **C-14** — run all four cases from run sheet C-14 (session=Kokoro/no
+   override; session=Qwen/character override=kokoro; character
+   override=coqui contrast; pending-picker-beats-persisted-default).
+   Observe the four distinct HTTP outcomes and exact 409 copy per case.
+   **Result:** _____________
+9. **C-15** — with a Broken cloned voice (reuse a revoked one), open the
+   generation view, start the failing chapter, watch for the immediate toast,
+   click its help link, then fail the same chapter again (no duplicate
+   toast) and a different chapter (does produce one) (run sheet C-15).
+   **Result:** _____________
+10. **C-16** — walk the state table in run sheet C-16 (healthy / revoked /
+    no-master / failed / repairable), reloading `#/voices` between each.
+    Observe the exact chip per state, and note the two documented KL-h
+    approximation gaps (no chip for a `.pt`-deleted Repairable, no chip for
+    wrong-engine) as expected, not defects. **Result:** _____________
+11. **C-17** ⭐ — snapshot the designed voice's persona (`instruct`,
+    `designModel`, `mintMethod`, `fallbackFor`), assign it to a speaking
+    character on Qwen, delete only its `.pt`, generate a **full chapter
+    render** (not a splice — #1972 makes a splice unsafe for this check; a
+    full chapter reads one source and is unaffected), re-read the manifest
+    and the Profile Drawer persona box, then trigger a re-design (run sheet
+    C-17). Observe: `instruct` byte-identical to the pre-heal snapshot,
+    `designModel`/`mintMethod`/`fallbackFor` preserved, persona box still
+    populated, re-design still works. This is the genuine re-run the
+    #1972-retracted run-2 attempt never actually exercised.
+    **Result:** _____________ **`instruct` identical?** ☐ yes ☐ no (fail)
+12. **C-20** — delete a Repairable clone's `.pt`, start the chapter, hit
+    Pause during the "Preparing voice…" window, observe no
+    `cloned-voice-broken` toast/failure and no `'failed'` stamp, then
+    resume (run sheet C-20). Repeat once against C-17's designed-voice setup.
+    **Result:** _____________
+13. **C-21** — open an exclusive file handle on `$K.pt` from a second shell,
+    revoke `$U` from the first, read the response and `logs\server.log` (run
+    sheet C-21). Observe: still HTTP 200 with `revokedAt` set, but
+    `artifactPurgeIncomplete: true` and `artifactPurgeFailedPaths` naming the
+    held path; every other artifact still erased. Close the handle, confirm
+    the straggler clears on a second revoke/delete. **Result:** _____________
+
+### 4.3 Teardown
+
+- [ ] Restore `SEG_CAPACITY_ADMISSION=1` if it was toggled in B-12.
+- [ ] Restore the session engine picker to Qwen (undoes C-13/C-14).
+- [ ] Restore any hand-edited `voice.json` from B-11/C-07/C-09/C-16/C-18, or
+      re-clone/re-design the affected voice.
+- [ ] Release the C-21 file handle if not already closed.
+- [ ] Restore `autoStartSidecar` preference if changed.
+- [ ] Confirm `$U` and the C-17 designed voice are left in a known state
+      (healthy, or explicitly note if revoked) before ending the sitting.
+
+---
+
+## 5. Sitting 4 — Coqui/XTTS Section E, cross-cutting VRAM, and the post-32 follow-ups (≈190 min)
+
+**Covers:** E-03, E-04, E-06 ⭐, E-07 ⭐ (run sheet §5, Section E), plus the
+six post-32 follow-up checks (register A1, "Six checks added by the post-32
+follow-up campaign" — pass/fail criteria in `docs/features/271-fs38-wave3c-xtts.md`).
+The only engine swap in this whole pack: Qwen → Coqui. Run this sitting last,
+alone, as `onbox-sitting-plan.md` §4 step 8 directs for the whole row.
+
+### 5.1 Preconditions
+
+- [ ] Same card (`cuda:0`), eGPU still unplugged.
+- [ ] Coqui/XTTS installed with weights present (`coqui_import_ok: true` in
+      `/health` — read that field, not `coqui_package_installed`, which is a
+      stale `find_spec` probe per the run sheet's own superseded-advice note
+      under Section E). No special `COQUI_PIN_IMPORT_ORDER` flag is needed —
+      #1944's fix is merged to `main` (confirmed §0), so a normal fresh
+      sidecar boot should load Coqui cleanly after `/embed`.
+- [ ] The Russian Coalfall book (`the-coalfall-commission.ru.md`) imported and
+      analysed — this is the fixture that actually routes to Coqui by
+      default (confirm the cast picker's resolved engine before relying on
+      it, per run sheet E-01 step 2).
+- [ ] A healthy cloned voice with an existing Coqui derive (`$KX =
+      "xtts-$U"`) — reuse `$U` from earlier sittings; if it was left revoked,
+      re-clone before this sitting.
+- [ ] A **designed** Qwen voice with no existing Coqui-side artifact yet, for
+      E-06/E-07.
+- [ ] A second, Qwen-cast character in the **same** Coqui-routed book, for
+      the VRAM-partitioning follow-up check (needs one Qwen voice + one Coqui
+      voice resolving in the same chapter).
+- [ ] `nvidia-smi` watchable in a spare shell throughout, for the VRAM
+      partitioning check.
+- [ ] A second shell to pre-stage the revoke command for E-03's timing race.
+
+### 5.2 Procedure
+
+1. **E-04 (re-run)** — reproduce the exact repro from the run sheet's E-04
+   row on the current (post-#2039) SHA: a 46-char line on `$KX` (expect
+   **200**, PCM as before) and a 245-char Russian line on the same voice
+   (expect **200 + PCM now**, not the old 500 — `#2017`'s fix declares
+   `spacy` and retries with `enable_text_splitting=False` on `ImportError`).
+   This clears the row's own stated debt ("re-run of the reproduction … on
+   real Coqui weights, not an outstanding bug"). **Result:** _____________
+2. **E-03** — delete `$KX.pt` to force a repair derive, pre-stage a revoke,
+   fire it in the window between the chapter starting and the derive
+   completing (run sheet E-03, same technique as C-01). Observe: `revokedAt`
+   survives; the chapter fails naming the character and `revoked`; no
+   `.pt`/`.json`/temp-WAV survives under `voices\xtts\`. If you land past
+   the window instead (mid-forward), the chapter may complete and return
+   audio for that one in-flight request — record which outcome, both are
+   informative per the run sheet's own note. Budget 3-5 attempts.
+   **Result:** _____________ **Attempts:** ____
+3. Re-clone/derive `$KX` back to healthy before continuing.
+4. **E-06** ⭐ — cast the designed voice on a Coqui-routed character with no
+   prior Coqui artifact, generate (triggers the lazy designed-voice-on-Coqui
+   derive), listen, and judge against how that character would have sounded
+   on the stock Coqui catalogue voice it replaces (run sheet E-06). This is
+   an open verdict, not pass/fail — record it honestly.
+   **Result:** ☐ Better ☐ Worse ☐ About the same **Notes:** _____________
+5. **E-07** ⭐ — with a designed voice cast on a Coqui character and no
+   existing artifact, force the derive to fail (stop the sidecar mid-chapter,
+   or remove the retained calibration clip), generate, restore afterward
+   (run sheet E-07). Observe: the chapter **completes** on the stock Coqui
+   catalogue voice, not silence/crash, and no coqui slot gets written for
+   this character — fail-**soft**, the deliberate opposite of E-02/E-03's
+   fail-loud cloned-voice policy. **Result:** _____________
+6. **Post-32 check 1 — `preparing-voice` phase.** Render a chapter with a
+   Repairable cloned voice or the E-06 self-healing designed voice and
+   confirm the Generate screen shows a "Preparing voice — `{character}`"
+   pill/caption before synthesis starts (already fixed per run sheet §6
+   KL-f/#1813 — this is the box confirmation, not a defect hunt). Then
+   render a chapter for a character with no library voice at all and confirm
+   the phase never appears. **Result:** _____________
+7. **Post-32 check 2 — cloned voice end-to-end on XTTS, concretely.** Play
+   the E-03/E-04 chapter's rendered audio and confirm it's recognisably the
+   cloned speaker, not a stock catalogue voice, and that `cast.json` records
+   `overrideTtsVoices.coqui.libraryUuid` matching the clone's uuid with
+   `provenance: 'cloned'`. Largely already established by E-01/E-03's own
+   measurements — this step is the explicit `cast.json` field check that
+   register text notes as not yet separately confirmed. **Result:** _____________
+8. **Post-32 check 3 — revoke-then-render on Coqui.** Revoke consent for a
+   voice already cast on Coqui, render a chapter using it. Observe: fails
+   loud with `UnresolvableClonedVoiceError`, **zero audio** for that
+   chapter — same shape as C-01/C-02 on Qwen, E-02/E-03 on Coqui, but this
+   time confirming it end to end through a real generation rather than the
+   API-level checks above. **Result:** _____________
+9. **Post-32 check 4 — VRAM partitioning across a mixed chapter.** Cast one
+   character to a Qwen cloned/designed voice and another to a Coqui
+   cloned/designed voice in the **same** book/chapter; watch `nvidia-smi`
+   through the resolver pre-pass while it renders. Observe: Qwen and Coqui
+   never both hold GPU memory resident at the same time — a spike showing
+   both resident simultaneously is a regression. **Result:** _____________
+10. **Post-32 check 5 — `voice_language_mismatch` advisory on all three
+    streams.** On the Russian book, with a reused designed voice originally
+    designed for a different language: (a) run a per-character re-record
+    from the cast profile drawer's "Fix … audio", and (b) hit the repair
+    button on a `suspect` chapter row in Listen view. Observe: each raises
+    ONE amber toast naming the cleared character, once per run not per
+    chapter, and the run still completes. An English-only book raises none
+    on either path. **Result:** _____________
+11. **Post-32 check 6 — Preview plays on the ready engine.** Get a voice into
+    a state where `engines.qwen.status` is not `ready` but
+    `engines.xtts.status` is `ready` (a revoked-then-restored Qwen leg, or a
+    Coqui-only clone with no Qwen derive), press Preview on its My-voices
+    card. Observe: real Coqui audio plays instead of a 409 toast. Then
+    confirm a voice with both engines ready still previews on Qwen (the
+    primary engine). **Result:** _____________
+
+### 5.3 Teardown
+
+- [ ] Restore any revoked voice from E-03/post-32-check-3 if it's needed for
+      a future session; otherwise leave revoked (revocation is deliberately
+      irreversible — note which uuids were spent here).
+- [ ] Restart the sidecar if E-07's derive-failure step stopped it; confirm
+      `/health` is clean.
+- [ ] Restore the calibration clip if you removed it for E-07.
+- [ ] Confirm no stray `voices\xtts\` temp files remain from the E-03 kill
+      window (an empty `voices\xtts\` directory after erasure is expected —
+      run sheet §7.3 — but a partial `.pt`/`.json` pair is not).
+- [ ] Fill run sheet §7.1's result table and §7.4's verdict block for every
+      test ID run across all four sittings; this pack's own `Result:` lines
+      are a per-step log, not a substitute for the run sheet's own record.
+- [ ] Follow run sheet §8 (record the run, update the plans, file defects,
+      release notes) once this pack's four sittings are complete.
+
+---
+
+## 6. Coverage reconciliation
+
+31 scheduled (Sittings 1-4) + 20 already `P`/discharged + 1 `N/A` (B-06) + 1
+`P` incidental (D-03) + 2 correctly excluded as blocked (C-02, D-02) +
+5 sub-tests folded into other IDs and not separately counted in the run
+sheet's own 60-test denominator (D-04's split into the C-05a/C-05b pieces is
+already counted under C-05 in the run sheet's own headcount, not additive) =
+**60** (D-04 counts once, under Section D's 4; C-05a/C-05b share C-05's single
+slot in Section C's 21 — the run sheet's own §7.1 "C-05 (one of the 18
+above)" note makes this explicit). Matches the run sheet's own Section
+totals (A 13 + B 13 + C 21 + D 4 + E 9 = 60) with nothing double-counted and
+nothing dropped.

--- a/docs/testing/onbox-sitting-multilanguage.md
+++ b/docs/testing/onbox-sitting-multilanguage.md
@@ -1,0 +1,240 @@
+# On-box sitting pack — multi-language render + ASR content-QA (D1, D2, A38, E4)
+
+> **Sitting pack** for wave 2 of `#2435`, step 7 of the `#2453` chain. Covers
+> register rows **D1, D2, A38, E4** — non-English ASR content-QA calibration,
+> zh/ja placeholder voice design, sidecar auto-scaled RAM/VRAM recycle
+> thresholds, and the engine-recommendation CPU caveat. Follows the shared
+> format fixed by [`onbox-sitting-plan.md`](onbox-sitting-plan.md) §5; the
+> re-resolution rule of §6 was applied to every row (see
+> [`## Excluded on re-resolution`](#excluded-on-re-resolution) — nothing was
+> excluded).
+>
+> **Box/card target:** the operator's GPU box, **single 8 GB card**, pinned
+> via `CUDA_VISIBLE_DEVICES=0`.
+>
+> **Running time total (recomputed 2026-08-20):** **165 minutes** — D1 ≈ 90,
+> D2 ≈ 25, A38 ≈ 35, E4 ≈ 15. Sum = 165, matching the plan of record's stated
+> total for this pack ([`onbox-sitting-plan.md`](onbox-sitting-plan.md) §2.1)
+> and the audit's own per-row estimates exactly — all four rows re-resolved
+> as still owed, so nothing changed the arithmetic.
+
+## Preconditions
+
+Stated once for the sitting; do not repeat per row.
+
+- [ ] **Single 8 GB card.** `CUDA_VISIBLE_DEVICES=0`.
+- [ ] **The fs-61 Coalfall demo books for es, ru, fr, de** — already
+      voice-designed (PR #1568, merged 2026-07-13; confirmed present at
+      `samples/the-coalfall-commission-es/` with `manuscript.epub` +
+      `voices/`). D1 needs all four ready to render; queue es and ru first
+      since those are the row's two named residual risks (gendered-number
+      mismatch, Russian oblique-case declension).
+- [ ] **The zh/ja Coalfall placeholder samples** — confirmed present at
+      `samples/the-coalfall-commission-zh/` and `-ja/`, each holding only
+      `README.md` + `manuscript.md` (no `.epub`, no `voices/`) — the
+      voice-design pipeline has not been run against either. D2 needs the
+      shipped Qwen VoiceDesign pipeline pointed at both.
+- [ ] **A fresh `server/.env`** with `SIDECAR_RESTART_MB`,
+      `SIDECAR_VRAM_RECYCLE_SOFT_MB`, and `SIDECAR_VRAM_RESTART_MB` all
+      **absent** (confirmed still commented out in `server/.env.example` at
+      `:659`, `:661`, `:663`) — copy `.env.example` verbatim rather than
+      hand-editing an existing `.env` that may already carry explicit
+      overrides from earlier sittings. A38's whole premise is the auto path
+      only activates when these three are unset.
+- [ ] **A way to force Qwen onto the CPU device** via the voice-engine
+      device setting (Settings → Voice Engine, or the equivalent env
+      override) for E4 — confirm the setting exists and is reachable before
+      committing GPU time to D1/D2.
+- [ ] **A second shell** free throughout the sitting to poll `GET /health`
+      (for A38's `recycle_pending` flag) and tail the sidecar log (for the
+      `[sidecar]` restart/recycle lines and D1/D2's render progress).
+- [ ] SHA and a clean tree recorded below.
+
+SHA: `____________`  Clean tree: ☐  Date: `__________`  Run by: `__________`
+
+## Procedure
+
+Ordered so the one env change (A38) happens before the sidecar is started for
+the sitting, D1 — the long pole at ~90 min, largely unattended once running —
+goes first and stays in the background as its own render doubles as A38's
+RAM/VRAM driver, and the short, genuinely interactive rows (D2's pipeline
+kick-off, E4's CPU-forced check) run in D1's shadow rather than after it.
+**Where D1/D2's GPU render is in flight, do not also drive E4's CPU-forced
+render on the same process** — E4 targets the CPU device explicitly and does
+not contend for VRAM, but starting it only after D1 is safely queued avoids
+two renders racing to write the same `render-integrity` state.
+
+### A38 · Sidecar auto-scaled RAM/VRAM recycle thresholds now actually apply on a fresh install ([#2179](https://github.com/dudarenok-maker/Castwright/issues/2179), PR [#2210](https://github.com/dudarenok-maker/Castwright/pull/2210))
+
+> **Criteria source:** `onbox-acceptance-register.md` A38 (`:2169-2209`).
+> Re-resolved 2026-08-20: `gh issue view 2179` → closed 2026-08-07T01:52:50Z;
+> `gh pr view 2210` → merged 2026-08-07T01:52:49Z, title "fix(server): ship
+> .env.example as documentation, not assignments" — the fix landed.
+> `server/.env.example` still ships all three vars commented out —
+> `# SIDECAR_RESTART_MB=0` (`:659`), `# SIDECAR_VRAM_RECYCLE_SOFT_MB=0`
+> (`:661`), `# SIDECAR_VRAM_RESTART_MB=0` (`:663`) — confirmed unchanged.
+> No later issue, PR, or run sheet records a real fresh-install
+> threshold-crossing run. STILL OWED. Setup runs first (below); the
+> threshold-crossing checks are folded into D1/D2's render further down
+> since a long multi-chapter batch is the row's own named RAM/VRAM driver.
+
+1. **Fresh-install confirmation.** With the fresh `.env` from Preconditions,
+   start the sidecar and confirm the startup log computes and logs the auto
+   thresholds — 70% of total physical RAM, 90% of the resident card's total
+   VRAM (soft), 98% (hard) — rather than treating the absent vars as
+   disabled.
+   - Result (RAM/VRAM ceilings logged at startup):
+2. **RAM ceiling — piggybacks on D1 below.** Once D1's four-language batch is
+   underway, watch host committed RAM climb toward the ~70% ceiling. If the
+   render alone does not reach it, add a synthetic host-memory hog alongside
+   it (the row's own named fallback) rather than waiting indefinitely.
+   Confirm the sidecar self-exits with code 43 for the supervisor to
+   respawn, not a silent stall or an uncontrolled crash.
+   - Result (RAM ceiling reached, exit code observed):
+3. **VRAM soft/hard thresholds — same render.** Watch reserved VRAM via
+   `nvidia-smi` alongside D1/D2's queued renders. At the 90% soft threshold,
+   confirm `GET /health` sets `recycle_pending` and a clean chapter-boundary
+   recycle fires (not a mid-chapter hard exit). If the soft recycle doesn't
+   relieve enough pressure, continue toward 98% and confirm the hard
+   self-exit fires instead of an uncontrolled OOM.
+   - Result (soft recycle at 90%, chapter-boundary not mid-chapter):
+   - Result (hard restart at 98%, if reached):
+4. **Thrash check.** Across D1/D2's ordinary batch peaks, confirm the auto
+   thresholds do **not** fire routinely — a card sitting in the high-80s/90s%
+   reserved as a normal batch peak should not trip a recycle storm now that
+   the ceiling is live where it was previously inert.
+   - Result:
+
+### D1 · Non-English ASR content-QA calibration ([#1527](https://github.com/dudarenok-maker/Castwright/issues/1527), [#1084](https://github.com/dudarenok-maker/Castwright/issues/1084))
+
+> **Criteria source:** `onbox-acceptance-register.md` D1 (`:2854-2867`).
+> Re-resolved 2026-08-20: `gh issue view 1527` → still **OPEN**
+> ("srv: on-box maxWer calibration for es/fr/de/ru (#1084 follow-up)"); `gh
+> issue view 1084` → still **OPEN** ("srv: ASR content-QA never
+> tuned/validated for non-English"). `server/src/config/registry.ts:300-330`
+> defines `qa.asr.maxWer.{es,ru,fr,de}`, every one still `default: 0.4` —
+> identical to the global default, confirmed unchanged.
+> `server/src/tts/segment-asr-qa.test.ts:688-711`
+> (`resolveAsrThresholds` per-language suite) exercises only the resolver
+> against synthetic override values fed in by the test — it proves the
+> plumbing reads a set knob, not that any knob has been set from a real
+> render-and-inspect pass. STILL OWED. **Sequenced first — the long pole at
+> ~90 min across four languages, largely unattended once running.**
+
+5. **Kick off the batch.** Render one chapter of each fs-61 demo book — es,
+   ru, then fr, de — through the shipped pipeline with the ASR content-QA
+   gate enabled. Queue all four; this is the row's own "largely unattended"
+   batch and the sitting's long pole — start it, then move to A38 step 1 and
+   D2/E4 below while it runs.
+   - Result (all four queued, start time):
+6. **Per-language WER inspection.** Once each language's chapter completes,
+   inspect the ASR content-QA gate's reported WER against the current
+   English-tuned `0.4` default. Record the observed WER for es, ru, fr, de.
+   - Result (WER: es / ru / fr / de):
+7. **Set the four knobs.** From the observed distribution, set
+   `qa.asr.maxWer.{es,ru,fr,de}` (`server/src/config/registry.ts:300-330`)
+   away from the inherited `0.4` default to values that reflect real
+   per-language ASR noise floors rather than the English-tuned figure.
+   - Result (knob values set):
+8. **Gendered-number mismatch rate.** Across the es/fr/ru renders, record how
+   often a gendered number word ("one"/"two" and their es/fr/ru
+   gender-agreement forms) is flagged as a false-positive WER mismatch by
+   the content-QA gate.
+   - Result:
+9. **Russian oblique-case declension.** In the ru render, record whether
+   oblique-case declensions (a word correctly inflected for case but
+   differing from the nominative form Whisper may output) are being
+   misflagged as content mismatches.
+   - Result:
+10. **German compound-number token check.** In the de render, confirm
+    whether Whisper's output for compound numbers matches the pipeline's
+    single-fused-token assumption, or whether it splits/differs in a way
+    that produces a false content mismatch.
+    - Result:
+
+### D2 · fs-61 zh/ja placeholder voices ([#1600](https://github.com/dudarenok-maker/Castwright/issues/1600))
+
+> **Criteria source:** `onbox-acceptance-register.md` D2 (`:2869-2873`).
+> Re-resolved 2026-08-20: `gh issue view 1600` → still **OPEN** ("fs-61 —
+> backfill designed voices + covers onto the zh/ja Coalfall placeholder
+> samples"). Directly compared the sample trees:
+> `samples/the-coalfall-commission-es/` (one of D1's done languages) holds
+> both `manuscript.epub` and a `voices/` directory; `-zh/` and `-ja/` hold
+> only `README.md` + `manuscript.md` — no `.epub`, no `voices/` — confirmed
+> unchanged. STILL OWED. **Runs in D1's shadow** — its own render is short
+> (two languages, unattended pipeline) and does not need to wait for D1 to
+> finish; queue it once D1's four renders are underway.
+
+11. **Kick off the pipeline.** Once D1's batch is queued (step 5), run the
+    shipped Qwen VoiceDesign pipeline against the zh Coalfall placeholder
+    sample, then the ja sample — the same pipeline already run for D1's five
+    languages.
+    - Result (zh voice-design run, artifacts produced):
+    - Result (ja voice-design run, artifacts produced):
+12. **Confirm parity with the done languages.** Compare the resulting zh/ja
+    sample trees against `samples/the-coalfall-commission-es/`'s shape —
+    each should now carry a `voices/` directory of designed voice artifacts,
+    matching the done languages rather than the placeholder-only state
+    confirmed in Preconditions.
+    - Result:
+
+### E4 · fe-51 engine-recommendation CPU caveat (plan [259](../features/259-fe51-engine-recommendation.md))
+
+> **Criteria source:** `docs/features/259-fe51-engine-recommendation.md:183-191`.
+> Re-resolved 2026-08-20: `server/src/tts/engine-recommendation.ts:34` still
+> defines `CAVEAT_VRAM` at the cited line, and its use at `:67`
+> (`caveat: fits ? null : CAVEAT_VRAM`) is unchanged. Plan 259 line 183 still
+> reads "On-box acceptance item (real hardware, not mock mode) — owed."
+> verbatim. STILL OWED. **Runs in D1/D2's shadow** — this is a CPU-only check
+> and does not contend with D1/D2's GPU renders; start it once both are
+> safely queued (step 5, step 11) rather than racing their kick-off.
+
+13. **Force CPU and render.** Force Qwen onto the CPU via the voice-engine
+    device setting (Preconditions) and render a short chapter or single
+    line. Confirm it actually renders — slow, not crashing.
+    - Result (renders on CPU, no crash; approximate time vs. GPU):
+14. **Fallback decision, only if step 13 fails.** If forcing CPU does **not**
+    render, the plan's own named fallback is to soften `CAVEAT_VRAM`
+    (`server/src/tts/engine-recommendation.ts:34`) to drop the CPU-mode
+    offer and keep only the "pick Kokoro below" nudge — flag this for the
+    operator rather than editing it during the sitting.
+    - Result (only if step 13 failed):
+
+## Excluded on re-resolution
+
+None excluded. All four rows were re-resolved against live repo/issue/PR
+state and the cited files themselves on 2026-08-20 and remain owed:
+
+- **D1** — `gh issue view 1527/1084` both still OPEN, matching the row's own
+  account. `registry.ts:300-330`'s four `qa.asr.maxWer.*` knobs confirmed
+  still `default: 0.4`; `segment-asr-qa.test.ts:688-711` confirmed
+  resolver-only synthetic coverage. STILL OWED.
+- **D2** — `gh issue view 1600` still OPEN. Sample-tree comparison confirmed
+  zh/ja still pre-pipeline placeholders (no `.epub`, no `voices/`) against
+  es's done state. STILL OWED.
+- **A38** — `gh issue view 2179` closed, `gh pr view 2210` merged, both match
+  the row's account of the fix landing. `.env.example`'s three vars
+  confirmed still commented out at the cited lines. No later run sheet
+  records a real threshold-crossing run. STILL OWED.
+- **E4** — `engine-recommendation.ts:34,67` confirmed unchanged; plan 259
+  line 183 confirmed still reads "owed" verbatim. STILL OWED.
+
+None of the four rows is AMBIGUOUS (that is A2/A16/A22's queue, not this
+pack's) — every cited plan/issue/PR agrees with its own row text.
+
+## Teardown
+
+- [ ] Evict Qwen (and Coqui/XTTS if either D2's pipeline or E4's CPU check
+      loaded it) so the next sitting starts cold.
+- [ ] Restore `server/.env` to whatever configuration the box normally runs
+      (if the fresh-install `.env` from Preconditions differs from the
+      operator's usual working config, note which is now active).
+- [ ] Confirm the sidecar is in a normal, non-recycling state — no
+      `recycle_pending` still set on `GET /health` — before ending the
+      sitting; if A38's hard-restart path fired, confirm the respawned
+      sidecar is healthy.
+- [ ] Confirm the card returns to baseline (`nvidia-smi` ≈ idle) before
+      ending the sitting.
+- [ ] Record the four `qa.asr.maxWer.*` values actually set (D1 step 7) and
+      the zh/ja artifact locations (D2 step 11) somewhere durable if this
+      sitting's config changes are meant to persist past the sitting.

--- a/docs/testing/onbox-sitting-plan.md
+++ b/docs/testing/onbox-sitting-plan.md
@@ -1,0 +1,234 @@
+# On-box sitting plan — the plan of record for wave 2 of #2435
+
+> **Plan of record.** This document bins **all 74 rows** of
+> [`onbox-acceptance-register.md`](onbox-acceptance-register.md) into exactly one
+> of three sets — an operator sitting pack, a wave-3 agent-runnable row, or a
+> blocked-on-acquisition row — and fixes the **shared pack format** every later
+> child in the #2453 chain obeys.
+>
+> Chain: #2453 (parent) → **#2464 (this step, the plan)** → #2463–#2455 (the nine
+> pack children) → #2454 (`[claude][verify]`, opens the single PR).
+> Audit input: [`onbox-acceptance-staleness-audit.md`](onbox-acceptance-staleness-audit.md).
+
+---
+
+## 1. Purpose
+
+A **sitting pack** is a runbook: a single, ordered, self-contained procedure the
+operator can execute start to finish on the box **without deciding anything**.
+Each pack covers one sitting — one contiguous block of box time that shares its
+hardware setup, its engine residency and its book/voice fixtures, so that
+expensive setup (plugging the eGPU, warming Qwen, loading a real book) happens
+**once** and every row that needs it rides on the same boot.
+
+**Packs are runbooks, not discharges.** Filling in a pack's `Result:` lines is
+the on-box run; it retires nothing by itself. A row leaves the register only when
+the acceptance was actually run and recorded, or the owner confirms it — exactly
+the rule the register already states.
+
+**No row is retired by this wave.** The register is unchanged. This plan and the
+nine packs that follow it are the runbooks that make running the owed acceptance
+cheap and ordered; they do not edit `onbox-acceptance-register.md`, the live-view
+HTML, the staleness audit, or any existing run sheet.
+
+---
+
+## 2. The three sets
+
+Every one of the 74 register rows appears **exactly once** across the three sets
+below. The arithmetic is stated under each table and reconciled in §6.
+
+### 2.1 Operator sittings (49 rows, 8 packs)
+
+These need the operator's GPU box — a live card, real engine residency, a real
+TTS sidecar, a real analyzer, or a real phone/browser on the LAN. Each is one
+sitting; A1 is several sittings inside one pack.
+
+| Pack file | Rows | Est. min |
+|---|---|---|
+| [`onbox-sitting-two-card-boot.md`](onbox-sitting-two-card-boot.md) | A2, A3, A8, A18 | 110 |
+| [`onbox-sitting-vram-contention.md`](onbox-sitting-vram-contention.md) | A5, A16, A19, A20, A25, A28, A34, A35, A36 | 155 |
+| [`onbox-sitting-voice-design.md`](onbox-sitting-voice-design.md) | A4, A6, A7, A14, A15, A17, A30 | 155 |
+| [`onbox-sitting-qa-gate.md`](onbox-sitting-qa-gate.md) | A9, A10, A11, A12, A13, A21, A22, A23, A37 | 155 |
+| [`onbox-sitting-cloning-identity.md`](onbox-sitting-cloning-identity.md) | A24, A26, A31, A32, A44, A45, A46, A47 | 170 |
+| [`onbox-sitting-multilanguage.md`](onbox-sitting-multilanguage.md) | D1, D2, A38, E4 | 165 |
+| [`onbox-sitting-device-browser.md`](onbox-sitting-device-browser.md) | E1, E2, E3, E5, E6, E9, E10 | 150 |
+| [`onbox-sitting-fs38-wave3.md`](onbox-sitting-fs38-wave3.md) | A1 | multi-hour, several sittings |
+
+**Row count:** 4 + 9 + 7 + 9 + 8 + 4 + 7 + 1 = **49**.
+
+### 2.2 Wave-3 agent-runnable (21 rows)
+
+These need no GPU and no operator box. They are excluded from every pack above
+and are run, on a machine of the agent's choosing, by the wave-3 pass — not by a
+pack child in this chain.
+
+A27, A29, A33, A39, A40, A41, A42, A43, B1, B2, B3, B4, C1, C2, C3, C4, E7, E8,
+E11, G1, G2.
+
+**Row count:** 8 (group A, excluding A16) + 4 (B) + 4 (C) + 3 (E7/E8/E11) + 2
+(G) = **21**.
+
+### 2.3 Blocked-on-acquisition (4 rows, 1 pack)
+
+These need hardware or material the operator does not yet have on the bench — a
+real Android phone (and, for one item, a CarPlay/Android Auto head unit), and
+real full-length CJK manuscripts. They get a pack so the procedure is ready the
+moment the hardware lands, but the sitting cannot be scheduled until acquisition.
+
+| Pack file | Rows | Est. min |
+|---|---|---|
+| [`onbox-sitting-blocked-prerequisites.md`](onbox-sitting-blocked-prerequisites.md) | F1, H1, H2, D3 | 50 (F1 unestimated) |
+
+**Row count:** **4**.
+
+### Arithmetic
+
+49 (operator) + 21 (wave-3) + 4 (blocked) = **74**. Every register row appears
+exactly once.
+---
+
+## 3. A16 — re-derived binning and reasoning
+
+The audit bins **A16** (`fe-16 Qwen auto-load on a Russian book`, plan 165) as
+`Hardware still required: real workspace, no GPU`. **That field is wrong**, and
+the audit's own evidence contradicts it:
+
+- The plan's walkthrough **step 4** (line 94) is labelled **`(owed, real backend
+  + GPU)`** and reads: *"Open a real Russian book's cast → the Qwen banner shows
+  and Qwen loads in the background (analyzer evicted)."*
+- The plan's **ship notes** (line 108): *"fe-16 Qwen auto-load is wired and
+  unit-covered; **live GPU acceptance is the only owed item**."*
+- The audit's own **Remains owed**: *"…confirm the Qwen banner shows and Qwen
+  auto-loads with the analyzer evicted … on real hardware."*
+
+Qwen is a GPU-resident model; "Qwen loads" means it loads into VRAM. "Analyzer
+ evicted" is VRAM contention — the analyzer is reclaimed to make room for Qwen.
+That is unambiguous GPU work, identical in kind to the eviction rows in the
+VRAM-contention pack (A19 mixed Qwen+Coqui evict, A20 idle Coqui reclaimed under
+VRAM pressure, A25 `/health` through a contended eviction, A28 stranded VRAM
+pool reclaimed). The audit's `no GPU` field appears to have followed the row's
+*frontend* framing ("open a cast view, see a banner") rather than what the
+owed step actually exercises on the box.
+
+**Decision: A16 moves from wave-3 agent-runnable to the operator sitting
+`onbox-sitting-vram-contention.md`** (its "Qwen auto-loads, analyzer evicted"
+observation is the same VRAM-contention family). This is a one-row correction to
+the coordinator's proposal, which had 52 operator / 22 wave-3; the corrected
+split is **49 operator + 21 wave-3 + 4 blocked = 74** (the four blocked rows are
+broken out as their own set in §2.3, where the proposal had counted them inside
+the operator total).
+
+> A16 is also one of the three **AMBIGUOUS** rows — its plan frontmatter says
+> `status: active` while its body says `Status: stable`. That ambiguity is about
+> the plan's *status* (whether the whole plan is open, or only the live-GPU item
+> remains), **not about its hardware**, so it does not prevent binning. The pack
+> child that writes the VRAM-contention pack marks A16 in its procedure: *"blocked
+> on a decision: plan 165 frontmatter says `active`, body says `stable` — run the
+> live-GPU step regardless, and flag the frontmatter contradiction for the
+> operator."*
+
+---
+
+## 4. Suggested order for the operator's sittings
+
+The ordering rule is **minimise setup churn**: the eGPU is not hot-pluggable, so
+the two-card sitting is a natural bookend; the single-card sittings are then
+ordered by what shares engine residency and book fixtures.
+
+1. **Two-card boot** (`onbox-sitting-two-card-boot.md`) — open with it. The eGPU
+   is plugged in once, the two-card rows run while both cards are present, then
+   the eGPU can be removed for the rest. Equally valid as the closing bookend if
+   the operator prefers to clear the single-card work first; the only hard rule
+   is that the eGPU is seated for this sitting and not for the others.
+2. **VRAM contention** (`onbox-sitting-vram-contention.md`) — single card, the
+   eviction family. Shares the warmed-Qwen + real-book state that several later
+   sittings also want, so run it while Qwen is resident.
+3. **Voice design** (`onbox-sitting-voice-design.md`) — same card, Qwen
+   VoiceDesign warm-resident; rides the residency the previous sitting
+   established.
+4. **Cloning & character identity** (`onbox-sitting-cloning-identity.md`) —
+   clone-voice derive + cast identity, same card and sidecar.
+5. **Multi-language render + ASR** (`onbox-sitting-multilanguage.md`) —
+   non-English books, Coqui/XTTS and ASR content-QA; needs the non-English
+   fixtures loaded.
+6. **QA gate, loudness & re-record** (`onbox-sitting-qa-gate.md`) — the loudness
+   measurement + re-record loop; runs after a render exists to measure against.
+7. **Device & browser** (`onbox-sitting-device-browser.md`) — phone/Mac/browser
+   and the Pinokio/ffmpeg-floor items; mostly off-card, so it can be slotted any
+   quiet window, but grouping it keeps the device pairing setup to one pass.
+8. **fs-38 Wave 3** (`onbox-sitting-fs38-wave3.md`) — **last**, and alone. It is
+   multi-hour and several sittings over the existing run sheet; give it a
+   dedicated block rather than crowding it against shorter sittings.
+---
+
+## 5. The pack format
+
+Every pack child in this chain produces one file following the shape of
+[`sidecar-evict-latency-onbox-acceptance.md`](sidecar-evict-latency-onbox-acceptance.md)
+— the model run sheet. It is five parts:
+
+1. **Header** — what this sitting covers: the register rows, the plans of record,
+   the linked issues, and the **running time total** for the sitting (the sum of
+   the est. minutes in §2.1 for this pack's rows). State the box/card it targets.
+2. **Preconditions** — a checkbox list stated **once for the sitting**, not
+   repeated per row. Hardware (which card, `CUDA_VISIBLE_DEVICES`, residency),
+   engine selection, env flags, which book/voice must exist and be loaded, how
+   many shells are needed, what must be warm vs. cold.
+3. **Procedure** — numbered and **ordered so shared setup happens once and engine
+   swaps happen as few times as possible**. Each step says what to **do** and what
+   to **observe**, concretely. Where a run sheet already carries a row's
+   criteria, **cite the file and section number** — do not copy the criteria
+   list, because a copy drifts from the original. **Concrete observations, not
+   "verify it works":** a step whose expected outcome is a judgement ("sounds
+   right", "looks correct") must state what the judgement is **against** — the
+   comparison, the threshold, or the prior recording.
+4. **`Result:` lines — left empty.** The run sheets carry the instruction *"Fill
+   in the `Result:` lines AS you run this on the box… Do not pre-fill them."*
+   Honour it. Each procedural step that produces an observation gets a blank
+   `Result:` line for the operator to fill at run time.
+5. **Teardown** — what to stop, unload or restore so the next sitting starts
+   clean (evict the warm engine, clear the env flags, unpair the device, close
+   the book).
+
+---
+
+## 6. The re-resolution rule
+
+The staleness audit is trustworthy but not proven — its verify pass (#2451)
+**sampled** the STILL-OWED rows' citations rather than re-running all 69, and the
+one defect it caught proves what that leaves open: row **A2**'s audit Evidence
+wrote up a `grep` as returning no matches when the pattern in fact matches at
+line 16 — *inside the very header range the row cites as its own evidence*. A
+false claim of that shape survives any amount of reading and only a real re-run
+surfaces it.
+
+**So: every pack child re-resolves its rows' citations itself.** For each row in
+its pack, the child opens the plan of record and reads its `status:` and Ship
+notes, runs `gh issue view <N> --repo dudarenok-maker/Castwright --json
+state,title,closedAt` and `gh pr view <N> --repo dudarenok-maker/Castwright
+--json state,mergedAt` for the row's linked issues/PRs, and **re-runs any command
+the audit quotes a result for** and compares. If a row turns out **already
+discharged, or self-contradictory**, the child excludes it from the pack and
+records it under a `## Excluded on re-resolution` heading with the evidence — it
+does not write steps for a sitting that should not happen. The **A2 false-grep
+incident** is the reason this rule exists and is named here.
+
+---
+
+## 7. Running totals
+
+- **Operator sittings:** 8 packs (A1's pack is several sittings inside one file).
+- **Total estimated operator minutes (runnable packs):** 110 + 155 + 155 + 155 +
+  170 + 165 + 150 = **1,060 minutes (~17.7 hours)**.
+- **Excluded from that total:**
+  - **A1** — "multi-hour" (the row's own unchanged estimate; not a single number).
+  - **F1** — not estimated in its plan; an entire untested axis (a real Android
+    device, and for one item a CarPlay/Android Auto head unit), not batchable
+    with any other group. The blocked pack carries the other three blocked rows'
+    **50 minutes** (H1 + H2 + D3) for when the hardware lands.
+- **Wave-3 agent-runnable:** 21 rows, no GPU, run off-box by the wave-3 pass —
+  not counted in operator minutes.
+
+**Grand reconciliation:** 49 operator + 21 wave-3 + 4 blocked = **74 rows**, the
+register's full owed count, each exactly once.

--- a/docs/testing/onbox-sitting-plan.md
+++ b/docs/testing/onbox-sitting-plan.md
@@ -47,13 +47,21 @@ sitting; A1 is several sittings inside one pack.
 | Pack file | Rows | Est. min |
 |---|---|---|
 | [`onbox-sitting-two-card-boot.md`](onbox-sitting-two-card-boot.md) | A2, A3, A8, A18 | 110 |
-| [`onbox-sitting-vram-contention.md`](onbox-sitting-vram-contention.md) | A5, A16, A19, A20, A25, A28, A34, A35, A36 | 155 |
-| [`onbox-sitting-voice-design.md`](onbox-sitting-voice-design.md) | A4, A6, A7, A14, A15, A17, A30 | 155 |
-| [`onbox-sitting-qa-gate.md`](onbox-sitting-qa-gate.md) | A9, A10, A11, A12, A13, A21, A22, A23, A37 | 155 |
-| [`onbox-sitting-cloning-identity.md`](onbox-sitting-cloning-identity.md) | A24, A26, A31, A32, A44, A45, A46, A47 | 170 |
-| [`onbox-sitting-multilanguage.md`](onbox-sitting-multilanguage.md) | D1, D2, A38, E4 | 165 |
-| [`onbox-sitting-device-browser.md`](onbox-sitting-device-browser.md) | E1, E2, E3, E5, E6, E9, E10 | 150 |
-| [`onbox-sitting-fs38-wave3.md`](onbox-sitting-fs38-wave3.md) | A1 | multi-hour, several sittings |
+| `onbox-sitting-vram-contention.md` | A5, A16, A19, A20, A25, A28, A34, A35, A36 | 155 |
+| `onbox-sitting-voice-design.md` | A4, A6, A7, A14, A15, A17, A30 | 155 |
+| `onbox-sitting-qa-gate.md` | A9, A10, A11, A12, A13, A21, A22, A23, A37 | 155 |
+| `onbox-sitting-cloning-identity.md` | A24, A26, A31, A32, A44, A45, A46, A47 | 170 |
+| `onbox-sitting-multilanguage.md` | D1, D2, A38, E4 | 165 |
+| `onbox-sitting-device-browser.md` | E1, E2, E3, E5, E6, E9, E10 | 150 |
+| `onbox-sitting-fs38-wave3.md` | A1 | multi-hour, several sittings |
+
+<!-- The seven rows above are plain code spans, not links, until their pack
+files exist — review of PR #2470 (attempting to fix this a different way)
+found that this repo's docs/testing link-scan guard (test:hooks) walks the
+WHOLE tree on every commit, so a real .md link to a not-yet-written sibling
+fails every intermediate commit in this chain, not just the one that would
+add the dangling link. #2454's final commit (once all eight packs exist)
+flips these back to real links. See #2463 for the incident this avoids. -->
 
 **Row count:** 4 + 9 + 7 + 9 + 8 + 4 + 7 + 1 = **49**.
 
@@ -78,9 +86,9 @@ moment the hardware lands, but the sitting cannot be scheduled until acquisition
 
 | Pack file | Rows | Est. min |
 |---|---|---|
-| [`onbox-sitting-blocked-prerequisites.md`](onbox-sitting-blocked-prerequisites.md) | F1, H1, H2, D3 | 50 (F1 unestimated) |
+| `onbox-sitting-blocked-prerequisites.md` | F1, H1, H2, D3 | 50 (F1 unestimated) |
 
-**Row count:** **4**.
+**Row count:** **4**. (Plain code span, not a link — same not-yet-written-sibling reason as §2.1's table; see the note there.)
 
 ### Arithmetic
 

--- a/docs/testing/onbox-sitting-qa-gate.md
+++ b/docs/testing/onbox-sitting-qa-gate.md
@@ -1,0 +1,225 @@
+# On-box sitting — QA gate, loudness provenance & re-record
+
+> **This is a working document.** Fill in the `Result:` lines AS you run this
+> on the box, with the real GPU + real TTS sidecar. Do not pre-fill them.
+>
+> Plan of record: [`onbox-sitting-plan.md`](onbox-sitting-plan.md) (§2.1, §5 pack
+> format), step 5 of the [#2453](https://github.com/dudarenok-maker/Castwright/issues/2453) chain.
+> Register rows: [`onbox-acceptance-register.md`](onbox-acceptance-register.md)
+> A9, A10, A11, A12, A13, A21, A22, A23, A37.
+> Row plans: [`228-batch-qa-rerecords.md`](../features/228-batch-qa-rerecords.md),
+> [`176-character-splice.md`](../features/176-character-splice.md),
+> [`173-failure-taxonomy.md`](../features/173-failure-taxonomy.md),
+> [`174-audio-qa-gate.md`](../features/174-audio-qa-gate.md),
+> [`175-resource-telemetry.md`](../features/175-resource-telemetry.md),
+> [`archive/274-loudness-measurement-provenance.md`](../features/archive/274-loudness-measurement-provenance.md),
+> [`2055`](https://github.com/dudarenok-maker/Castwright/issues/2055) (A37 fix), [`2026`](https://github.com/dudarenok-maker/Castwright/issues/2026) (A37 repro source).
+>
+> **Running time total (recomputed):** 20 (A9) + 20 (A10) + 15 (A11) + 15 (A12) +
+> 15 (A13) + 10 (A21) + 10 (A22) + 10 (A23) + 40 (A37) = **155 minutes**,
+> matching the plan of record's §2.1 estimate for this pack.
+
+---
+
+## Re-resolution note
+
+Every row below was re-resolved against live state on 2026-08-20, not taken from
+the staleness audit as given: `gh issue view`/`gh pr view` re-run for every
+issue/PR the audit cites, and each row's plan file re-read for its current
+`status:` frontmatter and Ship notes. All nine rows still match the audit's
+verdicts exactly — no row is discharged or self-contradictory. No row is
+excluded.
+
+**A22 is AMBIGUOUS** per the audit and the plan of record: whether #1909's
+"no change" closure (decided on a subjective A/B listen) retires A22's own
+`tp`-per-chapter distribution criterion, or leaves it independently owed. This
+pack does **not** resolve that — it is marked in Step 8 below as blocked on a
+decision, and its procedure is written so the operator can still capture the
+data if they choose to run it.
+
+---
+
+## Preconditions
+
+- [ ] Single 8 GB card (`CUDA_VISIBLE_DEVICES=0`), rides the same book/voice
+      residency the earlier sittings in this wave established (voice design →
+      cloning/identity → this sitting, per plan §4 step 6).
+- [ ] A rendered real book with at least one chapter already through the full
+      generation + QA gate pipeline (for A21's badge-agreement check) and
+      spare chapters available to re-render (for A9, A12, A23).
+- [ ] `SEG_ASR_ENABLED=1` set for the whole sitting except the A37 leg, which
+      additionally needs the Coqui/XTTS engine selected — see Step 9's own
+      engine-swap note.
+- [ ] A second shell free for `gh`/log tailing and for triggering the
+      sidecar-kill in Step 3.
+- [ ] Access to `#/admin` → "Resource trends" (A13) and to a chapter's
+      Generate + Listen rows (A9, A11, A12, A21).
+- [ ] A non-English (Russian ideal) book or chapter available for A37 —
+      required only for that step, sequence it last (Step 9).
+
+---
+
+## Procedure
+
+### 1. Batch QA re-record RTF (A9 — plan 228)
+
+**Do:** Regenerate a QA-flagging Qwen chapter (e.g. KotLC "Chapter Three") with
+the full gate stack on (`SEG_ASR_ENABLED=1`, signal-QA + ASR re-records at 2).
+
+**Observe:** RTF for the run, compared against the ~1.2 target (down from the
+pre-fix ~1.9–2.0 regression) — plan 228 §"Acceptance" (`:97-99`). Confirm the
+same suspect/asrSuspect flagging behaviour appears as on any other chapter.
+
+Result: _(fill in — measured RTF)_
+Result: _(fill in — suspect/asrSuspect flags present as expected: yes/no)_
+
+### 2. Per-character re-record / splice, +3 dB gain (A10 — plan 176)
+
+**Do:** On the rendered book from Step 1 (or another already-rendered book),
+open a character's profile → Fix audio → apply the **+3 dB gain** across all
+that character's chapters. Then re-record one chapter's lines for that
+character.
+
+**Observe (gain step):** the result is audibly louder, chapter duration is
+unchanged, `.previous.*` backup files are written, A/B playback (before/after)
+works, and the chapter's loudness stays ≈ −16 LUFS after the gain.
+**Observe (re-record step):** timing integrity holds — no seam at the
+re-recorded lines' boundaries, no doubled chapter title (this is the
+regression class fs-10/`#412` fixed and pinned; confirm it does not recur on a
+real render).
+
+Result: _(fill in — louder, duration unchanged, backups written, A/B works: yes/no)_
+Result: _(fill in — post-gain LUFS reading)_
+Result: _(fill in — re-record seam/doubled-title check: pass/fail, detail)_
+
+### 3. Structured failure taxonomy, ≥2 real failure modes (A11 — plan 173, fs-19)
+
+**Do:** Force two distinct real failure modes against a live render:
+1. **`sidecar-unreachable`** — stop the TTS sidecar process mid-render.
+2. **`vram-spill`** — oversubscribe VRAM (e.g. start a second concurrent
+   admission on the same card while the first is mid-forward) so the engine
+   raises an out-of-memory condition.
+
+**Observe:** for each, the Generate row and the toast both show the friendly
+message plus its remediation line (not a raw stack trace or generic error).
+
+Result: _(fill in — sidecar-unreachable: message + remediation shown, verbatim)_
+Result: _(fill in — vram-spill: message + remediation shown, verbatim)_
+
+### 4. Post-synthesis audio QA gate, deliberately degraded render (A12 — plan 174, srv-27)
+
+**Do:** Craft a chapter render that deliberately fails one of `DEFAULT_QA_THRESHOLDS`
+(plan 174 `:22`) — e.g. force a near-silent result (well under −40 LUFS) or a
+truncated/clipped one. The easiest reliable recipe: pause a source paragraph on
+an already-known-quiet voice, or truncate the sidecar's output stream before
+loudnorm.
+
+**Observe:** the amber **"Suspect"** badge appears on both the Generate row and
+the Listen row for that chapter, with the correct reason (near-silent /
+clipped / truncated) as its tooltip.
+
+Result: _(fill in — degraded condition used)_
+Result: _(fill in — Suspect badge shown on Generate row: yes/no, reason text)_
+Result: _(fill in — Suspect badge shown on Listen row: yes/no, reason text)_
+
+### 5. Resource trends admin panel, multi-chapter run (A13 — plan 175, fs-20)
+
+**Do:** Run a real multi-chapter render on the GPU box (the Step 1 and Step 2
+renders together should already qualify if run back-to-back; otherwise render
+2+ chapters here).
+
+**Observe:** `#/admin` → "Resource trends" shows RTF / QA / VRAM / wall-time
+rows for the run, and the sparkline actually tracks RTF across the chapters
+rendered (not flat / not the mock's placeholder value).
+
+Result: _(fill in — RTF/QA/VRAM/wall-time rows present: yes/no)_
+Result: _(fill in — sparkline tracks real per-chapter RTF: yes/no, describe)_
+
+### 6. Suspect-badge / Listen-badge dBTP agreement (A21 — plan 274 §6 row 1)
+
+**Do:** Using the full multi-chapter render already produced in Steps 1–2/5,
+check every chapter that carries a true-peak-related Suspect reason.
+
+**Observe:** for each such chapter, the Suspect badge's true-peak reason and
+the Listen-view loudness badge's dBTP figure quote the **same number**. Note
+any chapter where they disagree.
+
+Result: _(fill in — chapters checked, and per-chapter dBTP agreement: match/mismatch, figures)_
+
+### 7. Real-corpus true-peak distribution (A22 — AMBIGUOUS, plan 274 §6 row 2) — optional, do not resolve
+
+**Blocked on a decision:** whether #1909's 2026-07-31 closure ("current
+pipeline preferred, no code change" — decided on a subjective 4-pass A/B
+listen, not a per-chapter `tp` distribution) retires this row, or whether the
+real-corpus `tp`-vs-`QA_CLIP_TP_DB` observation A22 asks for remains
+independently owed for any future retune. This pack does not decide that.
+
+**Do (optional, if the operator chooses to capture the data anyway):** across
+the real book rendered in Steps 1–2/5, record the measured `tp` (true-peak)
+value per chapter.
+
+**Observe:** whether any chapter's `tp` approaches the `QA_CLIP_TP_DB` default
+ceiling (`-0.1` dBTP).
+
+Result: _(fill in, if run — per-chapter tp spread; "not run — left to operator decision" otherwise)_
+
+### 8. Measurement-failure path renders as untrusted (A23 — plan 274 §6 row 3) — opportunistic
+
+**Do:** Opportunistically, across the renders already produced in this
+sitting, watch for (or attempt to force, e.g. via a corrupted/short audio
+segment that would make `ebur128` fail its pass) a chapter whose loudness
+measurement pass genuinely fails.
+
+**Observe:** such a chapter carries `measurementSource: 'loudnorm'` — no,
+carries the **absence** of a trustworthy measurement — and both the
+Listen-view badge and the report-card row show "No measurement" rather than a
+fabricated `-1.5`-style figure. This row is hard to force naturally (plan 274
+`:872`); a genuine miss (no failure observed this sitting) is an acceptable
+outcome, but record the attempt.
+
+Result: _(fill in — failure forced or caught: yes/no; if yes, badge + report-card behaviour observed)_
+
+### 9. Catastrophic-WER override on a real Coqui language-collapse (A37 — #2055) — **engine swap, run last**
+
+**Engine swap:** switch the sidecar to the Coqui/XTTS engine with ASR
+content-QA on (`SEG_ASR_ENABLED=1`, Coqui selected) — this is why this step is
+sequenced last in the sitting, so the swap happens once.
+
+**Do:** With a Russian (or French/Spanish) book, reproduce #2026's own
+language-collapse recipe — short lines (e.g. two-word Russian phrases),
+repeated synthesis of the same short lines on a stock catalogue voice (#2026
+used `Damien Black`, `xtts_v2`, `language: ru`); the collapse is intermittent
+(#2026 needed 6 repeated runs to hit it once), so budget several repeats
+rather than a single pass. Then, across the same or a longer healthy-content
+render, confirm ordinary hard-to-transcribe-but-correct lines (invented
+character names, foreign phrases, background noise) do **not** trigger the
+override.
+
+**Observe:** on a genuine collapse, the segment carries `asr.verdict: drift`
+with a reason mentioning "catastrophically wrong" (was `inconclusive` and
+shipped unflagged before #2055). On the healthy-content pass, no new
+false-positive re-records versus the pre-#2055 baseline. Criteria: the
+`CATASTROPHIC_WER` / `qa.asr.catastrophicWer` comment in
+`server/src/tts/segment-asr-qa.ts`.
+
+Result: _(fill in — collapse reproduced: yes/no, attempts taken)_
+Result: _(fill in — if reproduced, verdict + reason text on the collapsed segment)_
+Result: _(fill in — healthy-content pass false-positive count, vs. pre-#2055 baseline)_
+**Run by:** _(fill in)_ **Date:** _(fill in)_
+
+---
+
+## Teardown
+
+- Evict the Coqui/XTTS engine loaded for Step 9 if nothing later needs it
+  resident.
+- Unset `SEG_ASR_ENABLED` if the next sitting does not want it on by default.
+- Clear any deliberately-degraded fixtures created for Steps 4/8 so they do
+  not linger in the book's chapter list.
+- Leave the admin "Resource trends" panel as-is (read-only view, nothing to
+  restore).
+
+_(Once every row above is actually run, mark the corresponding rows A9, A10,
+A11, A12, A13, A21, A23, A37 discharged in `onbox-acceptance-register.md` with
+a summary of each result — and record the A22 decision once the operator makes
+it — and remove them from the "owed" count. This pack does not do that.)_

--- a/docs/testing/onbox-sitting-two-card-boot.md
+++ b/docs/testing/onbox-sitting-two-card-boot.md
@@ -1,0 +1,136 @@
+# On-box sitting pack — two-card boot (A2, A3, A8, A18)
+
+> **Sitting pack** for wave 2 of `#2435`, step 2 of the `#2453` chain. Covers
+> register rows **A2, A3, A8, A18** — everything that needs the **2-card boot**
+> and nothing else. Follows the shared format fixed by
+> [`onbox-sitting-plan.md`](onbox-sitting-plan.md) §5; the re-resolution rule of
+> §6 was applied to every row (see [`## Excluded on re-resolution`](#excluded-on-re-resolution)).
+>
+> **Box/card target:** the operator's GPU box with **both** cards present —
+> 8 GB RTX 4070 (internal) + 16 GB RTX 5070 Ti (eGPU over OcuLink). The eGPU is
+> **not hot-pluggable** (OcuLink add/remove is reboot-only), so this sitting is a
+> single boot with the card connected; any step that needs a swapped enumeration
+> is a second 2-card boot, not a live replug.
+>
+> **Running time total (recomputed):** **~110 minutes** of runnable acceptance —
+> A2 step 9 ≈ 20, A3 ≈ 45, A8 ≈ 25, A18 ≈ 20 — plus **~15 minutes** for A2
+> steps 6–8, which are **blocked on the A2 AMBIGUOUS decision** (see §A2) and run
+> only if the operator resolves rows 6–8 as owed. A2 step 3 is observe-only/N-A
+> (cannot be forced on OcuLink). The plan of record estimated 110 min
+> ([`onbox-sitting-plan.md`](onbox-sitting-plan.md) §2.1); this recomputation
+> matches.
+
+## Preconditions
+
+Stated once for the sitting; do not repeat per row.
+
+- [ ] **Both cards booted.** Boot with the 16 GB eGPU connected over OcuLink. `nvidia-smi` lists two devices; `python -c "import torch; print(torch.cuda.device_count())"` returns 2. Record both device indices and UUIDs: `nvidia-smi --query-gpu=index,uuid,memory.total,name --format=csv`.
+- [ ] **Server up** on current `main`, built and running against the real (non-mock) sidecar.
+- [ ] **`SEG_CAPACITY_ADMISSION=1`** — the A2 walkthrough runs with admission on (plan 264 `:131`).
+- [ ] **A real, multi-chapter book loaded** (at least one non-trivial chapter for analysis and render).
+- [ ] **Advanced settings reachable** — A18 pins the Qwen/codec device there.
+- [ ] **Two shells** open: one for server control / `gh api` / `curl`, one for `nvidia-smi` / `ollama ps` observation.
+- [ ] **Engines available:** Ollama `qwen3.5:9b` analyzer installed; Coqui/Kokoro/Qwen TTS weights installed; ASR with `ASR_DEVICE=cuda` available for A2 step 8.
+- [ ] **Know which card is which** before pinning — the 8 GB internal card and the 16 GB eGPU, by both index and UUID.
+- [ ] **Cold start at A8.1** — no engine resident unless a step says otherwise.
+
+## Procedure
+
+Ordered so shared setup happens once and engine swaps happen as few times as
+possible. A8 steps 1–4 run first while the Ollama analyzer is the resident engine
+on the 8 GB card; A8 step 5 and A2 step 9 exercise the roomier/2-card paths; A3 is
+the multi-GPU Wave 2 checklist; A18 is the device-pin respawn set, done last
+because its enumeration-reorder bullet needs a reboot into a swapped-enumeration
+2-card config.
+
+### A8 · GPU residency safety + coexistence (plan 222) — steps 1–5
+
+> **Criteria source:** [`../features/222-gpu-residency-and-analysing-honesty.md`](../features/222-gpu-residency-and-analysing-honesty.md) §"Manual acceptance walkthrough (USER-RUN, live GPU — OWED)" at `:54-59`. Distinct from B1/plan 216 (that one is the device probe). This procedure orders the five steps for the sitting and gives the concrete observation; it does not restate the criteria list.
+>
+> **Step attribution (this row is mixed):** steps 1–4 need only the **8 GB card** (the internal card, present in this 2-card boot) and could equivalently ride with a single-card sitting; step 5 needs the **12/16 GB card** and belongs **only** to this 2-card sitting. All five are run here in one pass so no separate sitting is owed for A8.
+
+1. **(A8.1) 8 GB card, analyzer `qwen3.5:9b` resident:** run analysis on a multi-chapter book. Observe: VRAM holds ~steady (no per-section sawtooth on `nvidia-smi`); `ollama ps` shows the 9B resident throughout; no mid-stream "no response" stalls; the analysing chip reads "Qwen3.5 9B (local)" (not 4B); large chapters show "section M/N".
+   - Result:
+2. **(A8.2) 8 GB, analysis finished → start generation (Qwen TTS):** observe the server evicts the 9B before the sidecar loads (≤ ~8 GB peak, no OOM).
+   - Result:
+3. **(A8.3) 8 GB, start generation WHILE an analysis runs on another book:** observe a clear **409 "GPU busy with analysis"** refusal, not an OOM.
+   - Result:
+4. **(A8.4) 8 GB, voice design:** observe — while analysis is idle, eviction then design proceeds; while analysis is busy, a 409.
+   - Result:
+5. **(A8.5) 12/16 GB eGPU:** observe **no eviction** — analyzer + TTS coexist (set `GPU_SAFE_COEXIST_MB` if the detected total straddles the default 11000).
+   - Result:
+
+### A2 · Capacity-aware GPU placement (plan 264) — step 9, steps 6–8 (blocked), step 3 (N-A)
+
+> **Criteria source:** [`../features/264-vram-aware-gpu-placement.md`](../features/264-vram-aware-gpu-placement.md) §"Manual acceptance walkthrough (owed on-box — the 'no OOM' bar)" at `:129-179`; header `:9-22`.
+>
+> ⚠️ **AMBIGUOUS — blocked on a decision; do not resolve it here.** The plan
+> header names `S1/S2/S4/S6` as part of the exercised on-box synthesis-path
+> acceptance **and** lists rows 6–8 (which include item 6, the 2-card cold
+> `/load` steer) as "not force-driven on-box" — in the same paragraph.
+> Re-ran the cited grep: `grep -n "S6" docs/features/264-vram-aware-gpu-placement.md`
+> → `16:> (S1/S2/S4/S6 below). The manual **evict-under-contention** rows (6–8: cold`
+> (it **matches**, not misses — the register's original "no-match" claim is
+> wrong, as wave 1 already found). Whether rows 6–8 count as already-exercised or
+> still-owed-and-deferred-by-choice is the operator's design-pass decision. Steps
+> 6–8 below are marked **blocked on that decision** — run them only if the
+> operator resolves rows 6–8 as owed.
+
+6. **(A2.9 — #1730, 2-card only) Concurrent cross-card ops keep to their card:** with both cards up, run `design_voice` + `mint_variant` (and, if `ASR_DEVICE=cuda`, a `/transcribe` + `/embed`) concurrently so they land on **different** admitted cards. Observe: each op's entire run — load **and** forward — stays on its own card; no cross-card clobber, no OOM. (`GET /capacity` confirms the reservation per device.) This is the on-box confirmation of PR #1732 (re-resolved: merged 2026-07-19T22:44:02Z) still owed before the concurrent-multi-card flag flip. *Single-8 GB-card runs never hit this path — it is a 2-card-only check.*
+   - Result:
+7. **(A2.6 — blocked on decision) 2-card boot, cold `/load`:** loading Coqui/Kokoro/Qwen steers to the roomier of the two cards; `GET /capacity` shows the reservation landing on the expected device. **Run only if rows 6–8 are resolved as owed.**
+   - Result:
+8. **(A2.7 — blocked on decision) `design_voice` on a full 8 GB card:** the idle Ollama analyzer is evicted and the design proceeds; if there is still no room, the actionable busy/no-capacity toast surfaces instead of a hang. **Run only if rows 6–8 are resolved as owed.**
+   - Result:
+9. **(A2.8 — blocked on decision) GPU-configured ASR (`ASR_DEVICE=cuda`) `/transcribe` under contention:** 503s with `noCapacity`, Node evicts the idle analyzer and retries, and the transcription completes rather than silently falling back to CPU. **Run only if rows 6–8 are resolved as owed.**
+   - Result:
+10. **(A2.3 — observe-only, N-A) eGPU fault-drop:** IF the eGPU ever drops off the CUDA bus on its own mid-run ("GPU is lost"), the in-flight op fails fast, its reservation releases, a toast fires, and it re-queues onto the 8 GB card. **Cannot be safely triggered on OcuLink** (add/remove is reboot-only; yanking the cable is a hard crash). Mark **Blocked / N-A** unless it happens on its own; the recovery path is unit-covered and not required for sign-off.
+    - Result:
+
+### A3 · srv-57 Multi-GPU Wave 2 — ten checklist items (#1230)
+
+> **Criteria source:** issue [`#1230`](https://github.com/dudarenok-maker/Castwright/issues/1230) — the ten-item on-box checklist (re-resolved: still **OPEN**; ten unchecked `- [ ]` boxes confirmed by re-count). Do not restate the checklist here; run it item-by-item on the issue and tick each box as it passes. Task 16/16.5 (auto-revert on a repeated bad pin) is designed but **unbuilt**, gated on item 1 — note its unbuilt state, do not attempt to build it here.
+
+11. **Per-card UUIDs from torch:** confirm the sidecar reports each card's real CUDA UUID (the raw `cuda-uuid:` literal, not a translated `cuda:N`), per card.
+    - Result:
+12. **Starved card self-exits code 43:** drive a card below `SIDECAR_VRAM_FREE_FLOOR_MB`; the starved card self-exits with code 43, and `/health` shows the breach first.
+    - Result:
+13. **`QWEN_DEVICE`/`KOKORO_DEVICE` on different cards run concurrently:** confirm concurrent runs land on different cards; same-card pinning still blocks.
+    - Result:
+14. **Three code-43 exits in ten minutes — card-specific:** trips the streak guard (card-specific variant).
+    - Result:
+15. **Three code-43 exits in ten minutes — not card-specific:** manual-investigation path (not card-specific variant).
+    - Result:
+16. **Remaining #1230 checklist items:** complete the rest of the ten-item checklist on the issue (the analyzer CPU/GPU serialization checks and any other items not named above) and tick each box.
+    - Result:
+17. **Task 16/16.5 status:** confirm it remains unbuilt and gated on item 1 (it consumes the `tripEvent()` that item 1 exercises). Do not build it here.
+    - Result:
+
+### A18 · Device-pin resolution survives a respawn (#1870, closes #1857)
+
+> **Criteria source:** [`onbox-acceptance-register.md`](onbox-acceptance-register.md) `:829-842` — the four on-box bullets. Re-resolved: PR #1870 merged 2026-07-27T01:53:26Z; #1857 closed 2026-07-27T01:53:27Z; `server/src/tts/sidecar-env.test.ts` exists (unit-level only). The behaviour no CI test can reach is a respawn after the device index actually changes.
+
+18. **Pin Qwen to a specific card** in Advanced settings, restart the server, and force a supervisor respawn (`POST /api/sidecar/restart`, or let a recycle fire). Observe: the engine lands on the **pinned** card both times.
+    - Result:
+19. **(needs a reboot — do last) Change the enumeration order** — swap the cards physically, or set `CUDA_DEVICE_ORDER` — and confirm a respawn still finds the pinned card by **UUID** rather than failing `_validate_cuda_index` or landing on the wrong one. **This is the regression the change exists to prevent**, and it was previously reachable only when the user had opened Advanced settings during that server session. *Requires a second 2-card boot with swapped enumeration; do this as the last 2-card action of the sitting.*
+    - Result:
+20. **Pin `tts.qwen.codecDevice` to a card** and confirm the codec is actually placed there. Before #1870 the pin was silently ignored — the literal failed inside torch's `.to()` and rolled back to CPU.
+    - Result:
+21. **Point the codec pin at a card that is NOT present** and confirm the sidecar logs `QWEN_CODEC_DEVICE=… did not match any visible GPU` and leaves the codec on **cpu** — not on the model's card, which is what `auto` would have done.
+    - Result:
+
+## Excluded on re-resolution
+
+None excluded. All four rows were re-resolved against live repo/issue/PR state and remain owed:
+
+- **A2** — `grep -n "S6" docs/features/264-vram-aware-gpu-placement.md` re-run → matches line 16 (the register's original "no-match" claim is wrong; the wave-1 audit already corrected it); plan 264 frontmatter `status: active`; PR #1732 re-checked via `gh api …/pulls/1732` → merged 2026-07-19T22:44:02Z. **AMBIGUOUS** (the rows-6–8 decision) — marked in the procedure, not excluded.
+- **A3** — `gh api …/issues/1230` re-checked → `state: open`, `closed_at: null`; unchecked `- [ ]` count re-run = 10. STILL OWED.
+- **A8** — plan 222 frontmatter `status: active`; header `:9` "on-box GPU acceptance owed"; walkthrough at `:54`; PR #840 merged 2026-06-16T11:02:20Z; PR #841 merged 2026-06-16T11:02:59Z. STILL OWED. **Finding (routed to #2435, not fixed):** PR #839 (merged 2026-06-16T07:29:25Z, "fix(server): tolerate stray model keys in analyzer schema validation") is **misattributed** in the register's `*Shipped*` line for A8 — its body is about Ollama JSON schema salvage, unrelated to GPU residency/eviction. #840/#841 are the real match. Does not change the verdict (the walkthrough-owed statement is independently confirmed from the plan header and ship notes). Editing the register is out of scope for this pack.
+- **A18** — PR #1870 re-checked → merged 2026-07-27T01:53:26Z; #1857 re-checked → closed 2026-07-27T01:53:27Z; `server/src/tts/sidecar-env.test.ts` exists. STILL OWED.
+
+## Teardown
+
+- [ ] Evict the warm engines (Ollama analyzer + TTS sidecar) so the next sitting starts cold.
+- [ ] Clear the env flags set for this sitting — `SEG_CAPACITY_ADMISSION`, `ASR_DEVICE`, `CUDA_DEVICE_ORDER`, `GPU_SAFE_COEXIST_MB` — restoring each to its prior value.
+- [ ] Unpin the Qwen/codec device in Advanced settings (or note the pins left in place for the next sitting).
+- [ ] Close the book. The box remains in the 2-card boot state — the eGPU stays connected until the operator reboots back to single-card.

--- a/docs/testing/onbox-sitting-voice-design.md
+++ b/docs/testing/onbox-sitting-voice-design.md
@@ -1,0 +1,379 @@
+# On-box sitting pack — Qwen VoiceDesign, bulk cast design & audition (A4, A6, A7, A14, A15, A17, A30)
+
+> **Sitting pack** for wave 2 of `#2435`, step 3 of the `#2453` chain. Covers
+> register rows **A4, A6, A7, A14, A15, A17, A30** — the rows a human has to
+> **listen to**: Qwen VoiceDesign persona/A/B audition, bulk cast design, the
+> emotion-chip manuscript preview, cross-engine audition fidelity, and the
+> golden-audio bless guards. Follows the shared format fixed by
+> [`onbox-sitting-plan.md`](onbox-sitting-plan.md) §5; the re-resolution rule
+> of §6 was applied to every row (see
+> [`## Excluded on re-resolution`](#excluded-on-re-resolution) — nothing was
+> excluded).
+>
+> **Box/card target:** the operator's GPU box, **single 8 GB card**, pinned via
+> `CUDA_VISIBLE_DEVICES=0`. Qwen VoiceDesign is warm-resident coming in from
+> the preceding VRAM-contention sitting (`onbox-sitting-vram-contention.md`)
+> per the plan of record's suggested order (§4 item 3); this pack does not
+> depend on that residency surviving, but reuses it if present.
+>
+> **Running time total (recomputed 2026-08-20):** **155 minutes** — A4 ≈ 15,
+> A6 ≈ 20, A7 ≈ 30, A14 ≈ 15, A15 ≈ 15, A17 ≈ 15, A30 ≈ 45. Sum = 155,
+> matching the plan of record's stated total for this pack
+> ([`onbox-sitting-plan.md`](onbox-sitting-plan.md) §2.1) exactly — all seven
+> rows re-resolved as still owed, so nothing changed the arithmetic.
+
+## Preconditions
+
+Stated once for the sitting; do not repeat per row.
+
+- [ ] **Single 8 GB card.** `CUDA_VISIBLE_DEVICES=0`; `nvidia-smi` lists the
+      4070 8 GB as `cuda:0`. If the box policy pins renders to `cuda:1` (the
+      16 GB card, owner's call since 2026-08-01, git-ignored `server/.env`),
+      temporarily set `QWEN_DEVICE=cuda:0` / `COQUI_DEVICE=cuda:0` for this
+      sitting and restore in teardown — everything here targets the 8 GB card.
+- [ ] **Server started via `start-prod.bat`**, not a dev launcher — A6's
+      forced-recycle check specifically needs the `.env` ceilings that only
+      this launch path applies.
+- [ ] **A Qwen project/book with a multi-voice cast** (≥3 characters, at least
+      one with no persona yet and one already carrying an old-format persona
+      pre-dating plan 160's rewrite) — needed for A6, A7 and A14's "compare
+      against a character still on an old-format persona" step. A sibling book
+      in the same series, for A7's series-propagation check.
+- [ ] **Engines available and loadable from the UI:** Qwen VoiceDesign (0.6B
+      and 1.7B tiers), Coqui XTTS, Kokoro (`server/tts-sidecar/voices/kokoro/kokoro-v1.0.onnx`
+      + `voices-v1.0.bin` on disk, sidecar venv bootstrapped) — A4 needs all
+      three plus both Qwen tiers in the same session; A30 needs Kokoro
+      specifically.
+- [ ] **A book set to the 1.7B tier** and a book/character overridden to
+      Kokoro inside a Coqui book (A4's tier/engine-override checks).
+- [ ] **A manuscript with a Qwen-voiced character carrying a designed `angry`
+      emotion variant**, and the ability to remove/re-add that variant (A17).
+- [ ] **A second browser tab/session** (A7's 2nd-tab serialization check).
+- [ ] **A way to genuinely oversubscribe VRAM with Coqui resident** — e.g.
+      hold the card near capacity with a concurrent Qwen load — to force a
+      real capacity refusal (A4's fourth check).
+- [ ] **A way to force a sidecar `/recycle` mid-run** (A6) — the existing
+      recycle trigger the bug (#690) was filed against; the register names no
+      dedicated endpoint beyond letting the sidecar's own recycle ceiling
+      fire, so use whatever forces a recycle during a live bulk-design run
+      (e.g. hold the sidecar near its committed-memory ceiling, or the
+      supervisor's own forced-restart path if the box exposes one).
+- [ ] **`npm run test:golden-audio`** runnable from the worktree/repo root,
+      and the box **quiet** for A30 — `nvidia-smi` shows no concurrent GPU
+      work when that step runs (its own `--bless` contention warning should
+      print nothing).
+- [ ] **Permission to hand-edit a committed baseline JSON** for A30's forced-
+      refusal drills, with a plan to revert the hand-edit before committing
+      anything.
+- [ ] **One shell** for server/CLI control; a second free for `nvidia-smi` /
+      log tailing.
+
+## Procedure
+
+Ordered so the bulk-design (Qwen-heavy) rows run first while the cast/session
+setup is fresh, the single-voice persona/A/B/emotion rows follow on the same
+Qwen residency, the multi-engine audition row (A4) comes next since it is the
+one point this sitting swaps into Kokoro/Coqui/tier variations, and the
+golden-audio bless row (A30) — which needs Kokoro alone on a **quiet** card —
+runs last, after everything else is evicted.
+
+### A6 + A7 · Bulk voice-design recycle resilience (plan 200) + Design full cast (plan 195) — steps 1–3
+
+> **Criteria source:** [`onbox-acceptance-register.md`](onbox-acceptance-register.md)
+> A6 `:719-730`, A7 `:732-741`; ship notes in
+> `docs/features/200-bulk-design-recycle-resilience.md` and
+> `docs/features/195-design-full-cast.md`.
+> Re-resolved 2026-08-20: `gh issue view 690` → closed 2026-06-09T21:29:55Z,
+> title matches ("Design full cast halts after the first voice (sidecar
+> recycle not recovered)"); plan 200's own Ship notes read verbatim "Live-GPU
+> acceptance (restart via `start-prod.bat`...) is the only remaining check" —
+> unchanged, no later commit touches the file. `gh pr view 637` → merged
+> 2026-06-07T11:37:03Z; `gh pr view 638` → merged 2026-06-07T11:57:28Z (fills
+> the SHA only); plan 195's Ship notes still read "Live-GPU acceptance owed"
+> verbatim, unedited by #638 beyond the SHA. Both STILL OWED. Run together —
+> they exercise the same "Design full cast" bulk flow, so a single session
+> covers both rather than re-warming the cast twice.
+
+1. **(A7.1) Bulk "Design full cast" run — pill, navigation, reload-resume,
+   terminal summary.** From the cast view of the prepared multi-voice
+   project, click "Design full cast." Observe: the DesignPill shows
+   "Designing," **survives navigating away and back**, and **survives a
+   full page reload started mid-run** (the run resumes rather than
+   restarting or silently dying). Let it run to completion and observe the
+   terminal summary reads "Designed N · M failed · K skipped" with counts
+   that add up to the cast size, and every row flips to "Designed."
+   - Result:
+2. **(A7.2) Series propagation, 2nd-tab serialization, VRAM headroom,
+   re-analysis guard.** Confirm the same designed persona/voice propagates
+   to the **sibling book** in the series (no independent re-design there).
+   From the **second browser tab**, start a single-character design while
+   the bulk run from another tab is still in flight (or immediately after)
+   and confirm it **serializes** — no garbled/overlapping audition, no
+   corrupted `.pt`. Watch `nvidia-smi` across the whole bulk run (VoiceDesign
+   1.7B + a resident analyzer is the exact combination that caused the
+   plan-108 OOM) and confirm headroom holds — no OOM, no forced eviction that
+   interrupts the run. Then attempt a re-analysis of the same book mid- or
+   post-design and confirm it is refused with **409**, not silently
+   clobbering the just-designed voices.
+   - Result:
+3. **(A6) Forced `/recycle` mid-bulk-design.** With the sidecar started via
+   `start-prod.bat` (Preconditions), start another "Design full cast" run
+   (or continue one in flight) and force a sidecar `/recycle` partway
+   through. Observe: the DesignPill **rides through the respawn** — it does
+   not stall, hang, or silently drop the remaining characters — and the run
+   completes with a correct terminal summary once the sidecar comes back.
+   - Result:
+
+### A14 · Qwen VoiceDesign persona-prompt rewrite (plan 160) — steps 4–6
+
+> **Criteria source:** `docs/features/160-voicedesign-persona-format.md`
+> `:88-98` (manual acceptance walkthrough), `:9` (Status line), `:132-136`
+> (Ship notes, still the unfilled placeholder). Re-resolved 2026-08-20 by
+> direct read of the plan file: frontmatter `status: active`, body `> Status:
+> active — code shipped, GPU audition validation owed to the user` (`:9`),
+> Ship notes still literally "(Filled in when status flips to `stable`...)" —
+> unchanged. The 2026-06-16 age-audibility follow-up (`ca4b4a93`) is a real,
+> separately-landed fix informed by an informal listen, but it addresses a
+> narrower defect (age not translated to acoustics) and does not substitute
+> for the three-step walkthrough below — the plan's own text still lists it
+> as owed. STILL OWED.
+
+4. **(A14.1) Regenerate a persona.** On a Qwen character, hit "Regenerate
+   voice style" (Profile drawer, or
+   `POST /api/books/:bookId/cast/:characterId/voice-style/generate`).
+   Observe the persona text: a full sentence, ~15–40 words, containing a
+   pitch word and ending in a purpose clause (not a bare adjective list).
+   - Result:
+5. **(A14.2) Design → audition → A/B against the old format.** Design the
+   voice from that regenerated persona and audition it. **Listening target:**
+   compare it directly against a character still on an old-format (pre-plan-
+   160) persona in the same session — you are listening for the new
+   pitch/purpose-clause wording to produce an audibly different, more
+   deliberate-sounding voice than the old flat-attribute phrasing, not merely
+   "a voice." Confirm the cached `instruct` field at
+   `voices/qwen/<voiceId>.json` matches the new persona text.
+   - Result:
+6. **(A14.3) Un-regenerated character unaffected.** Play a character whose
+   persona was **not** regenerated this session. **Listening target:**
+   confirm it plays its pre-existing designed voice unchanged — no silent
+   drift in an existing book's cast just from this rewrite being live.
+   - Result:
+
+### A15 · A/B "current vs proposed" voice audition (plan 161) — steps 7–9
+
+> **Criteria source:** `docs/features/161-voice-design-compare.md` `:100-109`
+> (manual acceptance walkthrough), `:9` (Status line), `:117-121` (Ship
+> notes, unfilled placeholder). Re-resolved 2026-08-20 by direct read: same
+> pattern as A14 — frontmatter `status: active`, body `> Status: active —
+> code shipped, GPU audition validation owed` (`:9`), Ship notes still the
+> literal placeholder. `git log` on the plan file shows one commit only
+> (`6fb41b7a`), nothing since. STILL OWED. Register row A15 states this
+> explicitly: **"A non-destructive re-design — Cancel must leave the live
+> `.pt` untouched — plus an audible delta on approve."** Directly downstream
+> of A14; run in the same session.
+
+7. **(A15.1) Open the A/B modal, play both sides.** Profile drawer → "Design
+   & compare." Confirm Side A plays the **current** voice, Side B the
+   **proposed**. Edit the persona on Side B → Re-design → audition again.
+   **Listening target:** an audible delta between Side A and the freshly
+   re-designed Side B — not identical audio with a different waveform file.
+   - Result:
+8. **(A15.2) Cancel is genuinely non-destructive — test it, don't assume it.**
+   Before cancelling, note the live `qwen-<id>.pt`'s mtime/checksum and play
+   it once as a baseline. Re-design Side B again, then **Cancel** instead of
+   approving. Observe and record, explicitly:
+   - the live `qwen-<id>.pt` mtime/checksum is **unchanged** from the
+     pre-cancel baseline (only `qwen-<id>-preview.*` was written, then
+     discarded — confirm it is gone or was never promoted);
+   - the character's voice **plays and sounds identical** to the pre-cancel
+     baseline recording — this is the audible half of "non-destructive," not
+     just a file-timestamp check.
+   - Result:
+9. **(A15.3) Approve, save, render — the new voice is actually used.** Redo
+   the re-design, this time click "Use proposed voice" → Save → generate a
+   chapter using that character. **Listening target:** the rendered chapter
+   audibly uses the **proposed** (Side B) voice, not the original — confirm
+   against the Side B audition played in step 7.
+   - Result:
+
+### A17 · Emotion-chip preview from the manuscript (plan 180, fe-31) — step 10
+
+> **Criteria source:** `docs/features/180-fe31-emotion-chip-preview.md`
+> `:41-48` (manual walkthrough + live-GPU acceptance line), `:9` (Status
+> line), `:55-57` (Ship notes, unfilled placeholder). Re-resolved 2026-08-20
+> by direct read: frontmatter `status: active`, body `> Status: active`
+> (`:9`), Ship notes still the bare placeholder "(Filled in when status flips
+> to `stable`.)" Body text `:48` states verbatim: "**Live GPU acceptance
+> owed:** the audible difference between a designed variant and the base
+> voice can only be confirmed on a real sidecar." STILL OWED.
+
+10. **(A17) Designed variant vs. base voice, by ear.** In the manuscript view,
+    flip the speaking character to Qwen with its designed `angry` variant
+    present, tag a dialogue line `angry`, and press the ▶ preview next to
+    the chip. **Listening target:** the designed `angry` variant's
+    intonation/delivery should be audibly angrier than the character's base
+    voice — not a neutral read with a different filename. Then remove the
+    `angry` variant and press ▶ again: **Listening target:** it now falls
+    back to the base voice (calm/neutral relative to the first play), and
+    the UI shows the "no angry variant for `<name>` — renders neutral" note.
+    Switch the character to Kokoro and confirm ▶ is disabled with the
+    "Emotion only audible on Qwen" tooltip (mock-mode-covered, but confirm
+    it holds against the real cast state too).
+    - Result:
+
+### A4 · Audition engine + tier fidelity (#1849) — steps 11–14
+
+> **Criteria source:** [`onbox-acceptance-register.md`](onbox-acceptance-register.md)
+> `:690-703`. Re-resolved 2026-08-20: `gh pr view 1849` →
+> `{"mergedAt":"2026-07-26T21:39:59Z","state":"MERGED","title":"fix(frontend,server):
+> audition in the character's engine at the book's tier"}` — matches. No run
+> sheet or issue references an on-box listening pass since. All four checks
+> are audio-output/perceptual by construction — "never listened to" is
+> accurate. STILL OWED.
+
+11. **(A4.1) Engine-override preview.** In a Coqui-default book, override one
+    character to Kokoro and press Preview on that character. **Listening
+    target:** the stock Kokoro timbre (Kokoro's own catalogue voice) plays —
+    audibly distinct from the book's default Coqui voice — confirming the
+    preview honours the character-level engine override rather than the
+    book's engine.
+    - Result:
+12. **(A4.2) Tier fidelity at 1.7B.** In a book set to the 1.7B tier, press
+    Preview on a Qwen character. Confirm via the sidecar/server log or
+    response metadata (`modelKey`/tier field) that the **1.7B** model served
+    the request, not 0.6B — the two tiers are not reliably distinguishable
+    by ear alone, so this check is instrument-confirmed, not by-ear.
+    - Result:
+13. **(A4.3) Instant-replay cache.** Design a voice in My voices, then press
+    Play. **Observe:** the first play is **instant** — no visible/audible
+    synthesis wait — and the network/server log shows only **one** synth
+    call, not two (the design pass and the play pass now hash to the same
+    cached filename, where before they diverged). Record the elapsed time to
+    first audio.
+    - Result:
+14. **(A4.4) Capacity-refusal message names Coqui.** With Coqui resident,
+    force a genuine capacity failure (oversubscribe VRAM per Preconditions).
+    **Observe:** the error names **Coqui** specifically and points at where
+    its Stop button is — not a generic "free VRAM" message.
+    - Result:
+
+### A30 · Golden-audio bless guards + `_make_kokoro` against a real engine (PR #2032) — steps 15–18
+
+> **Criteria source:** [`onbox-acceptance-register.md`](onbox-acceptance-register.md)
+> `:1412-1518` (full procedure already spelled out there — cited, not
+> restated in full, except where a step needs the exact command). Re-resolved
+> 2026-08-20: `gh pr view 2032` →
+> `{"mergedAt":"2026-07-31T23:19:54Z","state":"MERGED"}`; `gh issue view
+> 1995/2003/1987` → all closed 2026-07-31T23:19:56Z; the amendment chain
+> `gh issue view 2069`/`2062` → both closed 2026-08-05T03:37:30Z — all match
+> the row's own text. No later issue/PR/run-sheet references `--bless`,
+> `IDENTITY_COSINE_EPSILON`, or `_make_kokoro` since. STILL OWED. Run this
+> **last**, on a **quiet** card — evict every engine from the rows above
+> first (see Teardown-before-A30 note below), because this row's own
+> contention warning must print nothing for the run to mean anything.
+
+> **Evict everything from A4–A17 before starting this row.** Stop Qwen,
+> Coqui, and any resident analyzer; confirm `nvidia-smi` ≈ idle. A30 does not
+> need CUDA (`ASR_DEVICE=cpu`/CPU Kokoro also exercises it) but does need the
+> card **uncontended** for a stable, reproducible measurement.
+
+15. **(A30.1) Clean bless run, byte-identical + noise-echo.** Run
+    `npm run test:golden-audio -- --bless --sidecar-only` on the now-quiet
+    box (confirm `nvidia-smi` first — the `--bless` contention warning
+    should print **nothing**). Confirm it completes and writes
+    `kokoro-baseline.json` / `instruct-baseline.json` **without** any of
+    `GOLDEN_REBLESS_CONTENT=1` / `GOLDEN_REBLESS_THRESHOLDS=1` /
+    `GOLDEN_REBLESS_MEASUREMENTS=1` set. **Observe two things, not one:**
+    (a) `git diff` on both baseline files shows `transcript`/`text_edits`,
+    the `tolerances` block, and the `identity`/`loudness_dbfs` figures all
+    staying **byte-identical**; (b) the console **echoes** a
+    `[golden-bless] identity moved within epsilon ... (noise -- reference
+    unchanged) -- ...` / `[golden-bless] loudness_dbfs moved ...` line
+    whenever this run's raw measurement differs at all from the committed
+    figure. A byte-identical diff with **no echo** is not proof the guard
+    fired — real hardware noise makes a nonzero diff near-certain, so the
+    echo is the falsifiable signal, not the byte-identical file alone.
+    Record the actual **per-leaf identity-cosine deltas** observed (the
+    open #2066 question this run is meant to retire) — not just pass/fail.
+    - Result:
+16. **(A30.2) Force a real refusal — corrupted field.** Hand-edit a committed
+    baseline to null out its `transcript` (or delete its `tolerances` key),
+    re-run the same `--bless` command, and confirm it **refuses** with the
+    expected `GOLDEN_REBLESS_*` message and leaves the file byte-identical
+    to before the attempt. Revert the hand-edit immediately after recording
+    the result.
+    - Result:
+17. **(A30.3) Force a real refusal — WINDOW-sized identity drift.** Hand-edit
+    one committed `instruct-baseline.json` `identity.cosine.<emotion>`
+    figure by clearly more than `IDENTITY_COSINE_EPSILON` (e.g. +0.05),
+    re-run the same `--bless` command, and confirm it refuses with
+    `GOLDEN_REBLESS_MEASUREMENTS` specifically (not `GOLDEN_REBLESS_THRESHOLDS`,
+    which is reserved for `tolerances`), and leaves the file byte-identical.
+    Revert the hand-edit immediately after recording the result.
+    - Result:
+18. **(A30.4) `_make_kokoro` fails, not skips, on a real broken engine.** Run
+    `npm run test:golden-audio -- --sidecar-only --engine=kokoro -m golden`
+    once normally (expect pass). Then deliberately break the engine — rename
+    the `.onnx` weight file mid-run, or force a CUDA OOM by holding VRAM —
+    and confirm the run now **FAILS**, not SKIPs (the #1987 defect this PR
+    closed). Restore the weights/state afterward and confirm a clean run
+    passes again.
+    - Result:
+
+## Excluded on re-resolution
+
+None excluded. All seven rows were re-resolved against live repo/issue/PR
+state and the plan-of-record files themselves on 2026-08-20 and remain owed:
+
+- **A4** — `gh pr view 1849` → merged 2026-07-26T21:39:59Z, title matches.
+  No on-box listening pass recorded since. STILL OWED.
+- **A6** — `gh issue view 690` → closed 2026-06-09T21:29:55Z, title matches;
+  plan 200 Ship notes re-read verbatim, unchanged: "Live-GPU acceptance... is
+  the only remaining check." STILL OWED.
+- **A7** — `gh pr view 637` → merged 2026-06-07T11:37:03Z; `gh pr view 638` →
+  merged 2026-06-07T11:57:28Z (SHA-fill only); plan 195 Ship notes re-read
+  verbatim, still "Live-GPU acceptance owed," unedited by #638 beyond the
+  SHA. STILL OWED.
+- **A14** — plan 160 frontmatter `status: active`, body `:9` re-read
+  verbatim ("code shipped, GPU audition validation owed to the user"), Ship
+  notes still the literal unfilled placeholder. The 2026-06-16
+  age-audibility follow-up is real but narrower than the full walkthrough
+  and does not discharge it (the plan's own text still lists the walkthrough
+  as owed). STILL OWED.
+- **A15** — plan 161 frontmatter `status: active`, body `:9` re-read verbatim
+  ("code shipped, GPU audition validation owed"), Ship notes still the
+  literal unfilled placeholder; `git log` shows one commit only, nothing
+  since. STILL OWED.
+- **A17** — plan 180 frontmatter `status: active`, body `:9` re-read verbatim
+  (`active`), Ship notes still the bare placeholder; body `:48` re-read
+  verbatim ("Live GPU acceptance owed: the audible difference... can only be
+  confirmed on a real sidecar"). STILL OWED.
+- **A30** — `gh pr view 2032` → merged 2026-07-31T23:19:54Z; `gh issue view
+  1995`/`2003`/`1987` → all closed 2026-07-31T23:19:56Z; amendment chain
+  `gh issue view 2069`/`2062` → both closed 2026-08-05T03:37:30Z. No later
+  bless run, per-leaf delta measurement, or forced-Kokoro-failure run
+  recorded anywhere since. STILL OWED.
+
+None of the seven rows is AMBIGUOUS (that is A2/A16/A22's queue, not this
+pack's) — every plan file's frontmatter and body `Status:` line agree with
+each other for A4, A6, A7, A14, A15, A17 and A30, unlike A16's genuine
+frontmatter-vs-body contradiction handled in `onbox-sitting-vram-contention.md`.
+
+## Teardown
+
+- [ ] Evict every warm engine (Qwen Base, Qwen VoiceDesign, Coqui, Kokoro) so
+      the next sitting starts cold.
+- [ ] Restore `server/.env`'s `QWEN_DEVICE` / `COQUI_DEVICE` pins back to
+      `cuda:1` (the owner's box policy) if they were changed for this
+      sitting.
+- [ ] Confirm any hand-edited baseline JSON from A30.2/A30.3 was reverted —
+      `git status`/`git diff` on `server/tts-sidecar/tests/golden/` shows
+      clean before this sitting ends.
+- [ ] Confirm the Kokoro `.onnx` weight file (or whatever was broken for
+      A30.4) is restored and a clean `test:golden-audio` run passes.
+- [ ] Close the second browser tab/session (A7's 2nd-tab check).
+- [ ] Remove/undo whatever forced the sidecar `/recycle` (A6) and whatever
+      held VRAM to force the capacity refusal (A4.4), if either is still
+      active.
+- [ ] Confirm the card returns to baseline (`nvidia-smi` ≈ idle) before
+      ending the sitting.

--- a/docs/testing/onbox-sitting-vram-contention.md
+++ b/docs/testing/onbox-sitting-vram-contention.md
@@ -1,0 +1,338 @@
+# On-box sitting pack — VRAM contention + eviction (A5, A16, A19, A20, A25, A28, A34, A35, A36)
+
+> **Sitting pack** for wave 2 of `#2435`, step 3 of the `#2453` chain. Covers
+> register rows **A5, A16, A19, A20, A25, A28, A34, A35, A36** — the rows that
+> only mean something when the single 8 GB card is genuinely full — and nothing
+> else. Follows the shared format fixed by
+> [`onbox-sitting-plan.md`](onbox-sitting-plan.md) §5; the re-resolution rule of
+> §6 was applied to every row (see
+> [`## Excluded on re-resolution`](#excluded-on-re-resolution)).
+>
+> **A16 is included per the plan of record's own re-derivation** (§3): the
+> issue #2462 brief's row list omits it, but the plan explicitly moves A16 into
+> this pack and is the document that "fixes… the binning you must not
+> re-litigate." Its AMBIGUOUS status (frontmatter `active` vs. body `stable`)
+> is a docs-status decision, not a reason to skip the live-GPU step — the plan
+> says to *run it regardless* and flag the contradiction. See §A16 below.
+>
+> **Box/card target:** the operator's GPU box, **single 8 GB card**, pinned via
+> `CUDA_VISIBLE_DEVICES=0` (internal `cuda:0`, 4070 8 GB). This box is
+> dual-GPU, so **every** step here must stay pinned to the one card —
+> `_worst_device_key` otherwise picks the roomier `cuda:1` and a row passes or
+> fails for entirely the wrong reason.
+>
+> **Running time total (recomputed):** **~155 minutes** — A5 ≈ 20, A19 ≈ 20,
+> A20 ≈ 25, A25 ≈ 20, A28 ≈ 15, A34 ≈ 10, A35 ≈ 15 (subtotal 125), plus **A16
+> ≈ 15** (runs in the same session — its book/cast precondition is already
+> met by A19/A5/A20's fixture) and **A36 ≈ 15** (also rides the same session's
+> ASR pass, folded into no separate block). 125 + 15 + 15 = **155**, matching
+> the plan of record's stated total for this pack exactly
+> ([`onbox-sitting-plan.md`](onbox-sitting-plan.md) §2.1).
+>
+> **A19/A5/A20/A25 share one session by design** — same card, same
+> mixed-cast non-English book, and A19 already stages the Qwen+Coqui
+> co-residency A20's first bullet needs (register `:969`, run sheet §2). Do not
+> give them separate sittings.
+
+## Preconditions
+
+Stated once for the sitting; do not repeat per row.
+
+- [ ] **Single 8 GB card.** `CUDA_VISIBLE_DEVICES=0`; `nvidia-smi` lists the
+      4070 8 GB as `cuda:0`. Record both device index and UUID:
+      `nvidia-smi --query-gpu=index,uuid,memory.total,name --format=csv`.
+- [ ] **Box policy pins temporarily undone.** `server/.env` currently pins
+      renders to the 16 GB card — `COQUI_DEVICE=cuda:1` / `QWEN_DEVICE=cuda:1` /
+      `ASR_DEVICE=cuda:1` (owner's call since 2026-08-01, git-ignored). Every
+      row in this sitting targets the **single 8 GB card**, so set all three to
+      `cuda:0` (or comment them out) before starting, and **restore them in
+      teardown**. Without this the sitting exercises the 16 GB card, not the
+      8 GB card these rows are about (register `:904-908`).
+- [ ] **Server up** on current `main`, built and running against the real
+      (non-mock) sidecar, started via `start-prod.bat` so the `.env` ceilings
+      are actually in effect.
+- [ ] **A mixed-cast non-English book loaded** — the Russian Coalfall chapter,
+      with one designed-Qwen character and one undesigned character that falls
+      back to Coqui (the fixture A19/A20/A5/A25/A16 all name). This also
+      satisfies A16's "open a real Russian book's cast view" precondition and
+      A5's "Russian book with an undesigned character" precondition.
+- [ ] **`SEG_CAPACITY_ADMISSION=1`** (the default) and **Qwen as the generation
+      engine** (also the default) — neither needs an explicit flip.
+- [ ] **Engines available:** Qwen VoiceDesign installed; Coqui XTTS weights
+      installed and loadable from the UI; Whisper ASR with `ASR_DEVICE=cuda`
+      and `SEG_ASR_ENABLED=1` set (A36 only).
+- [ ] **A way to make `/unload` fail** (A19): a `SIDECAR_URL` proxy that 500s
+      `POST /unload` and passes everything else through, or the ability to stop
+      the sidecar's unload path by hand.
+- [ ] **Two shells** open: one for server control / `gh api` / `curl`, one for
+      `nvidia-smi` / `/health` polling.
+- [ ] **A second browser tab/session** (A35's overlapping requests).
+- [ ] **OS-level process-kill access** (A34) — `taskkill` against the pid in
+      `.run/tts.pid`.
+- [ ] **Cold start** — no engine resident unless a step says otherwise. The
+      quiet-box caveat from A19's 2026-08-01 correction applies: a foreign
+      process holding `cuda:0` (e.g. another worktree's real-GPU pytest suite)
+      makes every reading uninterpretable. Confirm the card is free before the
+      first step (`nvidia-smi` ≈ baseline, and `ledger.engines_holding` from
+      `GET /api/sidecar/health` showing only this sidecar's reservations).
+
+## Procedure
+
+Ordered so shared setup happens once and engine swaps happen as few times as
+possible. A19 → A20 (with A36 riding) → A5 → A16 run as one mixed-cast session
+on the same card and book, because A19 stages the Qwen+Coqui co-residency
+A20's first bullet needs, A5 and A16 already share the Russian-book fixture,
+and A16's banner/auto-load check is a near-zero-cost add to a session that
+already has the book open. A28 follows the same session's completed renders
+(its stranded pool is exactly what a finished chapter leaves behind). A25
+re-uses the same warm card for its contended-eviction `/health` measurement.
+A34 and A35 are independent but cheap to run while the sidecar and book are
+up.
+
+### A19 · Mixed Qwen+Coqui evict fails soft (#1893) — steps 1–2
+
+> **Criteria source:** [`onbox-acceptance-register.md`](onbox-acceptance-register.md) `:847-932`
+> (the correction block at `:879-908` is the authoritative current state);
+> [`onbox-acceptance-staleness-audit.md`](onbox-acceptance-staleness-audit.md) `:777-812`.
+> Re-resolved: #1893 closed 2026-07-27T23:44:24Z; #1898 merged
+> 2026-07-27T23:44:23Z. The forced-evict scenario itself has never been run.
+> The unforced case completed 71/71 at 3.7 GB combined (row's own 2026-08-01
+> quiet-box correction), so this row's real question — whether a **failed**
+> evict makes co-residency worse — is still open.
+
+1. **(A19.1) Forced-evict mixed render.** Point `SIDECAR_URL` at the proxy that
+   500s `POST /unload` (or stop the sidecar's unload path by hand), then render
+   the mixed-cast chapter (Qwen + Coqui, Russian Coalfall). Observe: the
+   chapter **completes**, and the server log carries verbatim
+   `fs-60 Qwen→Coqui evict failed; continuing into the Coqui phase`.
+   - Result:
+2. **(A19.2) Classify the outcome + pause-during-stalled-evict.** Record which
+   of the three outcomes the co-residency produced — **clean completion**, a
+   **self-describing sidecar OOM** that fails the chapter with its own message,
+   or a **crash/recycle storm** (the third means the fail-soft policy needs
+   retry-then-abort instead of warn-and-continue — file it back on #1893).
+   Then start the render again with the evict stalled and press **Pause**:
+   observe the abort is forwarded to the fetch and the run stops **promptly**,
+   not after the 10-minute ceiling (register `:922-923`).
+   - Result:
+
+### A20 · Idle Coqui is reclaimed under VRAM pressure (#1894) — steps 3–5
+
+> **Criteria source:** [`onbox-acceptance-register.md`](onbox-acceptance-register.md) `:934-976`;
+> the spec at `docs/superpowers/specs/2026-07-28-coqui-residency-eviction-design.md` §6;
+> TTL rationale in the comment on `_COQUI_IDLE_TTL_DEFAULT` in `tts-sidecar/main.py`.
+> Re-resolved: #1894 closed 2026-07-28T05:48:34Z; #1921 closed
+> 2026-07-28T11:27:04Z; `_COQUI_IDLE_TTL_DEFAULT = 30.0` still the shipped
+> default. None of the four on-box bullets has been exercised — this row
+> carries no observation block at all.
+
+3. **(A20.1) Idle reclaim admits a blocked Qwen op.** Load Coqui from the UI so
+   it is resident, then start a Qwen-only render that would not otherwise fit
+   on the 8 GB card. Observe: the render **proceeds** and the sidecar log
+   carries `Coqui model unloaded.`; record whether the reclaimed ~3 GB actually
+   admitted the op, or was immediately taken by something else.
+   - Result:
+4. **(A20.2) Chapter-boundary TTL observation.** Render the mixed Qwen+Coqui
+   book and watch the chapter boundaries. Observe which it is: an
+   **evict→reload cycle repeating across chapters** means `COQUI_IDLE_TTL` is
+   too short (each reload ~90 s); a render that still fails `NoCapacityError`
+   with an idle Coqui resident means it is too long. Record the observed
+   interval between the evict and the next Coqui use, so the default can be
+   moved off 30 s with evidence rather than a guess.
+   - Result:
+5. **(A20.3) Stop-button crash fix + control timing.** Press **Stop** on Coqui
+   while a chapter is rendering through it. Observe: the chapter continues to
+   **completion** (before #1894 this could kill it with
+   `AttributeError: 'NoneType' object has no attribute 'tts'`). Record what the
+   Stop control itself reports — it must show a disabled **"Stopping…"** state
+   for the whole wait and complete without an error banner — and how long the
+   eventual unload actually took.
+   - Result:
+
+### A5 · fs-60 XTTS per-language engine eligibility (plan 249) — step 6
+
+> **Criteria source:** [`../features/249-fs60-xtts-language-eligibility.md`](../features/249-fs60-xtts-language-eligibility.md)
+> `:53-66` (five-step walkthrough). Re-resolved: plan frontmatter `status: active`;
+> body `:9` "Live-GPU acceptance owed (mock-mode e2e only)… stays `active`,
+> not `stable`, until that walkthrough runs" — re-read verbatim, still true.
+> STILL OWED.
+
+6. **(A5) Coqui-fallback banner, engine picker, real render, hard-block check.**
+   On the same Russian Coalfall book, open the undesigned character's row and
+   observe the Coqui-fallback banner (not a hard block); confirm the engine
+   picker offers Coqui; confirm the voice-readiness gate offers "Proceed
+   anyway"; render that character's line and confirm the player shows a
+   "Fallback (Coqui)" pill. Then switch to a still-unsupported language
+   (Chinese, no fixture change needed beyond the book's language field) and
+   confirm the **old hard block** still applies there — this is the
+   "supported-but-undesigned falls back, unsupported still blocks" contrast
+   the row exists to prove.
+   - Result:
+
+### A16 · fe-16 Qwen auto-load on a Russian book (plan 165) — step 7
+
+> **Criteria source:** [`../features/165-fe-15-16-language-and-revision-e2e.md`](../features/165-fe-15-16-language-and-revision-e2e.md)
+> `:9` (Status line) + ship notes ("live GPU acceptance is the only owed
+> item"). Re-resolved 2026-08-19: frontmatter `status: active` (`:2`), body
+> `> Status:` line (`:9`) reads `stable (shipped together; manual acceptance
+> owed only for the live Qwen auto-load)` — the contradiction the register
+> flags is real and unchanged.
+>
+> **Not in this pack's assigned issue list (#2462), but binned here by the
+> plan of record** (`onbox-sitting-plan.md` §3), which is the authoritative
+> document for this chain's row assignment. **Blocked on a decision: plan 165's
+> own status is `active` in frontmatter vs. `stable` in its body — that
+> contradiction is a docs-reconciliation call for the operator, not resolved
+> here. Run the live-GPU step regardless**, per the plan's explicit
+> instruction; only the frontmatter/body reconciliation is deferred.
+
+7. **(A16) Qwen auto-load banner + analyzer eviction.** On the same Russian
+   Coalfall book's cast view, confirm the Qwen banner shows and Qwen loads in
+   the background. Observe the analyzer (Ollama) log/process for eviction —
+   confirm it is evicted to make room, not left co-resident causing contention.
+   - Result:
+   - **Separately, flag for the operator:** plan 165 frontmatter says `active`,
+     body says `stable` — needs reconciliation, not resolved by this pack.
+
+### A25 · `/health` stays live through a contended eviction (#1919) — step 8
+
+> **Criteria source:** run sheet
+> [`sidecar-evict-latency-onbox-acceptance.md`](sidecar-evict-latency-onbox-acceptance.md)
+> §§2–3 — cited, not restated, per the plan-of-record rule against copying a
+> criteria list that then drifts from the original. Re-resolved: #1919 closed
+> 2026-07-31T00:32:59Z. STILL OWED — the run sheet itself has empty `Result:`
+> lines.
+
+8. **(A25) Run the sidecar-evict-latency run sheet's procedure §3, steps 1–6**
+   (its "optional second pass," step 7, is skippable — not required to clear
+   this row). Its own preconditions are already satisfied by this session's
+   Preconditions above (same card, same Qwen-design-then-render sequence). Fill
+   in that run sheet's own §5 `Result` block directly — do not duplicate its
+   fields here.
+   - Result: _(filled in `sidecar-evict-latency-onbox-acceptance.md` §5, not here)_
+
+### A28 · Stranded VRAM pool reclaimed on the admission-failure path (#1976, PR #1993) — step 9
+
+> **Criteria source:** [`onbox-acceptance-register.md`](onbox-acceptance-register.md) `:1321-1355`
+> (PR #1993's description + the C1/M3 review findings it quotes). Re-resolved:
+> #1976 still **OPEN** (`Refs #1976`, not closed by this PR — the
+> render/unload-completion reclaim is a separate, not-yet-built lever); PR
+> #1993 merged 2026-07-31T09:22:51Z. STILL OWED.
+
+9. **(A28) Stranded-pool reclaim + the two C1 guards.** Using the chapter
+   render just completed in A19/A20/A5 (or A16), let the engine report
+   unloaded and confirm via `nvidia-smi` and `GET /api/sidecar/health`'s
+   `vramReservedMbByDevice` that a reserved-but-unallocated pool is left
+   behind (~3.9 GB on this 8 GB card is #1976's own measured shape). With that
+   pool present and nothing resident, issue an ASR `/transcribe` or a voice
+   design that would otherwise be refused; confirm it is **admitted** and
+   `nvidia-smi` drops to near-baseline afterward. Then confirm the two C1
+   guards: (a) start a genuine render and, from a second client, issue a
+   refused op on the same card — the reclaim log line `stranded-cache reclaim`
+   must **not** appear while the render is in flight; (b) issue two refused
+   ops on the same card within 30 s of each other and confirm the reclaim log
+   line appears **only once**.
+   - Result:
+
+### A34 · Supervisor respawn survives a refused spawn attempt (#2037) — step 10
+
+> **Criteria source:** [`onbox-acceptance-register.md`](onbox-acceptance-register.md) `:2014-2055`;
+> code contract `scheduleRespawnAttempt` (`server/src/tts/sidecar-supervisor.ts`)
+> and `onSpawnRefused` (`server/src/tts/spawn-sidecar.ts`). Re-resolved: #2037
+> closed 2026-08-05T00:37:01Z. STILL OWED — real OS socket-teardown timing is
+> untestable in CI.
+
+10. **(A34) Kill the sidecar mid-render, watch respawn.** With a chapter
+    actively rendering, kill the sidecar's OS process directly —
+    `taskkill /PID <pid> /T /F` against the pid in `.run/tts.pid` (**do not**
+    use `POST /api/sidecar/restart`, which actively restarts rather than
+    passively observing the recovery this row is about). Grep the running
+    server's log for a fresh `[sidecar] spawned pid=` line appearing on its
+    own within the backoff window (`[2s, 5s, 15s]`, capped at 5 attempts ≈
+    52 s total); confirm the new pid differs from the killed one. While
+    recovery is in flight, poll `GET /api/setup/models-status` and confirm it
+    never reports the TTS engine ready while nothing is listening on `:9000`.
+    Confirm the in-flight chapter either rides out the respawn or fails
+    cleanly and is resumable.
+    - Result:
+
+### A35 · Design-wins VRAM contention timeout vs. a real 0.6B cold load (#2070) — step 11
+
+> **Criteria source:** [`onbox-acceptance-register.md`](onbox-acceptance-register.md) `:2057-2086`;
+> `unload_design`'s docstring and the `_DESIGN_CONTENTION_WAIT_S_DEFAULT`
+> comment in `server/tts-sidecar/main.py`. Re-resolved: #2070 closed
+> 2026-08-05T05:54:35Z. STILL OWED — the 150 s bound is sized off the design
+> path's documented budget, not an on-box measurement.
+
+11. **(A35) Overlapping design + render, then a forced timeout.** Start a
+    voice design (cast review → Design a new voice) on one browser
+    tab/session, and — timed to land mid-design, before the design's forward
+    completes — trigger an ordinary chapter render on a *different* voice from
+    the second tab/session. Confirm the render's synth call **waits** for the
+    design to finish (no error, delayed start only) rather than the design
+    failing with "VoiceDesign model was unloaded before this design could
+    render." Confirm the design itself completes and its audition plays. If
+    practical, force a genuinely wedged design and confirm the waiting synth
+    times out into the `design_in_flight` 503 somewhere in the 150 s
+    neighbourhood, not immediately and not never.
+    - Result:
+
+### A36 · ASR warm-reservation figure vs. a real resident `/transcribe` peak (#2094) — step 12
+
+> **Criteria source:** [`onbox-acceptance-register.md`](onbox-acceptance-register.md) `:2088-2127`;
+> the `asr.warm` seed comment in `SEED_FOOTPRINTS_MB` and `_device_free_mb`'s
+> docstring (`server/tts-sidecar/main.py`). Re-resolved: #2094 closed
+> 2026-08-05T05:54:36Z. STILL OWED. **Rides along with A20** — this step reuses
+> the same rendered chapter and warm sidecar; no separate sitting block.
+
+12. **(A36) Resident ASR under repeated `/transcribe`.** With
+    `ASR_DEVICE=cuda` and `SEG_ASR_ENABLED=1` set (per Preconditions), and
+    using the chapter already rendered in A19/A20, trigger several
+    `/transcribe` calls back-to-back (a re-record round is the natural
+    trigger). Confirm none 503 `noCapacity` on a card that has genuine room.
+    Watch `FootprintTable`'s learned `asr.warm` p95 after ≥5 real observations
+    (`_FOOTPRINT_MIN_SAMPLES`) and record what it converges to — double digits
+    to low hundreds of MB is a sane, uncontaminated read; hundreds of MB to
+    GB points at a foreign process on the card.
+    - Result:
+
+## Excluded on re-resolution
+
+None excluded. All nine rows were re-resolved against live repo/issue/PR
+state on 2026-08-19 and remain owed:
+
+- **A5** — plan 249 frontmatter `status: active`; body `:9` re-read, still
+  "Live-GPU acceptance owed." STILL OWED.
+- **A16** — plan 165 frontmatter `status: active` (`:2`), body `> Status:`
+  (`:9`) reads `stable`. Contradiction confirmed live, unchanged from the
+  register's note. STILL OWED, and the frontmatter/body contradiction is
+  flagged for the operator rather than resolved here (see §A16).
+- **A19** — `gh issue view 1893` → closed 2026-07-27T23:44:24Z; `gh pr view
+  1898` → merged 2026-07-27T23:44:23Z. Forced-evict scenario confirmed never
+  run. STILL OWED.
+- **A20** — `gh issue view 1894` → closed 2026-07-28T05:48:34Z; `gh issue view
+  1921` → closed 2026-07-28T11:27:04Z. `_COQUI_IDLE_TTL_DEFAULT = 30.0`
+  confirmed still the shipped default in `tts-sidecar/main.py`. STILL OWED.
+- **A25** — `gh issue view 1919` → closed 2026-07-31T00:32:59Z. Run sheet
+  `sidecar-evict-latency-onbox-acceptance.md` §5 confirmed all `Result:`
+  fields still blank. STILL OWED.
+- **A28** — `gh issue view 1976` → **still OPEN** (this PR only `Refs`, not
+  `Closes`, it); `gh pr view 1993` → merged 2026-07-31T09:22:51Z. STILL OWED.
+- **A34** — `gh issue view 2037` → closed 2026-08-05T00:37:01Z. STILL OWED.
+- **A35** — `gh issue view 2070` → closed 2026-08-05T05:54:35Z. STILL OWED.
+- **A36** — `gh issue view 2094` → closed 2026-08-05T05:54:36Z. STILL OWED.
+
+## Teardown
+
+- [ ] Evict the warm engines (Qwen Base, Qwen VoiceDesign, Coqui, ASR) so the
+      next sitting starts cold.
+- [ ] Restore `server/.env`'s `COQUI_DEVICE` / `QWEN_DEVICE` / `ASR_DEVICE`
+      pins back to `cuda:1` (the owner's box policy) if they were changed for
+      this sitting.
+- [ ] Remove the `/unload`-failing proxy or restore the sidecar's real unload
+      path (A19).
+- [ ] Clear `SEG_ASR_ENABLED` / `ASR_DEVICE=cuda` if they were set only for
+      this sitting and are not the box's standing default.
+- [ ] Close the second browser tab/session (A35) and the extra shells.
+- [ ] Confirm the card returns to baseline (`nvidia-smi` ≈ idle) before
+      ending the sitting.


### PR DESCRIPTION
## Summary

Delivers the plan of record and nine sitting packs for wave 2 of #2435, turning all 74 owed rows in `docs/testing/onbox-acceptance-register.md` into runnable, self-contained procedures. Closes #2453.

- **49 rows / 8 operator sitting packs**, one **4-row blocked-on-acquisition pack** (F1, H1, H2, D3 — waiting on a real Android device and full-length CJK manuscripts), and **21 rows** left to the wave-3 agent-runnable pass (not scheduled here).
- **Total estimated operator time (the 7 single-sitting packs): 1,060 minutes (~17.7 hours)**, plus **A1 (fs-38 Wave 3), multi-hour across 4 sittings (~150+170+170+190 ≈ 680 min / ~11.3 hrs)**, run separately since it is "multi-hour, several sittings," not a single number.
- **Excluded from the headline total:** A1 (fs-38 Wave 3, its own unchanged multi-hour estimate) and F1 (Android companion app — v1 live-device acceptance; not estimated in its plan, an entire untested axis).

## Verify pass (this PR, #2454)

I verdicted this chain's output against parent #2453's nine acceptance checks — all **PASS**:

1. **Coverage/disjointness** — enumerated all 74 row IDs the plan bins (49 operator + 21 wave-3 + 4 blocked) against the register's own `### [A-H][0-9]` headings (A1–A47, B1–B4, C1–C4, D1–D3, E1–E11, F1, G1–G2). Every row appears exactly once; no gaps, no duplicates.
2. **Plan↔pack cross-reference** — all 9 pack files referenced in `onbox-sitting-plan.md` exist on disk, and no pack file is missing from the plan. `git diff --stat main...HEAD` confirms only these 10 files changed.
3. **180-minute cap** — all 7 single-sitting packs state totals that match the plan's §2.1 estimate and stay ≤180 min (110/155/155/155/170/165/150). fs38-wave3 (A1) is the plan's own documented exception ("multi-hour, several sittings, not a single number"); one of its 4 internal sittings runs ≈190 min, which I'm flagging to you as an observation, not a chain-blocking defect — the plan explicitly exempts A1 from the single-total constraint and gives it a dedicated block.
4. **2-card work confinement** — A2, A3, A8, A18 (the only rows needing the eGPU/2-card boot per the register) are all and only in `onbox-sitting-two-card-boot.md`; no other pack references 2-card/eGPU work.
5. **No pre-filled `Result:` lines** — every `Result:` line across all 9 packs is blank (either bare or a `_(fill in...)_` placeholder).
6. **Citation discipline** — spot-checked A1, A25, A31, A32, A44, E9: all cite their run sheet's section/test-ID rather than restating criteria.
7. **AMBIGUOUS rows marked, not resolved** — A2, A16, A22 are each explicitly flagged AMBIGUOUS in their packs (two-card-boot, vram-contention, qa-gate respectively) with the decision left to the operator.
8. **File scope** — only `docs/testing/onbox-sitting-*.md` (plan + 9 packs) changed; register, live-view, audit and existing run sheets untouched.
9. **`npm run check:onbox-register`** — passed: `check:onbox-register: OK — docs/testing/onbox-acceptance-register.md and docs/testing/onbox-acceptance-register-live-view.html agree.`

### Re-check of the re-resolutions (the adversarial half)

Every pack carries its own re-resolution note (dated 2026-08-20, one dated 2026-08-19) with live `gh issue view`/`gh pr view`/`grep` re-runs rather than trusting the staleness audit. **Zero rows were excluded on re-resolution across all 9 packs** — I confirmed this is a genuine zero, not an omission: each pack has an explicit `## Excluded on re-resolution` (or equivalent re-resolution note) stating "None excluded" / "Nothing excluded" with the evidence. A pack that excludes nothing is normal per the plan and is not itself a finding. I independently re-ran the A2 `grep -n "S6" docs/features/264-vram-aware-gpu-placement.md` citation (the pack that fixed the wave-1 false-negative) and confirmed the match at line 16, matching the pack's own claim.

References #2435 (campaign).

This is a **docs-only PR**, exempt from the `pr-review-gate` pass.

## Test plan

- [x] `npm run check:onbox-register` — green (see check 9 above)
- [x] `git diff --stat main...HEAD` — only `docs/testing/onbox-sitting-*.md` changed (10 files, 2,995 insertions)
- [x] All 74 register rows re-enumerated and cross-checked for disjoint coverage against the plan's binning
- [x] All 9 packs' `Result:` lines spot-checked empty
- [x] AMBIGUOUS rows (A2, A16, A22) confirmed marked-not-resolved in their packs
- [x] Re-resolution evidence spot-checked in each pack; one citation (A2's S6 grep) independently re-run
