### PR TITLE
docs: re-run A39/A40 GPU-provider check after #2534's fix (still owed)

### DIFF
--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -2324,6 +2324,27 @@ scratch. *Criteria:* design doc §On-box acceptance item 1; run sheet §3 in
 > against the fixed pin; see evidence doc
 > `docs/testing/onbox-wave3-results/step-2-ort-marker.md`.
 
+> **Wave-4 step 8, 2026-08-21 — STILL OWED, re-run after #2534's fix landed.**
+> Re-ran the Kokoro GPU-provider check against `onnxruntime-gpu` 1.26.0 (the
+> version #2576's re-pin resolves to), commit `6e4eac6c0129b68e8ff47db7b1503f31344248ab`
+> (now on `main` via `4bb738d2`). `get_available_providers()` still lists
+> `CUDAExecutionProvider`, but actual `InferenceSession` construction — both
+> directly and through `kokoro_onnx.Kokoro` — still falls back to
+> `CPUExecutionProvider`. **This is not the #2534 defect recurring**: the
+> root cause is now confirmed as a *different*, more specific gap —
+> `onnxruntime-gpu` 1.26.0's own wheel metadata requires `nvidia-cudnn-cu12~=9.0`
+> only via its optional `[cudnn]` extra, which `install-ort.mjs` never
+> requests (and installs with `--no-deps` besides), so no cuDNN 9 runtime is
+> ever placed anywhere onnxruntime's CUDA provider will find it. A `cudnn64_9.dll`
+> exists on this box only bundled inside other packages' own directories
+> (`torch/lib`, `ctranslate2`), which onnxruntime does not search — confirmed
+> by adding `torch/lib` to the process DLL search path as a diagnostic, which
+> did not fix it either. Zero discharges this run — see evidence doc
+> `docs/testing/onbox-wave4-results/step-8-a39-a40-rerun.md`. **Follow-up
+> owed:** a new defect issue for the missing `nvidia-cudnn-cu12` dependency
+> (distinct from #2534, which is closed and did fix the CUDA-13-vs-12
+> mismatch it targeted).
+
 ### A40 · ORT marker — the reported bug: in-app Qwen3 install ([#2192](https://github.com/dudarenok-maker/Castwright/issues/2192), plan [282](../features/282-ort-pip-consistency-marker.md)) · **no GPU needed, sidecar venv only**
 
 Design doc §On-box acceptance, criterion 2 — **this is #2192 itself**, the alpha
@@ -2353,6 +2374,19 @@ filed against, and it has not been separately re-confirmed since the fix landed
 > (CUDA-12 line). The row remains STILL OWED because neither the app-level test
 > nor the Kokoro GPU-provider check have been re-run against the fixed pin; see
 > evidence doc `docs/testing/onbox-wave3-results/step-2-ort-marker.md`.
+
+> **Wave-4 step 8, 2026-08-21 — STILL OWED, GPU-provider sub-check re-run, in-app
+> install still not attempted.** Re-ran only the shared Kokoro GPU-provider
+> sub-check (this row's final check) against the #2534-fixed pin
+> (`onnxruntime-gpu` 1.26.0, commit `6e4eac6c0129b68e8ff47db7b1503f31344248ab`,
+> now on `main` via `4bb738d2`) — same procedure and result as A39 above:
+> `get_available_providers()` reports `CUDAExecutionProvider`, actual session
+> construction still falls back to CPU, root cause confirmed as the missing
+> `nvidia-cudnn-cu12` `[cudnn]` extra, not a #2534 recurrence. Zero discharges;
+> see evidence doc `docs/testing/onbox-wave4-results/step-8-a39-a40-rerun.md`.
+> The in-app Qwen3 install click-through part of this row remains untouched —
+> out of scope for this re-run (see #2561) — and would hit the same cuDNN gap
+> on its own Kokoro-afterward check even once attempted.
 
 ### A41 · ORT marker refuses — not repairs — a clobbered venv ([#2192](https://github.com/dudarenok-maker/Castwright/issues/2192), plan [282](../features/282-ort-pip-consistency-marker.md)) · **no GPU needed, sidecar venv only**
 

--- a/docs/testing/onbox-wave4-results/step-8-a39-a40-rerun.md
+++ b/docs/testing/onbox-wave4-results/step-8-a39-a40-rerun.md
@@ -1,0 +1,135 @@
+# Wave 4 step 8 — A39/A40 re-run after #2534 (Castwright#2568)
+
+Re-run of the A39 third check ("load Kokoro afterward and confirm it still
+reports `CUDAExecutionProvider`") and the shared A40 final check, gated on
+defect #2534. Filed by wave 4 step 5 (#2554), part of the on-box register
+campaign (#2435).
+
+**Run by:** claude. **Date:** 2026-08-21.
+
+## Commit run against
+
+`6e4eac6c0129b68e8ff47db7b1503f31344248ab` — the head of PR #2576
+(`fix/sidecar-2534-ort-cuda12-pin`), which re-pinned
+`ONNXRUNTIME_GPU_CONSTRAINT` in `server/tts-sidecar/scripts/install-ort.mjs`
+to `>=1.26,<1.27`. PR #2576 merged into `main` before this run started
+(merge commit `4bb738d2d2b1ddb26c8a0b21b4434abf77231419`); its own fix
+branch and worktree no longer exist, so this re-run works on a fresh branch
+off `origin/main` at that merge commit instead of the branch named in the
+original filing (see "Which branch" below).
+
+## Live venv safety
+
+Baseline recorded before any work: `server/tts-sidecar/.venv`,
+`onnxruntime-gpu` 1.27.0, `pip check` clean, dist-info set
+`{onnxruntime-1.27.0.dist-info (marker), onnxruntime_gpu-1.27.0.dist-info}`.
+Re-checked after all work below: identical version, identical `pip check`
+output, identical dist-info set. **Live venv is byte-unchanged.**
+
+Throwaway venv used: a full copy of the live venv (robocopy, not a fresh
+bootstrap — this check only needs the fixed onnxruntime-gpu pin in place,
+not a from-scratch install; that broader check is A39's first two parts,
+already discharged in wave 3). Created under this run's scratch directory
+and deleted after evidence was captured — confirmed via directory listing
+after `rm -rf`.
+
+## Which branch
+
+The original filing (#2568) named `fix/sidecar-2534-ort-cuda12-pin`
+(worktree `C:/Claude/Projects/wt-2534-ort-cuda12-pin`) as the branch to
+commit this discharge to, so it would land in the same PR as the fix. By the
+time this run executed, that PR (#2576) had already merged and its branch
+and worktree were gone (deleted post-merge) — the fix itself is now on
+`main`. This run instead opened a new worktree/branch,
+`docs/onbox-2568-a39-a40-rerun`, off `origin/main`, and this PR targets
+`main` directly rather than amending a merged one.
+
+## Procedure
+
+1. Copied the live sidecar venv to a throwaway path (robocopy).
+2. Removed the stale `onnxruntime-1.27.0.dist-info` marker and the
+   `onnxruntime_gpu-1.27.0.dist-info` distribution from the throwaway copy.
+3. Ran `CASTWRIGHT_ACCELERATOR_PROFILE=nvidia node
+   server/tts-sidecar/scripts/install-ort.mjs <throwaway-venv-python>` — the
+   real production swap path, not a hand-rolled pip install. It force-
+   reinstalled `onnxruntime-gpu>=1.26,<1.27` (resolved to 1.26.0) with
+   `--no-deps` and wrote the marker.
+4. Confirmed marker + `pip check`:
+   - `onnxruntime-1.26.0.dist-info` present, `INSTALLER` =
+     `castwright-ort-marker`, `RECORD` 0 bytes — version matches the
+     installed `onnxruntime-gpu` (1.26.0).
+   - `pip check`: exit 0, `No broken requirements found.`
+5. Loaded Kokoro's real model files
+   (`server/tts-sidecar/voices/kokoro/kokoro-v1.0.onnx` +
+   `voices-v1.0.bin`, read-only) from the throwaway venv's interpreter, both
+   via a direct `onnxruntime.InferenceSession(..., providers=
+   ["CUDAExecutionProvider", "CPUExecutionProvider"])` and via
+   `kokoro_onnx.Kokoro(..., providers=[...])` (the same call shape
+   `main.py`'s `_ensure_loaded` uses).
+
+## Result — third check (A39) / shared final check (A40)
+
+**FAIL — same symptom family as wave 3, root cause is more specific now.**
+
+- `onnxruntime.get_available_providers()`: still correctly lists
+  `CUDAExecutionProvider` (unchanged from wave 3).
+- Actual `InferenceSession` construction with
+  `providers=["CUDAExecutionProvider", "CPUExecutionProvider"]`: **falls
+  back to `CPUExecutionProvider`** — same as `kokoro_onnx.Kokoro`'s own
+  session. onnxruntime logs the reason explicitly:
+
+  ```
+  Error loading ".../onnxruntime/capi/onnxruntime_providers_cuda.dll"
+  which depends on "cudnn64_9.dll" which is missing. (Error 126: "The
+  specified module could not be found.")
+  Failed to create CUDAExecutionProvider. Require cuDNN 9.* and CUDA 12.*,
+  and the latest MSVC runtime.
+  ```
+
+- **The #2534/#2576 pin fix does not close this gap.** Re-pinning to
+  `onnxruntime-gpu>=1.26,<1.27` swapped which onnxruntime-gpu build is
+  installed, but 1.26.0's own wheel metadata still requires cuDNN **9.x**
+  (`Requires-Dist: nvidia-cudnn-cu12~=9.0; extra == "cudnn"` in its
+  `METADATA` — confirmed by direct read) — the original wave-3 diagnosis
+  ("1.27 needs CUDA 13/cuDNN 9, so pin back to the CUDA-12 line") doesn't
+  hold: **1.26 needs cuDNN 9 too.** The actual dependency chain: `nvidia-
+  cudnn-cu12` is only pulled in via onnxruntime-gpu's optional `[cudnn]`
+  extra, which `install-ort.mjs` never requests, and which `--no-deps`
+  would skip even if it did. No system-wide `cudnn64_9.dll` exists on this
+  box either — the only copies present anywhere are bundled inside other
+  packages' own directories (`torch/lib/cudnn64_9.dll`,
+  `ctranslate2/cudnn64_9.dll` in the *live* venv), which onnxruntime's CUDA
+  provider does not search.
+- **Diagnostic (not a fix attempt):** added `torch/lib` to the process DLL
+  search path via `os.add_dll_directory` before constructing the session
+  (torch's own bundled `cudnn64_9.dll` matches the version onnxruntime asks
+  for). This did **not** resolve it — same `Error 126` on the same DLL. The
+  proximate `pip install nvidia-cudnn-cu12~=9.0` diagnostic to confirm the
+  extra alone would fix it could not be run — this box's pip has no network
+  route to PyPI (`getaddrinfo failed` on `files.pythonhosted.org`) — so the
+  precise fix (the `[cudnn]` extra, a vendored wheel, or a working DLL
+  search path into an existing bundle) is not confirmed here, only the
+  failure mode.
+
+## Disposition
+
+**A39 (third check): STILL OWED.** Marker version and `pip check` parts
+remain discharged from wave 3; the GPU-provider part still fails, now for a
+more specific, confirmed reason (missing `nvidia-cudnn-cu12` / no reachable
+cuDNN 9 runtime) rather than the CUDA-13-vs-12 pin mismatch #2534 fixed.
+
+**A40 (final check, shared root cause): STILL OWED.** Its Kokoro-provider
+sub-check hits the identical gap; the in-app Qwen3 install-and-click-through
+part of A40 is out of scope for this issue (see #2561) and was not
+attempted.
+
+**Zero discharges this run** — a legitimate outcome per this issue's own
+governing rule: a row comes out only if the acceptance actually ran and
+passed.
+
+## Follow-up
+
+The register note below names the residual gap as its own defect, separate
+from #2534 (which is closed/merged and did fix the CUDA-13-vs-12 mismatch
+it targeted — this is a different dependency omission it happened to
+share a symptom with, not a reopening of #2534).


### PR DESCRIPTION
## Summary
- Re-runs Castwright#2568: register rows **A39** (third check) and **A40** (shared final check), gated on #2534.
- #2534's fix (PR #2576, merged) re-pinned `onnxruntime-gpu` to `>=1.26,<1.27`. Re-ran the Kokoro `CUDAExecutionProvider` check against that pin — still fails, for a different, now-confirmed reason: `onnxruntime-gpu` 1.26.0 needs the `nvidia-cudnn-cu12` `[cudnn]` extra, which `install-ort.mjs` never requests. No cuDNN 9 runtime is reachable, so the CUDA provider silently falls back to CPU.
- **Zero discharges** — the honest outcome per this issue's own governing rule. Live sidecar venv verified byte-unchanged throughout (all work ran against a throwaway copy, deleted after).
- Adds dated notes to both rows and a new evidence file `docs/testing/onbox-wave4-results/step-8-a39-a40-rerun.md` with full repro, root-cause trail, and the diagnostic steps tried.
- `npm run check:onbox-register` is green — no total/count drift.

## Follow-up (not filed here, out of this issue's scope)
The missing `nvidia-cudnn-cu12` dependency is a genuine, distinct defect from #2534 (which did fix the CUDA-13-vs-12 mismatch it targeted) and is owed its own tracking issue.

Closes #2568

🤖 Generated with [Claude Code](https://claude.com/claude-code)