### PR TITLE
chore(sidecar): add per-device memory_stats diagnostics + bare-reclaim endpoint

### DIFF
--- a/docs/testing/1996-stranded-vram-measurement.md
+++ b/docs/testing/1996-stranded-vram-measurement.md
@@ -89,7 +89,7 @@ Record, per device: `reserved`, `allocated`, `inactive_split`, and
 
 ## Results
 
-| Point | When | Device | reserved MB | allocated MB | inactive_split MB | reserved − allocated | nvidia-smi used | RSS MB | Engines loaded | reclaimed |
+| Point | When | Device | reserved bytes | allocated bytes | inactive_split bytes | reserved − allocated | nvidia-smi used | RSS MB | Engines loaded | reclaimed |
 |---|---|---|---|---|---|---|---|---|---|---|
 | P0 | fresh | | | | | | | | | |
 | P1 | mid-render | | | | | | | | | |

--- a/docs/testing/1996-stranded-vram-measurement.md
+++ b/docs/testing/1996-stranded-vram-measurement.md
@@ -35,7 +35,7 @@ Run this at each capture point and paste the output into the table below.
 $ts = (Get-Date).ToString('HH:mm:ss')
 $mem = Invoke-RestMethod http://127.0.0.1:9000/debug/memory
 "$ts  rss=$($mem.process.rss_mb)MB"
-$mem.cuda.per_device | ConvertTo-Json -Depth 4
+$mem.memory_stats | ConvertTo-Json -Depth 4
 $mem.engines | ConvertTo-Json -Depth 3
 nvidia-smi --query-gpu=index,memory.used,memory.total --format=csv,noheader
 ```

--- a/docs/testing/1996-stranded-vram-measurement.md
+++ b/docs/testing/1996-stranded-vram-measurement.md
@@ -73,7 +73,8 @@ Record, per device: `reserved`, `allocated`, `inactive_split`, and
    ```
 
    It returns the per-device figures **before and after** a bare
-   `empty_cache()`, bracketed with nothing in between. Record both as **P4**.
+   `empty_cache()`, bracketed with nothing in between, plus a `reclaimed: bool`
+   field indicating whether the reclaim actually ran. Record all three as **P4**.
 
    > Do **not** substitute a load/unload cycle. A load is an allocation pass that
    > refills and coalesces segments — conflating the two is the unsound inference
@@ -88,19 +89,19 @@ Record, per device: `reserved`, `allocated`, `inactive_split`, and
 
 ## Results
 
-| Point | When | Device | reserved MB | allocated MB | inactive_split MB | reserved − allocated | nvidia-smi used | RSS MB | Engines loaded |
-|---|---|---|---|---|---|---|---|---|---|
-| P0 | fresh | | | | | | | | |
-| P1 | mid-render | | | | | | | | |
-| P2 | +0 s | | | | | | | | |
-| P3 | +180 s | | | | | | | | |
-| P4 before | reclaim | | | | | | | | |
-| P4 after | reclaim | | | | | | | | |
-| P5 | cuda:1 render | | | | | | | | |
+| Point | When | Device | reserved MB | allocated MB | inactive_split MB | reserved − allocated | nvidia-smi used | RSS MB | Engines loaded | reclaimed |
+|---|---|---|---|---|---|---|---|---|---|---|
+| P0 | fresh | | | | | | | | | |
+| P1 | mid-render | | | | | | | | | |
+| P2 | +0 s | | | | | | | | | |
+| P3 | +180 s | | | | | | | | | |
+| P4 before | reclaim | | | | | | | | | |
+| P4 after | reclaim | | | | | | | | | |
+| P5 | cuda:1 render | | | | | | | | | |
 
 **RSS at P2 vs 8192 MB:** ☐ above ☐ below
 *(Above means the memory watchdog's unconditional 60 s `gc+empty_cache` was
-already firing throughout — `main.py:7915`, `:7953-7960`.)*
+already firing throughout — `main.py:7957-7964` (`_mem_warn_threshold_mb()`).)*
 
 ---
 
@@ -110,7 +111,8 @@ already firing throughout — `main.py:7915`, `:7953-7960`.)*
 |---|---|
 | Strand absent at P3 | Self-heals at the existing TTLs. #1996 criterion 1 is already satisfied on `main`. |
 | P4 `reserved` drops sharply | **Uncollected cache.** A scheduled reclaim is the fix — subject to every constraint in §7 of the design. |
-| P4 `reserved` barely moves, `inactive_split` dominates | **Fragmentation.** `empty_cache()` cannot fix this at any cadence; re-open the recycle threshold instead. |
+| P4 `reserved` barely moves, `inactive_split` dominates, `reclaimed: true` | **Fragmentation.** `empty_cache()` cannot fix this at any cadence; re-open the recycle threshold instead. |
+| P4 `reserved` barely moves, `reclaimed: false` | **Invalid reading.** The reclaim never ran — CUDA was unavailable or `empty_cache()` threw. Retry once; treat repeated `false` as a separate finding (a live-context problem), not a #1996 answer. |
 | Strand present at P3 *and* P4 frees it *and* RSS was above 8192 MB at P2 | Contradicts the 60 s watchdog reclaim having run. Investigate that before designing anything — one of the two observations is wrong. |
 
 Record the outcome as a comment on

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -9632,15 +9632,14 @@ def debug_reclaim() -> dict[str, Any]:
     surface that brackets `empty_cache()` with nothing else in between (a
     load/unload cycle would conflate the reclaim with an allocation pass).
 
-    Not inert: it frees real memory when it runs. The watchdog calls
-    `_reclaim_host_and_vram()`, which runs `gc.collect()` unconditionally then
-    `empty_cache()` conditionally (if CUDA available); `_reclaim_device_cache`
-    reverses the order (CUDA check first, then gc only if available), and
-    gates the whole operation on an RSS threshold (see main.py:7957-7964,
-    `_mem_warn_threshold_mb()`), so this route can trigger a reclaim below that
-    threshold too. No auth wrapper, matching every other `/debug` route in
-    this family (`debug_codec_timing`/`debug_codec_timing_reset` above) —
-    loopback-bound by default via LOCAL_TTS_HOST configuration."""
+    Not inert: it frees real memory when it runs. The memory watchdog checks
+    an RSS threshold (see main.py:8662, `if warn_threshold > 0 and rss >= ...`)
+    before calling `_reclaim_host_and_vram()`; this route calls `_reclaim_device_cache`
+    directly without that check, so it can trigger the identical `gc.collect()` +
+    `empty_cache()` operation regardless of RSS — even below the watchdog's
+    threshold. No auth wrapper, matching every other `/debug` route in this family
+    (`debug_codec_timing`/`debug_codec_timing_reset` above) — loopback-bound by
+    default via LOCAL_TTS_HOST configuration."""
     before = _cuda_memory_stats_per_device()
     reclaimed = _reclaim_device_cache("debug-reclaim")
     after = _cuda_memory_stats_per_device()

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -3764,9 +3764,10 @@ class ReservationLedger:
 _reclaim_failure_traced = False
 
 
-def _reclaim_device_cache(device_key: str) -> None:
+def _reclaim_device_cache(device_key: str) -> bool:
     """Bare `gc.collect()` + `torch.cuda.empty_cache()`, with no target model
-    to unload first (#1976).
+    to unload first (#1976). Returns True if the reclaim ran (CUDA available +
+    no exception), False if CUDA is unavailable or an exception occurred.
 
     Every reclaim ELSEWHERE in this file — `unload()`, `unload_design()`,
     `maybe_free_idle*` (Qwen/Coqui), the `_idle_evict_steps` ladder — is a
@@ -3818,15 +3819,17 @@ def _reclaim_device_cache(device_key: str) -> None:
 
     Best-effort: any torch/CUDA failure (no CUDA build, a poisoned context) is
     swallowed here, matching every other reclaim path in this file — this is
-    a last-resort cushion, not a step whose failure should propagate."""
+    a last-resort cushion, not a step whose failure should propagate. Returns
+    False so callers can distinguish "ran" from "did not run"."""
     global _reclaim_failure_traced
     try:
         import torch  # type: ignore
 
         if not torch.cuda.is_available():
-            return
+            return False
         gc.collect()
         torch.cuda.empty_cache()
+        return True
     except Exception:
         log.warning(
             "stranded-cache reclaim failed for %s",
@@ -3834,6 +3837,7 @@ def _reclaim_device_cache(device_key: str) -> None:
             exc_info=not _reclaim_failure_traced,
         )
         _reclaim_failure_traced = True
+        return False
 
 
 # #1993 review (C1) — the per-device reclaim cooldown. A module constant, not
@@ -9628,14 +9632,16 @@ def debug_reclaim() -> dict[str, Any]:
     surface that brackets `empty_cache()` with nothing else in between (a
     load/unload cycle would conflate the reclaim with an allocation pass).
 
-    Not inert: it frees real memory (same effect as the existing 60s
-    watchdog tick). No auth wrapper, matching every other `/debug` route in
+    Not inert: it frees real memory when it runs. The watchdog performs an
+    identical reclaim operation, but only above the 8192 MB RSS threshold
+    (see main.py:7953-7960), so this route can trigger a reclaim below that
+    threshold too. No auth wrapper, matching every other `/debug` route in
     this family (`debug_codec_timing`/`debug_codec_timing_reset` above) —
-    guarded by being loopback-bound, per this route family's convention."""
+    loopback-bound by default via LOCAL_TTS_HOST configuration."""
     before = _cuda_memory_stats_per_device()
-    _reclaim_device_cache("debug-reclaim")
+    reclaimed = _reclaim_device_cache("debug-reclaim")
     after = _cuda_memory_stats_per_device()
-    return {"before": before, "after": after}
+    return {"before": before, "reclaimed": reclaimed, "after": after}
 
 
 @app.post("/load")

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -3879,7 +3879,7 @@ class PlacementController:
         reserve_mb: Optional[Callable[[], int]] = None,
         idle_evict_steps: Optional[Callable[[str, str], list["EvictStep"]]] = None,
         is_resident: Optional[Callable[[str], Optional[str]]] = None,
-        reclaim: Optional[Callable[[str], None]] = None,
+        reclaim: Optional[Callable[[str], bool]] = None,
     ) -> None:
         self.probe = probe
         self.footprints = footprints if footprints is not None else FootprintTable()
@@ -9632,9 +9632,12 @@ def debug_reclaim() -> dict[str, Any]:
     surface that brackets `empty_cache()` with nothing else in between (a
     load/unload cycle would conflate the reclaim with an allocation pass).
 
-    Not inert: it frees real memory when it runs. The watchdog performs an
-    identical reclaim operation, but only above the 8192 MB RSS threshold
-    (see main.py:7953-7960), so this route can trigger a reclaim below that
+    Not inert: it frees real memory when it runs. The watchdog calls
+    `_reclaim_host_and_vram()`, which runs `gc.collect()` unconditionally then
+    `empty_cache()` conditionally (if CUDA available); `_reclaim_device_cache`
+    reverses the order (CUDA check first, then gc only if available), and
+    gates the whole operation on an RSS threshold (see main.py:7957-7964,
+    `_mem_warn_threshold_mb()`), so this route can trigger a reclaim below that
     threshold too. No auth wrapper, matching every other `/debug` route in
     this family (`debug_codec_timing`/`debug_codec_timing_reset` above) —
     loopback-bound by default via LOCAL_TTS_HOST configuration."""

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -8044,6 +8044,51 @@ def _cuda_vram_mb_per_device() -> dict[str, dict[str, float]]:
         return {}
 
 
+def _cuda_memory_stats_per_device() -> dict[str, dict[str, int]]:
+    """{"cuda:N"|"rocm:N": {"reserved", "allocated", "inactive_split",
+    "num_alloc_retries"}} for every CUDA-API-visible device, sourced from
+    `torch.cuda.memory_stats(i)` (#2423 — instrument for #1996's design
+    question).
+
+    Neither `_cuda_vram_mb_per_device` above (only `reserved_mb`/`total_mb`)
+    nor `debug_memory`'s `cuda` block (current-device-only, no
+    `inactive_split`) can discriminate #1996's two candidate causes:
+    uncollected cache (a scheduled reclaim fixes it) vs allocator
+    fragmentation (`empty_cache()` can never return it) — `inactive_split`
+    is the field that tells them apart. Values are raw units straight from
+    `memory_stats` (bytes for the byte-valued keys, a count for
+    `num_alloc_retries`) — deliberately NOT converted to MB like the
+    neighboring `_mb` fields, since these are new keys with their own
+    semantics, not a replacement for them.
+
+    Device keys use `probe_capacity`'s `{kind}:{i}` format (`kind = "rocm"
+    if _cuda_is_rocm() else "cuda"`), NOT a hardcoded `cuda:` prefix like
+    `_cuda_vram_mb_per_device` — copying that pattern would mislabel an
+    AMD/ROCm box's devices. `torch.cuda.memory_stats` is a CUDA/ROCm-only
+    API, so non-GPU kinds (`cpu`, `mps`) are simply never emitted here.
+
+    Never raises; {} when CUDA is unavailable — same fail-open contract as
+    `_cuda_vram_mb_per_device`."""
+    try:
+        import torch  # type: ignore
+
+        if not torch.cuda.is_available():
+            return {}
+        kind = "rocm" if _cuda_is_rocm() else "cuda"
+        out: dict[str, dict[str, int]] = {}
+        for i in range(torch.cuda.device_count()):
+            stats = torch.cuda.memory_stats(i)
+            out[f"{kind}:{i}"] = {
+                "reserved": stats.get("reserved_bytes.all.current", 0),
+                "allocated": stats.get("allocated_bytes.all.current", 0),
+                "inactive_split": stats.get("inactive_split_bytes.all.current", 0),
+                "num_alloc_retries": stats.get("num_alloc_retries", 0),
+            }
+        return out
+    except Exception:
+        return {}
+
+
 class DeviceLedger:
     """Thread-safe per-card VRAM reader wrapping the Wave-1 sampler
     (_sample_card). Read from three thread contexts (the _memory_watchdog
@@ -9556,6 +9601,10 @@ def debug_memory() -> dict[str, Any]:
     except Exception:
         pass
     out["cuda"] = cuda
+    # #2423 — per-device memory_stats() block (reserved/allocated/
+    # inactive_split/num_alloc_retries), the instrument #1996's design
+    # decision needs. Additive: the `cuda` block above is untouched.
+    out["memory_stats"] = _cuda_memory_stats_per_device()
     return out
 
 
@@ -9568,6 +9617,25 @@ async def debug_codec_timing() -> dict:
 async def debug_codec_timing_reset() -> dict:
     _codec_timing_reset()
     return {"ok": True}
+
+
+@app.post("/debug/reclaim")
+def debug_reclaim() -> dict[str, Any]:
+    """One bare `_reclaim_device_cache()` bracketed by before/after per-device
+    `memory_stats` snapshots, in a single response (#2423). #1996's design
+    decision (scheduled reclaim vs a boundary-recycle redesign) hinges on
+    whether a bare reclaim recovers the stranded pool — this is the only
+    surface that brackets `empty_cache()` with nothing else in between (a
+    load/unload cycle would conflate the reclaim with an allocation pass).
+
+    Not inert: it frees real memory (same effect as the existing 60s
+    watchdog tick). No auth wrapper, matching every other `/debug` route in
+    this family (`debug_codec_timing`/`debug_codec_timing_reset` above) —
+    guarded by being loopback-bound, per this route family's convention."""
+    before = _cuda_memory_stats_per_device()
+    _reclaim_device_cache("debug-reclaim")
+    after = _cuda_memory_stats_per_device()
+    return {"before": before, "after": after}
 
 
 @app.post("/load")

--- a/server/tts-sidecar/tests/test_memory.py
+++ b/server/tts-sidecar/tests/test_memory.py
@@ -579,6 +579,114 @@ def test_debug_memory_endpoint_shape(monkeypatch):
             assert body["cuda"]["host_pinned_active_mb"] >= 0
 
 
+# --- #2423: per-device memory_stats() diagnostics + bare-reclaim endpoint ---
+
+
+def test_debug_memory_includes_memory_stats_per_device(monkeypatch):
+    """/debug/memory's `memory_stats` block carries reserved/allocated/
+    inactive_split/num_alloc_retries per device, keyed `cuda:{i}` — the field
+    (`inactive_split`) neither the existing `cuda` block (current-device-only,
+    no inactive_split) nor `_cuda_vram_mb_per_device` (reserved/total only)
+    can surface, per #2423's rationale."""
+    torch = pytest.importorskip("torch")
+    monkeypatch.delitem(main.ENGINES, "kokoro", raising=False)
+    monkeypatch.setitem(main.ENGINES, "qwen", main.QwenEngine())
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 1)
+    monkeypatch.setattr(main, "_cuda_is_rocm", lambda: False)
+    stats = {
+        "reserved_bytes.all.current": 4_000_000,
+        "allocated_bytes.all.current": 3_500_000,
+        "inactive_split_bytes.all.current": 250_000,
+        "num_alloc_retries": 2,
+    }
+    monkeypatch.setattr(torch.cuda, "memory_stats", lambda i: stats)
+
+    with TestClient(main.app) as client:
+        body = client.get("/debug/memory").json()
+
+    assert body["memory_stats"] == {
+        "cuda:0": {
+            "reserved": 4_000_000,
+            "allocated": 3_500_000,
+            "inactive_split": 250_000,
+            "num_alloc_retries": 2,
+        }
+    }
+
+
+def test_cuda_memory_stats_per_device_empty_when_cuda_unavailable(monkeypatch):
+    """Fail-open contract, same as `_cuda_vram_mb_per_device`: no CUDA build
+    -> {} rather than a raise, never a 500 from the routes that call it."""
+    torch = pytest.importorskip("torch")
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    assert main._cuda_memory_stats_per_device() == {}
+
+
+def test_cuda_memory_stats_per_device_uses_rocm_prefix_on_rocm_box(monkeypatch):
+    """Device keys are derived the same way `probe_capacity` derives them
+    (`kind = "rocm" if _cuda_is_rocm() else "cuda"`), NOT a hardcoded
+    `cuda:` prefix — an AMD/ROCm box must read `rocm:N`, not silently
+    mislabel as `cuda:N` the way `_cuda_vram_mb_per_device` does."""
+    torch = pytest.importorskip("torch")
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 1)
+    monkeypatch.setattr(main, "_cuda_is_rocm", lambda: True)
+    stats = {
+        "reserved_bytes.all.current": 1_000,
+        "allocated_bytes.all.current": 900,
+        "inactive_split_bytes.all.current": 0,
+        "num_alloc_retries": 0,
+    }
+    monkeypatch.setattr(torch.cuda, "memory_stats", lambda i: stats)
+
+    out = main._cuda_memory_stats_per_device()
+
+    assert list(out.keys()) == ["rocm:0"]
+    assert "cuda:0" not in out
+
+
+def test_debug_reclaim_brackets_one_bare_reclaim_call(monkeypatch):
+    """POST /debug/reclaim returns {before, after} having run exactly ONE
+    `_reclaim_device_cache()` between the two snapshots — no other work in
+    between (a load/unload cycle would conflate the reclaim with an
+    allocation pass, per #2423's rationale)."""
+    monkeypatch.delitem(main.ENGINES, "kokoro", raising=False)
+    monkeypatch.setitem(main.ENGINES, "qwen", main.QwenEngine())
+
+    snapshots = [
+        {"cuda:0": {"reserved": 4_000_000, "allocated": 100, "inactive_split": 3_900_000, "num_alloc_retries": 0}},
+        {"cuda:0": {"reserved": 200_000, "allocated": 100, "inactive_split": 100_000, "num_alloc_retries": 0}},
+    ]
+    calls: list[str] = []
+    snapshot_calls = {"n": 0}
+
+    def fake_snapshot():
+        calls.append("snapshot")
+        result = snapshots[snapshot_calls["n"]]
+        snapshot_calls["n"] += 1
+        return result
+
+    def fake_reclaim(device_key):
+        calls.append("reclaim")
+
+    monkeypatch.setattr(main, "_cuda_memory_stats_per_device", fake_snapshot)
+    monkeypatch.setattr(main, "_reclaim_device_cache", fake_reclaim)
+
+    with TestClient(main.app) as client:
+        r = client.post("/debug/reclaim")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert calls == ["snapshot", "reclaim", "snapshot"]
+    assert calls.count("reclaim") == 1
+    assert body["before"] == snapshots[0]
+    assert body["after"] == snapshots[1]
+
+
 # --- side-11 item 2: SOFT recycle (recycle_pending → clean boundary recycle) ---
 
 

--- a/server/tts-sidecar/tests/test_memory.py
+++ b/server/tts-sidecar/tests/test_memory.py
@@ -756,6 +756,14 @@ def test_reclaim_device_cache_exercises_real_function(monkeypatch):
     assert result is True, "Should return True when CUDA is available and empty_cache succeeds"
     assert len(empty_cache_called) == 1, "empty_cache() should have been called exactly once"
 
+    # Case 3: CUDA available, but empty_cache() raises exception → False
+    def fake_empty_cache_raises():
+        raise RuntimeError("Simulated CUDA error in empty_cache")
+
+    monkeypatch.setattr(torch.cuda, "empty_cache", fake_empty_cache_raises)
+    result = main._reclaim_device_cache("test-device-exception")
+    assert result is False, "Should return False when an exception occurs during reclaim"
+
 
 # --- side-11 item 2: SOFT recycle (recycle_pending → clean boundary recycle) ---
 

--- a/server/tts-sidecar/tests/test_memory.py
+++ b/server/tts-sidecar/tests/test_memory.py
@@ -650,10 +650,12 @@ def test_cuda_memory_stats_per_device_uses_rocm_prefix_on_rocm_box(monkeypatch):
 
 
 def test_debug_reclaim_brackets_one_bare_reclaim_call(monkeypatch):
-    """POST /debug/reclaim returns {before, after} having run exactly ONE
+    """POST /debug/reclaim returns {before, reclaimed, after} having run exactly ONE
     `_reclaim_device_cache()` between the two snapshots — no other work in
     between (a load/unload cycle would conflate the reclaim with an
-    allocation pass, per #2423's rationale)."""
+    allocation pass, per #2423's rationale). The `reclaimed` field surfaces
+    whether the reclaim actually ran (True) or was skipped due to CUDA
+    unavailability or error (False)."""
     monkeypatch.delitem(main.ENGINES, "kokoro", raising=False)
     monkeypatch.setitem(main.ENGINES, "qwen", main.QwenEngine())
 
@@ -672,6 +674,7 @@ def test_debug_reclaim_brackets_one_bare_reclaim_call(monkeypatch):
 
     def fake_reclaim(device_key):
         calls.append("reclaim")
+        return True  # Success case
 
     monkeypatch.setattr(main, "_cuda_memory_stats_per_device", fake_snapshot)
     monkeypatch.setattr(main, "_reclaim_device_cache", fake_reclaim)
@@ -684,7 +687,47 @@ def test_debug_reclaim_brackets_one_bare_reclaim_call(monkeypatch):
     assert calls == ["snapshot", "reclaim", "snapshot"]
     assert calls.count("reclaim") == 1
     assert body["before"] == snapshots[0]
+    assert body["reclaimed"] is True
     assert body["after"] == snapshots[1]
+
+
+def test_debug_reclaim_surfaces_reclaimed_false_on_cuda_unavailable(monkeypatch):
+    """POST /debug/reclaim surfaces `reclaimed: False` when _reclaim_device_cache
+    returns False (CUDA unavailable or error occurred). This distinguishes
+    "ran and freed nothing" (before == after, reclaimed: True) from "never ran"
+    (before == after, reclaimed: False), so #1996's run sheet can reliably detect
+    whether the reclaim actually executed."""
+    monkeypatch.delitem(main.ENGINES, "kokoro", raising=False)
+    monkeypatch.setitem(main.ENGINES, "qwen", main.QwenEngine())
+
+    snapshots = [
+        {"cuda:0": {"reserved": 4_000_000, "allocated": 100, "inactive_split": 3_900_000, "num_alloc_retries": 0}},
+        {"cuda:0": {"reserved": 4_000_000, "allocated": 100, "inactive_split": 3_900_000, "num_alloc_retries": 0}},
+    ]
+    calls: list[str] = []
+    snapshot_calls = {"n": 0}
+
+    def fake_snapshot():
+        calls.append("snapshot")
+        result = snapshots[snapshot_calls["n"]]
+        snapshot_calls["n"] += 1
+        return result
+
+    def fake_reclaim_unavailable(device_key):
+        calls.append("reclaim")
+        return False  # CUDA unavailable or error
+
+    monkeypatch.setattr(main, "_cuda_memory_stats_per_device", fake_snapshot)
+    monkeypatch.setattr(main, "_reclaim_device_cache", fake_reclaim_unavailable)
+
+    with TestClient(main.app) as client:
+        r = client.post("/debug/reclaim")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["before"] == snapshots[0]
+    assert body["reclaimed"] is False  # The key signal: reclaim did NOT run
+    assert body["after"] == snapshots[1]  # before == after, but now we know why
 
 
 # --- side-11 item 2: SOFT recycle (recycle_pending → clean boundary recycle) ---

--- a/server/tts-sidecar/tests/test_memory.py
+++ b/server/tts-sidecar/tests/test_memory.py
@@ -730,6 +730,33 @@ def test_debug_reclaim_surfaces_reclaimed_false_on_cuda_unavailable(monkeypatch)
     assert body["after"] == snapshots[1]  # before == after, but now we know why
 
 
+def test_reclaim_device_cache_exercises_real_function(monkeypatch):
+    """#2423 pass-2 C — neither route-level test above exercises the real
+    _reclaim_device_cache return-value logic; both monkeypatch it away. This pins
+    the actual function's two cases: CUDA unavailable → False, CUDA available +
+    empty_cache() succeeds → True. Uses monkeypatch-real-torch.cuda style (patch
+    torch attributes, never a fake module) so _reclaim_device_cache's internal
+    `import torch` resolves to the patched singleton."""
+    torch = pytest.importorskip("torch")
+
+    # Case 1: CUDA unavailable → False
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    result = main._reclaim_device_cache("test-device")
+    assert result is False, "Should return False when CUDA is unavailable"
+
+    # Case 2: CUDA available, empty_cache() succeeds → True
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    empty_cache_called = []
+
+    def fake_empty_cache():
+        empty_cache_called.append(True)
+
+    monkeypatch.setattr(torch.cuda, "empty_cache", fake_empty_cache)
+    result = main._reclaim_device_cache("test-device")
+    assert result is True, "Should return True when CUDA is available and empty_cache succeeds"
+    assert len(empty_cache_called) == 1, "empty_cache() should have been called exactly once"
+
+
 # --- side-11 item 2: SOFT recycle (recycle_pending → clean boundary recycle) ---
 
 


### PR DESCRIPTION
## Summary
- GET /debug/memory gains a per-device memory_stats block (eserved, llocated, inactive_split, 
um_alloc_retries from 	orch.cuda.memory_stats(i), raw units), keyed cuda:N/ocm:N the same way probe_capacity() derives its device kind — not hardcoded cuda:.
- New POST /debug/reclaim brackets exactly one bare _reclaim_device_cache() call between a before/after snapshot pair, so #1996's design question (uncollected cache vs. allocator fragmentation) can finally be measured.
- Both fail soft ({} / omitted keys) when CUDA is unavailable. Existing /debug/memory fields are untouched.
- Read-only diagnostics; no placement/admission/eviction behaviour changes, no Node-side changes. POST /debug/reclaim does free real memory, and unlike the memory watchdog (which only reclaims when RSS crosses its threshold), this route calls _reclaim_device_cache unconditionally — allowing the same gc.collect() + mpty_cache() operation to be triggered regardless of RSS, even below the watchdog's threshold.

## Test plan
- [x] 6 new pytest cases in server/tts-sidecar/tests/test_memory.py: memory_stats shape/values, CUDA-unavailable fail-soft, ROCm key-prefix correctness, reclaim route's exactly-once/bracketing behaviour (call-order + call-count pinned via a counting stub), real _reclaim_device_cache return-value logic with exception handling (CUDA unavailable → False, available → True, exception during reclaim → False).
- [x] Full sidecar suite (pytest -m "not golden") green — 55/55 in 	est_memory.py, full suite passing with 2 unrelated skips. Run independently twice (once via the implementer, once via a fresh review pass) against the bootstrapped venv, since this worktree's own venv isn't bootstrapped.
- [x] 
pm run verify:fast:branch — sidecar-only diff, all other legs correctly out-of-scope.

Design context: docs/superpowers/specs/2026-08-18-stranded-vram-reclaim-design.md §4 (already on main). No new/updated regression plan — small, localized diagnostic addition; the issue body + paired tests are the spec per CLAUDE.md. No release-notes entry — internal diagnostic tooling with no user- or operator-visible effect.

Closes #2423
