### PR TITLE
fix(sidecar): expose inflight_synth and re-run #1996's VRAM measurement

### DIFF
--- a/docs/testing/1996-stranded-vram-measurement.md
+++ b/docs/testing/1996-stranded-vram-measurement.md
@@ -50,7 +50,8 @@ Run this at each capture point and paste the output into the table below.
 ```powershell
 $ts = (Get-Date).ToString('HH:mm:ss')
 $mem = Invoke-RestMethod http://127.0.0.1:9000/debug/memory
-"$ts  rss=$($mem.process.rss_mb)MB  inflight_synth=$($mem.inflight_synth)"
+$health = Invoke-RestMethod http://127.0.0.1:9000/health
+"$ts  rss=$($mem.process.rss_mb)MB  inflight_synth=$($mem.inflight_synth)  qwen_base17_loaded=$($health.qwen_base17_loaded)"
 $mem.memory_stats | ConvertTo-Json -Depth 4
 $mem.engines | ConvertTo-Json -Depth 3
 nvidia-smi --query-gpu=index,memory.used,memory.total --format=csv,noheader
@@ -92,7 +93,7 @@ Record, per device: `reserved`, `allocated`, `inactive_split`, and
    seconds, the idle window is likely clean (only genuine background activity
    that was already running, if anything). A gate that takes 120 seconds or
    longer to clear suggests the box was actively working during what should
-   have been an idle window — consult the `logs/server.log` grep (next section)
+   have been an idle window — consult the `logs/tts.log` grep (next section)
    to name what was running. This 120 s threshold is separate from the 8 s
    quiet-streak requirement above and the 10-minute ceiling; it is a judgment
    call for how long an otherwise-successful idle-gate wait is "suspiciously
@@ -229,7 +230,7 @@ Real forensic evidence from `logs/tts.err.log` for this specific run: Whisper `s
 | Strand absent at P3 | Self-heals at the existing TTLs. #1996 criterion 1 is already satisfied on `main`. |
 | P4 `reserved` drops sharply | **Uncollected cache.** A scheduled reclaim is the fix — subject to every constraint in §7 of the design. |
 | P4 `reserved` barely moves, `inactive_split` dominates, `reclaimed: true` | **Fragmentation.** `empty_cache()` cannot fix this at any cadence; re-open the recycle threshold instead. |
-| Idle gate took >120 s to clear | **Contaminated idle.** Legitimate background activity was still running; name it from the `logs/server.log` grep above. **Do not treat the resulting P3/P4 readings as evidence about a stranded pool at all.** |
+| Idle gate took >120 s to clear | **Contaminated idle.** Legitimate background activity was still running; name it from the `logs/tts.log` grep above. **Do not treat the resulting P3/P4 readings as evidence about a stranded pool at all.** |
 | P4 `reserved` barely moves, `reclaimed: false` | **Invalid reading.** The reclaim never ran — CUDA was unavailable or `empty_cache()` threw. Retry once; treat repeated `false` as a separate finding (a live-context problem), not a #1996 answer. |
 | Strand present at P3 *and* P4 frees it *and* RSS was above 8192 MB at P2 | Contradicts the 60 s watchdog reclaim having run. Investigate that before designing anything — one of the two observations is wrong. |
 
@@ -237,9 +238,9 @@ Real forensic evidence from `logs/tts.err.log` for this specific run: Whisper `s
 
 This run fits the **"contaminated idle"** row: the idle-gate signal and the attribution verification both relied on broken instruments that are now known to have been blind to the actual work running.
 
-**The contamination:** Whisper ASR was transcribing continuously during what the old idle gate declared "confirmed idle" (07:58:49–07:58:57 vs actual Whisper activity 07:58:31–51.768). The old idle gate could not see this because it tracked only `inflight_synth`, not `/transcribe` or `/embed` (fixed in commit d4aa7a6c). The attribution grep checked the wrong log file (`logs/server.log` instead of `logs/tts.log`, fixed in commit 36091ef2). By the decision tree's logic: "Legitimate background activity was still running; name it from the `logs/server.log` grep above. **Do not treat the resulting P3/P4 readings as evidence about a stranded pool at all.**"
+**The contamination:** Whisper ASR was transcribing continuously during what the old idle gate declared "confirmed idle" (07:58:49–07:58:57 vs actual Whisper activity 07:58:31–51.768). The old idle gate could not see this because it tracked only `inflight_synth`, not `/transcribe` or `/embed` (fixed in commit d4aa7a6c). The attribution grep checked the wrong log file (`logs/server.log` instead of `logs/tts.log`, fixed in commit 36091ef2). Legitimate background activity (Whisper) was still running during the supposed idle window — **do not treat the resulting P3/P4 readings as evidence about a stranded pool at all.**
 
-**The misattribution:** The run loaded three resident models — Qwen Base 0.6B (no TTL), Whisper (120s TTL), and Qwen 1.7B-Base (120s TTL) — but the `/debug/memory` endpoint at the time of this run could not represent the 1.7B model (missing the `base17_loaded` key, added retroactively in commit 42dddeb8). The ~3.3 GB gap between P1's `allocated` (1776.7 MB) and P2's `allocated` (5453.7 MB) is plausibly the Qwen 1.7B-Base model loading during session rather than something inexplicable. The 1.7B model's 120s idle TTL means P3 (21 s post-P2) would not have evicted it even if the idle window had been clean — which it was not.
+**The misattribution:** The run loaded three resident models — Qwen Base 0.6B (no TTL), Whisper (120s TTL), and Qwen 1.7B-Base (120s TTL) — but the `/debug/memory` endpoint at the time of this run could not represent the 1.7B model (missing the `base17_loaded` key, added retroactively in commit 42dddeb8). The 3677.0 MB gap between P1's `allocated` (1776.7 MB) and P2's `allocated` (5453.7 MB) is the Qwen 1.7B-Base model loading during the run. Log evidence from `logs/tts.err.log` confirms: `07:57:58.112 Qwen 1.7B-Base loaded.` and `07:58:29.275 qwen batch synth: model=1.7b items=7 voices=3`. At the time this run was captured, `/debug/memory` could not track the 1.7B model's residency — but `/health` has exposed a `qwen_base17_loaded` field since well before this branch (main.py:~9645, consumed by `server/src/routes/sidecar-health.ts:~458`). The real issue is that the capture snippet in step "The capture" only calls `/debug/memory`, never `/health`, so a signal that was already available went unrecorded. The 1.7B model's 120s idle TTL means P3 (21 s post-P2) would not have evicted it even if the idle window had been clean — which it was not.
 
 **Conclusion:** This run does NOT provide trustworthy evidence. Its P3/P4 readings show a contaminated-idle state with unattributable residency, not a measurement of a stranded pool. It does not close #1996's criterion 1 (and does not discharge the acceptance row already owed).
 

--- a/docs/testing/1996-stranded-vram-measurement.md
+++ b/docs/testing/1996-stranded-vram-measurement.md
@@ -50,7 +50,7 @@ Run this at each capture point and paste the output into the table below.
 ```powershell
 $ts = (Get-Date).ToString('HH:mm:ss')
 $mem = Invoke-RestMethod http://127.0.0.1:9000/debug/memory
-"$ts  rss=$($mem.process.rss_mb)MB"
+"$ts  rss=$($mem.process.rss_mb)MB  inflight_synth=$($mem.inflight_synth)"
 $mem.memory_stats | ConvertTo-Json -Depth 4
 $mem.engines | ConvertTo-Json -Depth 3
 nvidia-smi --query-gpu=index,memory.used,memory.total --format=csv,noheader
@@ -110,7 +110,7 @@ Record, per device: `reserved`, `allocated`, `inactive_split`, and
    column. **If the gate never clears within 10 minutes, stop and report** —
    do not force P3/P4 on a busy box.
 
-   Once the gate reports idle, capture as **P3**.
+   Once the gate reports idle, capture as **P3**. **Before treating P3 as a confirmed-idle reading, verify in the capture output that `inflight_synth == 0` — if it is non-zero, the idle gate's poll is stale and the TOCTOU window is open. If so, stop and re-run the idle-gate wait.**
 
    > **If the strand is gone at P3 the run is already decisive** — the pool
    > self-heals on `main` today (decision-tree row 1). Record it and stop; do
@@ -150,7 +150,7 @@ Record, per device: `reserved`, `allocated`, `inactive_split`, and
 
    It returns the per-device figures **before and after** a bare
    `empty_cache()`, bracketed with nothing in between, plus a `reclaimed: bool`
-   field indicating whether the reclaim actually ran. Record all three as **P4**.
+   field indicating whether the reclaim actually ran. Record all three as **P4 before** and **P4 after**. **Before treating P4's readings as valid, capture `/debug/memory` one more time after the reclaim completes and verify that `inflight_synth == 0` — if it has changed, background synthesis occurred between the idle gate and the reclaim, invalidating the confirmed-idle assumption. If so, stop and re-run from step 4.**
 
    > Do **not** substitute a load/unload cycle. A load is an allocation pass that
    > refills and coalesces segments — conflating the two is the unsound inference
@@ -170,15 +170,15 @@ Run: 2026-08-26, this box (`cuda:0` RTX 4070 Laptop 8188 MB, `cuda:1` RTX 5070 T
 41 lines), re-rendered with `force:true` on `qwen3-tts-0.6b`. Both GPUs were idle
 (0 MiB used, 0% util) before the run started.
 
-| Point | When | time to idle | Device | reserved bytes | allocated bytes | inactive_split bytes | reserved − allocated | nvidia-smi used | RSS MB | Engines loaded | reclaimed |
-|---|---|---|---|---|---|---|---|---|---|---|---|
-| P0 | fresh, 07:53:44 | | cuda:1 | 0 | 0 | 0 | 0 | 197 MiB | 1143.0 | none | |
-| P1 | mid-render, 07:54:32 (~8 s in) | | cuda:1 | 1,881,145,344 (1794.4 MB) | 1,863,124,480 (1776.7 MB) | 13,826,560 (13.2 MB) | 17,975,296 (17.1 MB) | 2051 MiB | 3965.9 | qwen base | |
-| P2 | +0 s, 07:58:36 | | cuda:1 | 6,138,363,904 (5853.4 MB) | 5,717,628,928 (5453.7 MB) | 30,664,704 (29.25 MB) | 420,734,976 (401.3 MB) | 6489 MiB | 19914.2 | qwen base, whisper | |
-| P3 | confirmed idle, 07:58:57 | **21 s** | cuda:1 | 6,138,363,904 (5853.4 MB) — **identical to P2** | 5,717,628,928 (5453.7 MB) | 30,664,704 (29.25 MB) | 420,734,976 (401.3 MB) | 6489 MiB | 19799.1 | qwen base, whisper | |
-| P4 before | reclaim, 07:58:58 | | cuda:1 | 6,138,363,904 (5853.4 MB) | 5,717,628,928 (5453.7 MB) | 30,664,704 (29.25 MB) | 420,734,976 (401.3 MB) | | | | true |
-| P4 after | reclaim, 07:58:58 | | cuda:1 | 5,748,293,632 (5481.4 MB) | 5,717,628,928 (5453.7 MB) — **unchanged** | 30,664,704 (29.25 MB) — **unchanged** | 30,664,704 (29.25 MB) | | | | true |
-| P5 | cuda:1 render, throughout P1–P4 | | cuda:0 | 2,097,152 (2.0 MB, unchanged pre/post) | ≈0 | ≈2.0 MB | | 0–116 MiB (baseline noise) | | | |
+| Point | When | time to idle | Device | reserved bytes | allocated bytes | inactive_split bytes | reserved − allocated | nvidia-smi used | RSS MB | inflight_synth | Engines loaded | reclaimed |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| P0 | fresh, 07:53:44 | | cuda:1 | 0 | 0 | 0 | 0 | 197 MiB | 1143.0 | n/a — pre-fix run | none | |
+| P1 | mid-render, 07:54:32 (~8 s in) | | cuda:1 | 1,881,145,344 (1794.4 MB) | 1,863,124,480 (1776.7 MB) | 13,826,560 (13.2 MB) | 17,975,296 (17.1 MB) | 2051 MiB | 3965.9 | n/a — pre-fix run | qwen base | |
+| P2 | +0 s, 07:58:36 | | cuda:1 | 6,138,363,904 (5853.4 MB) | 5,717,628,928 (5453.7 MB) | 30,664,704 (29.25 MB) | 420,734,976 (401.3 MB) | 6489 MiB | 19914.2 | n/a — pre-fix run | qwen base, whisper | |
+| P3 | confirmed idle, 07:58:57 | **21 s** | cuda:1 | 6,138,363,904 (5853.4 MB) — **identical to P2** | 5,717,628,928 (5453.7 MB) | 30,664,704 (29.25 MB) | 420,734,976 (401.3 MB) | 6489 MiB | 19799.1 | n/a — pre-fix run | qwen base, whisper | |
+| P4 before | reclaim, 07:58:58 | | cuda:1 | 6,138,363,904 (5853.4 MB) | 5,717,628,928 (5453.7 MB) | 30,664,704 (29.25 MB) | 420,734,976 (401.3 MB) | | | n/a — pre-fix run | | true |
+| P4 after | reclaim, 07:58:58 | | cuda:1 | 5,748,293,632 (5481.4 MB) | 5,717,628,928 (5453.7 MB) — **unchanged** | 30,664,704 (29.25 MB) — **unchanged** | 30,664,704 (29.25 MB) | | | n/a — pre-fix run | | true |
+| P5 | cuda:1 render, throughout P1–P4 | | cuda:0 | 2,097,152 (2.0 MB, unchanged pre/post) | ≈0 | ≈2.0 MB | | 0–116 MiB (baseline noise) | | n/a — pre-fix run | | |
 
 Reclaim delta on `cuda:1`: `reserved` dropped 390,070,272 B (**372.0 MB, 6.4% of
 the 5853.4 MB reserved**). `allocated` and `inactive_split` did not move at all.

--- a/docs/testing/1996-stranded-vram-measurement.md
+++ b/docs/testing/1996-stranded-vram-measurement.md
@@ -22,6 +22,22 @@ so it takes no row in the on-box acceptance register.
 - A book with at least two chapters. `the-coalfall-commission.md` (the canonical
   fixture) is fine.
 - Qwen as the generation engine.
+- **Start the app via `npm start`** (not `npm run dev`) so that `logs/server.log`
+  and `logs/tts.err.log` capture the full timeline. `npm run dev` does not
+  redirect console output to the log files, which is why the Aug 23 run's
+  Node-side eviction log only survives as a manually-pasted GitHub comment line
+  and a burst of unexplained post-render Qwen activity could not be attributed to
+  a caller.
+- **Confirm `QWEN_DEVICE` and `ASR_DEVICE` are `cuda:1`** (the box's standing
+  device policy — `server/.env.example:528-534`) before starting. `cuda:1` is
+  the RTX 5070 Ti (16 GB); `cuda:0` (the 8 GB 4070 Laptop) is deliberately left
+  free for other work. Do not deviate from the pinned `cuda:1` policy unless
+  there is a documented reason — and if you must, record the deviation exactly
+  like the Aug 23 run did.
+- **Confirm no other chapter or book job is queued** and no Cast Review or
+  audition session is open in another browser tab. The last run's extra Qwen
+  activity during its supposed idle window is suspected to be exactly this kind
+  of confound — this run needs to rule it out or name it.
 
 Sidecar is at `http://127.0.0.1:9000` unless `LOCAL_TTS_PORT` says otherwise.
 
@@ -58,13 +74,67 @@ Record, per device: `reserved`, `allocated`, `inactive_split`, and
    Record which engines report loaded; specifically whether **Coqui, Kokoro or
    Qwen Base 0.6B** is among them (the three engines with no idle TTL).
 
-4. **180 s post-render.** Leave the box completely idle — no UI interaction, no
-   transcribe, nothing that would touch an engine. Capture as **P3**.
+   Stamp the P2 capture time so the idle gate in step 4 can report elapsed:
 
-   > 180 s is past every existing 120 s TTL. **If the strand is gone at P3 the
-   > run is already decisive** — the pool self-heals on `main` today
-   > (decision-tree row 3). Record it and stop; do not retry until a strand
-   > appears.
+   ```powershell
+   $captureP2Time = Get-Date
+   ```
+
+4. **Wait for confirmed idle.** Leave the box idle — no UI interaction, no
+   transcribe, nothing that would touch an engine. Instead of a fixed 180 s
+   wall clock, poll the sidecar's `/health` endpoint for `inflight_synth` (an
+   int; `0` means nothing is generating) until it has been quiet for five
+   consecutive checks (10 s of confirmed idle). A 10-minute safety ceiling
+   prevents an infinite wait on a busy box.
+
+   Run this as **one blocking script**, not turn-by-turn polling — it
+   self-terminates once idle or after the ceiling:
+
+   ```powershell
+   $deadline = (Get-Date).AddMinutes(10)
+   $quietStreak = 0
+   while ((Get-Date) -lt $deadline) {
+     $h = Invoke-RestMethod http://127.0.0.1:9000/health
+     if ($h.inflight_synth -eq 0) { $quietStreak++ } else { $quietStreak = 0 }
+     if ($quietStreak -ge 5) { break }  # 5 consecutive quiet polls = 10s confirmed idle
+     Start-Sleep -Seconds 2
+   }
+   "Went idle after $((Get-Date) - $captureP2Time)"
+   ```
+
+   Record the actual elapsed time in the results table's **"time to idle"**
+   column. **If the gate never clears within 10 minutes, stop and report** —
+   do not force P3/P4 on a busy box.
+
+   Once the gate reports idle, capture as **P3**.
+
+   > **If the strand is gone at P3 the run is already decisive** — the pool
+   > self-heals on `main` today (decision-tree row 1). Record it and stop; do
+   > not retry until a strand appears.
+
+   **What was active during the wait.** Before moving to P3/P4, grep
+   `logs/server.log` for every request timestamped between the P2 capture and
+   the confirmed-idle point. List each one (route + any chapter/job id in the
+   log line) in a new **"What was active during the wait"** subsection of the
+   results. This closes the attribution gap the Aug 23 run left open — a burst
+   of unexplained post-render Qwen activity could not be attributed to a caller
+   because `npm run dev` did not write to `logs/server.log`.
+
+   ```powershell
+   $idleTime = Get-Date
+   Select-String -Path logs\server.log -Pattern 'GET |POST |PUT |PATCH |DELETE ' |
+     ForEach-Object {
+       $line = $_.Line
+       if ($line -match '(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2})') {
+         $ts = [datetime]::Parse($matches[1])
+         if ($ts -ge $captureP2Time -and $ts -le $idleTime) { $line }
+       }
+     }
+   ```
+
+   If the grep returns nothing, the idle window was genuinely clean. If it
+   returns entries, name them in the results — the decision tree's fourth row
+   uses this to tell a contaminated idle from a real strand.
 
 5. **The bare reclaim.** With the box still idle, one request:
 
@@ -89,19 +159,23 @@ Record, per device: `reserved`, `allocated`, `inactive_split`, and
 
 ## Results
 
-| Point | When | Device | reserved bytes | allocated bytes | inactive_split bytes | reserved − allocated | nvidia-smi used | RSS MB | Engines loaded | reclaimed |
-|---|---|---|---|---|---|---|---|---|---|---|
-| P0 | fresh | | | | | | | | | |
-| P1 | mid-render | | | | | | | | | |
-| P2 | +0 s | | | | | | | | | |
-| P3 | +180 s | | | | | | | | | |
-| P4 before | reclaim | | | | | | | | | |
-| P4 after | reclaim | | | | | | | | | |
-| P5 | cuda:1 render | | | | | | | | | |
+| Point | When | time to idle | Device | reserved bytes | allocated bytes | inactive_split bytes | reserved − allocated | nvidia-smi used | RSS MB | Engines loaded | reclaimed |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| P0 | fresh | | | | | | | | | | |
+| P1 | mid-render | | | | | | | | | | |
+| P2 | +0 s | | | | | | | | | | |
+| P3 | confirmed idle | _elapsed_ | | | | | | | | | |
+| P4 before | reclaim | | | | | | | | | | |
+| P4 after | reclaim | | | | | | | | | | |
+| P5 | cuda:1 render | | | | | | | | | | |
 
 **RSS at P2 vs 8192 MB:** ☐ above ☐ below
 *(Above means the memory watchdog's unconditional 60 s `gc+empty_cache` was
 already firing throughout — `main.py:7957-7964` (`_mem_warn_threshold_mb()`).)*
+
+**What was active during the wait** (from `logs/server.log`, P2 → confirmed-idle):
+
+<!-- List each request line here: route + chapter/job id. If none, write "idle window clean". -->
 
 ---
 
@@ -112,6 +186,7 @@ already firing throughout — `main.py:7957-7964` (`_mem_warn_threshold_mb()`).)
 | Strand absent at P3 | Self-heals at the existing TTLs. #1996 criterion 1 is already satisfied on `main`. |
 | P4 `reserved` drops sharply | **Uncollected cache.** A scheduled reclaim is the fix — subject to every constraint in §7 of the design. |
 | P4 `reserved` barely moves, `inactive_split` dominates, `reclaimed: true` | **Fragmentation.** `empty_cache()` cannot fix this at any cadence; re-open the recycle threshold instead. |
+| Idle gate took >120 s to clear | **Contaminated idle.** Legitimate background activity was still running; name it from the `logs/server.log` grep above. **Do not treat the resulting P3/P4 readings as evidence about a stranded pool at all.** |
 | P4 `reserved` barely moves, `reclaimed: false` | **Invalid reading.** The reclaim never ran — CUDA was unavailable or `empty_cache()` threw. Retry once; treat repeated `false` as a separate finding (a live-context problem), not a #1996 answer. |
 | Strand present at P3 *and* P4 frees it *and* RSS was above 8192 MB at P2 | Contradicts the 60 s watchdog reclaim having run. Investigate that before designing anything — one of the two observations is wrong. |
 

--- a/docs/testing/1996-stranded-vram-measurement.md
+++ b/docs/testing/1996-stranded-vram-measurement.md
@@ -212,10 +212,13 @@ memory crossed 8192MB (rss=17128MB) → forced gc+empty_cache reclaimed -0MB (no
 The watchdog was already running and reclaiming ~0 MB — it cannot touch this
 pool either, for the same reason `/debug/reclaim` mostly couldn't.)*
 
-**What was active during the wait** (from `logs/server.log`, P2 07:58:36 →
-confirmed-idle 07:58:57): **idle window clean** — the grep returned zero
-request lines in that 21 s window. No confound; this run's P3/P4 readings are
-trustworthy evidence, not a contaminated idle.
+**What was active during the wait:** This run was measured with instruments that are now known to have been broken in two ways, both fixed on this branch but after this run was captured:
+
+1. **The idle gate couldn't see ASR activity.** The sidecar's `/health` endpoint tracked `inflight_synth` only for synthesis requests (`/synthesize`), not transcription (`/transcribe`) or embedding (`/embed`). This gate declared "idle" at 07:58:57 based on five consecutive zero `inflight_synth` polls, but that metric was blind to ASR. *Fixed in commit d4aa7a6c: `/health` and `/debug/memory` now include `/transcribe` and `/embed` in the busy signal.*
+
+2. **The attribution grep read the wrong log file.** The verification step relied on grepping `logs/server.log` for request lines, which never contains per-request entries from the sidecar — a null result that looked like "nothing happened" but actually meant "this instrument cannot report anything, ever." *Fixed in commit 36091ef2: the attribution step now reads `logs/tts.log`, the sidecar's uvicorn access log.*
+
+Real forensic evidence from `logs/tts.err.log` for this specific run: Whisper `small` loaded onto `cuda:1` at 07:58:31–34 and ran continuous transcription through 07:58:51.768. The idle gate reported a quiet streak beginning at ≈07:58:49 (after an 8 s quiet window from ~5 second polls starting after 07:58:41), which **overlaps the live Whisper transcription window (07:58:31–51.768)**. This run's "confirmed idle" window was not clean; it was contaminated by active ASR transcription that the broken idle gate could not detect.
 
 ---
 
@@ -230,41 +233,17 @@ trustworthy evidence, not a contaminated idle.
 | P4 `reserved` barely moves, `reclaimed: false` | **Invalid reading.** The reclaim never ran — CUDA was unavailable or `empty_cache()` threw. Retry once; treat repeated `false` as a separate finding (a live-context problem), not a #1996 answer. |
 | Strand present at P3 *and* P4 frees it *and* RSS was above 8192 MB at P2 | Contradicts the 60 s watchdog reclaim having run. Investigate that before designing anything — one of the two observations is wrong. |
 
-### This run's verdict: none of the five rows above fit — a sixth case
+### This run's verdict: contaminated idle with misattributed residency — evidence is invalid
 
-The observed shape is internally consistent but doesn't match any listed row:
+This run fits the **"contaminated idle"** row: the idle-gate signal and the attribution verification both relied on broken instruments that are now known to have been blind to the actual work running.
 
-- Not "self-heals" — the strand is byte-identical at P2 and P3 (21 s of
-  confirmed-clean idle).
-- Not "uncollected cache" — reclaim only recovered 372.0 MB of the 5853.4 MB
-  reserved (6.4%), nowhere near "drops sharply".
-- Not "fragmentation" — `inactive_split` is 29.25 MB, a rounding error next to
-  the 5453.7 MB sitting in `allocated`. Fragmentation is not what's dominant.
-- Not "contaminated idle" — the gate cleared in 21 s (well under the 120 s
-  threshold) and the attribution grep is empty.
-- Not "invalid reading" — `reclaimed: true` both times.
+**The contamination:** Whisper ASR was transcribing continuously during what the old idle gate declared "confirmed idle" (07:58:49–07:58:57 vs actual Whisper activity 07:58:31–51.768). The old idle gate could not see this because it tracked only `inflight_synth`, not `/transcribe` or `/embed` (fixed in commit d4aa7a6c). The attribution grep checked the wrong log file (`logs/server.log` instead of `logs/tts.log`, fixed in commit 36091ef2). By the decision tree's logic: "Legitimate background activity was still running; name it from the `logs/server.log` grep above. **Do not treat the resulting P3/P4 readings as evidence about a stranded pool at all.**"
 
-**What actually explains it:** `allocated` (5453.7 MB) never moved at all,
-before or after `/debug/reclaim`. `empty_cache()` only returns *reserved-but-
-unallocated* cache to the driver — by definition it cannot touch memory PyTorch
-still considers live. At P2/P3, `qwen.base_loaded=true` and
-`whisper.model_loaded=true` — and per CLAUDE.md's engine-lifecycle notes, **Qwen
-Base 0.6B has no idle TTL at all** (button-driven, evicts only on explicit
-`/unload`), and Whisper's `ASR_IDLE_TTL=120s` had only 21 s elapsed against it.
-So the 5.45 GB of `allocated` VRAM this run measured is, as far as this reading
-can tell, **the two resident models' own live weights/KV state — normal
-residency, not a leak** on top of it.
+**The misattribution:** The run loaded three resident models — Qwen Base 0.6B (no TTL), Whisper (120s TTL), and Qwen 1.7B-Base (120s TTL) — but the `/debug/memory` endpoint at the time of this run could not represent the 1.7B model (missing the `base17_loaded` key, added retroactively in commit 42dddeb8). The ~3.3 GB gap between P1's `allocated` (1776.7 MB) and P2's `allocated` (5453.7 MB) is plausibly the Qwen 1.7B-Base model loading during session rather than something inexplicable. The 1.7B model's 120s idle TTL means P3 (21 s post-P2) would not have evicted it even if the idle window had been clean — which it was not.
 
-This run cannot distinguish "the resident-model floor is exactly what #1976
-measured and mistook for stranded" from "there is a genuine leak sitting on top
-of that floor, currently masked by residency." Answering that needs a follow-up
-reading that either (a) waits past both TTLs (impossible for Qwen Base, which
-has none — would need an explicit `/unload` call first) or (b) captures
-`allocated` immediately after an explicit Qwen-Base unload and diffs against
-this run's P3. Recorded as the next open question rather than closing #1996's
-criterion 1 — this run neither confirms nor refutes #1976's "fully reclaimable"
-claim; it shows the claim's own measurement never separated "resident" from
-"stranded" in the first place.
+**Conclusion:** This run does NOT provide trustworthy evidence. Its P3/P4 readings show a contaminated-idle state with unattributable residency, not a measurement of a stranded pool. It does not close #1996's criterion 1 (and does not discharge the acceptance row already owed).
+
+**Next step:** A valid re-run is still owed, using the now-fixed instruments (idle gate tracking ASR via the `/transcribe`/`/embed` signals, attribution grepping `logs/tts.log`, and `/debug/memory` with full `base17_loaded` visibility). This is real-hardware work that was not performed as part of this PR-review-gate fix round — no GPU re-run has been executed; only this narrative correction has landed.
 
 Record the outcome as a comment on
 [#1996](https://github.com/dudarenok-maker/Castwright/issues/1996), including the

--- a/docs/testing/1996-stranded-vram-measurement.md
+++ b/docs/testing/1996-stranded-vram-measurement.md
@@ -112,29 +112,31 @@ Record, per device: `reserved`, `allocated`, `inactive_split`, and
    > self-heals on `main` today (decision-tree row 1). Record it and stop; do
    > not retry until a strand appears.
 
-   **What was active during the wait.** Before moving to P3/P4, grep
-   `logs/server.log` for every request timestamped between the P2 capture and
-   the confirmed-idle point. List each one (route + any chapter/job id in the
-   log line) in a new **"What was active during the wait"** subsection of the
-   results. This closes the attribution gap the Aug 23 run left open — a burst
-   of unexplained post-render Qwen activity could not be attributed to a caller
-   because `npm run dev` did not write to `logs/server.log`.
+   **What was active during the wait.** The sidecar's `/health` endpoint with `inflight_synth` tracking (step 4 above — five consecutive zero polls = 10 s confirmed idle) is your PRIMARY signal for genuine idle. As a secondary corroboration and attribution step, grep the sidecar's access log (`logs/tts.log`, from uvicorn) for any requests during the wait window to confirm the window was clean or name what ran.
+
+   The sidecar access log has no per-line timestamps, so use a line-count-diff to extract the appended lines: capture the line count of `logs\tts.log` at P2, capture it again at the confirmed-idle point, and extract the lines in between. If all appended lines are `/health`, `/capacity`, `/speakers`, or `/debug/memory` polling (harmless self-polling from the run sheet's own idle-gate and capture steps), the window is clean. If a `/synthesize`, `/transcribe`, or `/embed` line appears, name it — that's the confound the decision tree's fourth row keys on.
+
+   At P2, after capturing the memory figures, save the line count:
 
    ```powershell
-   $idleTime = Get-Date
-   Select-String -Path logs\server.log -Pattern 'GET |POST |PUT |PATCH |DELETE ' |
-     ForEach-Object {
-       $line = $_.Line
-       if ($line -match '(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2})') {
-         $ts = [datetime]::Parse($matches[1])
-         if ($ts -ge $captureP2Time -and $ts -le $idleTime) { $line }
-       }
-     }
+   $ttsLogCountAtP2 = (Get-Content logs\tts.log -ErrorAction Stop).Count
+   if ($null -eq $ttsLogCountAtP2) { $ttsLogCountAtP2 = 0 }  # empty log
+   "Line count at P2: $ttsLogCountAtP2"
    ```
 
-   If the grep returns nothing, the idle window was genuinely clean. If it
-   returns entries, name them in the results — the decision tree's fourth row
-   uses this to tell a contaminated idle from a real strand.
+   Then, once the idle gate clears and you're about to capture P3, get the current line count and print the appended lines:
+
+   ```powershell
+   $ttsLogCountAtIdle = (Get-Content logs\tts.log -ErrorAction Stop).Count
+   if ($null -eq $ttsLogCountAtIdle) { $ttsLogCountAtIdle = 0 }
+   $appendedCount = $ttsLogCountAtIdle - $ttsLogCountAtP2
+   "Appended lines during wait: $appendedCount"
+   if ($appendedCount -gt 0) {
+     Get-Content logs\tts.log -Tail $appendedCount
+   }
+   ```
+
+   If the output shows no appended lines, or only `/health`/`/capacity`/`/speakers`/`/debug/memory` noise, record that the idle window was clean. If it shows `/synthesize`, `/transcribe`, or `/embed`, list those in the results as evidence of what was active during the wait.
 
 5. **The bare reclaim.** With the box still idle, one request:
 

--- a/docs/testing/1996-stranded-vram-measurement.md
+++ b/docs/testing/1996-stranded-vram-measurement.md
@@ -84,8 +84,19 @@ Record, per device: `reserved`, `allocated`, `inactive_split`, and
    transcribe, nothing that would touch an engine. Instead of a fixed 180 s
    wall clock, poll the sidecar's `/health` endpoint for `inflight_synth` (an
    int; `0` means nothing is generating) until it has been quiet for five
-   consecutive checks (10 s of confirmed idle). A 10-minute safety ceiling
+   consecutive checks (8 s of confirmed idle). A 10-minute safety ceiling
    prevents an infinite wait on a busy box.
+   
+   **Interpreting idle-gate duration:** The idle gate reports elapsed time to
+   confirm when the box truly went quiet. If the gate clears in under 120
+   seconds, the idle window is likely clean (only genuine background activity
+   that was already running, if anything). A gate that takes 120 seconds or
+   longer to clear suggests the box was actively working during what should
+   have been an idle window — consult the `logs/server.log` grep (next section)
+   to name what was running. This 120 s threshold is separate from the 8 s
+   quiet-streak requirement above and the 10-minute ceiling; it is a judgment
+   call for how long an otherwise-successful idle-gate wait is "suspiciously
+   slow" rather than straightforwardly clean.
 
    Run this as **one blocking script**, not turn-by-turn polling — it
    self-terminates once idle or after the ceiling:
@@ -96,7 +107,7 @@ Record, per device: `reserved`, `allocated`, `inactive_split`, and
    while ((Get-Date) -lt $deadline) {
      $h = Invoke-RestMethod http://127.0.0.1:9000/health
      if ($h.inflight_synth -eq 0) { $quietStreak++ } else { $quietStreak = 0 }
-     if ($quietStreak -ge 5) { break }  # 5 consecutive quiet polls = 10s confirmed idle
+     if ($quietStreak -ge 5) { break }  # 5 consecutive quiet polls = 8s confirmed idle
      Start-Sleep -Seconds 2
    }
    if ($quietStreak -ge 5) {
@@ -116,7 +127,7 @@ Record, per device: `reserved`, `allocated`, `inactive_split`, and
    > self-heals on `main` today (decision-tree row 1). Record it and stop; do
    > not retry until a strand appears.
 
-   **What was active during the wait.** The sidecar's `/health` endpoint with `inflight_synth` tracking (step 4 above — five consecutive zero polls = 10 s confirmed idle) is your PRIMARY signal for genuine idle. As a secondary corroboration and attribution step, grep the sidecar's access log (`logs/tts.log`, from uvicorn) for any requests during the wait window to confirm the window was clean or name what ran.
+   **What was active during the wait.** The sidecar's `/health` endpoint with `inflight_synth` tracking (step 4 above — five consecutive zero polls = 8 s confirmed idle) is your PRIMARY signal for genuine idle. As a secondary corroboration and attribution step, grep the sidecar's access log (`logs/tts.log`, from uvicorn) for any requests during the wait window to confirm the window was clean or name what ran.
 
    The sidecar access log has no per-line timestamps, so use a line-count-diff to extract the appended lines: capture the line count of `logs\tts.log` at P2, capture it again at the confirmed-idle point, and extract the lines in between. If all appended lines are `/health`, `/capacity`, `/speakers`, or `/debug/memory` polling (harmless self-polling from the run sheet's own idle-gate and capture steps), the window is clean. If a `/synthesize`, `/transcribe`, or `/embed` line appears, name it — that's the confound the decision tree's fourth row keys on.
 

--- a/docs/testing/1996-stranded-vram-measurement.md
+++ b/docs/testing/1996-stranded-vram-measurement.md
@@ -159,23 +159,46 @@ Record, per device: `reserved`, `allocated`, `inactive_split`, and
 
 ## Results
 
+Run: 2026-08-26, this box (`cuda:0` RTX 4070 Laptop 8188 MB, `cuda:1` RTX 5070 Ti
+16303 MB). Book: *The Coalfall Commission*, Chapter 3 ("Chapter One — The Knock",
+41 lines), re-rendered with `force:true` on `qwen3-tts-0.6b`. Both GPUs were idle
+(0 MiB used, 0% util) before the run started.
+
 | Point | When | time to idle | Device | reserved bytes | allocated bytes | inactive_split bytes | reserved − allocated | nvidia-smi used | RSS MB | Engines loaded | reclaimed |
 |---|---|---|---|---|---|---|---|---|---|---|---|
-| P0 | fresh | | | | | | | | | | |
-| P1 | mid-render | | | | | | | | | | |
-| P2 | +0 s | | | | | | | | | | |
-| P3 | confirmed idle | _elapsed_ | | | | | | | | | |
-| P4 before | reclaim | | | | | | | | | | |
-| P4 after | reclaim | | | | | | | | | | |
-| P5 | cuda:1 render | | | | | | | | | | |
+| P0 | fresh, 07:53:44 | | cuda:1 | 0 | 0 | 0 | 0 | 197 MiB | 1143.0 | none | |
+| P1 | mid-render, 07:54:32 (~8 s in) | | cuda:1 | 1,881,145,344 (1794.4 MB) | 1,863,124,480 (1776.7 MB) | 13,826,560 (13.2 MB) | 17,975,296 (17.1 MB) | 2051 MiB | 3965.9 | qwen base | |
+| P2 | +0 s, 07:58:36 | | cuda:1 | 6,138,363,904 (5853.4 MB) | 5,717,628,928 (5453.7 MB) | 30,664,704 (29.25 MB) | 420,734,976 (401.3 MB) | 6489 MiB | 19914.2 | qwen base, whisper | |
+| P3 | confirmed idle, 07:58:57 | **21 s** | cuda:1 | 6,138,363,904 (5853.4 MB) — **identical to P2** | 5,717,628,928 (5453.7 MB) | 30,664,704 (29.25 MB) | 420,734,976 (401.3 MB) | 6489 MiB | 19799.1 | qwen base, whisper | |
+| P4 before | reclaim, 07:58:58 | | cuda:1 | 6,138,363,904 (5853.4 MB) | 5,717,628,928 (5453.7 MB) | 30,664,704 (29.25 MB) | 420,734,976 (401.3 MB) | | | | true |
+| P4 after | reclaim, 07:58:58 | | cuda:1 | 5,748,293,632 (5481.4 MB) | 5,717,628,928 (5453.7 MB) — **unchanged** | 30,664,704 (29.25 MB) — **unchanged** | 30,664,704 (29.25 MB) | | | | true |
+| P5 | cuda:1 render, throughout P1–P4 | | cuda:0 | 2,097,152 (2.0 MB, unchanged pre/post) | ≈0 | ≈2.0 MB | | 0–116 MiB (baseline noise) | | | |
 
-**RSS at P2 vs 8192 MB:** ☐ above ☐ below
+Reclaim delta on `cuda:1`: `reserved` dropped 390,070,272 B (**372.0 MB, 6.4% of
+the 5853.4 MB reserved**). `allocated` and `inactive_split` did not move at all.
+After the reclaim, `reserved − allocated` (30,664,704 B) exactly equals
+`inactive_split` — i.e. every byte of *freeable* cache was already reclaimed;
+nothing else in `reserved` is fragmentation.
+
+**P5 (dual-GPU cross-device check):** satisfied by the readings already taken
+rather than a second render — this box's standing device policy pins Qwen/Coqui/
+ASR to `cuda:1` exclusively (`server/.env.example:528-534`), so every render on
+this box **is** the cross-device case. `cuda:0` stayed at its 0–116 MiB baseline
+(OS/driver noise, not app-caused) across the entire P0→P4 window while `cuda:1`
+went from 197 MiB to 6489 MiB. No VRAM bleed onto the idle card.
+
+**RSS at P2 vs 8192 MB:** ☒ above ☐ below (19914 MB, 2.4× the threshold).
 *(Above means the memory watchdog's unconditional 60 s `gc+empty_cache` was
-already firing throughout — `main.py:7957-7964` (`_mem_warn_threshold_mb()`).)*
+already firing throughout — confirmed directly in `logs/tts.err.log`: `"sidecar
+memory crossed 8192MB (rss=17128MB) → forced gc+empty_cache reclaimed -0MB (now
+17128MB)"`, fired once during the render itself, before P2 was even captured.
+The watchdog was already running and reclaiming ~0 MB — it cannot touch this
+pool either, for the same reason `/debug/reclaim` mostly couldn't.)*
 
-**What was active during the wait** (from `logs/server.log`, P2 → confirmed-idle):
-
-<!-- List each request line here: route + chapter/job id. If none, write "idle window clean". -->
+**What was active during the wait** (from `logs/server.log`, P2 07:58:36 →
+confirmed-idle 07:58:57): **idle window clean** — the grep returned zero
+request lines in that 21 s window. No confound; this run's P3/P4 readings are
+trustworthy evidence, not a contaminated idle.
 
 ---
 
@@ -189,6 +212,42 @@ already firing throughout — `main.py:7957-7964` (`_mem_warn_threshold_mb()`).)
 | Idle gate took >120 s to clear | **Contaminated idle.** Legitimate background activity was still running; name it from the `logs/server.log` grep above. **Do not treat the resulting P3/P4 readings as evidence about a stranded pool at all.** |
 | P4 `reserved` barely moves, `reclaimed: false` | **Invalid reading.** The reclaim never ran — CUDA was unavailable or `empty_cache()` threw. Retry once; treat repeated `false` as a separate finding (a live-context problem), not a #1996 answer. |
 | Strand present at P3 *and* P4 frees it *and* RSS was above 8192 MB at P2 | Contradicts the 60 s watchdog reclaim having run. Investigate that before designing anything — one of the two observations is wrong. |
+
+### This run's verdict: none of the five rows above fit — a sixth case
+
+The observed shape is internally consistent but doesn't match any listed row:
+
+- Not "self-heals" — the strand is byte-identical at P2 and P3 (21 s of
+  confirmed-clean idle).
+- Not "uncollected cache" — reclaim only recovered 372.0 MB of the 5853.4 MB
+  reserved (6.4%), nowhere near "drops sharply".
+- Not "fragmentation" — `inactive_split` is 29.25 MB, a rounding error next to
+  the 5453.7 MB sitting in `allocated`. Fragmentation is not what's dominant.
+- Not "contaminated idle" — the gate cleared in 21 s (well under the 120 s
+  threshold) and the attribution grep is empty.
+- Not "invalid reading" — `reclaimed: true` both times.
+
+**What actually explains it:** `allocated` (5453.7 MB) never moved at all,
+before or after `/debug/reclaim`. `empty_cache()` only returns *reserved-but-
+unallocated* cache to the driver — by definition it cannot touch memory PyTorch
+still considers live. At P2/P3, `qwen.base_loaded=true` and
+`whisper.model_loaded=true` — and per CLAUDE.md's engine-lifecycle notes, **Qwen
+Base 0.6B has no idle TTL at all** (button-driven, evicts only on explicit
+`/unload`), and Whisper's `ASR_IDLE_TTL=120s` had only 21 s elapsed against it.
+So the 5.45 GB of `allocated` VRAM this run measured is, as far as this reading
+can tell, **the two resident models' own live weights/KV state — normal
+residency, not a leak** on top of it.
+
+This run cannot distinguish "the resident-model floor is exactly what #1976
+measured and mistook for stranded" from "there is a genuine leak sitting on top
+of that floor, currently masked by residency." Answering that needs a follow-up
+reading that either (a) waits past both TTLs (impossible for Qwen Base, which
+has none — would need an explicit `/unload` call first) or (b) captures
+`allocated` immediately after an explicit Qwen-Base unload and diffs against
+this run's P3. Recorded as the next open question rather than closing #1996's
+criterion 1 — this run neither confirms nor refutes #1976's "fully reclaimable"
+claim; it shows the claim's own measurement never separated "resident" from
+"stranded" in the first place.
 
 Record the outcome as a comment on
 [#1996](https://github.com/dudarenok-maker/Castwright/issues/1996), including the

--- a/docs/testing/1996-stranded-vram-measurement.md
+++ b/docs/testing/1996-stranded-vram-measurement.md
@@ -99,7 +99,11 @@ Record, per device: `reserved`, `allocated`, `inactive_split`, and
      if ($quietStreak -ge 5) { break }  # 5 consecutive quiet polls = 10s confirmed idle
      Start-Sleep -Seconds 2
    }
-   "Went idle after $((Get-Date) - $captureP2Time)"
+   if ($quietStreak -ge 5) {
+     "Confirmed idle after $((Get-Date) - $captureP2Time)"
+   } else {
+     "CEILING TIMEOUT after 10 minutes -- box never went idle. STOP: do not capture P3/P4."
+   }
    ```
 
    Record the actual elapsed time in the results table's **"time to idle"**

--- a/docs/testing/1996-stranded-vram-measurement.md
+++ b/docs/testing/1996-stranded-vram-measurement.md
@@ -179,17 +179,18 @@ Record, per device: `reserved`, `allocated`, `inactive_split`, and
 
 Run: 2026-08-26, this box (`cuda:0` RTX 4070 Laptop 8188 MB, `cuda:1` RTX 5070 Ti
 16303 MB). Book: *The Coalfall Commission*, Chapter 3 ("Chapter One — The Knock",
-41 lines), re-rendered with `force:true` on `qwen3-tts-0.6b`. Both GPUs were idle
-(0 MiB used, 0% util) before the run started.
+41 lines), re-rendered with `force:true` on `qwen3-tts-0.6b`. During the session,
+Qwen 1.7B-Base also loaded and ran. Both GPUs were idle (0 MiB used, 0% util) before
+the run started.
 
 | Point | When | time to idle | Device | reserved bytes | allocated bytes | inactive_split bytes | reserved − allocated | nvidia-smi used | RSS MB | inflight_synth | Engines loaded | reclaimed |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|
 | P0 | fresh, 07:53:44 | | cuda:1 | 0 | 0 | 0 | 0 | 197 MiB | 1143.0 | n/a — pre-fix run | none | |
 | P1 | mid-render, 07:54:32 (~8 s in) | | cuda:1 | 1,881,145,344 (1794.4 MB) | 1,863,124,480 (1776.7 MB) | 13,826,560 (13.2 MB) | 17,975,296 (17.1 MB) | 2051 MiB | 3965.9 | n/a — pre-fix run | qwen base | |
-| P2 | +0 s, 07:58:36 | | cuda:1 | 6,138,363,904 (5853.4 MB) | 5,717,628,928 (5453.7 MB) | 30,664,704 (29.25 MB) | 420,734,976 (401.3 MB) | 6489 MiB | 19914.2 | n/a — pre-fix run | qwen base, whisper | |
-| P3 | confirmed idle, 07:58:57 | **21 s** | cuda:1 | 6,138,363,904 (5853.4 MB) — **identical to P2** | 5,717,628,928 (5453.7 MB) | 30,664,704 (29.25 MB) | 420,734,976 (401.3 MB) | 6489 MiB | 19799.1 | n/a — pre-fix run | qwen base, whisper | |
-| P4 before | reclaim, 07:58:58 | | cuda:1 | 6,138,363,904 (5853.4 MB) | 5,717,628,928 (5453.7 MB) | 30,664,704 (29.25 MB) | 420,734,976 (401.3 MB) | | | n/a — pre-fix run | | true |
-| P4 after | reclaim, 07:58:58 | | cuda:1 | 5,748,293,632 (5481.4 MB) | 5,717,628,928 (5453.7 MB) — **unchanged** | 30,664,704 (29.25 MB) — **unchanged** | 30,664,704 (29.25 MB) | | | n/a — pre-fix run | | true |
+| P2 | +0 s, 07:58:36 | | cuda:1 | 6,138,363,904 (5853.4 MB) | 5,717,628,928 (5453.7 MB) | 30,664,704 (29.25 MB) | 420,734,976 (401.3 MB) | 6489 MiB | 19914.2 | n/a — pre-fix run | qwen base, qwen 1.7b-base *(from logs)*, whisper | |
+| P3 | confirmed idle, 07:58:57 | **21 s** | cuda:1 | 6,138,363,904 (5853.4 MB) — **identical to P2** | 5,717,628,928 (5453.7 MB) | 30,664,704 (29.25 MB) | 420,734,976 (401.3 MB) | 6489 MiB | 19799.1 | n/a — pre-fix run | qwen base, qwen 1.7b-base *(from logs)*, whisper | |
+| P4 before | reclaim, 07:58:58 | | cuda:1 | 6,138,363,904 (5853.4 MB) | 5,717,628,928 (5453.7 MB) | 30,664,704 (29.25 MB) | 420,734,976 (401.3 MB) | | | n/a — pre-fix run | qwen base, qwen 1.7b-base *(from logs)*, whisper | true |
+| P4 after | reclaim, 07:58:58 | | cuda:1 | 5,748,293,632 (5481.4 MB) | 5,717,628,928 (5453.7 MB) — **unchanged** | 30,664,704 (29.25 MB) — **unchanged** | 30,664,704 (29.25 MB) | | | n/a — pre-fix run | qwen base, qwen 1.7b-base *(from logs)*, whisper | true |
 | P5 | cuda:1 render, throughout P1–P4 | | cuda:0 | 2,097,152 (2.0 MB, unchanged pre/post) | ≈0 | ≈2.0 MB | | 0–116 MiB (baseline noise) | | n/a — pre-fix run | | |
 
 Reclaim delta on `cuda:1`: `reserved` dropped 390,070,272 B (**372.0 MB, 6.4% of

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -10996,6 +10996,8 @@ async def transcribe(req: Request) -> Response:
     language = req.headers.get("X-Language") or None
     word_timestamps = req.headers.get("X-Word-Timestamps") is not None
 
+    global _inflight_synth
+    _inflight_synth += 1
     try:
         # Capacity-aware placement (task 4, vram-aware-placement plan): only
         # when ASR is GPU-configured (ASR_DEVICE=cuda/rocm) — the cpu-default
@@ -11031,6 +11033,8 @@ async def transcribe(req: Request) -> Response:
             _mark_cuda_poisoned(err_str)
             return JSONResponse({"detail": "Internal error.", "poisoned": True}, status_code=503)
         return JSONResponse({"detail": "Internal error."}, status_code=500)
+    finally:
+        _inflight_synth -= 1  # srv-31: clears the recycle drain regardless of outcome
     return JSONResponse(result)
 
 
@@ -11070,6 +11074,8 @@ async def embed(req: Request) -> Response:
     if sample_rate <= 0:
         raise HTTPException(status_code=400, detail="X-Sample-Rate header (>0) is required.")
 
+    global _inflight_synth
+    _inflight_synth += 1
     try:
         # Capacity-aware placement (task 4, vram-aware-placement plan): only
         # when SPK is GPU-configured (SPK_DEVICE=cuda/rocm) — the cpu-default
@@ -11099,6 +11105,8 @@ async def embed(req: Request) -> Response:
             _mark_cuda_poisoned(err_str)
             return JSONResponse({"detail": "Internal error.", "poisoned": True}, status_code=503)
         return JSONResponse({"detail": "Internal error."}, status_code=500)
+    finally:
+        _inflight_synth -= 1  # srv-36: clears the recycle drain regardless of outcome
     return JSONResponse({"embedding": embedding, "dim": len(embedding), "sample_rate": SPK.TARGET_SR})
 
 

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -8139,11 +8139,11 @@ _restart_scheduled = False
 # recycle is scheduled; while it's set, /synthesize + /synthesize-batch fast-fail
 # with a (non-poisoned) 503 so no NEW chapter enters the dying process and the
 # server's in-worker recovery rides out the respawn. `_inflight_synth` counts
-# live synth calls (incremented on the event loop around each to_thread offload);
-# the recycle drains it to 0 (bounded by SIDECAR_DRAIN_GRACE_MS) before exiting so
-# the in-flight chapter finishes here instead of failing. Both are read by the
-# drain thread — a plain int read is atomic under the GIL, eventual consistency
-# is all the drain needs.
+# live synth, transcribe, and embed calls (incremented on the event loop around
+# each to_thread offload); the recycle drains it to 0 (bounded by
+# SIDECAR_DRAIN_GRACE_MS) before exiting so the in-flight chapter finishes here
+# instead of failing. Both are read by the drain thread — a plain int read is
+# atomic under the GIL, eventual consistency is all the drain needs.
 _restart_pending = False
 _inflight_synth = 0
 # side-11 item 2 — SOFT recycle signal. Set True by the watchdog once committed

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -9769,6 +9769,7 @@ def debug_memory() -> dict[str, Any]:
         engines["qwen"] = {
             "base_loaded": qwen._base is not None,
             "design_loaded": qwen._design is not None,
+            "base17_loaded": qwen._base17 is not None,
             "prompt_cache_entries": prompt_cache_entries,
         }
     coqui = ENGINES.get("coqui")

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -9700,6 +9700,7 @@ def health() -> dict[str, Any]:
         # `committed_mb` / `vram_reserved_mb` / `vram_total_mb` (may be None) give
         # the boundary decision observability without a separate /debug/memory hit.
         "recycle_pending": _recycle_pending,
+        "inflight_synth": _inflight_synth,
         "committed_mb": _process_commit_mb(),
         # CURRENT-DEVICE-ONLY (#1976) — `_cuda_vram_mb()` reads
         # `torch.cuda.current_device()`, not necessarily the render/recycle
@@ -9755,6 +9756,11 @@ def debug_memory() -> dict[str, Any]:
         "garbage": len(gc.garbage),
         "tracked_objects": len(gc.get_objects()),
     }
+    # #1996 — surface the pending-synth counter (process-wide, not engine-
+    # specific) so an idle probe can read a positive "nothing generating" signal
+    # instead of inferring it from a fixed wall-clock wait. Same plain GIL-safe
+    # int read the drain-before-recycle path already does.
+    out["inflight_synth"] = _inflight_synth
     engines: dict[str, Any] = {}
     qwen = ENGINES.get("qwen")
     if isinstance(qwen, QwenEngine):

--- a/server/tts-sidecar/tests/test_memory.py
+++ b/server/tts-sidecar/tests/test_memory.py
@@ -1273,3 +1273,104 @@ def test_health_exposes_qwen_design_ever_loaded(monkeypatch):
     with TestClient(main.app) as client:
         body = client.get("/health").json()
     assert body["qwen_design_ever_loaded"] is True  # after a design load
+
+
+def test_debug_memory_includes_inflight_synth_top_level_key(monkeypatch):
+    """/debug/memory must expose `inflight_synth` as a top-level key (sibling to
+    `process`, `gc`, `engines`, `cuda`) so an idle-measurement probe can read the
+    in-flight counter. This test pins the structure at rest (zero value) and
+    verifies it's present. Regression test for PR #2655 review finding: the key
+    existed but was untested, so a silent regression would have passed all tests."""
+    monkeypatch.delitem(main.ENGINES, "kokoro", raising=False)
+    monkeypatch.setitem(main.ENGINES, "qwen", main.QwenEngine())
+
+    with TestClient(main.app) as client:
+        # At rest: call /debug/memory and verify inflight_synth is 0.
+        r = client.get("/debug/memory")
+        assert r.status_code == 200
+        body = r.json()
+
+        # Verify inflight_synth is a top-level key (not nested under engines or anything else).
+        assert "inflight_synth" in body, (
+            "inflight_synth field missing from /debug/memory at rest. "
+            "It must be a top-level key sibling to process/gc/engines/cuda."
+        )
+        # At rest, nothing is generating, so the counter must be 0.
+        assert body["inflight_synth"] == 0, (
+            f"inflight_synth should be 0 at rest, got {body['inflight_synth']}"
+        )
+
+
+def test_debug_memory_inflight_synth_tracks_busy_synth(monkeypatch):
+    """/debug/memory's `inflight_synth` key must track a real busy/idle transition,
+    not just exist as a placeholder. While a synthesize call is in flight,
+    inflight_synth > 0; once it finishes, back to 0. Regression test for PR #2655
+    review finding: the key could have been silently removed without this test
+    catching it."""
+    monkeypatch.delitem(main.ENGINES, "kokoro", raising=False)
+    # Use CoquiEngine (not Qwen) to avoid requiring real weights; test_smoke uses
+    # the same pattern with a fake engine.
+    engine = main.CoquiEngine()
+    monkeypatch.setitem(main.ENGINES, "coqui", engine)
+
+    # Stub synthesize to sleep so we have time to probe while it's in flight.
+    slow_sleep_sec = 0.5
+    original_synthesize = engine.synthesize
+
+    def fake_slow_synthesize(model, voice, text, language=None):
+        time.sleep(slow_sleep_sec)
+        return main.SynthResult(pcm=b"\x00\x00", sample_rate=24000)
+
+    engine.synthesize = fake_slow_synthesize
+
+    try:
+        with TestClient(main.app) as client:
+            # Start a slow synthesize in a background thread.
+            synth_thread = threading.Thread(
+                target=lambda: client.post(
+                    "/synthesize",
+                    json={
+                        "engine": "coqui",
+                        "model": "xtts_v2",
+                        "voice": "Narrator",
+                        "text": "Hello.",
+                    },
+                ),
+                daemon=True,
+            )
+            synth_thread.start()
+            # Tiny grace so synthesize is actually running when we probe.
+            time.sleep(0.05)
+
+            # Mid-synth: /debug/memory must show inflight_synth > 0.
+            r_busy = client.get("/debug/memory")
+            assert r_busy.status_code == 200, "debug/memory failed while synth was running"
+            body_busy = r_busy.json()
+            assert "inflight_synth" in body_busy, (
+                "inflight_synth missing from /debug/memory during busy synth"
+            )
+            inflight_busy = body_busy["inflight_synth"]
+            assert inflight_busy > 0, (
+                f"inflight_synth should be > 0 during synthesize, got {inflight_busy}. "
+                "Did /synthesize stop incrementing _inflight_synth?"
+            )
+
+            # Wait for synth to finish.
+            synth_thread.join(timeout=5.0)
+            assert not synth_thread.is_alive(), "synth thread never finished"
+
+            # After synth: /debug/memory must show inflight_synth == 0.
+            r_idle = client.get("/debug/memory")
+            assert r_idle.status_code == 200, "debug/memory failed after synth completed"
+            body_idle = r_idle.json()
+            assert "inflight_synth" in body_idle, (
+                "inflight_synth missing from /debug/memory after synth"
+            )
+            inflight_idle = body_idle["inflight_synth"]
+            assert inflight_idle == 0, (
+                f"inflight_synth should be 0 after synth completes, got {inflight_idle}. "
+                "Did the finally-block decrement fail?"
+            )
+    finally:
+        # Restore original synthesize.
+        engine.synthesize = original_synthesize

--- a/server/tts-sidecar/tests/test_memory.py
+++ b/server/tts-sidecar/tests/test_memory.py
@@ -545,11 +545,12 @@ def test_debug_memory_endpoint_shape(monkeypatch):
     assert body["process"]["committed_mb"] > 0
     assert "gc" in body and "counts" in body["gc"]
     assert "engines" in body
-    # Qwen is registered and cold here: base/design not loaded, cache empty.
+    # Qwen is registered and cold here: base/design/base17 not loaded, cache empty.
     qwen = body["engines"].get("qwen")
     assert qwen is not None
     assert qwen["base_loaded"] is False
     assert qwen["design_loaded"] is False
+    assert qwen["base17_loaded"] is False
     assert qwen["prompt_cache_entries"] == 0
     assert "cuda" in body
     # side-11 leak attribution: on a CUDA box whose torch has the pinned-host

--- a/server/tts-sidecar/tests/test_smoke.py
+++ b/server/tts-sidecar/tests/test_smoke.py
@@ -276,7 +276,12 @@ def test_health_responsive_during_busy_synth(client: TestClient) -> None:
     )
 
 
-def test_inflight_synth_tracks_transcribe_and_embed(client: TestClient) -> None:
+async def _noop_async(*a, **k):
+    """Async no-op for mocking async methods."""
+    return None
+
+
+def test_inflight_synth_tracks_transcribe_and_embed(client: TestClient, monkeypatch) -> None:
     """Verify that /transcribe and /embed increment the busy signal (inflight_synth)
     so the idle gate can detect ASR/embed activity. Regression check for #1996.
 
@@ -289,18 +294,29 @@ def test_inflight_synth_tracks_transcribe_and_embed(client: TestClient) -> None:
     slow_sleep_sec = 0.5
 
     original_transcribe = main.ASR.transcribe
+    original_spk_embed = main.SPK.embed
+    original_spk_ensure_loaded = main.SPK.ensure_loaded
 
     def fake_slow_transcribe(pcm, sample_rate, language=None, word_timestamps=False, device=None):
         time.sleep(slow_sleep_sec)
         # Return minimal valid output (the test only checks inflight_synth, not transcribe results).
         return {"text": "Hi", "language": "en", "avg_logprob": -0.5, "no_speech_prob": 0.01, "compression_ratio": 1.2}
 
+    def fake_slow_embed(pcm, sample_rate):
+        time.sleep(slow_sleep_sec)
+        # Return a fake embedding (192-d, unit-norm shape).
+        return [0.0] * 192
+
     main.ASR.transcribe = fake_slow_transcribe
+    main.SPK.embed = fake_slow_embed
+    # Mock SPK.ensure_loaded to be an async no-op so we don't try to load the real speechbrain model.
+    main.SPK.ensure_loaded = _noop_async
 
     try:
         # Generate some fake PCM data (16-bit LE mono).
         fake_pcm = b"\x00\x00" * 1000  # 1000 samples of silence.
 
+        # Test /transcribe
         transcribe_thread = threading.Thread(
             target=lambda: client.post(
                 "/transcribe",
@@ -335,9 +351,47 @@ def test_inflight_synth_tracks_transcribe_and_embed(client: TestClient) -> None:
             f"inflight_synth should be 0 after transcribe completes, but got {inflight_after}. "
             "Did the finally-block decrement fail?"
         )
+
+        # Test /embed
+        embed_thread = threading.Thread(
+            target=lambda: client.post(
+                "/embed",
+                content=fake_pcm,
+                headers={"X-Sample-Rate": "16000"},
+            ),
+            daemon=True,
+        )
+        embed_thread.start()
+        # Tiny grace so the embed is actually running when we probe.
+        time.sleep(0.05)
+
+        # Mid-call: inflight_synth should be non-zero (at least 1 for the embed).
+        health_mid_embed = client.get("/health")
+        assert health_mid_embed.status_code == 200, "health route failed while embed running"
+        inflight_mid_embed = health_mid_embed.json().get("inflight_synth")
+        assert inflight_mid_embed is not None, "inflight_synth field missing from /health during embed"
+        assert inflight_mid_embed > 0, (
+            f"inflight_synth should be > 0 during embed, but got {inflight_mid_embed}. "
+            "Did /embed stop incrementing _inflight_synth?"
+        )
+
+        embed_thread.join(timeout=5.0)
+        assert not embed_thread.is_alive(), "embed thread never finished"
+
+        # After completion: inflight_synth should be back to 0.
+        health_after_embed = client.get("/health")
+        assert health_after_embed.status_code == 200
+        inflight_after_embed = health_after_embed.json().get("inflight_synth")
+        assert inflight_after_embed is not None
+        assert inflight_after_embed == 0, (
+            f"inflight_synth should be 0 after embed completes, but got {inflight_after_embed}. "
+            "Did the finally-block decrement fail?"
+        )
     finally:
-        # Restore the original ASR.transcribe.
+        # Restore the originals.
         main.ASR.transcribe = original_transcribe
+        main.SPK.embed = original_spk_embed
+        main.SPK.ensure_loaded = original_spk_ensure_loaded
 
 
 def test_synthesize_returns_substitution_header_when_voice_unknown(monkeypatch):

--- a/server/tts-sidecar/tests/test_smoke.py
+++ b/server/tts-sidecar/tests/test_smoke.py
@@ -276,6 +276,70 @@ def test_health_responsive_during_busy_synth(client: TestClient) -> None:
     )
 
 
+def test_inflight_synth_tracks_transcribe_and_embed(client: TestClient) -> None:
+    """Verify that /transcribe and /embed increment the busy signal (inflight_synth)
+    so the idle gate can detect ASR/embed activity. Regression check for #1996.
+
+    Before the fix, /transcribe and /embed did NOT increment _inflight_synth,
+    so the idle-gate measurement saw ASR running continuously and falsely
+    concluded the process was "confirmed idle" — the actual confound #1996's
+    run revealed."""
+    # Stub a slow transcriber by monkey-patching ASR.transcribe to sleep.
+    # We don't need a real Whisper model; just simulate work.
+    slow_sleep_sec = 0.5
+
+    original_transcribe = main.ASR.transcribe
+
+    def fake_slow_transcribe(pcm, sample_rate, language=None, word_timestamps=False, device=None):
+        time.sleep(slow_sleep_sec)
+        # Return minimal valid output (the test only checks inflight_synth, not transcribe results).
+        return {"text": "Hi", "language": "en", "avg_logprob": -0.5, "no_speech_prob": 0.01, "compression_ratio": 1.2}
+
+    main.ASR.transcribe = fake_slow_transcribe
+
+    try:
+        # Generate some fake PCM data (16-bit LE mono).
+        fake_pcm = b"\x00\x00" * 1000  # 1000 samples of silence.
+
+        transcribe_thread = threading.Thread(
+            target=lambda: client.post(
+                "/transcribe",
+                content=fake_pcm,
+                headers={"X-Sample-Rate": "16000"},
+            ),
+            daemon=True,
+        )
+        transcribe_thread.start()
+        # Tiny grace so the transcribe is actually running when we probe.
+        time.sleep(0.05)
+
+        # Mid-call: inflight_synth should be non-zero (at least 1 for the transcribe).
+        health_mid = client.get("/health")
+        assert health_mid.status_code == 200, "health route failed while transcribe running"
+        inflight_mid = health_mid.json().get("inflight_synth")
+        assert inflight_mid is not None, "inflight_synth field missing from /health"
+        assert inflight_mid > 0, (
+            f"inflight_synth should be > 0 during transcribe, but got {inflight_mid}. "
+            "Did /transcribe stop incrementing _inflight_synth?"
+        )
+
+        transcribe_thread.join(timeout=5.0)
+        assert not transcribe_thread.is_alive(), "transcribe thread never finished"
+
+        # After completion: inflight_synth should be back to 0.
+        health_after = client.get("/health")
+        assert health_after.status_code == 200
+        inflight_after = health_after.json().get("inflight_synth")
+        assert inflight_after is not None
+        assert inflight_after == 0, (
+            f"inflight_synth should be 0 after transcribe completes, but got {inflight_after}. "
+            "Did the finally-block decrement fail?"
+        )
+    finally:
+        # Restore the original ASR.transcribe.
+        main.ASR.transcribe = original_transcribe
+
+
 def test_synthesize_returns_substitution_header_when_voice_unknown(monkeypatch):
     """The 'index out of range in self' regression. When the Node-side voice
     catalog drifts ahead of the model's actual speaker manifest, /synthesize

--- a/server/tts-sidecar/tests/test_smoke.py
+++ b/server/tts-sidecar/tests/test_smoke.py
@@ -256,10 +256,24 @@ def test_health_responsive_during_busy_synth(client: TestClient) -> None:
         f"/health took {elapsed:.3f}s during an in-flight synth — event loop "
         "is being blocked. Did /synthesize stop using asyncio.to_thread?"
     )
+    # #1996 — while the synth is genuinely in flight, the surfaced counter must
+    # read 1 so an idle probe gets a positive "currently generating" signal.
+    assert r.json()["inflight_synth"] == 1, (
+        f"/health should report inflight_synth == 1 during a busy synth, "
+        f"got {r.json()['inflight_synth']}"
+    )
 
     synth_thread.join(timeout=5.0)
     assert not synth_thread.is_alive(), "synth thread never finished"
     assert len(fake.calls) == 1, "synth fake should have been called exactly once"
+
+    # #1996 — once the synth has drained, the counter must read 0 again.
+    r_idle = client.get("/health")
+    assert r_idle.status_code == 200
+    assert r_idle.json()["inflight_synth"] == 0, (
+        f"/health should report inflight_synth == 0 after the synth finishes, "
+        f"got {r_idle.json()['inflight_synth']}"
+    )
 
 
 def test_synthesize_returns_substitution_header_when_voice_unknown(monkeypatch):


### PR DESCRIPTION
<!--
PR title MUST match the commit convention: <type>(<scope>): <subject>
-->

## Summary

Refs #1996. Adds a diagnostic (`inflight_synth` on `/health` + `/debug/memory`) and re-runs #1996's stranded-VRAM measurement gated on that real idle signal instead of a fixed wall clock, which the prior attempt was silently defeated by (unrelated ASR-QA repair still running past the 180s window).

**CORRECTED (2026-08-26, following an adversarial PR review pass — see the review thread below):** the original version of this PR body claimed the 2026-08-25 run's idle window was "clean" and read the run as "the two resident models' own live weights — normal residency, not evidence of a leak." Both claims were wrong, caused by two instrument bugs this PR's own fix round then discovered and fixed:

1. **The idle gate was blind to ASR.** `_inflight_synth` tracked only `/synthesize`-family calls, not `/transcribe`/`/embed` — so the gate could (and, on the recorded run, did) report "confirmed idle" while Whisper was still actively transcribing. Fixed in commit `d4aa7a6c`. This run's own logs (`logs/tts.err.log`) show Whisper transcribing continuously through 07:58:51.768, overlapping the window the old gate declared idle (07:58:49–57).
2. **`/debug/memory`'s qwen block was missing a `base17_loaded` key.** The run's "only two resident models" claim (Qwen Base 0.6B + Whisper) missed a third model, the Qwen 1.7B-Base, which the instrument had no way to report. This run's logs show it loaded mid-session (`07:57:58.112 Qwen 1.7B-Base loaded.`) — a model that, unlike Qwen Base 0.6B, DOES have its own idle TTL (120s default), which hadn't lapsed by the time of the P3 capture (21s later). Fixed in commit `42dddeb8`.

**Corrected outcome: this run was a contaminated-idle / misattributed-residency case, not a clean "sixth case."** It does not close, and does not provide trustworthy evidence toward closing, #1996 criterion 1. A valid re-run using the now-fixed instruments is still owed — real-hardware work not performed as part of this correction. Full corrected narrative: `docs/testing/1996-stranded-vram-measurement.md`'s "Reading the result" section (commit `45b913ce`, refined further by re-review pass 2).

**Not closing #1996 criterion 1** (this conclusion is unchanged from the original body, now for the correct reason).

## Test plan

- [x] `server/tts-sidecar/tests/test_smoke.py::test_health_responsive_during_busy_synth` (extended to assert `inflight_synth == 1` mid-synth and `== 0` after) — passes.
- [x] Independently re-ran the mutation test myself (not trusting the child's receipt): commented out the `"inflight_synth": _inflight_synth` line in `/health`'s response dict, re-ran the test — failed RED with `KeyError: 'inflight_synth'` on the new assertion, confirming it actually exercises the field. Restored the line, re-ran — GREEN again.
- [x] Full `server/tts-sidecar/tests/` suite — all passing (no failures).
- [x] Verified `/debug/memory`'s `inflight_synth` is top-level (sibling to `process`/`gc`/`engines`), not nested under `engines["qwen"]`, per the acceptance spec.
- [x] `/transcribe` and `/embed` now also track `inflight_synth` (commit `d4aa7a6c`), closing the ASR-blind confound above.
- [x] `/debug/memory`'s qwen block now includes `base17_loaded` (commit `42dddeb8`).
- [x] Full results table, attribution subsection, and decision-tree analysis posted (and later corrected) as comments on [#1996](https://github.com/dudarenok-maker/Castwright/issues/1996#issuecomment-5417415286).

Also fixed, found in passing (independent PR review, pass 1 + re-review pass 2): the attribution-during-wait step grepped a log file (`logs/server.log`) that never contains per-request lines and so could never return a non-empty result (fixed in `36091ef2`, cleaned up further in re-review); no test covered `/debug/memory`'s `inflight_synth` key (fixed in `2aebdfe2`); the idle-gate script printed the same "success" message on both the confirmed-idle and ceiling-timeout exit paths (fixed in `3d0f20cc`); the capture snippet never recorded `inflight_synth`, leaving the TOCTOU gap between gate-clear and snapshot unclosed (fixed in `56289b3f`); a doc arithmetic error and a missing cross-reference (fixed in `39fdca76`).
