### PR TITLE
docs(docs): B3/B4 acceptance re-run after #2536 fix

### DIFF
--- a/docs/testing/cast-id-drift-onbox-acceptance.md
+++ b/docs/testing/cast-id-drift-onbox-acceptance.md
@@ -236,6 +236,27 @@ Result (roster otherwise intact — still 13 characters, no duplicate row, no ch
 - [x] §§7.4-7.6 run — 2026-08-20, real local-Ollama re-analysis against the live workspace book, evidence above.
 - [x] Defects filed: **not filed as a GitHub issue by this step** (docs-only wave-3 step, per the campaign rule this is reported for a fix agent to pick up cold rather than fixed or filed here) — full detail recorded in `docs/testing/onbox-wave3-results/step-5-group-b.md` and above. Mechanism: `server/src/store/merge-analysis-cast.ts:205-206,282-284` (exact-name-match fallback has no tolerance for a name gaining/losing a trailing surname token between analyzer runs).
 
+> **Re-run, 2026-08-21 (Castwright#2570, wave-4 step 7) — after #2536's fix
+> (PR #2562) merged.** A second full re-analysis of the same fixture, against
+> code including the fix, confirmed both effects at once: no NEW
+> near-duplicate pair formed, and the ONE existing duplicate pair left by the
+> 2026-08-20 run above (`brann-weir`/`brann-wire`, `berrin-weir`/`berrin-wire`)
+> was itself retroactively collapsed to a single surviving id apiece via
+> `retireCharacterId` — live evidence the fix works, not just that it didn't
+> regress further. `mairin`/`coalfall-dragon` remain unchanged. **B3's
+> criteria are now met; the row discharges.**
+>
+> A second, distinct defect surfaced in the same run, unrelated to #2536: the
+> established ASCII id `oduvan` was retired IN FAVOUR OF a freshly-minted
+> Cyrillic id `одуван` (`cast-id-history.json`: `"oduvan": "одуван"`) —
+> backwards from the direction the other three retirements in the same run
+> took (fresh id retired in favour of the established one). This is a B4
+> failure (ids must stay ASCII kebab-case) but not a B3 failure (no
+> duplicate — the character has exactly one id, just the wrong one). Filed as
+> [#2584](https://github.com/dudarenok-maker/Castwright/issues/2584) for a fix
+> agent. **B4 stays STILL OWED.** Full evidence:
+> `docs/testing/onbox-wave4-results/step-7-b3-b4-rerun.md`.
+
 Record what was observed, by whom, and when — here and in register row B3. An id that happens to match this run's non-deterministic analyzer output is a weaker result than a genuine mismatch that gets correctly recorded — if the ids come back unchanged, note whether the analyzer's raw output (before the remap) could be inspected to confirm the remap actually did something, rather than the model simply reproducing `mairin`/`coalfall-dragon` on its own. **Do not run the Wave-3 repair pass against this book as part of this acceptance run** — this section is scoped to the early remap alone; Wave 3 has its own section (§8) below.
 
 ---

--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -2737,6 +2737,18 @@ Wave 1 (A32 above, in Group A) resolves drift that already exists, at render tim
 > [#2536](https://github.com/dudarenok-maker/Castwright/issues/2536)
 > (see #2536).
 
+> **Wave-4 step 7, 2026-08-21 — DISCHARGED, after #2536's fix (PR #2562)
+> merged.** Re-ran the same fixture against code including the fix
+> (Castwright#2570). `mairin`/`coalfall-dragon` still unchanged. **No new
+> near-duplicate formed, and the existing `brann-weir`/`brann-wire` +
+> `berrin-weir`/`berrin-wire` duplicate pair left by the 2026-08-20 run was
+> itself collapsed to one id apiece via `retireCharacterId`** — the fix
+> repaired the live defect, not just prevented a fresh one. Roster 16→14 (−2
+> from the consolidation, ±0 for a legitimate re-detection rename). Full
+> evidence: `docs/testing/onbox-wave4-results/step-7-b3-b4-rerun.md`; SHA
+> `88fe477a` (primary checkout HEAD at re-analysis time, confirmed ancestor of
+> the fix merge). **Row discharges — do not re-run.**
+
 ### B4 · Stage-1 returns cast names in the manuscript's own script ([#2313](https://github.com/dudarenok-maker/Castwright/issues/2313), PR #2317)
 
 `buildStage1ChapterInbox` never bound `name`/`aliases` to the book's script. `languagePreamble` already bound `tone`/`role`/`description`/`attributes` for a non-English book and still does — names were the one identifying field left free, and they drifted: *Ночной дозор*'s cast lists handed to stage-2 went from **0 of 75 Latin-named** (2026-08-06) to **42 of 71, 59%** (2026-08-13) across two runs of the same book with the same model weights and the same prompt; chapter 2 came back 15/15 Latin. A controlled 5× replay of the recorded stage-1 prompt reproduced 100% Latin 5/5 against the recorded response's 0/3.
@@ -2765,6 +2777,21 @@ If the run instead happens on a book whose language was never declared (imported
 > `docs/testing/onbox-wave3-results/step-5-group-b.md`. Same defect as B3,
 > filed as [#2536](https://github.com/dudarenok-maker/Castwright/issues/2536)
 > (see #2536).
+
+> **Wave-4 step 7, 2026-08-21 — STILL OWED, new defect (not #2536), after
+> #2536's fix merged.** Re-ran the same fixture (Castwright#2570) against code
+> including PR #2562. Cyrillic-names and no-second-id criteria **passed**
+> (B3's near-duplicate pair was itself cleaned up this run — see B3 above).
+> **"Every id is ASCII kebab-case" FAILED again, for a different reason**: the
+> established id `oduvan` was retired IN FAVOUR OF a freshly-minted Cyrillic
+> id `одуван` (`cast-id-history.json`: `"oduvan": "одуван"` — backwards from
+> the direction three other retirements took in the same run). Not a
+> surname-drift case, not a `safeId`/transliteration bug (Cyrillic ids are
+> correct-by-design for genuinely new characters, plan 219) — the defect is
+> the retirement direction choice for an already-matched character. Filed as
+> [#2584](https://github.com/dudarenok-maker/Castwright/issues/2584). Full
+> evidence: `docs/testing/onbox-wave4-results/step-7-b3-b4-rerun.md`. **Row
+> stays owed.**
 
 ---
 

--- a/docs/testing/onbox-wave4-results/step-7-b3-b4-rerun.md
+++ b/docs/testing/onbox-wave4-results/step-7-b3-b4-rerun.md
@@ -1,0 +1,122 @@
+# Wave 4 step 7 — B3/B4 acceptance re-run after #2536's fix (PR #2562, merged)
+
+Issue: [Castwright#2570](https://github.com/dudarenok-maker/Castwright/issues/2570) · Filed by wave 4 step 5 (#2554), gated on #2536's surname-tolerant name comparator, part of the on-box register campaign (#2435).
+
+## Provenance note — this run was already complete when this pass began
+
+This issue is a **resumable claim**. An earlier run of this same issue (scratch
+stamp `claude-2570-20260821-071823`, `AGENT CLAIMED` at `2026-08-21T07:19:49Z`)
+already triggered the real re-analysis this row needs and the run completed —
+`.audiobook/cast.json` and `.audiobook/cast-id-history.json` for *Заказ
+Коалфолла* both carry a final write timestamp of `2026-08-21T07:47:44Z`
+(confirmed via filesystem mtime, converted from the box's local `+10:00`
+`17:47:44` — matches the history file's own `recordedAtIso` entries exactly).
+No evidence file or register update existed yet, and the worktree
+`wt-2570-b3-b4-rerun` (branch `docs/docs-2570-b3-b4-rerun`) was clean at
+`origin/main`'s tip with no local commits — i.e. the earlier run did the real
+work and stopped before writing it up, per the runner prompt's own
+"parked-claim" case. This pass reconstructs the evidence from the artifacts
+the completed run left behind rather than re-triggering a second ~20-minute
+re-analysis, which would have been wasteful and would have overwritten the
+very state being verified.
+
+**Which code ran:** the earlier run's `AGENT CLAIMED` note records that PR
+#2562 (the #2536 fix) was already merged into `main` by the time it claimed,
+so it worked "against latest main instead of the (now-merged) PR branch". The
+primary checkout (`C:\Claude\Projects\Audiobook-Generator`, whose `server/.env`
+points `WORKSPACE_DIR` at the real `C:\AudiobookWorkspace` and whose `npm
+--prefix server run dev` process is what was live on this box through the run
+window) is at `88fe477a`, confirmed an ancestor-inclusive descendant of the fix
+merge commit `1a09755a` (`git merge-base --is-ancestor 1a09755a 88fe477a` →
+true). So the re-analysis whose output is examined below ran against code that
+includes the fix.
+
+## Fixture and baseline
+
+*Заказ Коалфолла* (`C:\AudiobookWorkspace\books\Castwright\Standalones\Заказ
+Коалфолла`), the same fixture B3/B4 have used since Wave 2. **Baseline for
+this run is Wave 3's own after-state** (`docs/testing/onbox-wave3-results/step-5-group-b.md`,
+2026-08-20), the last recorded state before today: **16 characters**,
+including the pre-fix defect's two near-duplicate pairs coexisting —
+`brann-weir`/`brann-wire` and `berrin-weir`/`berrin-wire` — none of the four
+linked via `retireCharacterId`.
+
+## Re-analysis run
+
+A full re-analysis ran against the fixture between (at latest) `07:25:12Z` and
+`07:47:44Z` today (2026-08-21) — inferred from `cast-id-history.json`'s own
+`recordedAtIso`/`recordedAtSeq` entries added this run (seq 9, 12-14), which
+land inside that window in ascending seq order, consistent with characters
+being retired as chapters are merged sequentially through one continuous
+run. This resumed pass did not capture the originating run's own SSE/API
+transcript (the claiming run's process had already exited); the evidence
+below is the after-state read directly from both JSON files, which is what
+B3/B4's own row text asks be confirmed regardless of how the run was driven.
+
+## Result — `cast.json` after re-analysis (14 characters)
+
+| id | name |
+|---|---|
+| narrator | Рассказчик |
+| **одуван** | Одуван |
+| ren | Рен |
+| mairin | Мэйрин |
+| coalfall-dragon | Коалфолл |
+| pell-hollis | Пелл Холлис |
+| widow-kasper | Вдова Каспер |
+| brann-wire | Бранн Уир |
+| berrin-wire | Беррин Уир |
+| father-lessom | Отец Лессом |
+| ivo | Иво |
+| sela | Села |
+| hart | Харт |
+| unknown-male | Незнакомый Парень |
+
+## Result — `cast-id-history.json` `supersededBy` (new entries this run, in bold)
+
+```
+mayrin        -> mairin            (2026-08-11, pre-existing)
+coalfall      -> coalfall-dragon   (2026-08-11, pre-existing)
+мэйрин        -> mairin            (2026-08-20, wave-3)
+коалфолл      -> coalfall-dragon   (2026-08-20, wave-3)
+widow-casper  -> widow-kasper      (2026-08-20, wave-3)
+**brann        -> brann-wire**       (2026-08-21T07:47:44Z)
+**berrin       -> berrin-wire**      (2026-08-21T07:47:44Z)
+**lessom       -> father-lessom**    (2026-08-21T07:25:12Z)
+**oduvan       -> одуван**           (2026-08-21T07:47:44Z)
+**brann-weir   -> brann-wire**       (2026-08-21T07:47:44Z)
+**berrin-weir  -> berrin-wire**      (2026-08-21T07:47:44Z)
+```
+
+## B3 — verdict: **PASSED, discharge**
+
+- `mairin` / `coalfall-dragon` — **unchanged**, exactly as Wave 2/3 recorded. ✅
+- **No near-duplicate row formed, and the pre-existing pair from Wave 3's bug was actually cleaned up**: `brann-weir`/`brann-wire` and `berrin-weir`/`berrin-wire` — each pair that coexisted un-retired since Wave 3 is now correctly linked via `retireCharacterId` and collapsed to a single surviving id apiece (`brann-wire`, `berrin-wire`). This is stronger evidence than "the bug didn't reproduce" — the same mechanism that stops a *new* duplicate from forming also repaired the *existing* one, live, on the real fixture. ✅
+- Roster count: 16 → 14. Net change accounts fully: −2 for the two pairs collapsing to one id each, ±0 for `unknown-man`→`unknown-male` (re-detected, same single row, not a second id) and `oduvan`→`одуван` (see B4 below — an id change, not an added row). No unexplained growth. ✅
+
+`#2536`'s core defect (near-duplicate roster ids on a surname-token-drifted name-fallback match) does not reproduce, and the fix's mechanism also retroactively repaired the one instance already on disk. **B3 discharges.**
+
+## B4 — verdict: **STILL OWED — new, distinct defect found**
+
+- Cyrillic names, zero Latin transliteration: **PASSED** — all 14 `name` fields above are Cyrillic.
+- No character gained a second id: **PASSED** — see B3 above, no duplicate pair exists post-run.
+- Roster size vs. B3's original 13: now 14, +1 (`unknown-male`, a legitimate re-detection carried over from Wave 3's `unknown-man`) — consistent with "no recall lost", not a regression.
+- **Every id is ASCII kebab-case: FAILED.** `одуван` (id, not name) is Cyrillic. `cast-id-history.json` records `"oduvan": "одуван"` — i.e. the system correctly recognised this run's fresh detection as the *same* character previously held under the established ASCII id `oduvan`, called `retireCharacterId`, but chose the **freshly-generated Cyrillic id as the survivor** instead of keeping the established ASCII one. `Одуван` is a plain first-name-only Cyrillic string with no surname-drift shape at all — unrelated to #2536's surname-token fallback — so this is not a recurrence of #2536, it is a new failure of the *same criterion* B4 exists to guard (design plan `docs/superpowers/plans/2026-08-01-cast-character-identity.md`, `cast-create.ts`'s `safeId` call is documented to keep ids ASCII/transliteration-free-but-still-kebab for the common case; here the retirement path picked the wrong side).
+
+**Root cause (routed to a fix agent, not fixed here):** `server/src/util/safe-id.ts`'s `unicodeKebab` deliberately preserves non-Latin letters by design (plan 219, "Option C, transliteration deliberately NOT used") — so a *brand-new* character's Cyrillic name legitimately mints a Cyrillic id, which is correct. The defect is one layer up, in whichever caller of `retireCharacterId` in `server/src/store/merge-analysis-cast.ts` decided, for `oduvan`/`одуван`, that the fresh raw id should be the survivor (`from=oduvan, to=одуван`) rather than the existing cast id (which the `мэйрин→mairin` / `коалфолл→coalfall-dragon` / `lessom→father-lessom` cases in the SAME run correctly kept as the survivor). Filed as **[#2584](https://github.com/dudarenok-maker/Castwright/issues/2584)** for a fix agent to pick up cold.
+
+Because a row-defined criterion genuinely failed against real evidence, **B4 stays STILL OWED**, not discharged, per the register's own governing rule.
+
+## Files written this step
+
+- `docs/testing/onbox-wave4-results/step-7-b3-b4-rerun.md` (this file)
+- `docs/testing/cast-id-drift-onbox-acceptance.md` §7 — dated addendum recording this run
+- `docs/testing/onbox-acceptance-register.md` — B3/B4 dated notes
+
+## Box safety
+
+No book other than *Заказ Коалфолла* was touched by this pass (read-only —
+the write already happened before this pass started). No server, sidecar or
+model was stopped by this pass. No `--apply`/`--fix` flag invoked. Worktree
+`wt-2570-b3-b4-rerun` stayed clean except for this step's own three docs
+edits.


### PR DESCRIPTION
## Summary

Acceptance re-run of register rows **B3** and **B4** (`docs/testing/onbox-acceptance-register.md`) now that #2536's surname-tolerant name-comparator fix (PR #2562) has merged. Closes #2570.

- **B3 discharges.** `mairin`/`coalfall-dragon` ids stay unchanged across a real re-analysis of *Заказ Коалфолла*, and no new near-duplicate roster row formed — the same mechanism also retroactively repaired the one duplicate pair (`brann-weir`/`brann-wire`, `berrin-weir`/`berrin-wire`) left over from the pre-fix run on 2026-08-20.
- **B4 stays owed.** A different, unrelated defect surfaced in the same run: the established ASCII id `oduvan` got retired IN FAVOUR OF a freshly-minted Cyrillic id (`одуван`) — backwards from the direction three other retirements took in the same run. Filed as #2584 for a fix agent.

## Changes

- `docs/testing/cast-id-drift-onbox-acceptance.md` — §7 dated addendum recording this run
- `docs/testing/onbox-acceptance-register.md` — B3/B4 dated notes
- `docs/testing/onbox-wave4-results/step-7-b3-b4-rerun.md` — new evidence file

Docs-only; `npm run check:onbox-register` passes.

## Test plan

- [x] `npm run check:onbox-register` green
- [x] Real re-analysis of the live *Заказ Коалфолла* fixture (already run before this PR was opened — see provenance note in the evidence file)

🤖 Generated with Claude Code
