### PR TITLE
chore(scripts): add oe-detached-commit.ps1, close the missing -WindowStyle Hidden gap

### DIFF
--- a/.clinerules/cline.md
+++ b/.clinerules/cline.md
@@ -162,67 +162,44 @@ before 20.** Recorded on this repo: `test:server` **518.8 s** and `test`
 vitest run can report far less wall-clock on an idle box, so treat these as the
 range, not a constant.
 
-**Copy the recipe below verbatim -- do not improvise your own inline variant.**
-It avoids shell-quoting entirely by design: the commit message is written to a file with `[IO.File]::WriteAllText`, and the child script receives `$Dir` and `$Worktree` as parameters via its `param()` block rather than having anything interpolated into a command string. A freelanced one-liner that rebuilds this by hand -- embedding `$variables` or escaped `\"` quotes inside a wrapped double-quoted command -- reintroduces exactly the quoting bug this recipe exists to avoid. On `Castwright#2520` a local-model run did this, hit `The string is missing the terminator` / `Missing type name after '['` / `Exception calling "Create" with "1" argument(s)` across four self-invented variants, spent its whole turn reasoning line-by-line about *why* each one broke, and died on the output-token cap with no commit, no push, and no receipt -- while the two-file edit it was committing was already correct. **Two things require substitution per-use:** your worktree path (replace the placeholder in the `$W` assignment) and your commit message (replace `'fix(scope): subject line'` in the `[IO.File]::WriteAllText` line with a real message following Conventional Commits). **Important:** if your commit subject contains a single quote (e.g. `don't clobber X`), escape it by doubling it inside the PowerShell single-quoted string (e.g. `'don''t clobber X'`), so the quote is preserved in the final commit message and does not break the PowerShell string. The structure and quoting style are copied verbatim; the paths and message are filled in for each use.
-
-**If the detached commit command reports `The string is missing the terminator` (sometimes preceded by `Missing ')' in method call.` from the same root cause), do not diagnose it.** This is almost always an unescaped single quote in the commit message: fix it by doubling the quote (e.g. `'don''t'` for a subject containing "don't"), then retry the recipe with the same structure. Stop reasoning about it after one sentence -- that reasoning is usually wrong anyway (as it was on #2520) and it is the expensive way to fail. **If the retry produces the identical error, stop retrying** and say so once with the exact command and the error, per "Do not end your turn while it runs" below.
-
-**`Missing type name after '['` is a DIFFERENT case -- not the apostrophe bug above.** It means the command being run is not this recipe at all, but an improvised variant of it (this is exactly what happened on #2520: four self-invented wrapper attempts, none of them this recipe). The fix is not to retry that broken command -- it is to discard it and copy the recipe below verbatim instead.
-
-Note: `Exception calling "Create" with "1" argument(s)` is not a signal on its own -- it is a generic .NET method-call exception wrapper. It can wrap either error above, or an unrelated failure entirely (permission denied, missing path). Read the full message it wraps before deciding which case you are in.
-
-Launch it detached and poll. Each poll returns instantly, so the cap stops
-mattering:
+**Call `scripts/oe-detached-commit.ps1` -- do not freelance your own inline
+Start-Process variant.** It lives in every worktree (it's a tracked file, so
+`git worktree add` brings it along) and does what the old inline recipe did,
+but as a real script instead of a copy-pasted snippet a model can misremember:
+writes the message to a BOM-less file, launches `git commit` via
+`Start-Process -WindowStyle Hidden`, and hands back the scratch dir to poll.
+Because `-Message` is a bound **parameter** rather than text interpolated into
+a command string, **no apostrophe escaping is needed** -- pass the message
+exactly as written, single quotes and all:
 
 ```powershell
-# Per-run directory. A FIXED log path is read by the next poll as the PREVIOUS
-# run's result: Start-Process returns before the child truncates the file, so a
-# stale EXIT=0 reports success for a commit that is still running.
-$run = Get-Date -Format 'yyyyMMdd-HHmmss'
-$T   = Join-Path $env:TEMP "cw-commit-$run"
-$W   = 'C:\Claude\Projects\wt-<your-worktree>'
-New-Item -ItemType Directory -Path $T -Force | Out-Null
-
-# NO BOM. PS 5.1's `Set-Content -Encoding utf8` writes one, `git commit -F` does
-# NOT strip it, and scripts/validate-commit-msg.mjs then rejects the subject --
-# AFTER you have paid the whole battery, with an error echoing a subject that
-# looks perfectly valid because the BOM is invisible.
-[IO.File]::WriteAllText("$T\msg.txt", 'fix(scope): subject line', (New-Object System.Text.UTF8Encoding $false))
+$T = & 'C:\Claude\Projects\wt-<your-worktree>\scripts\oe-detached-commit.ps1' `
+       -Worktree 'C:\Claude\Projects\wt-<your-worktree>' `
+       -Message "fix(scope): subject line, don't escape apostrophes here"
 ```
 
-The child script takes its paths as parameters, so nothing has to be
-interpolated into the here-string and `$LASTEXITCODE` resolves in the child:
+Two failure modes this script exists to close, both hit by freelanced
+variants in the past -- **do not rebuild either by hand**:
 
-```powershell
-@'
-param([string]$Dir, [string]$Worktree)
-$ErrorActionPreference = 'Continue'
-git -C $Worktree commit -F (Join-Path $Dir 'msg.txt') *>&1 |
-  Out-File -FilePath (Join-Path $Dir 'commit.log') -Encoding utf8
-"EXIT=$LASTEXITCODE" | Out-File -FilePath (Join-Path $Dir 'commit.log') -Append -Encoding utf8
-'@ | Set-Content "$T\commit.ps1" -Encoding utf8
-```
+- **Dropping `-WindowStyle Hidden`.** A `cline-free` lane on `Castwright#2659`
+  (2026-08-26) wrote its own launcher without it, popping a visible
+  PowerShell window per commit -- and per pre-commit hook run that commit
+  triggers. The script always passes the flag; if a window is still showing,
+  something bypassed the script rather than a flag being missing from it.
+- **Quoting the message by hand.** On `Castwright#2520` a local-model run
+  built the git command as an interpolated string with an unescaped `'`, hit
+  `The string is missing the terminator` / `Missing type name after '['` /
+  `Exception calling "Create" with "1" argument(s)` across four
+  self-invented variants, spent its whole turn reasoning line-by-line about
+  *why* each one broke, and died on the output-token cap with no commit, no
+  push, and no receipt -- while the two-file edit it was committing was
+  already correct. Passing `-Message` as a parameter makes this class of bug
+  impossible: if you see one of those errors, stop reasoning about it after
+  one sentence and re-check you're actually calling the script, not a
+  hand-built variant of it.
 
-**That closing `'@` must be at column zero** -- indent it (as happens
-automatically inside a markdown list item) and PS 5.1 fails with
-`WhitespaceBeforeHereStringFooter` before running anything, so no log is ever
-created and a naive poll waits forever. Same family as the `.ps1` traps under
-"Never do these".
-
-```powershell
-# Clear the log FIRST. Start-Process returns before the child truncates it, so
-# on a RETRY inside the same $T the very first poll reads the PREVIOUS
-# attempt's sentinel and reports a verdict for a run that is still going.
-Remove-Item "$T\commit.log" -ErrorAction SilentlyContinue
-
-# Quote each path argument: -ArgumentList does NOT quote its elements.
-$p = Start-Process powershell -WindowStyle Hidden -PassThru -ArgumentList @(
-  '-NoProfile','-ExecutionPolicy','Bypass','-File',"`"$T\commit.ps1`"",
-  '-Dir',"`"$T`"",'-Worktree',"`"$W`"")
-$p.Id | Set-Content "$T\commit.pid"
-```
-
-Then poll until it resolves. **Check the process as well as the sentinel** --
+Then poll until it resolves. Each poll returns instantly, so the output-token
+cap stops mattering. **Check the process as well as the sentinel** --
 those two disagreeing is how you learn the child died at parse time instead of
 waiting on it forever:
 

--- a/.clinerules/cline.md
+++ b/.clinerules/cline.md
@@ -173,10 +173,13 @@ a command string, **no apostrophe escaping is needed** -- pass the message
 exactly as written, single quotes and all:
 
 ```powershell
-$T = & 'C:\Claude\Projects\wt-<your-worktree>\scripts\oe-detached-commit.ps1' `
-       -Worktree 'C:\Claude\Projects\wt-<your-worktree>' `
+$W = 'C:\Claude\Projects\wt-<your-worktree>'
+$T = & "$W\scripts\oe-detached-commit.ps1" -Worktree $W `
        -Message "fix(scope): subject line, don't escape apostrophes here"
 ```
+
+**Keep `$W` around** -- the poll steps below and the tiebreaker
+(`git -C $W log --oneline -1`) both use it.
 
 Two failure modes this script exists to close, both hit by freelanced
 variants in the past -- **do not rebuild either by hand**:
@@ -194,9 +197,11 @@ variants in the past -- **do not rebuild either by hand**:
   *why* each one broke, and died on the output-token cap with no commit, no
   push, and no receipt -- while the two-file edit it was committing was
   already correct. Passing `-Message` as a parameter makes this class of bug
-  impossible: if you see one of those errors, stop reasoning about it after
-  one sentence and re-check you're actually calling the script, not a
-  hand-built variant of it.
+  impossible. **If you see one of those errors anyway, stop reasoning about
+  it after one sentence and re-check you're actually calling the script, not
+  a hand-built variant of it -- and if a retry produces the identical error
+  even after confirming that, stop retrying** and say so once with the exact
+  command and the error, per "Do not end your turn while it runs" below.
 
 Then poll until it resolves. Each poll returns instantly, so the output-token
 cap stops mattering. **Check the process as well as the sentinel** --

--- a/scripts/oe-detached-commit.ps1
+++ b/scripts/oe-detached-commit.ps1
@@ -1,0 +1,82 @@
+<#
+.SYNOPSIS
+  Launches `git commit` detached and hidden, for headless/OE agent lanes.
+
+.DESCRIPTION
+  Replaces the freelanced inline Start-Process snippets OE lanes have been
+  writing per-run (documented in .clinerules/cline.md "commit detached"
+  recipe). Two failure modes that recipe already warns against, and that a
+  freelanced variant hit on 2026-08-26 (Castwright open-engine ticket #2659):
+    - dropping `-WindowStyle Hidden`, which pops a visible PowerShell window
+      for the commit itself AND for the husky pre-commit hook it triggers
+    - reintroducing commit-message quoting bugs (unescaped `'` in the subject)
+      by building the git command as an interpolated string
+
+  Call this script directly with -Message as a bound parameter (never build
+  a command string containing the message) so quoting is a non-issue: no
+  escaping of apostrophes is needed by the caller.
+
+.PARAMETER Worktree
+  Absolute path to the worktree/checkout to commit in.
+
+.PARAMETER Message
+  Full commit message (subject, optionally with a blank line + body).
+
+.OUTPUTS
+  The scratch directory path (also written nowhere else) -- poll it per the
+  "commit detached" recipe in .clinerules/cline.md:
+    - alive:  Get-Process -Id (Get-Content "$T\commit.pid") -ErrorAction SilentlyContinue
+    - done:   Test-Path "$T\commit.log" -and it contains a line starting "EXIT="
+    - result: Get-Content "$T\commit.log" once done is true and alive is false
+
+.EXAMPLE
+  $T = & C:\Claude\Projects\wt-1994-qwen-duration-baseline\scripts\oe-detached-commit.ps1 `
+         -Worktree 'C:\Claude\Projects\wt-1994-qwen-duration-baseline' `
+         -Message "test(sidecar): add Qwen duration golden-audio baseline scaffold (#2659)"
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$Worktree,
+    [Parameter(Mandatory)][string]$Message
+)
+
+$ErrorActionPreference = 'Stop'
+
+$run = Get-Date -Format 'yyyyMMdd-HHmmss'
+$T = Join-Path $env:TEMP "cw-commit-$run"
+New-Item -ItemType Directory -Path $T -Force | Out-Null
+
+# No BOM: PS 5.1's default utf8 write adds one, `git commit -F` does not
+# strip it, and scripts/validate-commit-msg.mjs then rejects a subject that
+# LOOKS fine (the BOM is invisible) -- after the whole verify battery has
+# already paid.
+[IO.File]::WriteAllText((Join-Path $T 'msg.txt'), $Message, (New-Object System.Text.UTF8Encoding $false))
+
+# Paths come in via param() rather than string interpolation, so nothing
+# about $Worktree or the scratch dir can reintroduce a quoting bug either.
+$childScript = @'
+param([string]$Dir, [string]$Worktree)
+$ErrorActionPreference = 'Continue'
+git -C $Worktree commit -F (Join-Path $Dir 'msg.txt') *>&1 |
+  Out-File -FilePath (Join-Path $Dir 'commit.log') -Encoding utf8
+"EXIT=$LASTEXITCODE" | Out-File -FilePath (Join-Path $Dir 'commit.log') -Append -Encoding utf8
+'@
+Set-Content -Path (Join-Path $T 'commit.ps1') -Value $childScript -Encoding utf8
+
+# Clear the log FIRST: Start-Process returns before the child truncates it,
+# so a poll against a stale file from a prior run in the same $T would
+# report a verdict for a run that is still going. ($T is timestamped fresh
+# above, so this is a defensive no-op today -- kept because a caller could
+# reuse a $T.)
+Remove-Item (Join-Path $T 'commit.log') -ErrorAction SilentlyContinue
+
+# -WindowStyle Hidden is the whole point of this script: a freelanced
+# Start-Process call that omits it pops a visible console for the commit
+# AND for the husky pre-commit hook `git commit` triggers.
+# -ArgumentList does NOT quote its elements, so each path arg is quoted here.
+$p = Start-Process powershell -WindowStyle Hidden -PassThru -ArgumentList @(
+    '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', "`"$T\commit.ps1`"",
+    '-Dir', "`"$T`"", '-Worktree', "`"$Worktree`"")
+$p.Id | Set-Content (Join-Path $T 'commit.pid')
+
+Write-Output $T

--- a/scripts/oe-detached-commit.ps1
+++ b/scripts/oe-detached-commit.ps1
@@ -5,19 +5,27 @@
 .DESCRIPTION
   Replaces the freelanced inline Start-Process snippets OE lanes have been
   writing per-run (documented in .clinerules/cline.md "commit detached"
-  recipe). Two failure modes that recipe already warns against, and that a
-  freelanced variant hit on 2026-08-26 (Castwright open-engine ticket #2659):
+  recipe). Failure modes that recipe already warns against, and that
+  freelanced variants hit on 2026-08-26 (Castwright open-engine ticket #2659)
+  and in review of this very script (PR #2662):
     - dropping `-WindowStyle Hidden`, which pops a visible PowerShell window
       for the commit itself AND for the husky pre-commit hook it triggers
     - reintroducing commit-message quoting bugs (unescaped `'` in the subject)
       by building the git command as an interpolated string
+    - a trailing backslash on a quoted path argument escaping the closing
+      quote instead of terminating the path (Win32 argv quoting: a backslash
+      run immediately before a `"` is only literal if doubled)
+    - a same-second scratch dir colliding between two concurrently-launched
+      commits and silently mixing up which message lands where
 
   Call this script directly with -Message as a bound parameter (never build
   a command string containing the message) so quoting is a non-issue: no
   escaping of apostrophes is needed by the caller.
 
 .PARAMETER Worktree
-  Absolute path to the worktree/checkout to commit in.
+  Absolute path to the worktree/checkout to commit in. A trailing backslash
+  is tolerated (stripped before quoting) -- it would otherwise escape the
+  closing quote in the launched command line.
 
 .PARAMETER Message
   Full commit message (subject, optionally with a blank line + body).
@@ -30,8 +38,8 @@
     - result: Get-Content "$T\commit.log" once done is true and alive is false
 
 .EXAMPLE
-  $T = & C:\Claude\Projects\wt-1994-qwen-duration-baseline\scripts\oe-detached-commit.ps1 `
-         -Worktree 'C:\Claude\Projects\wt-1994-qwen-duration-baseline' `
+  $W = 'C:\Claude\Projects\wt-1994-qwen-duration-baseline'
+  $T = & "$W\scripts\oe-detached-commit.ps1" -Worktree $W `
          -Message "test(sidecar): add Qwen duration golden-audio baseline scaffold (#2659)"
 #>
 [CmdletBinding()]
@@ -42,8 +50,18 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+# Strip a trailing backslash: a quoted "...\" argument has its closing quote
+# escaped by the preceding backslash under Win32 argv parsing, which folds
+# the rest of the command line into this one argument instead of ending it.
+$Worktree = $Worktree.TrimEnd('\')
+
+# GUID-suffixed, not just second-resolution timestamped: two lanes launching
+# in the same second (the normal case for parallel worktree lanes, which is
+# the intended usage of this script) would otherwise collide on one scratch
+# dir and each poll the other's commit -- reporting EXIT=0 for a commit that
+# is not theirs, with no error at all.
 $run = Get-Date -Format 'yyyyMMdd-HHmmss'
-$T = Join-Path $env:TEMP "cw-commit-$run"
+$T = Join-Path ([System.IO.Path]::GetTempPath()) "cw-commit-$run-$([Guid]::NewGuid().ToString('N').Substring(0, 8))"
 New-Item -ItemType Directory -Path $T -Force | Out-Null
 
 # No BOM: PS 5.1's default utf8 write adds one, `git commit -F` does not
@@ -53,7 +71,8 @@ New-Item -ItemType Directory -Path $T -Force | Out-Null
 [IO.File]::WriteAllText((Join-Path $T 'msg.txt'), $Message, (New-Object System.Text.UTF8Encoding $false))
 
 # Paths come in via param() rather than string interpolation, so nothing
-# about $Worktree or the scratch dir can reintroduce a quoting bug either.
+# about $Worktree or the scratch dir can reintroduce a quoting bug in the
+# CHILD script's own source (it never contains a literal path or message).
 $childScript = @'
 param([string]$Dir, [string]$Worktree)
 $ErrorActionPreference = 'Continue'
@@ -63,20 +82,22 @@ git -C $Worktree commit -F (Join-Path $Dir 'msg.txt') *>&1 |
 '@
 Set-Content -Path (Join-Path $T 'commit.ps1') -Value $childScript -Encoding utf8
 
-# Clear the log FIRST: Start-Process returns before the child truncates it,
-# so a poll against a stale file from a prior run in the same $T would
-# report a verdict for a run that is still going. ($T is timestamped fresh
-# above, so this is a defensive no-op today -- kept because a caller could
-# reuse a $T.)
-Remove-Item (Join-Path $T 'commit.log') -ErrorAction SilentlyContinue
+# Win32 argv quoting: -ArgumentList does NOT quote its elements, and a naive
+# `"`"$Value`""` wrap breaks the instant $Value ends in a backslash (the
+# backslash-quote pair is read as an escaped quote, not path-then-terminator).
+# $Worktree is already stripped above; double any trailing backslash here so
+# the rule applies uniformly to every path this script quotes.
+function ConvertTo-QuotedArg([string]$Value) {
+    if ($Value.EndsWith('\')) { $Value += '\' }
+    return '"' + $Value + '"'
+}
 
 # -WindowStyle Hidden is the whole point of this script: a freelanced
 # Start-Process call that omits it pops a visible console for the commit
 # AND for the husky pre-commit hook `git commit` triggers.
-# -ArgumentList does NOT quote its elements, so each path arg is quoted here.
 $p = Start-Process powershell -WindowStyle Hidden -PassThru -ArgumentList @(
-    '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', "`"$T\commit.ps1`"",
-    '-Dir', "`"$T`"", '-Worktree', "`"$Worktree`"")
+    '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', (ConvertTo-QuotedArg (Join-Path $T 'commit.ps1')),
+    '-Dir', (ConvertTo-QuotedArg $T), '-Worktree', (ConvertTo-QuotedArg $Worktree))
 $p.Id | Set-Content (Join-Path $T 'commit.pid')
 
 Write-Output $T

--- a/scripts/oe-detached-commit.ps1
+++ b/scripts/oe-detached-commit.ps1
@@ -85,8 +85,10 @@ Set-Content -Path (Join-Path $T 'commit.ps1') -Value $childScript -Encoding utf8
 # Win32 argv quoting: -ArgumentList does NOT quote its elements, and a naive
 # `"`"$Value`""` wrap breaks the instant $Value ends in a backslash (the
 # backslash-quote pair is read as an escaped quote, not path-then-terminator).
-# $Worktree is already stripped above; double any trailing backslash here so
-# the rule applies uniformly to every path this script quotes.
+# Doubles a single trailing backslash, which is the only case any caller of
+# this helper can actually produce: $Worktree is fully stripped by TrimEnd
+# above, and the other two callers (the scratch dir, the commit.ps1 path)
+# are both Join-Path results, which never end in a separator.
 function ConvertTo-QuotedArg([string]$Value) {
     if ($Value.EndsWith('\')) { $Value += '\' }
     return '"' + $Value + '"'

--- a/scripts/tests/oe-detached-commit.Tests.ps1
+++ b/scripts/tests/oe-detached-commit.Tests.ps1
@@ -2,14 +2,24 @@
 # Pester 5.x tests for scripts\oe-detached-commit.ps1. Invoke via
 # scripts\tests\run.ps1 or `npm run test:scripts`.
 #
-# The static checks below parse the script's AST rather than grepping its
+# Most static checks below parse the script's AST rather than grepping its
 # text: a naive `Should -Match '-WindowStyle\s+Hidden'` against the whole
 # file also matches the docstring and an explanatory comment, so it stays
 # green even if the real Start-Process call is edited to drop the flag (this
 # happened during review of PR #2662 -- a mutation that deleted the flag
-# from the live call passed the whole-file-grep version of this test).
-# Matching against the parsed CommandAst only sees executable code: comments
-# and the comment-based help block are not part of the AST at all.
+# from the live call passed the whole-file-grep version of this test, and a
+# later round found the fix had reintroduced the same blind spot for two
+# more assertions before those were AST-ified too). Matching against the
+# parsed CommandAst only sees executable code: comments and the comment-
+# based help block are not part of the AST at all.
+#
+# One exception, by design: the "no Delete-Item" check further down IS a
+# whole-file text match. It is a NEGATIVE assertion (asserts an absence, not
+# a presence), so the blind spot above cannot make it falsely pass -- at
+# worst a comment mentioning the word turns it red on a change that made no
+# real difference, never green over a real regression. Cataloguing every
+# spelling of a hallucinated cmdlet name via AST would cost more than the
+# false-red risk it avoids.
 
 BeforeAll {
     $script:scriptPath = Join-Path $PSScriptRoot '..\oe-detached-commit.ps1'

--- a/scripts/tests/oe-detached-commit.Tests.ps1
+++ b/scripts/tests/oe-detached-commit.Tests.ps1
@@ -31,6 +31,28 @@ BeforeAll {
             $node.Left.VariablePath.UserPath -eq 'childScript'
         },
         $true) | Select-Object -First 1
+
+    $script:worktreeTrimAssignment = $script:ast.FindAll(
+        {
+            param($node)
+            $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+            $node.Left -is [System.Management.Automation.Language.VariableExpressionAst] -and
+            $node.Left.VariablePath.UserPath -eq 'Worktree' -and
+            $node.Right.Expression -is [System.Management.Automation.Language.InvokeMemberExpressionAst] -and
+            $node.Right.Expression.Member.Value -eq 'TrimEnd' -and
+            $node.Right.Expression.Expression -is [System.Management.Automation.Language.VariableExpressionAst] -and
+            $node.Right.Expression.Expression.VariablePath.UserPath -eq 'Worktree'
+        },
+        $true) | Select-Object -First 1
+
+    $script:scratchDirAssignment = $script:ast.FindAll(
+        {
+            param($node)
+            $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+            $node.Left -is [System.Management.Automation.Language.VariableExpressionAst] -and
+            $node.Left.VariablePath.UserPath -eq 'T'
+        },
+        $true) | Select-Object -First 1
 }
 
 Describe 'oe-detached-commit.ps1 static shape (AST-based, comment/docstring-proof)' {
@@ -54,7 +76,17 @@ Describe 'oe-detached-commit.ps1 static shape (AST-based, comment/docstring-proo
             }
         }
         $windowStyleIndex | Should -BeGreaterThan -1 -Because 'a -WindowStyle parameter must be bound on the real Start-Process call, not just mentioned in a comment'
-        $elements[$windowStyleIndex + 1].Extent.Text | Should -Be 'Hidden'
+        $windowStyleParam = $elements[$windowStyleIndex]
+        # Accept -WindowStyle Hidden (separate token), -WindowStyle:Hidden
+        # (bound directly on the parameter AST via colon syntax), and a
+        # quoted 'Hidden' -- all three are the same real flag, and a false
+        # red on the colon/quoted forms would be its own bug in this guard.
+        $value = if ($windowStyleParam.Argument) {
+            $windowStyleParam.Argument.Extent.Text.Trim("'`"")
+        } else {
+            $elements[$windowStyleIndex + 1].Extent.Text.Trim("'`"")
+        }
+        $value | Should -Be 'Hidden'
     }
 
     It 'takes the commit message as a bound parameter, never interpolated into a command string' {
@@ -84,11 +116,28 @@ Describe 'oe-detached-commit.ps1 static shape (AST-based, comment/docstring-proo
     }
 
     It 'strips a trailing backslash from -Worktree before it can escape a closing quote' {
-        $script:scriptText | Should -Match ([regex]::Escape('$Worktree = $Worktree.TrimEnd(''\'')'))
+        # AST-based, not a whole-file grep: a text match against
+        # '$Worktree.TrimEnd(''\'')' stays green even if the line is
+        # commented out (this happened during review -- pass 2 on #2662
+        # found the pass-1 fix had reintroduced the exact blind spot it had
+        # just closed, for its own two new assertions).
+        $script:worktreeTrimAssignment | Should -Not -BeNullOrEmpty -Because '$Worktree = $Worktree.TrimEnd(...) must be a real, executed assignment'
+        $trimArgs = $script:worktreeTrimAssignment.Right.Expression.Arguments
+        $trimArgs.Count | Should -Be 1
+        $trimArgs[0].Value | Should -Be '\'
     }
 
     It 'gives every scratch directory a per-call GUID component, not just a per-second timestamp' {
-        $script:scriptText | Should -Match '\[Guid\]::NewGuid\(\)'
+        $script:scratchDirAssignment | Should -Not -BeNullOrEmpty -Because 'the scratch directory ($T) must be assigned somewhere'
+        $guidCalls = $script:scratchDirAssignment.FindAll(
+            {
+                param($node)
+                $node -is [System.Management.Automation.Language.InvokeMemberExpressionAst] -and
+                $node.Member.Value -eq 'NewGuid' -and
+                $node.Static
+            },
+            $true)
+        $guidCalls.Count | Should -BeGreaterThan 0 -Because '[Guid]::NewGuid() must be part of the actual $T assignment, not just present elsewhere in the file'
     }
 }
 
@@ -106,12 +155,19 @@ Describe 'oe-detached-commit.ps1 functional smoke tests' -Skip:($env:OS -ne 'Win
         git -C $script:repoDir config user.name 'Test'
         Set-Content -Path (Join-Path $script:repoDir 'file.txt') -Value 'hello' -Encoding utf8
         git -C $script:repoDir add file.txt
+        $script:scratchDirs = @()
     }
 
     AfterEach {
         if (Test-Path $script:repoDir) {
             Remove-Item $script:repoDir -Recurse -Force -ErrorAction SilentlyContinue
         }
+        foreach ($dir in $script:scratchDirs) {
+            if (Test-Path $dir) {
+                Remove-Item $dir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+        $script:scratchDirs = @()
     }
 
     BeforeAll {
@@ -126,15 +182,24 @@ Describe 'oe-detached-commit.ps1 functional smoke tests' -Skip:($env:OS -ne 'Win
                 Start-Sleep -Milliseconds 200
                 $procId = Get-Content $pidPath -ErrorAction SilentlyContinue
                 $alive = $procId -and (Get-Process -Id $procId -ErrorAction SilentlyContinue)
-                $done = (Test-Path $logPath) -and (Select-String -Path $logPath -Pattern '^EXIT=' -Quiet)
             } while ($alive -and (Get-Date) -lt $deadline)
             return $logPath
+        }
+
+        # Every It below launches the real script, which creates a fresh
+        # %TEMP%\cw-commit-* scratch dir it never cleans up itself (by
+        # design -- the caller polls it after the process exits). Track
+        # each one so the test suite doesn't leak them into %TEMP% run
+        # after run (79 had accumulated there before this fix).
+        function Register-ScratchDir([string]$Dir) {
+            $script:scratchDirs += $Dir
+            return $Dir
         }
     }
 
     It 'commits detached and the commit lands with the exact message, apostrophe included' {
         $message = "test: verify detached commit don't drop quoting"
-        $scratchDir = & $script:scriptPath -Worktree $script:repoDir -Message $message
+        $scratchDir = Register-ScratchDir (& $script:scriptPath -Worktree $script:repoDir -Message $message)
         $logPath = Wait-ForDetachedCommit -ScratchDir $scratchDir
 
         (Get-Content $logPath -Raw) | Should -Match 'EXIT=0'
@@ -144,7 +209,7 @@ Describe 'oe-detached-commit.ps1 functional smoke tests' -Skip:($env:OS -ne 'Win
     It 'tolerates a trailing backslash on -Worktree instead of swallowing the rest of the command line' {
         $worktreeWithTrailingSlash = $script:repoDir + '\'
         $message = 'test: trailing backslash on worktree path'
-        $scratchDir = & $script:scriptPath -Worktree $worktreeWithTrailingSlash -Message $message
+        $scratchDir = Register-ScratchDir (& $script:scriptPath -Worktree $worktreeWithTrailingSlash -Message $message)
         $logPath = Wait-ForDetachedCommit -ScratchDir $scratchDir
 
         (Get-Content $logPath -Raw) | Should -Match 'EXIT=0'
@@ -162,8 +227,8 @@ Describe 'oe-detached-commit.ps1 functional smoke tests' -Skip:($env:OS -ne 'Win
         git -C $repoB add file.txt
 
         try {
-            $scratchA = & $script:scriptPath -Worktree $repoA -Message 'test: lane A commit'
-            $scratchB = & $script:scriptPath -Worktree $repoB -Message 'test: lane B commit'
+            $scratchA = Register-ScratchDir (& $script:scriptPath -Worktree $repoA -Message 'test: lane A commit')
+            $scratchB = Register-ScratchDir (& $script:scriptPath -Worktree $repoB -Message 'test: lane B commit')
 
             $scratchA | Should -Not -Be $scratchB
 

--- a/scripts/tests/oe-detached-commit.Tests.ps1
+++ b/scripts/tests/oe-detached-commit.Tests.ps1
@@ -1,0 +1,71 @@
+#requires -Version 5.1
+# Pester 5.x tests for scripts\oe-detached-commit.ps1. Invoke via
+# scripts\tests\run.ps1 or `npm run test:scripts`.
+
+BeforeAll {
+    $script:scriptPath = Join-Path $PSScriptRoot '..\oe-detached-commit.ps1'
+    $script:scriptText = Get-Content -Raw $script:scriptPath
+}
+
+Describe 'oe-detached-commit.ps1 static shape' {
+    It 'launches the commit hidden -- the whole point of this script' {
+        $script:scriptText | Should -Match '-WindowStyle\s+Hidden'
+    }
+
+    It 'takes the commit message as a bound parameter, never interpolated into a command string' {
+        $script:scriptText | Should -Match '\[Parameter\(Mandatory\)\]\[string\]\$Message'
+        # The child script must read the message from a file, not from a
+        # string built with $Message inside it -- that reintroduces the
+        # single-quote "missing terminator" bug the caller no longer has to
+        # dodge.
+        $script:scriptText | Should -Not -Match 'commit -m'
+        $script:scriptText | Should -Match 'commit -F \(Join-Path \$Dir ''msg\.txt''\)'
+    }
+
+    It 'writes the commit message without a BOM' {
+        $script:scriptText | Should -Match 'UTF8Encoding \$false'
+    }
+
+    It 'does not reference a nonexistent Delete-Item cmdlet (the real one is Remove-Item)' {
+        $script:scriptText | Should -Not -Match 'Delete-Item'
+    }
+}
+
+Describe 'oe-detached-commit.ps1 functional smoke test' {
+    BeforeEach {
+        $script:repoDir = Join-Path ([System.IO.Path]::GetTempPath()) "oe-commit-test-$([Guid]::NewGuid())"
+        New-Item -ItemType Directory -Path $script:repoDir -Force | Out-Null
+        git -C $script:repoDir init --quiet
+        git -C $script:repoDir config user.email 'test@example.com'
+        git -C $script:repoDir config user.name 'Test'
+        Set-Content -Path (Join-Path $script:repoDir 'file.txt') -Value 'hello' -Encoding utf8
+        git -C $script:repoDir add file.txt
+    }
+
+    AfterEach {
+        if (Test-Path $script:repoDir) {
+            Remove-Item $script:repoDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'commits detached and the commit lands with the exact message, apostrophe included' {
+        $message = "test: verify detached commit don't drop quoting"
+        $scratchDir = & $script:scriptPath -Worktree $script:repoDir -Message $message
+
+        $deadline = (Get-Date).AddSeconds(30)
+        $pidPath = Join-Path $scratchDir 'commit.pid'
+        $logPath = Join-Path $scratchDir 'commit.log'
+        do {
+            Start-Sleep -Milliseconds 200
+            $procId = Get-Content $pidPath -ErrorAction SilentlyContinue
+            $alive = $procId -and (Get-Process -Id $procId -ErrorAction SilentlyContinue)
+            $done = (Test-Path $logPath) -and (Select-String -Path $logPath -Pattern '^EXIT=' -Quiet)
+        } while ($alive -and (Get-Date) -lt $deadline)
+
+        $done | Should -Be $true
+        (Get-Content $logPath -Raw) | Should -Match 'EXIT=0'
+
+        $landedMessage = git -C $script:repoDir log -1 --format=%s
+        $landedMessage | Should -Be $message
+    }
+}

--- a/scripts/tests/oe-detached-commit.Tests.ps1
+++ b/scripts/tests/oe-detached-commit.Tests.ps1
@@ -1,37 +1,103 @@
 #requires -Version 5.1
 # Pester 5.x tests for scripts\oe-detached-commit.ps1. Invoke via
 # scripts\tests\run.ps1 or `npm run test:scripts`.
+#
+# The static checks below parse the script's AST rather than grepping its
+# text: a naive `Should -Match '-WindowStyle\s+Hidden'` against the whole
+# file also matches the docstring and an explanatory comment, so it stays
+# green even if the real Start-Process call is edited to drop the flag (this
+# happened during review of PR #2662 -- a mutation that deleted the flag
+# from the live call passed the whole-file-grep version of this test).
+# Matching against the parsed CommandAst only sees executable code: comments
+# and the comment-based help block are not part of the AST at all.
 
 BeforeAll {
     $script:scriptPath = Join-Path $PSScriptRoot '..\oe-detached-commit.ps1'
     $script:scriptText = Get-Content -Raw $script:scriptPath
+
+    $tokens = $null
+    $errors = $null
+    $script:ast = [System.Management.Automation.Language.Parser]::ParseFile($script:scriptPath, [ref]$tokens, [ref]$errors)
+
+    $script:startProcessCalls = $script:ast.FindAll(
+        { param($node) $node -is [System.Management.Automation.Language.CommandAst] -and $node.GetCommandName() -eq 'Start-Process' },
+        $true)
+
+    $script:childScriptAssignment = $script:ast.FindAll(
+        {
+            param($node)
+            $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+            $node.Left -is [System.Management.Automation.Language.VariableExpressionAst] -and
+            $node.Left.VariablePath.UserPath -eq 'childScript'
+        },
+        $true) | Select-Object -First 1
 }
 
-Describe 'oe-detached-commit.ps1 static shape' {
+Describe 'oe-detached-commit.ps1 static shape (AST-based, comment/docstring-proof)' {
+    It 'parses without errors' {
+        $script:ast | Should -Not -BeNullOrEmpty
+    }
+
+    It 'calls Start-Process exactly once, to launch the commit' {
+        $script:startProcessCalls.Count | Should -Be 1
+    }
+
     It 'launches the commit hidden -- the whole point of this script' {
-        $script:scriptText | Should -Match '-WindowStyle\s+Hidden'
+        $call = $script:startProcessCalls[0]
+        $elements = $call.CommandElements
+        $windowStyleIndex = -1
+        for ($i = 0; $i -lt $elements.Count; $i++) {
+            if ($elements[$i] -is [System.Management.Automation.Language.CommandParameterAst] -and
+                $elements[$i].ParameterName -eq 'WindowStyle') {
+                $windowStyleIndex = $i
+                break
+            }
+        }
+        $windowStyleIndex | Should -BeGreaterThan -1 -Because 'a -WindowStyle parameter must be bound on the real Start-Process call, not just mentioned in a comment'
+        $elements[$windowStyleIndex + 1].Extent.Text | Should -Be 'Hidden'
     }
 
     It 'takes the commit message as a bound parameter, never interpolated into a command string' {
-        $script:scriptText | Should -Match '\[Parameter\(Mandatory\)\]\[string\]\$Message'
-        # The child script must read the message from a file, not from a
-        # string built with $Message inside it -- that reintroduces the
-        # single-quote "missing terminator" bug the caller no longer has to
-        # dodge.
-        $script:scriptText | Should -Not -Match 'commit -m'
-        $script:scriptText | Should -Match 'commit -F \(Join-Path \$Dir ''msg\.txt''\)'
+        $script:childScriptAssignment | Should -Not -BeNullOrEmpty
+        $childScriptValue = $script:childScriptAssignment.Right.Expression.Value
+        $childScriptValue | Should -Not -BeNullOrEmpty
+        $childScriptValue | Should -Not -Match 'commit -m'
+        $childScriptValue | Should -Match 'commit -F \(Join-Path \$Dir ''msg\.txt''\)'
     }
 
     It 'writes the commit message without a BOM' {
-        $script:scriptText | Should -Match 'UTF8Encoding \$false'
+        $writeAllTextCalls = $script:ast.FindAll(
+            {
+                param($node)
+                $node -is [System.Management.Automation.Language.InvokeMemberExpressionAst] -and
+                $node.Member.Value -eq 'WriteAllText'
+            },
+            $true)
+        $writeAllTextCalls.Count | Should -Be 1 -Because 'exactly one WriteAllText call should write msg.txt'
+        # The 3rd argument is the encoding; must be UTF8Encoding constructed with $false (no BOM), not just
+        # mentioned somewhere else in the file.
+        $writeAllTextCalls[0].Arguments[2].Extent.Text | Should -Match 'UTF8Encoding.*\$false'
     }
 
     It 'does not reference a nonexistent Delete-Item cmdlet (the real one is Remove-Item)' {
         $script:scriptText | Should -Not -Match 'Delete-Item'
     }
+
+    It 'strips a trailing backslash from -Worktree before it can escape a closing quote' {
+        $script:scriptText | Should -Match ([regex]::Escape('$Worktree = $Worktree.TrimEnd(''\'')'))
+    }
+
+    It 'gives every scratch directory a per-call GUID component, not just a per-second timestamp' {
+        $script:scriptText | Should -Match '\[Guid\]::NewGuid\(\)'
+    }
 }
 
-Describe 'oe-detached-commit.ps1 functional smoke test' {
+Describe 'oe-detached-commit.ps1 functional smoke tests' -Skip:($env:OS -ne 'Windows_NT') {
+    # Start-Process launches a `powershell` binary that only exists on
+    # Windows; `npm run verify`'s Linux CI runner has no target for it. These
+    # tests are a no-op there rather than a false failure, matching the
+    # Windows-only pattern already used by prevent-sleep.Tests.ps1.
+
     BeforeEach {
         $script:repoDir = Join-Path ([System.IO.Path]::GetTempPath()) "oe-commit-test-$([Guid]::NewGuid())"
         New-Item -ItemType Directory -Path $script:repoDir -Force | Out-Null
@@ -48,24 +114,66 @@ Describe 'oe-detached-commit.ps1 functional smoke test' {
         }
     }
 
+    BeforeAll {
+        # Defined in BeforeAll (not loose in the Describe body) so it is
+        # visible to every It block's own scope -- Pester 5 does not share
+        # a plain `function` statement dropped directly in a Describe body.
+        function Wait-ForDetachedCommit([string]$ScratchDir, [int]$TimeoutSeconds = 30) {
+            $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+            $pidPath = Join-Path $ScratchDir 'commit.pid'
+            $logPath = Join-Path $ScratchDir 'commit.log'
+            do {
+                Start-Sleep -Milliseconds 200
+                $procId = Get-Content $pidPath -ErrorAction SilentlyContinue
+                $alive = $procId -and (Get-Process -Id $procId -ErrorAction SilentlyContinue)
+                $done = (Test-Path $logPath) -and (Select-String -Path $logPath -Pattern '^EXIT=' -Quiet)
+            } while ($alive -and (Get-Date) -lt $deadline)
+            return $logPath
+        }
+    }
+
     It 'commits detached and the commit lands with the exact message, apostrophe included' {
         $message = "test: verify detached commit don't drop quoting"
         $scratchDir = & $script:scriptPath -Worktree $script:repoDir -Message $message
+        $logPath = Wait-ForDetachedCommit -ScratchDir $scratchDir
 
-        $deadline = (Get-Date).AddSeconds(30)
-        $pidPath = Join-Path $scratchDir 'commit.pid'
-        $logPath = Join-Path $scratchDir 'commit.log'
-        do {
-            Start-Sleep -Milliseconds 200
-            $procId = Get-Content $pidPath -ErrorAction SilentlyContinue
-            $alive = $procId -and (Get-Process -Id $procId -ErrorAction SilentlyContinue)
-            $done = (Test-Path $logPath) -and (Select-String -Path $logPath -Pattern '^EXIT=' -Quiet)
-        } while ($alive -and (Get-Date) -lt $deadline)
-
-        $done | Should -Be $true
         (Get-Content $logPath -Raw) | Should -Match 'EXIT=0'
+        (git -C $script:repoDir log -1 --format=%s) | Should -Be $message
+    }
 
-        $landedMessage = git -C $script:repoDir log -1 --format=%s
-        $landedMessage | Should -Be $message
+    It 'tolerates a trailing backslash on -Worktree instead of swallowing the rest of the command line' {
+        $worktreeWithTrailingSlash = $script:repoDir + '\'
+        $message = 'test: trailing backslash on worktree path'
+        $scratchDir = & $script:scriptPath -Worktree $worktreeWithTrailingSlash -Message $message
+        $logPath = Wait-ForDetachedCommit -ScratchDir $scratchDir
+
+        (Get-Content $logPath -Raw) | Should -Match 'EXIT=0'
+        (git -C $script:repoDir log -1 --format=%s) | Should -Be $message
+    }
+
+    It 'gives two same-second launches independent scratch directories, so neither commit is misattributed to the other' {
+        $repoA = $script:repoDir
+        $repoB = Join-Path ([System.IO.Path]::GetTempPath()) "oe-commit-test-$([Guid]::NewGuid())"
+        New-Item -ItemType Directory -Path $repoB -Force | Out-Null
+        git -C $repoB init --quiet
+        git -C $repoB config user.email 'test@example.com'
+        git -C $repoB config user.name 'Test'
+        Set-Content -Path (Join-Path $repoB 'file.txt') -Value 'hello' -Encoding utf8
+        git -C $repoB add file.txt
+
+        try {
+            $scratchA = & $script:scriptPath -Worktree $repoA -Message 'test: lane A commit'
+            $scratchB = & $script:scriptPath -Worktree $repoB -Message 'test: lane B commit'
+
+            $scratchA | Should -Not -Be $scratchB
+
+            Wait-ForDetachedCommit -ScratchDir $scratchA | Out-Null
+            Wait-ForDetachedCommit -ScratchDir $scratchB | Out-Null
+
+            (git -C $repoA log -1 --format=%s) | Should -Be 'test: lane A commit'
+            (git -C $repoB log -1 --format=%s) | Should -Be 'test: lane B commit'
+        } finally {
+            Remove-Item $repoB -Recurse -Force -ErrorAction SilentlyContinue
+        }
     }
 }


### PR DESCRIPTION
## Summary
- OE lanes were freelancing their own inline `Start-Process` launchers for the "commit detached" recipe in `.clinerules/cline.md`. A `cline-free` lane on ticket #2659 (2026-08-26) dropped `-WindowStyle Hidden`, popping a visible PowerShell window per commit (and per pre-commit-hook run it triggers).
- Added `scripts/oe-detached-commit.ps1`: a tracked, real script (ships in every worktree) that launches `git commit` detached and hidden. `-Message` is a bound parameter rather than interpolated into a command string, so callers no longer need to escape apostrophes either — closing the `#2520` quoting-bug class the same recipe already documented.
- Rewrote `.clinerules/cline.md`'s "commit detached" section to call the script instead of hosting a copy-pasted, freelance-prone inline snippet.
- Three review rounds (see PR comments) found and fixed real bugs in the fix itself: a `$env:TEMP` crash on Linux CI, a static guard test that greped the whole file (so it couldn't fail when the real `-WindowStyle Hidden` was deleted), a same-second scratch-directory collision that could swap which commit message lands in which repo, a trailing-backslash-on-`-Worktree` quoting bug, and a dangling `$W` reference left in the rewritten doc after round 1's edit. Round 2 also found its own fix had reintroduced the identical grep blind spot for two new checks — converted both to AST-based assertions. Round 3 was clean.
- Skipped release notes: internal agent-tooling chore, no user- or operator-visible effect.
- Skipped a `docs/features/` plan doc: small/localized change, the issue body + paired tests are the spec.

## Test plan
- [x] `npm run test:scripts` green in the worktree: **78 passed**, 2 pre-existing venv-bootstrap skips unrelated to this change (0 failed)
- [x] Static AST-based guards: `-WindowStyle Hidden` (and its `-WindowStyle:Hidden` / quoted-`'Hidden'` equivalents) is bound on the real `Start-Process` call; `-Message` never reaches `commit -m`; the message is written without a BOM; `$Worktree = $Worktree.TrimEnd('\')` and `[Guid]::NewGuid()` are both real, executed AST nodes, not just text present somewhere in the file
- [x] Functional smoke tests (Windows-only, `-Skip:($env:OS -ne 'Windows_NT')`): a real detached commit lands byte-for-byte including an apostrophe; a trailing backslash on `-Worktree` no longer breaks the launch; two same-second launches get independent scratch dirs and each commit lands in the right repo
- [x] Self-verified every guard against the exact mutation it exists to catch (deleting the real flag/line while leaving the surrounding comment) — each fails closed; restored before committing
- [x] Dogfooded: every commit on this branch, from the first onward, was made via the script under review

Closes #2661