### PR TITLE
fix(server): applyOverrideToCastFiles refuses the whole propagation on a series-wide clone

### DIFF
--- a/docs/superpowers/plans/2026-08-26-clone-consent-series-wide-veto.md
+++ b/docs/superpowers/plans/2026-08-26-clone-consent-series-wide-veto.md
@@ -1,0 +1,2175 @@
+# Clone-Consent Series-Wide Veto Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the two remaining clone-consent TOCTOU/scope gaps tracked on #2006 (srv-81) by making both `voices.ts`'s `applyOverrideToCastFiles` (base-voice override) and `qwen-voice.ts`'s `persistEmotionVariant` (emotion-variant) refuse a write the instant a clone exists **anywhere in the linked series**, not just in the requesting book — checked fresh immediately before the write, not trusted from a stale pre-GPU snapshot — while leaving every other engine, every other route, and `forEachMatchingCastCharacter`'s shared signature untouched.
+
+**Architecture:** One already-exported/soon-to-be-exported predicate, `hasClonedSlotAmongMatches` (`voices.ts`), is reused at four call sites (two upfront pre-GPU checks, two write-time re-checks) instead of the book-local `characterHasClonedSlot` test each currently uses. Both write functions add a residual-window backstop inside their per-book mutate closure (the walk still takes nonzero time after the fresh scan passes) and both callers of each write function branch on its new typed outcome instead of assuming success. A new `clonedElsewhereInSeries` field on the `Character` API shape lets the two frontend gates mirror the same rule. No lock-model change (best-effort, not fully atomic — #2000 §3.2 stays out of scope), no change to `forEachMatchingCastCharacter`'s signature or its other two callers.
+
+**Tech Stack:** TypeScript, Express, Vitest (server), React + Redux Toolkit + Vitest/RTL (frontend), OpenAPI (`openapi.yaml` → `npm run openapi:types`).
+
+**Spec:**
+- `docs/superpowers/specs/2026-08-22-clone-consent-voices-override-refusal-design.md` (v2 — `voices.ts`/`applyOverrideToCastFiles`, `cast-design.ts:544`, frontend `clonedElsewhereInSeries`)
+- `docs/superpowers/specs/2026-08-26-clone-consent-qwen-voice-refusal-design.md` (v5 — `qwen-voice.ts`/`persistEmotionVariant`, both its call sites)
+
+Both specs travel with this plan — read the relevant section before starting a task; this plan does not restate their rationale, only the concrete diffs.
+
+## Global Constraints
+
+- **No signature change to `forEachMatchingCastCharacter`** (`server/src/routes/voices.ts:779-861`) or its `mutate` parameter — both specs commit to this explicitly; its other two callers (`applyTierToCastFiles`, `ensureCharacterVoiceUuid`'s `stamp`) are out of scope.
+- **Not fully atomic.** Every fresh series-wide check races the walk that follows it; the residual window is closed by a per-book backstop inside the mutate closure, not by a lock. Do not reach for `#2000 §3.2`'s workspace-lock model — it is explicitly out of scope for this work.
+- **No artifact teardown on refusal, anywhere.** A refused write never deletes an already-minted `.pt`/embedding — see the qwen-voice spec's "Why the just-minted artifact is left alone" for why.
+- **`otherThanEngine` stays specific to `voices.ts`'s own SET-branch asymmetry** — every new call site in this plan passes it as `undefined` except `applyOverrideToCastFiles`'s own existing SET branch.
+- **One user-facing refusal message per concern, reused everywhere it fires**: `clonedVariantRefusal` (qwen-voice.ts) for the variant path, the (new) book-agnostic base-voice message for the base-voice path — never a third, slightly-different wording at a new call site.
+- **This branch is ~12 lines behind `main`** in `qwen-voice.ts` (missing #2246's `language_unset` block) as of the specs' own citations. Most of this plan's own citations were independently re-verified against the worktree on 2026-08-26 by directly reading the files, not by trusting the specs — but not uniformly: `qwen-voice.test.ts:1504-1660ish` (Task 5) and `openapi.yaml`'s exact insertion line (Task 9) are approximate. Re-verify any citation you're about to act on against the actual working tree first regardless of what this plan claims.
+- **Every task that changes a shared function's return type must update every existing call site and every existing test that consumes the old shape in the same commit.** This plan's own enumeration (Task 2) was checked against a mandatory review pass and still initially missed `server/src/routes/variant-propagation.test.ts`, which imports both `applyOverrideToCastFiles` and `persistEmotionVariant` via `typeof import(...)` type aliases — now called out explicitly in Task 2 and Task 5. Grep again before committing regardless (`grep -rln "applyOverrideToCastFiles\|persistEmotionVariant" server/src --include=*.ts`); a missed call site is a build break, not a design gap.
+- **A cloned character in a series book whose cast isn't yet confirmed (`castConfirmed: false`) must still be refused — a decision the user made explicitly.** `hasClonedSlotAmongMatches`'s series/workspace scan skips any book (including potentially the caller's own) whose `state.castConfirmed` is false, matching its existing scanning convention everywhere else. Left unpatched, that would let a cloned-but-unconfirmed character's design attempt silently pass the upfront gate it used to fail (today's plain `characterHasClonedSlot(character)` check has no such filter). Fixed by keeping that plain, unconditional check as a first-line OR alongside the new series-wide call at all FOUR upfront sites (Tasks 3, 4, 7, 8): `characterHasClonedSlot(character) || await hasClonedSlotAmongMatches(...)`. The two write-time fresh checks (Task 2's inside `applyOverrideToCastFiles`, Task 6's inside `persistEmotionVariant`'s series branch) do NOT need the same patch: `forEachMatchingCastCharacter`'s own walk applies the identical `castConfirmed` filter to what it will actually WRITE to, so an unconfirmed caller's own book can never be silently overwritten there regardless of what the upfront gate caught — the castConfirmed gap only ever affected the upfront refusal (GPU-waste + user-facing message), never cast.json integrity.
+- **`otherThanEngine` asymmetry between the upfront and write-time checks is deliberate, not a bug — but it means the two layers are not equivalent.** Every upfront check this plan adds (Tasks 3, 7, 8) passes `otherThanEngine: undefined` (any clone-capable engine blocks). The write-time check inside `applyOverrideToCastFiles` (Task 2) is called with `otherThanEngine = override.engine` (`'qwen'` for every design caller), which — per `voices.ts`'s existing SET-branch asymmetry — excludes a qwen-clone from consideration. Net effect: the upfront gate is strictly *more* conservative than the write-time gate behind it, so a real qwen-cloned-on-a-sibling-book character is always caught upstream and the write-time `applyOverrideToCastFiles` path can only be exercised for that exact case via a mock, never a real fixture (a coqui-cloned-sibling fixture exercises it for real). This is safe (over-inclusive refusal, never under-inclusive) but is a real constraint on what the write-time tests in Tasks 2/3/4 can prove with real fixtures vs. mocks — don't try to "fix" this asymmetry by loosening the upfront check.
+
+---
+
+## File Structure
+
+| File | Responsibility in this plan |
+|---|---|
+| `server/src/routes/voices.ts` | Export `hasClonedSlotAmongMatches`; new batched `findClonedVoiceIdsAmongMatches`; `applyOverrideToCastFiles` gains the fresh series-wide check + typed `{updated, skipped}` return + residual backstop; its own route handler updated for the new shape. |
+| `server/src/routes/single-design.ts` | Upfront check upgraded to series-wide; write-time `{updated, skipped}` outcome now wired to a `clone_protected` SSE error instead of discarded. |
+| `server/src/routes/cast-design.ts` | New branch at the base-voice call site (`:544`) mirroring the variant branch; base AND variant upfront checks (`:402-412`, `:430-440`) both upgraded to series-wide; variant write-time call (`:555`) branches on `persistEmotionVariant`'s new outcome. |
+| `server/src/routes/qwen-voice.ts` | `persistEmotionVariant` return type becomes a 3-state union; book-scoped and series-scoped branches both gain a fresh/residual clone check; `clonedVariantRefusal` reworded; JSON route's upfront check and write-time integration both upgraded. |
+| `server/src/routes/book-state.ts` | `GET /:bookId/state` computes `clonedElsewhereInSeries` per character via ONE batched scan per request; `PUT /:bookId/state`'s two cast-merge normalisers strip the field so it can't round-trip into `cast.json`. |
+| `openapi.yaml` / `src/lib/api-types.ts` | New `clonedElsewhereInSeries: boolean` field on `Character`; new/previously-undocumented `200`/`409` responses on `PUT /api/voices/{voiceId}/override`; `clone_protected` added to `SingleDesignEvent.code`. |
+| `src/modals/profile-drawer.tsx`, `src/components/emotion-variant-designer.tsx` | Both clone gates read the new field in addition to the existing book-local provenance check; copy reworded. |
+
+Existing test files touched: `server/src/routes/voices.test.ts`, `server/src/routes/single-design.test.ts`, `server/src/routes/cast-design.test.ts`, `server/src/routes/qwen-voice.test.ts`, `server/src/routes/book-state.test.ts`, `server/src/routes/openapi-design-parity.test.ts` (registers the new `clone_protected` code — Task 3), `server/src/routes/variant-propagation.test.ts` (re-run only, not edited — Task 2/5 confirm it), plus new/updated frontend tests for the two gated components.
+
+---
+
+### Task 1: Export `hasClonedSlotAmongMatches` and fix its stale doc comment
+
+**Files:**
+- Modify: `server/src/routes/voices.ts:588-645`
+- Test: `server/src/routes/voices.test.ts` (new, small, at the end of the existing `describe('GET /api/voices...')` block or its own top-level `describe`)
+
+**Interfaces:**
+- Produces: `export async function hasClonedSlotAmongMatches(voiceId: string, seriesFilter?: { author: string; series: string }, otherThanEngine?: TtsEngine, onlyBookDir?: string): Promise<boolean>` — exported, AND gains a 4th parameter (see Step 3a below — found necessary under review, not present in either source spec). Every later task in this plan imports this from `./voices.js`.
+
+**This task also closes a scope-mismatch defect found under review, beyond a bare export.** `hasClonedSlotAmongMatches` originally took no book-scoping parameter at all — every call is either workspace-wide or series-wide. But `forEachMatchingCastCharacter` (the function whose write this predicate gates) has a THIRD mode: when `seriesFilter` is absent and `onlyBookDir` is given, it scans only that one book (`voices.ts:809-826`) — the fs-61 guard against a bare shared id like `narrator` silently matching an unrelated standalone book elsewhere in the workspace. Every upfront/write-time check this plan adds for a standalone book (Tasks 2, 3, 4, 7, 8) calls with `seriesFilter: undefined`, which — without this fix — would make the CHECK scan the whole workspace even though the WRITE it's gating is correctly scoped to one book. That reopens exactly the hole fs-61 closed, one layer up, at the gate instead of the write: a user designing a voice in one standalone book could be refused because an unrelated standalone book elsewhere in the workspace happens to share the bare id and carries a clone. Step 3a below adds a matching `onlyBookDir` special case to `hasClonedSlotAmongMatches` itself, mirroring `forEachMatchingCastCharacter`'s own condition exactly, so every caller downstream (Tasks 2-4, 7-8) can pass the same `onlyBookDir` it already has in scope and get the correctly-narrowed check.
+
+- [ ] **Step 1: Write the failing test — the function is importable from outside `voices.ts`**
+
+```ts
+// server/src/routes/voices.test.ts (add near the top-level describes, after existing imports)
+it('hasClonedSlotAmongMatches is exported for reuse by qwen-voice.ts and single-design.ts', async () => {
+  const mod = await import('./voices.js');
+  expect(typeof mod.hasClonedSlotAmongMatches).toBe('function');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- --run server/src/routes/voices.test.ts -t "hasClonedSlotAmongMatches is exported"`
+Expected: FAIL — `mod.hasClonedSlotAmongMatches` is `undefined` (the function exists but is not exported).
+
+- [ ] **Step 3: Export the function ONLY — no behavioural change yet**
+
+At `voices.ts:615`, change just the declaration:
+
+```ts
+async function hasClonedSlotAmongMatches(
+```
+
+to:
+
+```ts
+export async function hasClonedSlotAmongMatches(
+```
+
+Leave the body exactly as it is today — the `onlyBookDir` fix is a separate step (Step 6) with its own failing test (Step 5), so this task stays test-first at each behavioural change rather than implementing ahead of its test.
+
+- [ ] **Step 3b: Make the export actually callable from this file's own tests**
+
+`voices.test.ts` does not use plain top-level imports for functions under test — it binds them via module-scope `let` declarations assigned inside its own `beforeAll` from a single dynamic `import('./voices.js')` (`voices.test.ts:65`, `:147-153`: `const { …, applyOverrideToCastFiles: aotcf } = await import('./voices.js'); applyOverrideToCastFiles = aotcf;`). A bare `hasClonedSlotAmongMatches(...)` call in a test body will be a `ReferenceError` unless it follows the same pattern. Add, alongside the existing declarations:
+
+```ts
+// near voices.test.ts:65
+let hasClonedSlotAmongMatches: typeof import('./voices.js').hasClonedSlotAmongMatches;
+```
+
+and in the `beforeAll` at `:147-153`, extend the destructuring and assignment:
+
+```ts
+const { voicesRouter, applyTierToCastFiles: atcf, applyOverrideToCastFiles: aotcf, hasClonedSlotAmongMatches: hcsam } =
+  await import('./voices.js');
+// ...
+hasClonedSlotAmongMatches = hcsam;
+```
+
+(Task 9 adds `findClonedVoiceIdsAmongMatches` to this same pattern when it introduces that function.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- --run server/src/routes/voices.test.ts -t "hasClonedSlotAmongMatches is exported"`
+Expected: PASS.
+
+- [ ] **Step 5: Write a failing test for the scope-mismatch defect, against REAL isolated fixtures — and confirm it actually fails**
+
+`hasClonedSlotAmongMatches` originally took no book-scoping parameter — every call is either workspace-wide or series-wide. But `forEachMatchingCastCharacter` (the function whose write this predicate gates) has a THIRD mode: when `seriesFilter` is absent and `onlyBookDir` is given, it scans only that one book (`voices.ts:809-826`) — the fs-61 guard against a bare shared id like `narrator` silently matching an unrelated standalone book elsewhere in the workspace. Every upfront/write-time check this plan adds for a standalone book (Tasks 2, 3, 4, 7, 8) calls with `seriesFilter: undefined` — without a matching fix here, the CHECK would scan the whole workspace even though the WRITE it gates stays correctly single-book-scoped, reopening fs-61's hole one layer up.
+
+Mint two dedicated, fresh, isolated standalone books via this file's own `writeBookOnDisk` helper (`voices.test.ts:70-102`) — do NOT reuse `standaloneA`/`standaloneB` (they exist for a different describe's own fixture and neither carries a clone). Add near the top of the file, alongside the other top-level constants:
+
+```ts
+const SCOPE_TEST_AUTHOR = 'Ines Halvorsen';
+```
+
+Then the test itself:
+
+```ts
+describe('hasClonedSlotAmongMatches — onlyBookDir scope (found under review)', () => {
+  let bookOneDir: string;
+  let bookTwoDir: string;
+
+  beforeEach(() => {
+    bookOneDir = writeBookOnDisk(
+      workspaceRoot, SCOPE_TEST_AUTHOR, 'Standalones', 'Onyx Reach', 'book-onyx',
+      [{ id: 'narrator', name: 'Narrator' }], // no clone
+      true,
+    );
+    bookTwoDir = writeBookOnDisk(
+      workspaceRoot, SCOPE_TEST_AUTHOR, 'Standalones', 'Salt Line', 'book-salt',
+      [{ id: 'narrator', name: 'Narrator', overrideTtsVoices: { coqui: { name: 'clone-x', provenance: 'cloned' } } }],
+      true,
+    );
+  });
+
+  it('with no seriesFilter but an onlyBookDir, scopes the scan to that one book — a clone in an unrelated standalone book sharing the same bare id must not cause a false refusal', async () => {
+    const result = await hasClonedSlotAmongMatches('narrator', undefined, undefined, bookOneDir);
+    expect(result).toBe(false);
+  });
+});
+```
+
+Both books are standalone and share the bare id `narrator`. `bookTwoDir`'s copy is cloned; `bookOneDir`'s is not. Because `seriesFilter` is absent, TODAY's (pre-fix) 3-parameter function ignores `onlyBookDir` and falls all the way through to the workspace-wide triple loop — and critically, its `if (seriesFilter) { if (state.isStandalone === true) continue; ... }` guard only runs when `seriesFilter` is truthy, so with `seriesFilter` absent NEITHER standalone book is excluded from the scan. The scan reaches `bookTwoDir`'s cloned `narrator` and returns `true` — this test's `expect(result).toBe(false)` genuinely fails against the current 3-parameter function.
+
+Run: `npm run test -- --run server/src/routes/voices.test.ts -t "onlyBookDir scope"`
+Expected: **FAIL** (confirms the test is red against the real, current, unfixed code — not vacuously passing either way, which is what an earlier revision of this task shipped and a review pass caught).
+
+- [ ] **Step 6: Implement the `onlyBookDir` special case, mirroring `forEachMatchingCastCharacter`'s own condition exactly**
+
+At `voices.ts:615-645`, change the signature and body:
+
+```ts
+async function hasClonedSlotAmongMatches(
+  voiceId: string,
+  seriesFilter?: { author: string; series: string },
+  otherThanEngine?: TtsEngine,
+): Promise<boolean> {
+  for (const authorName of listDirs(BOOKS_ROOT)) {
+    for (const seriesName of listDirs(join(BOOKS_ROOT, authorName))) {
+      for (const titleName of listDirs(join(BOOKS_ROOT, authorName, seriesName))) {
+        const bookDir = join(BOOKS_ROOT, authorName, seriesName, titleName);
+        const state = await readJson<BookStateJson>(stateJsonPath(bookDir));
+        if (!state || !state.castConfirmed) continue;
+        if (seriesFilter) {
+          if (state.isStandalone === true) continue;
+          if (state.author !== seriesFilter.author || state.series !== seriesFilter.series) continue;
+        }
+        const cast = await readJson<CastJson>(castJsonPath(bookDir));
+        if (!cast?.characters?.length) continue;
+        for (const c of cast.characters) {
+          if ((c.voiceId ?? c.id) !== voiceId) continue;
+          const cloned = otherThanEngine
+            ? CLONE_ENGINE_LIST.some(
+                (e) => e !== otherThanEngine && hasClonedProvenance(c, e),
+              )
+            : characterHasClonedSlot(c);
+          if (cloned) return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+```
+
+to (this is the 3a fix — the new branch mirrors `forEachMatchingCastCharacter`'s own condition at `voices.ts:809`, `!seriesFilter && onlyBookDir`, exactly):
+
+```ts
+export async function hasClonedSlotAmongMatches(
+  voiceId: string,
+  seriesFilter?: { author: string; series: string },
+  otherThanEngine?: TtsEngine,
+  onlyBookDir?: string,
+): Promise<boolean> {
+  const cloned = (c: CastCharacter): boolean =>
+    otherThanEngine
+      ? CLONE_ENGINE_LIST.some((e) => e !== otherThanEngine && hasClonedProvenance(c, e))
+      : characterHasClonedSlot(c);
+
+  /* Mirrors forEachMatchingCastCharacter's own onlyBookDir special case
+     (voices.ts:809) exactly: a caller with no series context must not fall
+     through to a workspace-wide scan on a bare character id (fs-61) — that
+     would make THIS predicate refuse across unrelated standalone books even
+     though the write it gates stays correctly single-book-scoped. */
+  if (!seriesFilter && onlyBookDir) {
+    const cast = await readJson<CastJson>(castJsonPath(onlyBookDir));
+    if (!cast?.characters?.length) return false;
+    for (const c of cast.characters) {
+      if ((c.voiceId ?? c.id) !== voiceId) continue;
+      if (cloned(c)) return true;
+    }
+    return false;
+  }
+
+  for (const authorName of listDirs(BOOKS_ROOT)) {
+    for (const seriesName of listDirs(join(BOOKS_ROOT, authorName))) {
+      for (const titleName of listDirs(join(BOOKS_ROOT, authorName, seriesName))) {
+        const bookDir = join(BOOKS_ROOT, authorName, seriesName, titleName);
+        const state = await readJson<BookStateJson>(stateJsonPath(bookDir));
+        if (!state || !state.castConfirmed) continue;
+        if (seriesFilter) {
+          if (state.isStandalone === true) continue;
+          if (state.author !== seriesFilter.author || state.series !== seriesFilter.series) continue;
+        }
+        const cast = await readJson<CastJson>(castJsonPath(bookDir));
+        if (!cast?.characters?.length) continue;
+        for (const c of cast.characters) {
+          if ((c.voiceId ?? c.id) !== voiceId) continue;
+          if (cloned(c)) return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+```
+
+Replace the comment above it (`voices.ts:588-614`, currently scoped to "the clear branch below" and one caller) with:
+
+```ts
+/* Read-only scan: does any confirmed-cast character matching `voiceId`
+   (optionally scoped to a series, optionally excluding one engine) carry a
+   consented cloned voice? Exported — reused by:
+     - this file's own PUT /:voiceId/override (both the CLEAR and SET
+       upfront checks, and applyOverrideToCastFiles's own fresh write-time
+       check, all below);
+     - single-design.ts's upfront gate;
+     - qwen-voice.ts's persistEmotionVariant (write-time) and its two
+       callers' upfront checks.
+   Walks the SAME (workspace- or series-scoped) match set
+   forEachMatchingCastCharacter does, but read-only — deliberately NOT
+   implemented by reusing forEachMatchingCastCharacter itself (which always
+   persists, even for a no-op mutate) — a validation pass must not touch disk.
+
+   `otherThanEngine` serves ONLY voices.ts's own SET-branch asymmetry (a SET
+   pins `ttsEngine` to the incoming engine, so a clone on a DIFFERENT
+   clone-capable engine would go inert — see the SET branch below); every
+   other caller passes it as `undefined`, meaning "any clone-capable engine
+   counts".
+
+   `onlyBookDir` scopes the scan to exactly one book when `seriesFilter` is
+   absent — mirrors forEachMatchingCastCharacter's own special case
+   (voices.ts:809) so a caller with no series context (a standalone book)
+   gets a book-scoped check instead of an accidental workspace-wide one on a
+   bare shared id (fs-61). Ignored whenever `seriesFilter` is present, same
+   as forEachMatchingCastCharacter. */
+```
+
+- [ ] **Step 7: Run the test to verify it now passes**
+
+Run: `npm run test -- --run server/src/routes/voices.test.ts -t "onlyBookDir scope"`
+Expected: PASS.
+
+- [ ] **Step 8: Run the full voices.ts test file to confirm no regression**
+
+Run: `npm run test -- --run server/src/routes/voices.test.ts`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add server/src/routes/voices.ts server/src/routes/voices.test.ts
+git commit -m "refactor(server): export hasClonedSlotAmongMatches, add its onlyBookDir scope"
+```
+
+---
+
+### Task 2: `applyOverrideToCastFiles` — series-wide fresh check + typed return + residual backstop
+
+**Files:**
+- Modify: `server/src/routes/voices.ts:731` (route handler call site), `server/src/routes/voices.ts:875-954` (`applyOverrideToCastFiles`)
+- Modify: `openapi.yaml` (the `PUT /api/voices/{voiceId}/override` path's response documentation)
+- Test: `server/src/routes/voices.test.ts` (new tests + migrate ~7 existing call sites off the old `Promise<number>` shape)
+
+**Interfaces:**
+- Consumes: `hasClonedSlotAmongMatches` (Task 1), `forEachMatchingCastCharacter` (unchanged, `voices.ts:779`), `characterHasClonedSlot`/`hasClonedProvenance`/`CLONE_ENGINE_LIST` (already imported at `voices.ts:67-70`).
+- Produces: `applyOverrideToCastFiles(voiceId, override, seriesFilter?, onlyBookDir?): Promise<{ updated: number; skipped: Array<{ bookDir: string; characterId: string; reason: string }> }>` — **breaking change** from today's `Promise<number>`. Tasks 3 and 4 depend on this exact shape.
+- **Also consumed (not just produced) by `server/src/routes/variant-propagation.test.ts:30-31, :188`**, which type-aliases `typeof import('./voices.js').applyOverrideToCastFiles` and `typeof import('./qwen-voice.js').persistEmotionVariant`. Neither alias captures or asserts on a return value in that file, so this change does not require an edit there, but run its suite in Step 6 anyway to confirm — this file was missed by this plan's own first-pass enumeration and only surfaced under review.
+
+- [ ] **Step 1: Write the failing tests (new behavior)**
+
+Add to `voices.test.ts`, near the existing `describe('applyOverrideToCastFiles — standalone book-scoping (fs-61)', ...)` block:
+
+```ts
+describe('applyOverrideToCastFiles — series-wide veto (v2)', () => {
+  /* Fresh, dedicated fixture — do NOT reuse AUTHOR/SERIES/BOOK_ONE/BOOK_TWO
+     (voices.test.ts:30-33): those books' cast.json already has fixed
+     characters (char-brann / v_brann) seeded once in this file's top-level
+     beforeAll and read by ~8 other describes; `setOverrideOnDisk` can only
+     rewrite an EXISTING character's override, it cannot mint a character
+     with a NEW voiceId like 'shared-voice-id'. This describe mints its own
+     two books via this file's `writeBookOnDisk` helper (:70-102), each
+     seeded with two characters whose ids/voiceIds this describe controls
+     directly, and rewrites both books fresh in `beforeEach` so no test can
+     leak state into another. */
+  const VETO_AUTHOR = 'Petra Solberg';
+  const VETO_SERIES = 'The Amber Coast';
+  const VETO_BOOK_ONE = 'First Light';
+  const VETO_BOOK_TWO = 'Second Light';
+  let bookOneDir: string;
+  let bookTwoDir: string;
+
+  function seedVetoBooks(bookOneCloned: boolean, bookTwoCloned: boolean) {
+    const charFor = (cloned: boolean) => [
+      {
+        id: 'shared',
+        name: 'Shared',
+        voiceId: 'shared-voice-id',
+        ...(cloned ? { overrideTtsVoices: { coqui: { name: 'clone-x', provenance: 'cloned' } } } : {}),
+      },
+      { id: 'uncloned', name: 'Uncloned', voiceId: 'uncloned-voice-id' },
+    ];
+    bookOneDir = writeBookOnDisk(
+      workspaceRoot, VETO_AUTHOR, VETO_SERIES, VETO_BOOK_ONE, 'book-veto-one',
+      charFor(bookOneCloned),
+    );
+    bookTwoDir = writeBookOnDisk(
+      workspaceRoot, VETO_AUTHOR, VETO_SERIES, VETO_BOOK_TWO, 'book-veto-two',
+      charFor(bookTwoCloned),
+    );
+  }
+
+  it('refuses the ENTIRE propagation when a clone exists on a sibling book, not just that book', async () => {
+    seedVetoBooks(true, false); // book one's 'shared' is cloned; book two's is not
+    const result = await applyOverrideToCastFiles(
+      'shared-voice-id',
+      { engine: 'qwen', name: 'qwen-new-pick' },
+      { author: VETO_AUTHOR, series: VETO_SERIES },
+    );
+    expect(result.updated).toBe(0);
+    expect(result.skipped).toEqual([
+      { bookDir: '(series-wide)', characterId: 'shared-voice-id', reason: 'already_cloned' },
+    ]);
+    // Neither book was written — this is the corrected v2 behavior; v1 would
+    // have written book two and only skipped book one.
+    const bookTwo = readCastFromDisk(workspaceRoot, VETO_AUTHOR, VETO_SERIES, VETO_BOOK_TWO);
+    expect(
+      (bookTwo.characters[0].overrideTtsVoices as { qwen?: { name?: string } } | undefined)?.qwen
+        ?.name,
+    ).toBeUndefined();
+  });
+
+  it('with a seriesFilter AND onlyBookDir both set (the real single-design.ts/cast-design.ts shape), the refusal is still "(series-wide)", not the caller\'s own book — onlyBookDir is not a scoping parameter once seriesFilter is present', async () => {
+    seedVetoBooks(true, false);
+    const result = await applyOverrideToCastFiles(
+      'shared-voice-id',
+      { engine: 'qwen', name: 'qwen-new-pick' },
+      { author: VETO_AUTHOR, series: VETO_SERIES },
+      bookOneDir, // present, but forEachMatchingCastCharacter ignores it whenever seriesFilter is set
+    );
+    expect(result.skipped[0].bookDir).toBe('(series-wide)');
+  });
+
+  it('with onlyBookDir set and NO seriesFilter (the genuine single-book case), the refusal entry names that exact book', async () => {
+    seedVetoBooks(true, false);
+    const result = await applyOverrideToCastFiles(
+      'shared-voice-id',
+      { engine: 'qwen', name: 'qwen-new-pick' },
+      undefined,
+      bookOneDir,
+    );
+    expect(result.skipped[0].bookDir).toBe(bookOneDir);
+  });
+
+  it('proceeds and reports updated>0, skipped:[] when no clone exists anywhere in the match set', async () => {
+    seedVetoBooks(false, false);
+    const result = await applyOverrideToCastFiles(
+      'uncloned-voice-id',
+      { engine: 'qwen', name: 'qwen-pick' },
+      { author: VETO_AUTHOR, series: VETO_SERIES },
+    );
+    expect(result.updated).toBeGreaterThan(0);
+    expect(result.skipped).toEqual([]);
+  });
+
+  it('residual-window case: a clone injected after the fresh scan but before the walk reaches that book lands in skipped, other books still update', async () => {
+    /* Critical fixture requirement, found under review: seed NEITHER book
+       cloned. If book two starts cloned, the FRESH series-wide check (which
+       runs before forEachMatchingCastCharacter's walk even starts) refuses
+       the whole call immediately and the walk this test is trying to
+       instrument never runs at all — an earlier revision of this test made
+       exactly that mistake and the interception it scripted below was
+       unreachable. The clone must be injected mid-walk, not pre-seeded. */
+    seedVetoBooks(false, false);
+
+    const stateIo = await import('../workspace/state-io.js');
+    const actual = await vi.importActual<typeof import('../workspace/state-io.js')>(
+      '../workspace/state-io.js',
+    );
+    const bookTwoCastPath = join(bookTwoDir, '.audiobook', 'cast.json');
+    let released!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      released = resolve;
+    });
+    let callsForBookTwoPath = 0;
+    let intercepted = false;
+    const spy = vi.mocked(stateIo.readJson).mockImplementation(async (path: string) => {
+      if (path !== bookTwoCastPath) return actual.readJson(path);
+      callsForBookTwoPath += 1;
+      // Call #1 is the fresh hasClonedSlotAmongMatches scan's read — let it
+      // through unheld (book two has no clone yet at this point, by design
+      // above). Call #2 is forEachMatchingCastCharacter's own per-book read
+      // inside its lock — hold THAT one open so the direct writer below can
+      // land first.
+      if (callsForBookTwoPath === 2) {
+        intercepted = true;
+        await gate;
+      }
+      return actual.readJson(path);
+    });
+
+    let resultPromise: ReturnType<typeof applyOverrideToCastFiles> | undefined;
+    try {
+      resultPromise = applyOverrideToCastFiles(
+        'shared-voice-id',
+        { engine: 'qwen', name: 'qwen-new-pick' },
+        { author: VETO_AUTHOR, series: VETO_SERIES },
+      );
+      const deadline = Date.now() + 2000;
+      while (!intercepted && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 5));
+      }
+      expect(intercepted).toBe(true);
+
+      // Write the clone marker directly to disk while book two's read is held.
+      setOverrideOnDisk(workspaceRoot, VETO_AUTHOR, VETO_SERIES, VETO_BOOK_TWO, {
+        coqui: { name: 'clone-x', provenance: 'cloned' },
+      });
+      released();
+    } finally {
+      released();
+      spy.mockImplementation(actual.readJson);
+      await resultPromise?.catch(() => {});
+    }
+
+    const result = await resultPromise!;
+    expect(result.updated).toBeGreaterThan(0); // book one still got it
+    expect(result.skipped).toContainEqual(
+      expect.objectContaining({ characterId: 'shared-voice-id', reason: 'already_cloned' }),
+    );
+    const bookOne = readCastFromDisk(workspaceRoot, VETO_AUTHOR, VETO_SERIES, VETO_BOOK_ONE);
+    expect(
+      (bookOne.characters[0].overrideTtsVoices as { qwen?: { name?: string } } | undefined)?.qwen?.name,
+    ).toBe('qwen-new-pick');
+    const bookTwo = readCastFromDisk(workspaceRoot, VETO_AUTHOR, VETO_SERIES, VETO_BOOK_TWO);
+    expect(
+      (bookTwo.characters[0].overrideTtsVoices as { qwen?: { name?: string } } | undefined)?.qwen?.name,
+    ).toBeUndefined(); // book two's own residual backstop declined the write
+  });
+  /* Load-bearing and worth stating: this test's premise — that book one is
+     written before the walk reaches book two, so gating book two's read
+     proves something about a book visited AFTER an unrelated write —
+     depends on `forEachMatchingCastCharacter`'s directory walk visiting
+     'First Light' before 'Second Light'. `listDirs` (voices.ts) is presumed
+     to return entries in a stable, sorted order (as this file's own
+     pre-existing race tests, e.g. 'workspace walk: a concurrent
+     propagation...', already rely on) — this is not a new assumption this
+     task introduces, but re-verify it holds if `listDirs`'s ordering ever
+     changes. */
+
+  it('mutation-verified: deleting the fresh series-wide check turns the sibling-clone test red', () => {
+    /* Not automated — run by hand once, per this repo's testing discipline
+       (paired mutation verification, not a permanent test). Comment out the
+       `if (await hasClonedSlotAmongMatches(...)) { return {...}; }` block at
+       the top of applyOverrideToCastFiles, re-run
+       `npm run test -- --run server/src/routes/voices.test.ts -t "refuses the ENTIRE propagation"`,
+       confirm it goes red (book two would now get `updated` and the sibling
+       clone would be silently overwritten), capture that failure output,
+       then restore the code and confirm the test is green again. Paste the
+       captured red-run output into the PR description. */
+  });
+});
+```
+
+**Note for the implementer:** the mutation-verification item above has no automated body by design (it verifies the *absence* of a guard, which can't be asserted as a standing test without deleting the guard permanently) — its instructions are the deliverable, and the PR body must show the captured failure output per this repo's testing discipline. Every OTHER test in this block, including the residual-window one, has a real, executable body above — do not leave any of them as comment-only stubs; Vitest passes an empty `it()` body silently, which is indistinguishable from a real assertion in CI output.
+
+This block's fixture went through two revisions under review. The first assumed `setOverrideOnDisk`/`readCastFromDisk` and this file's shared `AUTHOR`/`SERIES`/`BOOK_ONE`/`BOOK_TWO` fixture (voices.test.ts:30-33) could seed characters with custom voiceIds like `'shared-voice-id'` — they cannot; `setOverrideOnDisk` only rewrites an *existing* character's override field, and that shared fixture's characters are fixed (`char-brann`/`v_brann`) and consumed by ~8 other describes with no safe way to add new ids to it. The revision above instead mints two fully dedicated books via `writeBookOnDisk` (`voices.test.ts:70-102`, real signature: `writeBookOnDisk(workspace, author, series, title, bookId, characters, isStandalone = false)`, returns the bookDir) inside each test itself (or a shared `seedVetoBooks` helper), so every test controls its own character ids and clone state directly rather than depending on a fixture built for a different describe. A second, independent bug the first revision's residual-window test carried: it pre-seeded book two's `'shared-voice-id'` as ALREADY cloned in its own `beforeEach`, which means the FRESH series-wide check (which runs before the walk even starts) refuses the whole call immediately — the interception this test scripts against `forEachMatchingCastCharacter`'s own read is never reached, because that function is never called. The revision above seeds neither book cloned and injects the clone only during the held read, which is the only way to actually reach the walk's own per-book backstop. `writeBookOnDisk`, `readCastFromDisk`, and `setOverrideOnDisk` are real, top-level, module-scope helpers in this file (`:70-102`, `:104-107`, `:126-139`) — verify them against the actual current file before writing code regardless, the same caution this whole plan's revision history keeps re-learning.
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `npm run test -- --run server/src/routes/voices.test.ts -t "series-wide veto"`
+Expected: FAIL — `result.updated` etc. are `undefined` today (`applyOverrideToCastFiles` still returns a bare number).
+
+- [ ] **Step 3: Implement the fresh check + typed return + residual backstop**
+
+Replace `applyOverrideToCastFiles` (`voices.ts:875-954`) with:
+
+```ts
+export async function applyOverrideToCastFiles(
+  voiceId: string,
+  override: { engine: TtsEngine; name: string } | null,
+  seriesFilter?: { author: string; series: string },
+  onlyBookDir?: string,
+): Promise<{ updated: number; skipped: Array<{ bookDir: string; characterId: string; reason: string }> }> {
+  const otherThanEngine = override === null ? undefined : override.engine;
+  /* Which sentinel a caller gets right: forEachMatchingCastCharacter's own
+     branch at voices.ts:809 only honours `onlyBookDir` when `seriesFilter`
+     is ABSENT — with a seriesFilter present it always runs the general
+     multi-book walk regardless of onlyBookDir (voices.ts:827-861). Both
+     single-design.ts and cast-design.ts pass BOTH a seriesFilter AND
+     job.bookDir, so `onlyBookDir` does NOT mean "this call touches exactly
+     that book" whenever seriesFilter is set — using it as a per-entry label
+     in that case would name the WRONG book (the caller's own, when the
+     clone could be on any matched sibling). Only compute a real single-book
+     label when seriesFilter is absent, matching forEachMatchingCastCharacter's
+     own condition exactly. */
+  const singleBookDir = !seriesFilter ? onlyBookDir : undefined;
+  /* v2 — fresh, series-wide re-check immediately before any write, replacing
+     the caller's stale pre-scan. Refuses the WHOLE propagation on a hit —
+     no book is written — rather than the v1 per-book-independent contract.
+     See docs/superpowers/specs/2026-08-22-clone-consent-voices-override-
+     refusal-design.md "The decision this spec finalizes". This IS a
+     genuinely series-wide (or workspace-wide) verdict, not a per-book one —
+     labelled accordingly rather than with the residual backstop's
+     "unknown" sentinel below. */
+  if (await hasClonedSlotAmongMatches(voiceId, seriesFilter, otherThanEngine, onlyBookDir)) {
+    return {
+      updated: 0,
+      skipped: [{
+        bookDir: singleBookDir ?? (seriesFilter ? '(series-wide)' : '(workspace-wide)'),
+        characterId: voiceId,
+        reason: 'already_cloned',
+      }],
+    };
+  }
+  const skipped: Array<{ bookDir: string; characterId: string; reason: string }> = [];
+  const updated = await forEachMatchingCastCharacter(
+    voiceId,
+    seriesFilter,
+    (original) => {
+      /* Residual-window backstop: the walk still takes nonzero time after
+         the fresh scan above passed. Immune to unrelated intermediate
+         writes because it re-checks the FRESH per-book read
+         forEachMatchingCastCharacter already did before calling this
+         closure. `singleBookDir` names this entry's book ONLY in the
+         genuinely single-book case (no seriesFilter, onlyBookDir set) —
+         the same case forEachMatchingCastCharacter itself treats as
+         single-book. Every other case (a series or workspace walk touching
+         possibly-many books) can't attribute a specific book from inside
+         this closure, so it uses '(unknown)' — no caller of this function
+         reads `skipped[].bookDir` for logic, only `skipped.length`, so this
+         is for human/API-consumer legibility, not correctness. */
+      const cloned = override === null
+        ? characterHasClonedSlot(original)
+        : CLONE_ENGINE_LIST.some((e) => e !== override.engine && hasClonedProvenance(original, e));
+      if (cloned) {
+        skipped.push({ bookDir: singleBookDir ?? '(unknown)', characterId: voiceId, reason: 'already_cloned' });
+        return original; // unchanged — dirty=true still fires (harmless idempotent rewrite)
+      }
+      const normalised = normaliseCastCharacter(original);
+      const replacement: CastCharacter = { ...normalised };
+      if (override === null) {
+        delete replacement.overrideTtsVoices;
+      } else {
+        const map = { ...(normalised.overrideTtsVoices ?? {}) };
+        const nextSlot = { ...(map[override.engine] ?? {}), name: override.name };
+        if (!hasClonedProvenance(normalised, override.engine)) {
+          delete nextSlot.libraryUuid;
+          delete nextSlot.provenance;
+        }
+        map[override.engine] = nextSlot;
+        replacement.overrideTtsVoices = map;
+        replacement.ttsEngine = override.engine;
+      }
+      delete replacement.overrideTtsVoice;
+      return replacement;
+    },
+    onlyBookDir,
+  );
+  if (updated > 0) invalidateBaseVoiceCache();
+  return { updated, skipped };
+}
+```
+
+(The mutate closure body after the `cloned` branch is unchanged from today's implementation — only the clone check and the wrapping return shape are new.)
+
+- [ ] **Step 4: Update the one production call site whose destructuring changes shape — the route handler**
+
+At `voices.ts:731-739`:
+
+```ts
+// before:
+const updates = await applyOverrideToCastFiles(voiceId, parsed, seriesFilter);
+if (updates === 0) {
+  const where = seriesFilter
+    ? `in series "${seriesFilter.author} / ${seriesFilter.series}"`
+    : 'in any confirmed cast';
+  return res
+    .status(404)
+    .json({ error: `No character with voiceId "${voiceId}" found ${where}.` });
+}
+res.status(204).end();
+
+// after:
+const { updated, skipped } = await applyOverrideToCastFiles(voiceId, parsed, seriesFilter);
+if (updated === 0 && skipped.length === 0) {
+  const where = seriesFilter
+    ? `in series "${seriesFilter.author} / ${seriesFilter.series}"`
+    : 'in any confirmed cast';
+  return res
+    .status(404)
+    .json({ error: `No character with voiceId "${voiceId}" found ${where}.` });
+}
+if (updated === 0 && skipped.length > 0) {
+  return res.status(409).json({
+    error:
+      `Voice "${voiceId}" has a consented cloned voice on a linked character somewhere in ` +
+      `this series — the override was not applied anywhere. Reassign that character directly instead.`,
+    skipped,
+  });
+}
+if (skipped.length > 0) {
+  return res.status(200).json({ updated, skipped });
+}
+res.status(204).end();
+```
+
+This implements the response table from the sibling spec's "Response contract for `voices.ts` `PUT /:voiceId/override`" section (204 / 200-partial / 409-with-skipped / 404, in that order).
+
+- [ ] **Step 5: Migrate every existing test that consumes the old `Promise<number>` shape**
+
+Grep first to catch anything this plan's own reading missed:
+
+Run: `grep -n "applyOverrideToCastFiles(" server/src/routes/voices.test.ts`
+
+Apply this transform at each hit that captures the return value as a bare number (confirmed present at the following; re-check the grep output for any this plan didn't enumerate):
+
+- `voices.test.ts:1790` (`const n = await applyOverrideToCastFiles(...)`) → `const { updated: n } = await applyOverrideToCastFiles(...)` (keeps the rest of the test, which asserts `expect(n).toBe(1)`, unchanged).
+- `voices.test.ts:1811` → same transform (`expect(n).toBeGreaterThanOrEqual(2)` stays as-is).
+- `voices.test.ts:1916-1973` (the `overridePromise: Promise<number>` race test): change the type annotation `let overridePromise: Promise<number> | undefined;` to `let overridePromise: Promise<{ updated: number; skipped: unknown[] }> | undefined;`, and change the destructuring at the `Promise.all` site from `[n, wrote] = await Promise.all([overridePromise, personaPromise]);` to `[{ updated: n }, wrote] = await Promise.all([overridePromise, personaPromise]);` (braces added around the first destructured element; `n`'s own declaration, `let n: number;`, is unchanged).
+- `voices.test.ts:2005-2069` (the `walkPromise` race test) and `voices.test.ts:2089+` (the per-book-lock test): identical transform — `Promise<number>` → `Promise<{ updated: number; skipped: unknown[] }>`, and `[n, wrote]`/`[n, writerSettled]` destructuring becomes `[{ updated: n }, wrote]` / `[{ updated: n }, writerSettled]`.
+- `voices.test.ts:1615` and `:1768-1769` (calls whose return is never captured) — no change needed.
+
+- [ ] **Step 6: Also run `variant-propagation.test.ts` — a consumer this plan's first pass missed**
+
+Run: `npm run test -- --run server/src/routes/variant-propagation.test.ts`
+Expected: PASS. This file type-aliases both `applyOverrideToCastFiles` and `persistEmotionVariant` (`typeof import(...)`) but does not capture or assert on either's return value, so no edit is expected here — this step exists to confirm that, not to skip it.
+
+- [ ] **Step 7: Update `openapi.yaml` for `PUT /api/voices/{voiceId}/override`'s new/previously-undocumented responses**
+
+The route's existing documentation lists only `204`/`400`/`404`. This step both documents this task's new `200` and closes a pre-existing gap the sibling spec flagged and this plan had dropped: the `409` already exists in code (`voices.ts:713`, `:724`, both pre-existing) but was never in `openapi.yaml` either. Find the path entry (`grep -n "override:" openapi.yaml` near the `/api/voices/{voiceId}/override` path item) and add, alongside the existing `204`/`400`/`404` responses:
+
+```yaml
+        '200':
+          description: >-
+            Applied to at least one linked character, but at least one other
+            linked character was skipped (a residual-window clone, or —
+            pre-existing — a same-book conflict). See `skipped`.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [updated, skipped]
+                properties:
+                  updated: { type: integer }
+                  skipped:
+                    type: array
+                    items:
+                      type: object
+                      required: [bookDir, characterId, reason]
+                      properties:
+                        bookDir: { type: string }
+                        characterId: { type: string }
+                        reason: { type: string }
+        '409':
+          description: >-
+            Refused entirely — a consented cloned voice exists on this
+            linked character somewhere in the series (or, for a SET, on a
+            different clone-capable engine). No book was written.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [error]
+                properties:
+                  error: { type: string }
+                  skipped:
+                    type: array
+                    items:
+                      type: object
+                      required: [bookDir, characterId, reason]
+                      properties:
+                        bookDir: { type: string }
+                        characterId: { type: string }
+                        reason: { type: string }
+```
+
+- [ ] **Step 8: Check the frontend's `PUT /override` client for the new `200` response**
+
+Grep `src/lib/api.ts` for the function that calls `PUT /api/voices/:voiceId/override` (search for `/override` or `setVoiceOverride`; it is `realSetVoiceOverride`, currently `Promise<void>`, throws on `!res.ok`, never calls `.json()`). Before this task, that endpoint only ever returned `204` (no body) or an error status; this task adds a `200` with a JSON body reporting a PARTIAL success (some linked books updated, some refused). Today's client silently treats the new `200` exactly like the old `204` — success, nothing read from the body — which means a user who asked to propagate a voice across a series and had it silently apply to only SOME books gets no different feedback than full success. **This is a real product gap this task's own change creates, not something to silently bless as "no change required."** Fixing the UI to surface partial success is out of scope for this backend-focused plan (it needs a UI decision this plan shouldn't make unilaterally, mirroring the same judgment-call carve-out the qwen-voice spec applied to its own analogous UI gap) — but do not close this step by declaring it a non-issue. File a follow-up issue naming the gap explicitly (per this repo's incidental-findings rule: a finding that needs a design decision is filed with the decision named, not silently deferred) rather than treating today's "any 2xx is success" behavior as sufficient.
+
+- [ ] **Step 9: Run the full voices.ts test file**
+
+Run: `npm run test -- --run server/src/routes/voices.test.ts`
+Expected: PASS — every existing test green under the new shape, plus the new series-wide-veto tests from Step 1.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add server/src/routes/voices.ts server/src/routes/voices.test.ts openapi.yaml src/lib/api.ts
+git commit -m "feat(server): applyOverrideToCastFiles refuses the whole propagation on a series-wide clone"
+```
+
+---
+
+### Task 3: `single-design.ts` — series-wide upfront check + wire the write-time outcome
+
+**Note — this task extends beyond the sibling spec's literal text.** The spec states single-design.ts's write-time behavior is "unchanged from v1: a non-empty `skipped` for its own book means refuse that job" — but direct inspection of the current code (`single-design.ts:179-184`) shows the call to `applyOverrideToCastFiles` today discards its return value entirely and unconditionally emits a `'designed'` success event, the exact defect the sibling spec fixed at `cast-design.ts:544` for the bulk job. This is the same shape, in a file this plan already touches, found during plan authoring — per this repo's incidental-findings rule it is fixed in this same round, not filed separately. The upfront check (`single-design.ts:273`) is upgraded to series-wide for the same reason `qwen-voice.ts`'s JSON route upfront check was (Task 7) — a character cloned on a sibling book is a stable, routine case, not a rare race, and leaving the upfront check book-local here would make every such attempt run a full GPU round before failing at the write-time check this task also adds.
+
+**Files:**
+- Modify: `server/src/routes/single-design.ts:103-192` (`runSingleDesign`), `single-design.ts:230-311` (route handler)
+- Test: `server/src/routes/single-design.test.ts`
+
+**Interfaces:**
+- Consumes: `hasClonedSlotAmongMatches` (Task 1), `applyOverrideToCastFiles` (Task 2's new return shape).
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// server/src/routes/single-design.test.ts, new describe block after the
+// existing 'single-design job — clone protection (GATE 2 fix-lane-1b)' one
+
+describe('single-design job — series-wide clone veto (#2006)', () => {
+  /* This file's own `writeBookOnDisk(dir, id)` (single-design.test.ts:50) is
+     a fixed-shape helper for THIS ONE book (bookDir/BOOK_ID, characters
+     c1/c2) — it takes no characters param and can't mint a sibling book, so
+     don't try to reuse it for this. Write the sibling book directly,
+     mirroring its exact on-disk shape (state.json + manuscript.txt +
+     cast.json), in the SAME series (AUTHOR/SERIES) so
+     findAuthorSeriesForBookId's real (unmocked) scan finds it. `c1` (this
+     file's existing fixture character, no `voiceId` of its own — so its
+     link key is the bare id `'c1'`) is the target; the sibling's character
+     shares that same link key via its OWN `voiceId: 'c1'` and carries the
+     clone. */
+  let siblingDir: string;
+
+  beforeEach(() => {
+    siblingDir = join(workspaceRoot, 'books', AUTHOR, SERIES, 'Sibling Book');
+    mkdirSync(join(siblingDir, '.audiobook'), { recursive: true });
+    writeFileSync(
+      join(siblingDir, '.audiobook', 'state.json'),
+      JSON.stringify({
+        bookId: 'sibling-book-id',
+        manuscriptId: 'm_sibling-book-id',
+        title: 'Sibling Book',
+        author: AUTHOR,
+        series: SERIES,
+        seriesPosition: 2,
+        isStandalone: false,
+        manuscriptFile: 'manuscript.txt',
+        castConfirmed: true,
+        chapters: [],
+        coverGradient: ['#000', '#fff'],
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+    writeFileSync(join(siblingDir, 'manuscript.txt'), 'placeholder');
+    writeFileSync(
+      join(siblingDir, '.audiobook', 'cast.json'),
+      JSON.stringify({
+        characters: [
+          {
+            id: 'sibling-c1', name: 'Aria (sibling)', voiceId: 'c1',
+            overrideTtsVoices: { coqui: { name: 'clone-y', provenance: 'cloned' } },
+          },
+        ],
+      }),
+    );
+  });
+
+  it('refuses (409) up front when the character is cloned on a SIBLING book, not this one', async () => {
+    const res = await request(app)
+      .post(`/api/books/${BOOK_ID}/cast/c1/design-voice/stream`)
+      .send({ persona: 'a warm voice', sampleVoiceId: 'char-c1', modelKey: 'qwen3-tts-0.6b' });
+
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('clone_protected');
+    expect(applyOverrideStub).not.toHaveBeenCalled();
+  });
+
+  it('write-time: when applyOverrideToCastFiles reports a series-wide skip, the job ends with a clone_protected error event instead of "designed"', async () => {
+    applyOverrideStub.mockResolvedValueOnce({
+      updated: 0,
+      skipped: [{ bookDir, characterId: 'c1', reason: 'already_cloned' }],
+    });
+    const res = await request(app)
+      .post(`/api/books/${BOOK_ID}/cast/c1/design-voice/stream`)
+      .send({ persona: 'a warm voice', sampleVoiceId: 'char-c1', modelKey: 'qwen3-tts-0.6b' });
+
+    expect(res.status).toBe(200); // SSE stream itself opens fine
+    const events = collectSse(res);
+    const err = events.find((e) => e.type === 'error');
+    expect(err).toMatchObject({ code: 'clone_protected' });
+    expect(events.some((e) => e.type === 'designed')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify both fail**
+
+Run: `npm run test -- --run server/src/routes/single-design.test.ts -t "series-wide clone veto"`
+Expected: FAIL — today's code either doesn't 409 for a sibling-book clone (upfront check is book-local), or emits `'designed'` unconditionally (write-time result discarded).
+
+- [ ] **Step 3: Update the applyOverrideStub's default return shape**
+
+At `single-design.test.ts:31`:
+
+```ts
+// before:
+const applyOverrideStub = vi.fn(async () => 1);
+// after:
+const applyOverrideStub = vi.fn(async () => ({ updated: 1, skipped: [] }));
+```
+
+- [ ] **Step 4: Reorder `isStandalone`/`seriesInfo` earlier and upgrade the upfront check**
+
+**Confirm before moving anything**: this reorder is the mirror image of Task 7's move in `qwen-voice.ts` (which goes the OTHER way — moves the CHECK down rather than the series lookup up — specifically to avoid pushing a workspace scan ahead of unrelated 400 validators). The two tasks aren't inconsistent, but the safety of moving the lookup UP here, rather than moving the check DOWN as Task 7 does, depends entirely on this file's own layout: verify that every validator/early-return between the character lookup (`:256`) and the clone check's current position (`:273`) — re-check this range directly rather than trusting this citation — sits BEFORE `:256`, not between it and `:273`. As of this plan's own reading, `single-design.ts`'s three 400 validators (persona, sampleVoiceId, modelKey) sit at `:242-250`, above the character lookup, so moving the lookup up to `:256` does NOT push the scan ahead of any of them here. It DOES, however, move the scan ahead of the SSE framing (`res.flushHeaders()` etc., `:280-286`) and the `unsupported_language` early return (`:302-309`) that currently sit between the old and new positions — meaning a request for an unsupported language now pays a workspace scan before its own error, where it didn't before. This is a minor, not a blocking cost (a single directory walk, not per-character), but name it rather than silently absorb it, the same way Task 7 explicitly weighed its own version of this tradeoff.
+
+At `single-design.ts:310-311`, the computation currently sits AFTER the clone check (`:273`) and the SSE framing (`:280-286`). Move it up, immediately after the character lookup (`single-design.ts:256`):
+
+```ts
+const isStandalone = located.state?.isStandalone === true;
+const seriesInfo = isStandalone ? null : await findAuthorSeriesForBookId(bookId);
+```
+
+Then change the check at `single-design.ts:273-278` from:
+
+```ts
+if (!preview && characterHasClonedSlot(character)) {
+  return res.status(409).json({
+    error: `"${character.name ?? characterId}" already has a cloned voice and cannot be designed on Qwen without silently retargeting it off that clone.`,
+    code: 'clone_protected',
+  });
+}
+```
+
+to:
+
+```ts
+if (!preview && (characterHasClonedSlot(character) || await hasClonedSlotAmongMatches(character.voiceId ?? character.id, seriesInfo ?? undefined, undefined, bookDir))) {
+  return res.status(409).json({
+    error: `"${character.name ?? characterId}" has a consented cloned voice on a linked character somewhere in this series and cannot be designed on Qwen without silently retargeting it off that clone.`,
+    code: 'clone_protected',
+  });
+}
+```
+
+Remove the now-unused `isStandalone`/`seriesInfo` computation at the old location (`:310-311`) — it's the same two lines, just moved.
+
+- [ ] **Step 5: Wire the write-time outcome**
+
+At `single-design.ts:174-192`, change:
+
+```ts
+const matchKey = character.voiceId ?? character.id;
+await applyOverrideToCastFiles(
+  matchKey,
+  { engine: 'qwen', name: voiceId },
+  seriesFilter,
+  job.bookDir,
+);
+endJob(job, {
+  type: 'designed',
+  characterId: job.characterId,
+  name: job.characterName,
+  voiceId,
+  url,
+  voiceUuid: characterForDesign.voiceUuid,
+});
+```
+
+to:
+
+```ts
+const matchKey = character.voiceId ?? character.id;
+const { updated, skipped } = await applyOverrideToCastFiles(
+  matchKey,
+  { engine: 'qwen', name: voiceId },
+  seriesFilter,
+  job.bookDir,
+);
+if (updated === 0 && skipped.length > 0) {
+  endJob(job, {
+    type: 'error',
+    code: 'clone_protected',
+    message: `"${job.characterName}" has a consented cloned voice on a linked character somewhere in this series — the design was not persisted.`,
+  });
+  return;
+}
+endJob(job, {
+  type: 'designed',
+  characterId: job.characterId,
+  name: job.characterName,
+  voiceId,
+  url,
+  voiceUuid: characterForDesign.voiceUuid,
+});
+```
+
+- [ ] **Step 6: Add the import**
+
+At the top of `single-design.ts`, alongside the existing `import { applyOverrideToCastFiles } from './voices.js';` (line 30), add `hasClonedSlotAmongMatches` to that same import:
+
+```ts
+import { applyOverrideToCastFiles, hasClonedSlotAmongMatches } from './voices.js';
+```
+
+- [ ] **Step 7: Register the new `'clone_protected'` `error` event code — a mechanical guard will otherwise fail this task's own suite**
+
+`server/src/routes/openapi-design-parity.test.ts` extracts every `type: 'error', code: '<literal>'` pair from `single-design.ts`'s source via regex and asserts the extracted set equals a hardcoded array, which it separately asserts equals `openapi.yaml`'s `SingleDesignEvent.code` enum. Step 5 just added exactly this shape (`endJob(job, { type: 'error', code: 'clone_protected', message: … })`), so both sides of that test need the new code or the whole file goes red — not only the tests this task's own Step 1 added.
+
+1. In `openapi-design-parity.test.ts`, find the hardcoded array (`grep -n "design_failed" server/src/routes/openapi-design-parity.test.ts`) and add `'clone_protected'` to it. **Position matters**: both sides of this comparison are `.sort()`ed before comparing, so the array's literal order in the source doesn't need to match the enum's — but `'clone_protected'` alphabetically precedes `'design_failed'`, so if you're editing in place rather than appending, put it first, not last, or the `.sort()` step (not manual ordering) is what actually makes this safe either way. Simplest: just add it anywhere in the array and let `.sort()` do the work — don't try to hand-order it.
+2. In `openapi.yaml`, find `SingleDesignEvent`'s `code` property (`SingleDesignEvent.code`'s `enum`, currently `[design_failed, lock-contention, not_found, unsupported_language]`) and add `clone_protected` to its `enum` list — order doesn't matter here either, for the same reason.
+3. **Separately, an existing test's title is now misleading, not just its data**: `openapi-design-parity.test.ts:191`'s test title hardcodes "the four codes" (or similar wording naming today's four) — update the title's wording so it doesn't claim a count this task just changed. This is a chore the work makes owed (CLAUDE.md's incidental-findings rule), fixed in this same commit, not filed separately.
+4. **Also check `openapi.yaml`'s own prose**: the codes are documented twice — once in the `enum`, once in nearby descriptive prose (`grep -n "design_failed" openapi.yaml` finds both). Update the prose list too, in the same edit, so the two don't drift.
+5. **A comment in `openapi-design-parity.test.ts` (near `:192-199`) explains that `clone_protected` is deliberately excluded from the regex-matched set because it names "the unrelated plain-JSON 409"** — the pre-existing upfront gate's `res.status(409).json({ error, code: 'clone_protected' })` shape, which the regex's `type: 'error', code: '...'` pattern was never meant to catch. This task adds a SECOND, legitimate use of the same code string, in a DIFFERENT shape (`endJob(job, { type: 'error', code: 'clone_protected', ... })`, an SSE event) — which the regex DOES match. Both are correct; `clone_protected` now genuinely appears in this file via two distinct response shapes for two distinct moments (upfront refusal vs. write-time refusal), not a contradiction. Update that comment so it explains both shapes rather than asserting the code is regex-invisible, which is no longer true for its second occurrence.
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run: `npm run test -- --run server/src/routes/single-design.test.ts server/src/routes/openapi-design-parity.test.ts`
+Expected: PASS — including all pre-existing tests in `single-design.test.ts` (the `applyOverrideStub` default-return-shape change from Step 3 must not break the "first design" / "preview" describe blocks, which only assert `applyOverrideStub` was/wasn't called, not its return value), and `openapi-design-parity.test.ts` green with the new code registered on both sides.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add server/src/routes/single-design.ts server/src/routes/single-design.test.ts server/src/routes/openapi-design-parity.test.ts openapi.yaml
+git commit -m "fix(server): single-design refuses on a series-wide clone instead of silently discarding the check"
+```
+
+---
+
+### Task 4: `cast-design.ts:544` — mirror the variant branch's clone-skip reporting, and upgrade the base-voice upfront check to series-wide
+
+**This task also resolves an inconsistency between Task 3 and Task 8.** An earlier revision of this plan left the base-voice branch's upfront check (`cast-design.ts:402-412`) book-local while upgrading the variant branch's (`:430-440`, Task 8) and `single-design.ts`'s (Task 3) to series-wide — on the stated grounds that the sibling spec's "Signature change" section lists no upfront change for the base branch. Under review, that reasoning didn't survive: it is the identical fact pattern Task 3's own preamble uses to justify the identical upgrade one file over ("leaving the upfront check book-local here would make every such attempt run a full GPU round before failing at the write-time check this task also adds"). A character cloned on a sibling book is exactly as routine and exactly as deterministic a case for the base-voice path as for the variant path or the single-design path — there is no principled reason to leave this one book-local. This task upgrades it too, for consistency with Tasks 3 and 8 rather than as a new decision.
+
+**Files:**
+- Modify: `server/src/routes/cast-design.ts:402-412` (base-voice upfront check, upgraded), `cast-design.ts:537-551` (write-time, mirrored)
+- Test: `server/src/routes/cast-design.test.ts`
+
+**Interfaces:**
+- Consumes: `applyOverrideToCastFiles`'s new `{updated, skipped}` return (Task 2), `hasClonedSlotAmongMatches` (Task 1 — this task is what actually adds the import to `cast-design.ts`; Task 8 relies on it already being present by the time it runs).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add near the existing `'GATE 2 fix-lane-1b: skips a coqui-cloned character instead of retargeting it, and reports it'` test in `cast-design.test.ts` (~line 350):
+
+```ts
+it('base-voice path: a series-wide clone (sibling book) is reported through clonedSkips instead of silently "designed"', async () => {
+  // Requires a second book in this file's SERIES/AUTHOR fixture with a
+  // character sharing the target voiceId, carrying a consented clone.
+  // (Mirror this file's top-level workspaceRoot/AUTHOR/SERIES/BOOK setup
+  // to add a sibling book directory in beforeEach for this describe.)
+  const res = await request(app)
+    .post(`/api/books/${bookId}/cast/design`)
+    .send({ characterIds: ['linked-char'], modelKey: QWEN_KEY });
+
+  expect(res.status).toBe(200);
+  const events = parseSse(res.text);
+  expect(events.some((e) => e.type === 'character_designed' && e.characterId === 'linked-char')).toBe(false);
+  expect(
+    events.some(
+      (e) =>
+        e.type === 'character_skipped' &&
+        e.characterId === 'linked-char' &&
+        e.reason === 'already_cloned',
+    ),
+  ).toBe(true);
+  const idle = events.find((e) => e.type === 'idle');
+  expect(idle?.clonedSkips).toContainEqual({ characterId: 'linked-char', name: expect.any(String) });
+});
+
+it('base-voice path, upfront: a series-wide clone (sibling book) is reported before any sidecar call, not after', async () => {
+  // Same sibling-book fixture as the write-time test above.
+  const res = await request(app)
+    .post(`/api/books/${bookId}/cast/design`)
+    .send({ characterIds: ['linked-char'], modelKey: QWEN_KEY });
+
+  expect(res.status).toBe(200);
+  const events = parseSse(res.text);
+  expect(
+    events.some(
+      (e) => e.type === 'character_skipped' && e.characterId === 'linked-char' && e.reason === 'already_cloned',
+    ),
+  ).toBe(true);
+  expect(fetchMock).not.toHaveBeenCalled(); // no sidecar call reached for this character
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npm run test -- --run server/src/routes/cast-design.test.ts -t "base-voice path"`
+Expected: FAIL — today's write-time code at `:544-551` calls `applyOverrideToCastFiles` and unconditionally does `job.done += 1; broadcast(..., 'character_designed', ...)`, so `character_skipped` never fires for that path; today's upfront check at `:402-412` is book-local `characterHasClonedSlot`, so a sibling-book clone isn't caught until (in this task's own fixed code) the write-time check, after a full sidecar round-trip.
+
+- [ ] **Step 3: Upgrade the base-voice upfront check to series-wide**
+
+At `cast-design.ts:402-412`, change:
+
+```ts
+      if (characterHasClonedSlot(character)) {
+        job.skipped += 1;
+        job.clonedSkips.push({ characterId, name: character.name ?? characterId });
+        broadcast(job, {
+          type: 'character_skipped',
+          characterId,
+          name: character.name ?? characterId,
+          reason: 'already_cloned',
+        });
+        continue;
+      }
+```
+
+to:
+
+```ts
+      if (characterHasClonedSlot(character) || await hasClonedSlotAmongMatches(character.voiceId ?? character.id, seriesFilter, undefined, job.bookDir)) {
+        job.skipped += 1;
+        job.clonedSkips.push({ characterId, name: character.name ?? characterId });
+        broadcast(job, {
+          type: 'character_skipped',
+          characterId,
+          name: character.name ?? characterId,
+          reason: 'already_cloned',
+        });
+        continue;
+      }
+```
+
+Add the import — `cast-design.ts:50` currently has `import { applyOverrideToCastFiles } from './voices.js';`; extend it:
+
+```ts
+import { applyOverrideToCastFiles, hasClonedSlotAmongMatches } from './voices.js';
+```
+
+(Task 8, which upgrades the variant branch's own upfront check at `:430-440`, relies on this import already being present — do this task first, or add the import once and note it in both tasks' commits.)
+
+- [ ] **Step 4: Implement the mirrored write-time branch**
+
+At `cast-design.ts:544-551`, change:
+
+```ts
+const matchKey = character.voiceId ?? character.id;
+await applyOverrideToCastFiles(
+  matchKey,
+  { engine: 'qwen', name: voiceId },
+  seriesFilter,
+  job.bookDir,
+);
+job.done += 1;
+broadcast(job, { type: 'character_designed', characterId, voiceId });
+```
+
+to:
+
+```ts
+const matchKey = character.voiceId ?? character.id;
+const { updated, skipped } = await applyOverrideToCastFiles(
+  matchKey,
+  { engine: 'qwen', name: voiceId },
+  seriesFilter,
+  job.bookDir,
+);
+if (updated === 0 && skipped.length > 0) {
+  job.skipped += 1;
+  job.clonedSkips.push({ characterId, name: character.name ?? characterId });
+  broadcast(job, {
+    type: 'character_skipped',
+    characterId,
+    name: character.name ?? characterId,
+    reason: 'already_cloned',
+  });
+} else {
+  job.done += 1;
+  broadcast(job, { type: 'character_designed', characterId, voiceId });
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npm run test -- --run server/src/routes/cast-design.test.ts -t "base-voice path"`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full cast-design.ts test file**
+
+Run: `npm run test -- --run server/src/routes/cast-design.test.ts`
+Expected: PASS (no other test in this file destructures the base-voice call's return value, so this is additive).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/src/routes/cast-design.ts server/src/routes/cast-design.test.ts
+git commit -m "fix(server): bulk-design base-voice path is series-wide and reports a clone skip instead of discarding it"
+```
+
+---
+
+### Task 5: `persistEmotionVariant` — return-contract change + book-scoped branch check
+
+**Files:**
+- Modify: `server/src/routes/qwen-voice.ts:99-107` (`clonedVariantRefusal`), `qwen-voice.ts:144-209` (`persistEmotionVariant`)
+- Test: `server/src/routes/qwen-voice.test.ts:1504-1660ish` (the existing `describe('persistEmotionVariant', ...)` block)
+
+**Interfaces:**
+- Produces: `type PersistEmotionVariantOutcome = 'applied' | 'skippedClone' | 'notFound'`; `persistEmotionVariant(...): Promise<PersistEmotionVariantOutcome>` — changed from `Promise<void>`. Task 6 (series branch), Task 7, and Task 8 all consume this.
+- Also type-aliased (not asserted-on) by `server/src/routes/variant-propagation.test.ts:30` — Step 6 below re-runs that file's suite to confirm the `void`→union change doesn't need an edit there (same note as Task 2's Step 6).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the existing `describe('persistEmotionVariant', ...)` block in `qwen-voice.test.ts` (after the existing `beforeEach`/`afterEach`):
+
+```ts
+it('book-scoped: no clone — returns applied and records the variant', async () => {
+  const outcome = await persistEmotionVariantFn(bookDir, 'wren', 'angry', 'qwen-wren__angry');
+  expect(outcome).toBe('applied');
+});
+
+it('book-scoped: clone present at call time — returns skippedClone and does not mutate the field', async () => {
+  const { readFile, writeFile } = await import('node:fs/promises');
+  await writeFile(
+    join(bookDir, '.audiobook', 'cast.json'),
+    JSON.stringify({
+      characters: [
+        {
+          id: 'wren',
+          voiceId: 'wren',
+          overrideTtsVoices: { coqui: { name: 'clone-x', provenance: 'cloned' } },
+        },
+      ],
+    }),
+  );
+  const outcome = await persistEmotionVariantFn(bookDir, 'wren', 'angry', 'qwen-wren__angry');
+  expect(outcome).toBe('skippedClone');
+  const cast = JSON.parse(await readFile(join(bookDir, '.audiobook', 'cast.json'), 'utf8'));
+  expect(cast.characters[0].overrideTtsVoices.qwen).toBeUndefined();
+});
+
+it('is a no-op returning notFound for an unknown character', async () => {
+  const outcome = await persistEmotionVariantFn(bookDir, 'ghost', 'angry', 'x');
+  expect(outcome).toBe('notFound');
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npm run test -- --run server/src/routes/qwen-voice.test.ts -t "book-scoped:"`
+Expected: FAIL — `persistEmotionVariant` currently resolves to `undefined` (its return type is `void`), and the book-scoped branch never checks for a clone at all.
+
+- [ ] **Step 3: Reword `clonedVariantRefusal`**
+
+At `qwen-voice.ts:99-107`, change:
+
+```ts
+export function clonedVariantRefusal(name: string): string {
+  return (
+    `"${name}" uses a cloned voice, so emotion variants are unavailable — ` +
+    `they are only offered for a designed voice. Minting one would re-derive a ` +
+    `new performance of a real person's voice under a key their consent record ` +
+    `does not cover and revoking consent does not erase. Assign a designed ` +
+    `voice to this character to use emotion variants.`
+  );
+}
+```
+
+to:
+
+```ts
+export function clonedVariantRefusal(name: string): string {
+  return (
+    `"${name}" is linked to a cloned voice somewhere in this series, so emotion variants are unavailable — ` +
+    `they are only offered for a designed voice. Minting one would re-derive a ` +
+    `new performance of a real person's voice under a key their consent record ` +
+    `does not cover and revoking consent does not erase. Remove the clone from ` +
+    `every linked book to use emotion variants for this character.`
+  );
+}
+```
+
+- [ ] **Step 4: Change the return type and the book-scoped branch**
+
+At `qwen-voice.ts:144-209`, change the signature (line 144-150):
+
+```ts
+export async function persistEmotionVariant(
+  bookDir: string,
+  characterId: string,
+  emotion: Exclude<Emotion, 'neutral'>,
+  variantVoiceId: string,
+  seriesFilter?: { author: string; series: string },
+): Promise<void> {
+```
+
+to:
+
+```ts
+export type PersistEmotionVariantOutcome = 'applied' | 'skippedClone' | 'notFound';
+
+export async function persistEmotionVariant(
+  bookDir: string,
+  characterId: string,
+  emotion: Exclude<Emotion, 'neutral'>,
+  variantVoiceId: string,
+  seriesFilter?: { author: string; series: string },
+): Promise<PersistEmotionVariantOutcome> {
+```
+
+Change the early-out at `qwen-voice.ts:153`:
+
+```ts
+if (!cast || !character) return;
+```
+
+to:
+
+```ts
+if (!cast || !character) return 'notFound';
+```
+
+**Also patch the series branch's own bare `return;` right now, temporarily** — Task 6 replaces this whole branch properly, but between THIS task's commit and Task 6's, the function's declared return type is already `Promise<PersistEmotionVariantOutcome>` while the series branch (`qwen-voice.ts:186-189`) still has a bare `return;`, which fails to typecheck. At `qwen-voice.ts:189`:
+
+```ts
+    await forEachMatchingCastCharacter(character.voiceId ?? character.id, seriesFilter, (c) =>
+      addVariant(c, baseVoiceId),
+    );
+    return;
+```
+
+change the last line only, to keep this task's own commit type-checking and behaviourally unchanged (still applies unconditionally, exactly as today — Task 6 is what adds the actual clone check to this branch):
+
+```ts
+    await forEachMatchingCastCharacter(character.voiceId ?? character.id, seriesFilter, (c) =>
+      addVariant(c, baseVoiceId),
+    );
+    return 'applied'; // temporary — Task 6 replaces this whole branch with the real series-wide check
+```
+
+Change the book-scoped branch at `qwen-voice.ts:200-208` (Task 6 handles the series branch above it, lines 168-190, separately):
+
+```ts
+await withCastLock(bookDir, async () => {
+  const fresh = await readJson<CastFile>(castJsonPath(bookDir));
+  const idx = fresh?.characters?.findIndex((c) => c.id === characterId) ?? -1;
+  if (!fresh || idx === -1) return;
+  const freshCharacter = fresh.characters[idx];
+  const baseVoiceId = qwenStorageKey(freshCharacter, characterId);
+  fresh.characters[idx] = addVariant(freshCharacter, baseVoiceId);
+  await writeJsonAtomic(castJsonPath(bookDir), fresh);
+});
+```
+
+to:
+
+```ts
+return withCastLock(bookDir, async () => {
+  const fresh = await readJson<CastFile>(castJsonPath(bookDir));
+  const idx = fresh?.characters?.findIndex((c) => c.id === characterId) ?? -1;
+  if (!fresh || idx === -1) return 'notFound';
+  const freshCharacter = fresh.characters[idx];
+  if (characterHasClonedSlot(freshCharacter)) return 'skippedClone';
+  const baseVoiceId = qwenStorageKey(freshCharacter, characterId);
+  fresh.characters[idx] = addVariant(freshCharacter, baseVoiceId);
+  await writeJsonAtomic(castJsonPath(bookDir), fresh);
+  return 'applied';
+});
+```
+
+`characterHasClonedSlot` is already imported at `qwen-voice.ts:56`.
+
+- [ ] **Step 5: Run the new tests to verify they pass**
+
+Run: `npm run test -- --run server/src/routes/qwen-voice.test.ts -t "book-scoped:" -t "no-op returning notFound"`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full existing `persistEmotionVariant` describe block**
+
+Run: `npm run test -- --run server/src/routes/qwen-voice.test.ts -t "persistEmotionVariant"`
+Expected: PASS — every pre-existing test in this block calls `persistEmotionVariantFn(...)` without capturing or asserting on the return value (confirmed by inspection: `qwen-voice.test.ts:1550-1660`), so the `void` → union-type change is additive and breaks nothing there. TypeScript will still typecheck fine since none of them type-annotate the awaited result.
+
+- [ ] **Step 7: Also run `variant-propagation.test.ts`**
+
+Run: `npm run test -- --run server/src/routes/variant-propagation.test.ts`
+Expected: PASS — same "type-aliased but not asserted-on" situation as Task 2's Step 6.
+
+- [ ] **Step 8: Typecheck before committing**
+
+Run: `npm run typecheck`
+Expected: PASS. Vitest alone (Steps 5-7) does not typecheck — this is what actually catches the series branch's return-type mismatch if the temporary `return 'applied';` patch from Step 4 was skipped or mis-applied.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add server/src/routes/qwen-voice.ts server/src/routes/qwen-voice.test.ts
+git commit -m "feat(server): persistEmotionVariant returns a typed outcome and checks the book-scoped branch for a clone"
+```
+
+---
+
+### Task 6: `persistEmotionVariant` — series branch: fresh check + residual backstop + count threading
+
+**Files:**
+- Modify: `server/src/routes/qwen-voice.ts:47` (import), `qwen-voice.ts:168-190` (series branch)
+- Test: `server/src/routes/qwen-voice.test.ts`
+
+**Interfaces:**
+- Consumes: `hasClonedSlotAmongMatches` (Task 1), `forEachMatchingCastCharacter`'s existing `Promise<number>` return (`voices.ts:779`, already imported at `qwen-voice.ts:47`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+it('series-scoped: two linked books, no clones anywhere — both get the variant, returns applied', async () => {
+  // Second temp bookDir sharing voiceId 'wren' — write it in this test
+  // (mirror bookDirFresh's beforeEach shape above), pass a seriesFilter,
+  // and mock/point findAuthorSeriesForBookId-equivalent scanning at both
+  // directories the way this file's own series-scope helpers already do
+  // elsewhere (search this file for an existing seriesFilter-based
+  // persistEmotionVariant/forEachMatchingCastCharacter integration test to
+  // copy the workspace-root wiring from, rather than re-deriving it).
+  const outcome = await persistEmotionVariantFn(bookDir, 'wren', 'angry', 'qwen-wren__angry', {
+    author: 'A', series: 'S',
+  });
+  expect(outcome).toBe('applied');
+});
+
+it('series-scoped: clone on a DIFFERENT linked book — skippedClone, and NO book (including uncloned ones) gets the variant', async () => {
+  // Seed the sibling book's character with a consented cloned slot instead
+  // of a qwen override. Assert via direct cast.json reads of BOTH books
+  // that neither gained a qwen variant.
+  const outcome = await persistEmotionVariantFn(bookDir, 'wren', 'angry', 'qwen-wren__angry', {
+    author: 'A', series: 'S',
+  });
+  expect(outcome).toBe('skippedClone');
+});
+
+it('series-scoped: no confirmed-cast book matches at all — returns notFound, distinct from applied', async () => {
+  // seriesFilter that matches zero books in the workspace scan.
+  const outcome = await persistEmotionVariantFn(bookDir, 'wren', 'angry', 'qwen-wren__angry', {
+    author: 'nonexistent-author', series: 'nonexistent-series',
+  });
+  expect(outcome).toBe('notFound');
+});
+
+it('series-scoped: residual-window skip on one linked book still returns applied (other books updated) and logs a warning', async () => {
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  // Inject a clone directly onto one linked book's character AFTER the
+  // fresh hasClonedSlotAmongMatches call would have already passed — e.g.
+  // by mocking hasClonedSlotAmongMatches (imported from voices.js) to
+  // resolve false once, then writing the clone marker to that one book's
+  // cast.json before forEachMatchingCastCharacter's walk reaches it (same
+  // scripted-interleaving technique as voices.test.ts's own residual-window
+  // test in Task 2 — gate on that specific book's cast.json read).
+  const outcome = await persistEmotionVariantFn(bookDir, 'wren', 'angry', 'qwen-wren__angry', {
+    author: 'A', series: 'S',
+  });
+  expect(outcome).toBe('applied'); // the OTHER matched book still got it
+  expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('residual-window skip'));
+  warnSpy.mockRestore();
+});
+```
+
+Follow this file's own established convention (seen at `qwen-voice.test.ts:1590-1660`, the `#1981` concurrent-write test) for scripting an interleaving via `vi.mocked(stateIo.readJson).mockImplementation(...)` — reuse that exact pattern for the residual-window test rather than inventing a new harness.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npm run test -- --run server/src/routes/qwen-voice.test.ts -t "series-scoped:"`
+Expected: FAIL — the series branch today propagates unconditionally with no clone check at all, and returns `undefined`.
+
+- [ ] **Step 3: Implement the series branch**
+
+Add the import at `qwen-voice.ts:47`:
+
+```ts
+// before:
+import { forEachMatchingCastCharacter } from './voices.js';
+// after:
+import { forEachMatchingCastCharacter, hasClonedSlotAmongMatches } from './voices.js';
+```
+
+Replace the series branch (`qwen-voice.ts:168-190`):
+
+```ts
+if (seriesFilter) {
+  const baseVoiceId = qwenStorageKey(character, characterId);
+  await forEachMatchingCastCharacter(character.voiceId ?? character.id, seriesFilter, (c) =>
+    addVariant(c, baseVoiceId),
+  );
+  return;
+}
+```
+
+with:
+
+```ts
+if (seriesFilter) {
+  const baseVoiceId = qwenStorageKey(character, characterId);
+
+  /* Fresh, series-wide re-check immediately before the walk — replaces the
+     caller's stale pre-GPU snapshot. A hit refuses the WHOLE propagation:
+     no book is written. See the qwen-voice spec's "Series-wide check,
+     reused, not reimplemented". */
+  const stillCloned = await hasClonedSlotAmongMatches(character.voiceId ?? character.id, seriesFilter);
+  if (stillCloned) return 'skippedClone';
+
+  /* Residual-window backstop: the walk still takes nonzero time after the
+     scan above passed. Threading the walk's own returned count through
+     (rather than discarding it, as an earlier revision did) is what lets
+     'applied' and 'notFound' be told apart below. */
+  let residualSkip = false;
+  const updated = await forEachMatchingCastCharacter(character.voiceId ?? character.id, seriesFilter, (c) => {
+    if (characterHasClonedSlot(c)) {
+      residualSkip = true;
+      return c; // unchanged — this book's own write correctly declined
+    }
+    return addVariant(c, baseVoiceId);
+  });
+  if (residualSkip) {
+    console.warn(
+      `[persistEmotionVariant] residual-window skip: a clone appeared on a linked book for ${characterId} between the series-wide scan and this walk reaching it (${updated} book(s) still received the variant).`,
+    );
+  }
+  return updated > 0 ? 'applied' : 'notFound';
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm run test -- --run server/src/routes/qwen-voice.test.ts -t "series-scoped:"`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full qwen-voice.ts test file**
+
+Run: `npm run test -- --run server/src/routes/qwen-voice.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/routes/qwen-voice.ts server/src/routes/qwen-voice.test.ts
+git commit -m "feat(server): persistEmotionVariant series branch vetoes on a series-wide clone, with a residual-window backstop"
+```
+
+---
+
+### Task 7: `qwen-voice.ts` JSON route — series-wide upfront check + write-time integration
+
+**Files:**
+- Modify: `server/src/routes/qwen-voice.ts:590-605` (upfront check, reordered against `:638-639`), `qwen-voice.ts:668-681` (write-time call site)
+- Test: `server/src/routes/qwen-voice.test.ts` (the existing `describe('#1954 — emotion variants for a CLONED voice', ...)` block, ~line 670)
+
+**Interfaces:**
+- Consumes: `hasClonedSlotAmongMatches` (already imported by Task 6), `persistEmotionVariant`'s new outcome (Tasks 5-6), `findAuthorSeriesForBookId` (already imported at `qwen-voice.ts:48`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the existing `describe('#1954 — emotion variants for a CLONED voice', ...)` block:
+
+```ts
+it('409s before any GPU design call when the character is cloned on a SIBLING book, not this one (v5 upfront fix)', async () => {
+  // Seed a second book in the same series whose matching character
+  // (shared voiceId) carries a consented cloned slot; THIS book's own
+  // character has none. Spy on designQwenVoiceForCharacter (or the
+  // sidecar fetch mock this file already uses elsewhere) to assert zero
+  // invocations.
+  const res = await request(app)
+    .post(`/api/books/${bookId}/cast/linked-char/design-voice`)
+    .send({ persona: 'x', sampleVoiceId: 'char-linked', modelKey: 'qwen3-tts-0.6b', emotion: 'angry' });
+
+  expect(res.status).toBe(409);
+  expect(res.body.code).toBe('clone_protected');
+  // assert the sidecar/design-core mock was never called for this request
+});
+
+it('write-time: when persistEmotionVariant resolves skippedClone, the route answers 409 clone_protected', async () => {
+  // Mock persistEmotionVariant (imported by this test file's module under
+  // test) to resolve 'skippedClone' for this one call.
+  const res = await request(app)
+    .post(`/api/books/${bookId}/cast/c1/design-voice`)
+    .send({ persona: 'x', sampleVoiceId: 'char-c1', modelKey: 'qwen3-tts-0.6b', emotion: 'angry' });
+
+  expect(res.status).toBe(409);
+  expect(res.body.code).toBe('clone_protected');
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npm run test -- --run server/src/routes/qwen-voice.test.ts -t "409s before any GPU design call"`
+Expected: FAIL — today's upfront check is book-local, and the write-time call site never inspects `persistEmotionVariant`'s return.
+
+- [ ] **Step 3: Move the clone check down to where `isStandalone`/`seriesInfo` already sit — do NOT move the series lookup earlier**
+
+An earlier revision of this plan moved `isStandalone`/`seriesInfo` (currently computed at `:638-639`) up to replace the check at `:600-605`. Under review that was wrong: between those two positions sit three early-return 400 validators (missing-persona `:612-617`, missing-`sampleVoiceId` `:623-627`, bad-`modelKey` `:628-632`) that have nothing to do with cloning — moving the series lookup (a full workspace directory scan via `findAuthorSeriesForBookId`) above them would make every malformed request pay that scan before its 400, and it orphans the "Plan 161" comment that sits directly above the existing `:635-637` computation. The fix that actually matches this handler's control flow: leave `isStandalone`/`seriesInfo` exactly where they are; move the CHECK down to sit right next to them instead.
+
+Delete the existing check at `:600-605`:
+
+```ts
+    if (emotion && characterHasClonedSlot(character)) {
+      return res.status(409).json({
+        error: clonedVariantRefusal(character.name ?? characterId),
+        code: 'clone_protected',
+      });
+    }
+```
+
+(leaving the persona/`sampleVoiceId`/`modelKey` 400 validators immediately below it untouched and in their original position), and insert the upgraded check immediately after the existing `isStandalone`/`seriesInfo` computation at `:638-639` (which stays exactly where it is, "Plan 161" comment and all):
+
+```ts
+    const isStandalone = located.state?.isStandalone === true;
+    const seriesInfo = isStandalone ? null : await findAuthorSeriesForBookId(bookId);
+    if (emotion && (characterHasClonedSlot(character) || await hasClonedSlotAmongMatches(character.voiceId ?? character.id, seriesInfo ?? undefined, undefined, bookDir))) {
+      return res.status(409).json({
+        error: clonedVariantRefusal(character.name ?? characterId),
+        code: 'clone_protected',
+      });
+    }
+```
+
+Net effect: the three unrelated 400s still run first and still pay no workspace-scan cost; the clone check (now series-wide) runs once, right where the series info it needs is already computed, still strictly before `ensureCharacterVoiceUuid`/`designQwenVoiceForCharacter` (i.e. still before any GPU work).
+
+- [ ] **Step 4: Wire the write-time integration**
+
+At `qwen-voice.ts:668-681`, change:
+
+```ts
+      if (emotion && body.preview !== true) {
+        await persistEmotionVariant(
+          bookDir,
+          characterId,
+          emotion,
+          voiceId,
+          seriesInfo ?? undefined,
+        );
+      }
+      return res.status(200).json({ voiceId, url, voiceUuid });
+```
+
+to:
+
+```ts
+      if (emotion && body.preview !== true) {
+        const outcome = await persistEmotionVariant(
+          bookDir,
+          characterId,
+          emotion,
+          voiceId,
+          seriesInfo ?? undefined,
+        );
+        if (outcome === 'skippedClone') {
+          return res.status(409).json({
+            error: clonedVariantRefusal(character.name ?? characterId),
+            code: 'clone_protected',
+          });
+        }
+        /* 'notFound' (no confirmed-cast book in scope matched this
+           character at write time — a genuinely empty write, not a
+           refusal) falls through to the same 200 as 'applied' below.
+           This is NOT a new gap this task introduces: before this task,
+           persistEmotionVariant returned void unconditionally and the
+           route always answered 200 regardless of whether anything was
+           actually written for this exact case — this branch makes that
+           pre-existing disposition explicit rather than changing it. Only
+           'skippedClone' is new, deliberate refusal-reporting behaviour;
+           'notFound' intentionally keeps today's behaviour, named rather
+           than left as a silent fallthrough. */
+      }
+      return res.status(200).json({ voiceId, url, voiceUuid });
+```
+
+- [ ] **Step 5: Run the new tests to verify they pass**
+
+Run: `npm run test -- --run server/src/routes/qwen-voice.test.ts -t "409s before any GPU design call" -t "write-time: when persistEmotionVariant"`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full qwen-voice.ts test file**
+
+Run: `npm run test -- --run server/src/routes/qwen-voice.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/src/routes/qwen-voice.ts server/src/routes/qwen-voice.test.ts
+git commit -m "feat(server): design-voice route's clone gate is series-wide, both upfront and at write time"
+```
+
+---
+
+### Task 8: `cast-design.ts` SSE bulk job — series-wide upfront check + write-time integration (variant path)
+
+**Files:**
+- Modify: `server/src/routes/cast-design.ts:430-440` (upfront), `cast-design.ts:552-559` (write-time)
+- Test: `server/src/routes/cast-design.test.ts`
+
+**Interfaces:**
+- Consumes: `hasClonedSlotAmongMatches` (import from `./voices.js`), `persistEmotionVariant`'s new outcome (Tasks 5-6). `seriesFilter` is already in scope at both sites (`runDesignJob`'s own parameter).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add near the existing variant-branch clone tests in `cast-design.test.ts` (~line 700):
+
+```ts
+it('variant upfront: a series-wide clone (sibling book) is reported before any GPU call, not after', async () => {
+  // Same sibling-book fixture as Task 4's test — reuse it if this describe
+  // shares a beforeEach with Task 4's, otherwise add an equivalent one.
+  const res = await request(app)
+    .post(`/api/books/${bookId}/cast/design`)
+    .send({ characterIds: ['linked-char'], modelKey: QWEN_KEY, emotion: 'angry' });
+
+  expect(res.status).toBe(200);
+  const events = parseSse(res.text);
+  expect(
+    events.some(
+      (e) => e.type === 'character_skipped' && e.characterId === 'linked-char' && e.reason === 'already_cloned',
+    ),
+  ).toBe(true);
+  expect(fetchMock).not.toHaveBeenCalled(); // no sidecar call reached for this character
+});
+
+it('variant write-time: persistEmotionVariant resolving skippedClone reports through the same clonedSkips channel', async () => {
+  // Mock persistEmotionVariant (this test file's module under test import)
+  // to resolve 'skippedClone' for one call.
+  const res = await request(app)
+    .post(`/api/books/${bookId}/cast/design`)
+    .send({ characterIds: ['c1'], modelKey: QWEN_KEY, emotion: 'angry' });
+
+  const events = parseSse(res.text);
+  expect(
+    events.some(
+      (e) => e.type === 'character_skipped' && e.characterId === 'c1' && e.reason === 'already_cloned',
+    ),
+  ).toBe(true);
+  expect(events.some((e) => e.type === 'variant_designed' && e.characterId === 'c1')).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npm run test -- --run server/src/routes/cast-design.test.ts -t "variant upfront:" -t "variant write-time:"`
+Expected: FAIL — today's upfront variant check (`:430`) is book-local `characterHasClonedSlot`, and the write-time call (`:555`) discards `persistEmotionVariant`'s return.
+
+- [ ] **Step 3: Upgrade the upfront check**
+
+At `cast-design.ts:430-440`, change:
+
+```ts
+      if (characterHasClonedSlot(character)) {
+        job.skipped += 1;
+        job.clonedSkips.push({ characterId, name: character.name ?? characterId });
+        broadcast(job, {
+          type: 'character_skipped',
+          characterId,
+          name: character.name ?? characterId,
+          reason: 'already_cloned',
+        });
+        continue;
+      }
+```
+
+to:
+
+```ts
+      if (characterHasClonedSlot(character) || await hasClonedSlotAmongMatches(character.voiceId ?? character.id, seriesFilter, undefined, job.bookDir)) {
+        job.skipped += 1;
+        job.clonedSkips.push({ characterId, name: character.name ?? characterId });
+        broadcast(job, {
+          type: 'character_skipped',
+          characterId,
+          name: character.name ?? characterId,
+          reason: 'already_cloned',
+        });
+        continue;
+      }
+```
+
+The import (`applyOverrideToCastFiles, hasClonedSlotAmongMatches` from `./voices.js`) was already added by Task 4, which makes the identical upgrade to the base-voice branch's own upfront check (`:402-412`) for consistency — do Task 4 before this task, or if doing them out of order, add the import here instead and note it in this task's commit.
+
+- [ ] **Step 4: Wire the write-time integration**
+
+At `cast-design.ts:552-559`, change:
+
+```ts
+          } else {
+            await persistEmotionVariant(job.bookDir, characterId, emotion, voiceId, seriesFilter);
+            job.done += 1;
+            broadcast(job, { type: 'variant_designed', characterId, emotion, voiceId,
+              ...(fellBackToDesignVoice ? { viaFallback: true, fallbackReason } : {}) });
+          }
+```
+
+to:
+
+```ts
+          } else {
+            const outcome = await persistEmotionVariant(job.bookDir, characterId, emotion, voiceId, seriesFilter);
+            if (outcome === 'skippedClone') {
+              job.skipped += 1;
+              job.clonedSkips.push({ characterId, name: character.name ?? characterId });
+              broadcast(job, {
+                type: 'character_skipped',
+                characterId,
+                name: character.name ?? characterId,
+                reason: 'already_cloned',
+              });
+            } else {
+              /* 'applied' AND 'notFound' both reach here, deliberately —
+                 same pre-existing disposition as the JSON route (Task 7),
+                 not a new gap this task introduces. See that task's own
+                 comment for the full rationale. */
+              job.done += 1;
+              broadcast(job, { type: 'variant_designed', characterId, emotion, voiceId,
+                ...(fellBackToDesignVoice ? { viaFallback: true, fallbackReason } : {}) });
+            }
+          }
+```
+
+- [ ] **Step 5: Run the new tests to verify they pass**
+
+Run: `npm run test -- --run server/src/routes/cast-design.test.ts -t "variant upfront:" -t "variant write-time:"`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full cast-design.ts test file**
+
+Run: `npm run test -- --run server/src/routes/cast-design.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/src/routes/cast-design.ts server/src/routes/cast-design.test.ts
+git commit -m "feat(server): bulk-design variant path's clone gate is series-wide, both upfront and at write time"
+```
+
+---
+
+### Task 9: `clonedElsewhereInSeries` — API field + backend wiring
+
+**This task's biggest risk is performance, not location.** Under review, the naive approach — call `hasClonedSlotAmongMatches` once per character on the book's canonical GET — was found to turn a single book-state fetch into `C × B` full-workspace directory walks (each doing two uncached `readJson` calls per book): a 30-character book in a 20-book workspace becomes ~1,200 file reads and JSON parses, serially, on every page load. Neither design spec caught this because neither one wrote out the call site's loop; it only became visible when the plan specified where the call actually lands. This task adds a **batched** scan (one walk per request, not one per character) instead.
+
+**The serialization site**, found under review (grep commands in an earlier revision of this task did not actually find it — corrected here): `server/src/routes/book-state.ts`'s `GET /:bookId/state` handler, whose own code and comments describe it as the canonical book read (the frontend's `characters` slice is populated from this response). **Re-confirm this against the actual working tree before editing** — read the handler yourself rather than trusting this citation, per this plan's own established caution; if `book-state.ts` has been restructured since 2026-08-26, `grep -n "castConfirmed" server/src/routes/book-state.ts` and read outward from there.
+
+**The write path is a second real risk, separate from performance.** `PUT /:bookId/state`'s two cast-merge normalisers in the same file (currently `~:119` and `~:151`) do a bare `{ ...cast, characters }` spread with no field allowlist. A derived, GET-only field spread onto a character object will round-trip verbatim into `cast.json` if the frontend ever sends a previously-fetched character back in a state-save payload (which its autosave path does) — freezing a stale boolean into the on-disk cast permanently, with nothing to invalidate it. This task strips the field at that boundary explicitly.
+
+**Files:**
+- Modify: `server/src/routes/voices.ts` (new batched scan function), `openapi.yaml` (Character schema, near where the `overrideTtsVoices` block ends — grep `overrideTtsVoices:` and read forward, don't trust a specific line number), `src/lib/api-types.ts` (regenerated, not hand-edited)
+- Modify: `server/src/routes/book-state.ts` (both the GET response — compute the field — and the PUT write-path normalisers — strip it)
+- Test: `server/src/routes/voices.test.ts` (new function), `server/src/routes/book-state.test.ts` (GET computes it; PUT strips it)
+
+**Interfaces:**
+- Produces: `findClonedVoiceIdsAmongMatches(seriesFilter?, excludeBookDir?): Promise<Set<string>>` (new, `voices.ts`) — one walk, returns every voiceId with a clone anywhere in the matched scope, instead of `hasClonedSlotAmongMatches`'s one-walk-per-voiceId `boolean`. Also produces `Character.clonedElsewhereInSeries?: boolean` on the API shape. Task 10 consumes the latter from the frontend.
+
+- [ ] **Step 1: Write the failing test for the batched scan**
+
+```ts
+// voices.test.ts, new describe near hasClonedSlotAmongMatches's own coverage.
+// This describe is self-contained (its own beforeEach), not nested inside
+// Task 2's own describe — do not reach for that block's local variables.
+describe('findClonedVoiceIdsAmongMatches', () => {
+  /* Own dedicated fixture, same reasoning as Task 2's describe: this file's
+     shared AUTHOR/SERIES/BOOK_ONE/BOOK_TWO fixture can't mint new voiceIds
+     and is consumed by other describes. Mint via writeBookOnDisk
+     (voices.test.ts:70-102) instead. */
+  const SCAN_AUTHOR = 'Odalys Marchetti';
+  const SCAN_SERIES = 'The Winter Ferry';
+  let bookOneDir: string;
+
+  beforeEach(() => {
+    bookOneDir = writeBookOnDisk(
+      workspaceRoot, SCAN_AUTHOR, SCAN_SERIES, 'Departure', 'book-scan-one',
+      [
+        {
+          id: 'shared', name: 'Shared', voiceId: 'shared-voice-id',
+          overrideTtsVoices: { coqui: { name: 'clone-x', provenance: 'cloned' } },
+        },
+        { id: 'uncloned', name: 'Uncloned', voiceId: 'uncloned-voice-id' },
+      ],
+    );
+    writeBookOnDisk(
+      workspaceRoot, SCAN_AUTHOR, SCAN_SERIES, 'Arrival', 'book-scan-two',
+      [
+        { id: 'shared', name: 'Shared', voiceId: 'shared-voice-id' }, // uncloned here
+        { id: 'uncloned', name: 'Uncloned', voiceId: 'uncloned-voice-id' },
+      ],
+    );
+  });
+
+  it('returns the set of voiceIds cloned anywhere in the series scan, in one pass', async () => {
+    const ids = await findClonedVoiceIdsAmongMatches({ author: SCAN_AUTHOR, series: SCAN_SERIES });
+    expect(ids.has('shared-voice-id')).toBe(true);
+    expect(ids.has('uncloned-voice-id')).toBe(false);
+  });
+
+  it('excludes a clone on the given excludeBookDir', async () => {
+    // 'shared-voice-id' is cloned only on bookOneDir's own copy (seeded
+    // above; 'Arrival' carries no clone at all). Excluding bookOneDir must
+    // make the returned set NOT include it.
+    const ids = await findClonedVoiceIdsAmongMatches({ author: SCAN_AUTHOR, series: SCAN_SERIES }, bookOneDir);
+    expect(ids.has('shared-voice-id')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm run test -- --run server/src/routes/voices.test.ts -t "findClonedVoiceIdsAmongMatches"`
+Expected: FAIL — the function doesn't exist yet.
+
+- [ ] **Step 3: Implement the batched scan**
+
+Add to `voices.ts`, near `hasClonedSlotAmongMatches`:
+
+```ts
+/* Batched sibling of hasClonedSlotAmongMatches: ONE walk of the matched
+   scope returns every voiceId with a consented cloned slot anywhere in it,
+   instead of one walk PER voiceId. Exists specifically so a caller who
+   needs a per-character answer for MANY characters at once (Character API
+   serialization, below) does one scan and then O(1) Set lookups, rather
+   than re-walking the whole workspace once per character — the latter is
+   an O(characters × books) cost on a hot read path. `excludeBookDir` drops
+   one specific book from consideration (used to answer "cloned on some
+   OTHER linked book", excluding the caller's own). */
+export async function findClonedVoiceIdsAmongMatches(
+  seriesFilter?: { author: string; series: string },
+  excludeBookDir?: string,
+): Promise<Set<string>> {
+  const cloned = new Set<string>();
+  for (const authorName of listDirs(BOOKS_ROOT)) {
+    for (const seriesName of listDirs(join(BOOKS_ROOT, authorName))) {
+      for (const titleName of listDirs(join(BOOKS_ROOT, authorName, seriesName))) {
+        const bookDir = join(BOOKS_ROOT, authorName, seriesName, titleName);
+        if (excludeBookDir && bookDir === excludeBookDir) continue;
+        const state = await readJson<BookStateJson>(stateJsonPath(bookDir));
+        if (!state || !state.castConfirmed) continue;
+        if (seriesFilter) {
+          if (state.isStandalone === true) continue;
+          if (state.author !== seriesFilter.author || state.series !== seriesFilter.series) continue;
+        }
+        const cast = await readJson<CastJson>(castJsonPath(bookDir));
+        if (!cast?.characters?.length) continue;
+        for (const c of cast.characters) {
+          if (characterHasClonedSlot(c)) cloned.add(c.voiceId ?? c.id);
+        }
+      }
+    }
+  }
+  return cloned;
+}
+```
+
+**Also wire the new function into `voices.test.ts`'s binding pattern** — same as Task 1 Step 3b did for `hasClonedSlotAmongMatches`: add `let findClonedVoiceIdsAmongMatches: typeof import('./voices.js').findClonedVoiceIdsAmongMatches;` near `voices.test.ts:65`, add `findClonedVoiceIdsAmongMatches: fcvim` to the `beforeAll`'s destructuring (`:147`), and `findClonedVoiceIdsAmongMatches = fcvim;` to its assignment block (`:152-155`). A bare call in the test body (Step 1 above) is a `ReferenceError` without this.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm run test -- --run server/src/routes/voices.test.ts -t "findClonedVoiceIdsAmongMatches"`
+Expected: PASS.
+
+- [ ] **Step 5: Confirm the serialization site, then write the failing GET test**
+
+`server/src/routes/book-state.ts:238` (`bookStateRouter.get('/:bookId/state', ...)`) is the real handler — verified by direct reading, not by trusting either spec's citation. It reads cast.json at `:251` as `const cast = await readJson<{ characters: unknown[] }>(castJsonPath(bookDir));`, then later mutates `cast.characters` **in place** to backfill a `lines` field (`:380-385`) — that in-place-mutation shape is the established pattern to follow here, not building a new `characters` array (an earlier revision of this task assumed the latter and was wrong). The final response is `res.json({ state: stateView, cast, ... })` at `:567-569` — `cast` (with its now-mutated `characters`) goes out verbatim.
+
+Add a test to `book-state.test.ts`: given a book in a series where a linked character (same `voiceId`) is cloned on a DIFFERENT confirmed-cast book, `GET /:bookId/state`'s response body's `cast.characters` has the matching entry carrying `clonedElsewhereInSeries: true`; given no such sibling clone (or a clone only on THIS book's own copy), it is `false` — reuse this plan's established two-book-same-series fixture pattern (Tasks 2/4/8).
+
+- [ ] **Step 6: Run to verify it fails**
+
+Run: `npm run test -- --run server/src/routes/book-state.test.ts -t "clonedElsewhereInSeries"`
+Expected: FAIL — the field does not exist on the response yet.
+
+- [ ] **Step 7: Add the field to `openapi.yaml`**
+
+In the `Character` schema, immediately after the `overrideTtsVoices` property block, add:
+
+```yaml
+        clonedElsewhereInSeries:
+          type: boolean
+          description: |
+            True when a consented cloned voice exists on some OTHER linked
+            character in this book's series — false or absent when the only
+            clone (if any) is this book's own copy (already exposed via
+            overrideTtsVoices.*.provenance) or there is none. Excludes the
+            caller's own book deliberately, to avoid a redundant "double
+            true" when both this book and a sibling are independently
+            cloned. A UX convenience for the two frontend clone gates
+            (profile-drawer.tsx, emotion-variant-designer.tsx) — the
+            backend's own series-wide checks (#2006) are what actually
+            enforce consent; a stale value here degrades to "the button is
+            offered when it shouldn't be," never to "the write happens when
+            it shouldn't." Computed fresh on every GET — see book-state.ts's
+            write-path normalisers for why it must never be accepted back
+            from a client PUT.
+```
+
+- [ ] **Step 8: Regenerate the frontend types**
+
+Run: `npm run openapi:types`
+Expected: `src/lib/api-types.ts` gains `clonedElsewhereInSeries?: boolean` on the generated `Character` type. Do not hand-edit that file.
+
+- [ ] **Step 9: Compute the field on GET — ONE scan per request, not per character, mutating `cast.characters` in place**
+
+Add the imports (alongside `book-state.ts`'s existing import block, `:12-79`):
+
+```ts
+import { findAuthorSeriesForBookId } from '../workspace/series-cast-scan.js';
+import { findClonedVoiceIdsAmongMatches } from './voices.js';
+```
+
+In the `GET /:bookId/state` handler, immediately after the existing `lines`-backfill block (`:380-385` — `state` and `bookDir` are already in scope from earlier in this same handler, `:243-244`; `req.params.bookId` is the route param):
+
+```ts
+const isStandalone = state.isStandalone === true;
+const seriesInfo = isStandalone ? null : await findAuthorSeriesForBookId(req.params.bookId);
+const clonedVoiceIds = seriesInfo
+  ? await findClonedVoiceIdsAmongMatches(seriesInfo, bookDir)
+  : new Set<string>();
+if (cast?.characters && Array.isArray(cast.characters)) {
+  for (const c of cast.characters as Array<{ id?: unknown; voiceId?: unknown } & Record<string, unknown>>) {
+    if (!c || typeof c !== 'object') continue;
+    const linkId = (typeof c.voiceId === 'string' ? c.voiceId : undefined)
+      ?? (typeof c.id === 'string' ? c.id : undefined);
+    c.clonedElsewhereInSeries = linkId ? clonedVoiceIds.has(linkId) : false;
+  }
+}
+```
+
+Placed after the `lines` backfill purely to keep the two `cast.characters` mutation passes adjacent — order between them doesn't matter, since each only touches its own field.
+
+- [ ] **Step 10: Check for an import-cycle regression before going further**
+
+`book-state.ts` importing from `./voices.js` is new. Run: `npx --yes madge@8.0.0 --circular --extensions ts server/src` (or `npm run check:cycles` if that script wraps the same invocation — confirm via `package.json`) and compare against `server/madge-cycles-allowlist.json`. If a new cycle appears and is genuinely load-bearing (unlikely — `voices.ts` does not import anything from `book-state.ts`), add it to the allowlist with justification; otherwise this step should simply pass. This plan's earlier revisions never mentioned this check at all — added here because a cross-route-module import is exactly the shape `check:cycles` (a required `verify.yml` leg, scope-gated to `server/**`) exists to catch.
+
+- [ ] **Step 11: Strip the field on the write path so it can never persist into `cast.json`**
+
+**Do not modify `denormaliseCastReusedVoices` or `preserveDesignedVoices`** (`book-state.ts:113-152`) — both already bind their own `const characters`, and both are the durable guard against the 2026-06-05 Drowning Bell voice-strip incident (`:122-128`'s comment); redeclaring `characters` inside either is a compile error, and replacing their existing binding would silently drop the reuse-hydration / designed-voice-preservation guarantee those functions exist for. Strip at the single point these two normalisers already funnel through instead — the write call itself, `book-state.ts:708-709`:
+
+```ts
+// before:
+const guarded = await preserveDesignedVoices(bookDir, body.patch);
+await writeJsonAtomic(castJsonPath(bookDir), await denormaliseCastReusedVoices(guarded));
+
+// after:
+const guarded = await preserveDesignedVoices(bookDir, body.patch);
+const denormalised = await denormaliseCastReusedVoices(guarded);
+await writeJsonAtomic(castJsonPath(bookDir), stripDerivedCharacterFields(denormalised));
+```
+
+Add the helper near the other two normalisers, following their own established "tolerates a non-cast-shaped patch" idiom exactly:
+
+```ts
+/* Strip fields the GET response computes fresh (currently just
+   clonedElsewhereInSeries, #2006) before any cast write — a client that
+   echoes back a just-fetched character (the autosave path does this) must
+   never freeze a derived, point-in-time value into cast.json, where
+   nothing would ever invalidate it. Tolerates a non-cast-shaped patch
+   (returns it untouched), matching denormaliseCastReusedVoices and
+   preserveDesignedVoices above. */
+function stripDerivedCharacterFields(patch: unknown): unknown {
+  if (!patch || typeof patch !== 'object' || !Array.isArray((patch as { characters?: unknown }).characters)) {
+    return patch;
+  }
+  const cast = patch as { characters: Array<Record<string, unknown>> };
+  const characters = cast.characters.map((c) => {
+    const { clonedElsewhereInSeries: _derived, ...rest } = c;
+    return rest;
+  });
+  return { ...cast, characters };
+}
+```
+
+Add a regression test: PUT a `{ slice: 'cast', patch: { characters: [...] } }` body whose `characters` include `clonedElsewhereInSeries: true` on some character, then read `cast.json` directly off disk and assert the field is absent from the written file.
+
+- [ ] **Step 12: Run the tests to verify everything passes**
+
+Run: `npm run test -- --run server/src/routes/book-state.test.ts server/src/routes/voices.test.ts`
+Expected: PASS.
+
+- [ ] **Step 13: Typecheck**
+
+Run: `npm run typecheck` (confirms `api-types.ts` regeneration didn't break any consumer, and that `stripDerivedCharacterFields`/the GET-side mutation both type-check against `book-state.ts`'s real surrounding types).
+Expected: PASS.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add server/src/routes/voices.ts server/src/routes/voices.test.ts server/src/routes/book-state.ts server/src/routes/book-state.test.ts openapi.yaml src/lib/api-types.ts
+git commit -m "feat(server): expose clonedElsewhereInSeries on Character via a batched scan, stripped on write"
+```
+
+---
+
+### Task 10: Frontend clone gates read `clonedElsewhereInSeries`
+
+**Files:**
+- Modify: `src/modals/profile-drawer.tsx:1102-1111`
+- Modify: `src/components/emotion-variant-designer.tsx:125-135`
+- Test: each component's existing test file (find via `src/modals/profile-drawer.test.tsx`, `src/components/emotion-variant-designer.test.tsx` or equivalent — grep for the existing book-local-clone test to mirror)
+
+**Interfaces:**
+- Consumes: `Character.clonedElsewhereInSeries` (Task 9, via the regenerated `src/lib/api-types.ts`).
+
+- [ ] **Step 1: Write the failing tests, against each file's REAL fixture pattern**
+
+Neither file uses a `makeCharacter` helper (an earlier revision of this task invented one) — verified by reading both files directly:
+
+`emotion-variant-designer.test.tsx`'s existing `describe('#1954 — cloned voices', ...)` (`:90-98`) uses a plain object literal passed straight as the `character` prop, backed by a redux store built via its own `makeStore(characters)` helper (`:17-22`):
+
+```tsx
+// emotion-variant-designer.test.tsx, inside describe('#1954 — cloned voices', ...)
+it('replaces the designer with an actionable hint when clonedElsewhereInSeries is true, even with no book-local clone', () => {
+  const clonedElsewhere = { id: 'lyra', name: 'Lyra', attributes: [], clonedElsewhereInSeries: true };
+  const store = makeStore([clonedElsewhere]);
+  render(
+    <Provider store={store}>
+      <EmotionVariantDesigner
+        bookId="b1"
+        character={clonedElsewhere as never}
+        sampleVoiceId="v1"
+        modelKey="qwen3-tts-0.6b"
+        baseDesigned
+        variants={undefined}
+      />
+    </Provider>,
+  );
+  const hint = screen.getByTestId('variant-cloned-hint');
+  expect(hint.textContent).toMatch(/cloned voice/i);
+  expect(screen.queryByTestId('variant-designer')).toBeNull();
+});
+```
+
+`profile-drawer.test.tsx`'s existing `'[C-6] refuses a FIRST design when the character already has a cloned Coqui voice...'` test (`:1692-1714`) uses this file's own `renderWithBook({...baseChar, ...})` helper, `selectQwen()`, and asserts on the `qwen-design-error` testid plus a `dispatchSpy` non-call:
+
+```tsx
+// profile-drawer.test.tsx, near the existing [C-6] test
+it('[C-6b] refuses a FIRST design when clonedElsewhereInSeries is true, even with no book-local clone', async () => {
+  const { dispatchSpy } = renderWithBook({
+    ...baseChar,
+    clonedElsewhereInSeries: true,
+  });
+  dispatchSpy.mockClear();
+  selectQwen();
+  fireEvent.click(screen.getByTestId('qwen-design-voice'));
+
+  expect(screen.getByTestId('qwen-design-error')).toHaveTextContent('cloned voice');
+  expect(dispatchSpy).not.toHaveBeenCalledWith(
+    expect.objectContaining({ type: castDesignActions.designSingleRequested.type }),
+  );
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npm run test -- --run -t "clonedElsewhereInSeries"`
+Expected: FAIL — neither gate reads this field yet.
+
+- [ ] **Step 3: Update `emotion-variant-designer.tsx`**
+
+At `emotion-variant-designer.tsx:125-135`, change:
+
+```tsx
+  const cloned =
+    character.overrideTtsVoices?.qwen?.provenance === 'cloned' ||
+    character.overrideTtsVoices?.coqui?.provenance === 'cloned';
+  if (cloned) {
+    return (
+      <p data-testid="variant-cloned-hint" className="text-xs text-ink/50 mt-2">
+        {character.name} uses a cloned voice, so emotion variants are unavailable — they are
+        only offered for a designed voice. Assign a designed voice to add them.
+      </p>
+    );
+  }
+```
+
+to:
+
+```tsx
+  const cloned =
+    character.overrideTtsVoices?.qwen?.provenance === 'cloned' ||
+    character.overrideTtsVoices?.coqui?.provenance === 'cloned' ||
+    character.clonedElsewhereInSeries === true;
+  if (cloned) {
+    return (
+      <p data-testid="variant-cloned-hint" className="text-xs text-ink/50 mt-2">
+        {character.name} is linked to a cloned voice somewhere in this series, so emotion
+        variants are unavailable — they are only offered for a designed voice. Remove the clone
+        from every linked book to add them.
+      </p>
+    );
+  }
+```
+
+- [ ] **Step 4: Update `profile-drawer.tsx`**
+
+At `profile-drawer.tsx:1102-1111`, change:
+
+```tsx
+    if (
+      !isRedesign &&
+      (character.overrideTtsVoices?.qwen?.provenance === 'cloned' ||
+        character.overrideTtsVoices?.coqui?.provenance === 'cloned')
+    ) {
+      setEngineError(
+        `"${character.name}" already has a cloned voice and cannot be designed on Qwen without silently retargeting it off that clone.`,
+      );
+      return;
+    }
+```
+
+to:
+
+```tsx
+    if (
+      !isRedesign &&
+      (character.overrideTtsVoices?.qwen?.provenance === 'cloned' ||
+        character.overrideTtsVoices?.coqui?.provenance === 'cloned' ||
+        character.clonedElsewhereInSeries === true)
+    ) {
+      setEngineError(
+        `"${character.name}" is linked to a cloned voice somewhere in this series and cannot be designed on Qwen without silently retargeting it off that clone.`,
+      );
+      return;
+    }
+```
+
+- [ ] **Step 5: Run the new tests to verify they pass**
+
+Run: `npm run test -- --run -t "clonedElsewhereInSeries"`
+Expected: PASS.
+
+- [ ] **Step 6: Run each component's full test file**
+
+Run: `npm run test -- --run src/modals/profile-drawer.test.tsx src/components/emotion-variant-designer.test.tsx` (adjust paths to whatever Step 1's grep found)
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/modals/profile-drawer.tsx src/components/emotion-variant-designer.tsx <the two test files>
+git commit -m "feat(frontend): clone gates disable on a series-wide clone, not just this book's own copy"
+```
+
+---
+
+## Final verification
+
+- [ ] Run `npm run typecheck` — confirms every changed signature (`applyOverrideToCastFiles`, `persistEmotionVariant`, the new `Character` field) type-checks across every consumer, not just the files this plan touched directly.
+- [ ] Run `npm run test:fast` (frontend + server) — full regression sweep.
+- [ ] Re-grep for any remaining bare-number consumer of `applyOverrideToCastFiles` or `void`-typed consumer of `persistEmotionVariant` this plan's own reading may have missed: `grep -rln "applyOverrideToCastFiles\|persistEmotionVariant" server/src --include=*.ts` — cross-check every hit against this plan's enumeration (Tasks 2, 3, 4, 5, 6, 7, 8), including `variant-propagation.test.ts`, which this plan's own first pass missed and a review pass caught.
+- [ ] Confirm `openapi-design-parity.test.ts` is green (Task 3's `clone_protected` registration) and that `openapi.yaml`'s `PUT /api/voices/{voiceId}/override` documents `200`/`409` alongside the pre-existing `204`/`400`/`404` (Task 2).
+- [ ] Confirm `clonedElsewhereInSeries` never appears in an on-disk `cast.json` after a `PUT /:bookId/state` round-trip (Task 9's write-path strip) — this is a correctness property, not just a passing test; spot-check by hand on a real book if time allows.
+- [ ] Confirm the PR body's "Also fixed, found in passing" section names: Task 3's `single-design.ts` write-time-discard fix (goes beyond the sibling spec's literal text), and Task 4's base-voice-upfront-check upgrade (resolves an inconsistency this plan's own review pass found between Task 3 and Task 8, not something either spec asked for) — per this repo's incidental-findings rule.
+- [ ] Follow this repo's Before-shipping checklist (docs/features regression plan — likely `docs/BACKLOG.md`/`docs/features/INDEX.md` entries for #2006 if one exists; release-notes-next.md + RELEASE_NOTES.md entries; on-box acceptance is NOT owed here — no real hardware/GPU/sidecar behavior is exercised by this change, it's pure cast.json logic).
+- [ ] Close #2006 via `Closes #2006` in the PR body once all tasks land — confirm this is the LAST open TOCTOU gate the issue tracks before closing it outright rather than `Refs`.

--- a/docs/superpowers/specs/2026-08-21-clone-consent-toctou-full-scope-design.md
+++ b/docs/superpowers/specs/2026-08-21-clone-consent-toctou-full-scope-design.md
@@ -1,6 +1,24 @@
 ---
-status: draft
+status: superseded
 ---
+
+> **SUPERSEDED — adversarial review found the `voices.ts` mechanism is
+> attempt #1 ("fold into the lock") relabeled, not a new mechanism.**
+> Skip-and-continue answers the abort half of #1's rejection but IS the
+> "demotes a workspace veto to a per-book one" half — it produces the exact
+> split #2006's own history names as the danger this design was supposed to
+> avoid, while "Out of scope" forbids the §3.2 reopening that would actually
+> fix it. Also found: Class E's `series-mint` lock sits outside the documented
+> `design→library-voice→cast` order (a new ordering hazard, and wrongly
+> attributed to §12.2, which proposes no such thing); Class B's
+> peek-then-lock-then-reverify can't live inside `withCastLocks`'s
+> response-sending callback and, as written, reintroduces an AB/BA deadlock
+> `withCastLocks` already sorts keys to prevent; two issue-documented defects
+> were omitted (one of which can silently revert Class E's own fix); and
+> `SingleDesignEvent.code` was invented — no such enum exists in
+> `openapi.yaml`. Kept as a record of the sixth failed attempt (four prior +
+> this repo's two). Next attempt works the `voices.ts` partial-application
+> question directly with the user rather than solo — see conversation.
 
 # Clone-consent TOCTOU: full-scope design (closes #2006 / srv-81)
 

--- a/docs/superpowers/specs/2026-08-21-clone-consent-toctou-full-scope-design.md
+++ b/docs/superpowers/specs/2026-08-21-clone-consent-toctou-full-scope-design.md
@@ -1,0 +1,266 @@
+---
+status: draft
+---
+
+# Clone-consent TOCTOU: full-scope design (closes #2006 / srv-81)
+
+Supersedes `2026-08-21-clone-consent-write-time-refusal-design.md` (kept as a
+record of a failed fifth attempt — see that file's header). This version is
+grounded in #2006's own comment history ("Four mechanisms designed, four
+failures"), the design-of-record
+(`docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md` §7/§12.2/§13),
+and a fresh read of every site named across both, not just the three the
+original issue body cited.
+
+## Scope, corrected
+
+#2006's own history names more sites than its issue body. Reading every one of
+them (not just the three cited) splits them into four severity classes:
+
+### Class A — genuine clone-consent TOCTOU: read/decide and write in different lock scopes, and the write CAN silently mute a consented clone
+
+1. `voices.ts` `PUT /:voiceId/override` — `hasClonedSlotAmongMatches` (unlocked
+   workspace/series walk) decides; `applyOverrideToCastFiles` writes per book.
+2. `single-design.ts` — `characterHasClonedSlot` decides before the SSE stream
+   starts; `applyOverrideToCastFiles` writes from `runSingleDesign`, detached
+   after `res.flushHeaders()` and after GPU work.
+3. `qwen-voice.ts` — `characterHasClonedSlot` decides before GPU work;
+   `persistEmotionVariant` writes after, in both its book-scoped and
+   series-propagation branches.
+4. `cast-design.ts`'s bulk job — found during this design, not named in the
+   original issue. Same shape as (3): `characterHasClonedSlot` re-checked
+   fresh each loop iteration, but only *before* that character's GPU work, not
+   after (`:369-412` decides, `:544-555` writes).
+
+### Class B — a lock-participation gap, not a validate/write staleness
+
+5. `cast-link-prior.ts` — its clone check (`characterHasClonedSlot` at
+   `:206-207`) and its write (`:239-260`) are **already in one lock span**
+   (`withCastLocks([source, target], ...)` at `:120`), so there is no
+   TOCTOU on the consent decision itself. The real defect: when it plants a
+   `libraryUuid` reference onto the source character (`:250-256`,
+   gated by `shouldDenormaliseVoice`), it never acquires that uuid's
+   `library-voice:<uuid>` key — so a concurrent `DELETE /voice-library/:uuid`
+   (which does take that key, per #2000 §7) can erase the artifact this write
+   just planted a fresh reference to. This is a missing-lock-participant bug,
+   not a stale-decision bug, and needs a different fix shape (below).
+
+### Class C — already correct; no fix needed
+
+6. `voice-override-linked.ts` — `applyToBook` → `applyToBookLocked`
+   (`:252-296`) re-checks `characterHasClonedSlot` **inside** its own per-book
+   `withCastLock`, on freshly-read data (`:296`). The write-list that decides
+   *which* books get called is derived from an earlier, unlocked snapshot —
+   but since every individual call still independently re-validates clone
+   status against fresh data, list staleness can cause a book to be
+   incorrectly included or excluded from the propagation; it cannot cause a
+   clone to be silently muted, because the per-book gate that prevents that is
+   already race-free. **No change proposed for this site.**
+
+### Class D — mislabeled; doesn't touch clone-bearing fields at all
+
+7. `cast-series-patch.ts` — `applyPatchToCastFile` (`:206-230`) only ever
+   writes `gender`/`ageRange`/`tone`. It cannot mute a clone because it never
+   touches `overrideTtsVoices`/`ttsEngine`. Its cross-book write-list
+   staleness is real but cosmetic (a stale gender/tone patch), not a
+   consent issue.
+8. `cast-add-from-roster.ts` — copies `voiceId` (a linkage key) from the
+   target character, never `overrideTtsVoices` (`:138-153`). Same conclusion:
+   no clone-consent risk. Its own comment already documents the residual as
+   "out of scope for this task."
+
+Both Class D sites were grouped under #2006 as "cross-book consultations" in
+the design-of-record's §12.2, but neither is actually reachable by the
+clone-muting failure #2006 exists to prevent. **This design proposes no
+change to either** — closing that portion of #2006's scope by finding it was
+never actually live, not by deferring it again.
+
+### Class E — a separate bug, same issue, no shared mechanism
+
+9. **Cross-book `voiceUuid` double-mint** — every design gate keys its
+   mutual-exclusion on `bookDir` (`withDesignLock`, `isDesignBusy`,
+   `cast-design.ts`'s `inFlightByBook`), but `ensureCharacterVoiceUuid`'s
+   series-propagation branch (`qwen-voice.ts:230-237`) mints once and stamps
+   it across every book in the series in one unlocked walk. Two concurrent
+   designs of the same linked character, from two different books in the
+   series, can each pass the `!character.voiceUuid` early-out and each mint
+   a distinct uuid. This shares #2006's root cause (a decision — "does this
+   character already have a uuid" — made outside the scope that acts on it)
+   but not its consent-mute failure mode, and not the same fix mechanism as
+   classes A/B. Addressed separately, below.
+
+## Why mechanism #1 ("fold into the lock") was rejected before, and why it's viable now
+
+The prior attempt's mechanism #1 was rejected for `voices.ts` specifically
+("re-validating under a per-book lock demotes a workspace veto to a per-book
+one, and honouring it mid-walk means aborting after k books are already
+written") — an **abort-on-conflict** semantic. The prior attempt's strongest
+mechanism (#4, a sha256 fingerprint) failed for a *different* reason:
+`ensureCharacterVoiceUuid`'s intermediate write (`qwen-voice.ts:235`/`:258`,
+verified in this checkout) sets `voiceUuid` and nothing else —
+`{ ...c, voiceUuid: uuid }` — so it never touches `overrideTtsVoices` or any
+clone-provenance field. A whole-file byte/hash comparison ("did anything
+change") trips on this unrelated write; **a predicate re-check ("is this
+character's clone status the same, evaluated fresh") does not, structurally,
+because the predicate never reads the field the intermediate write touches.**
+
+This design uses a predicate re-check, not a fingerprint CAS, and — for
+`voices.ts` — skip-and-continue-and-report rather than abort-on-conflict. Both
+changes were named as open, untried options in #2006's own "what the next
+attempt needs to answer" list, not among the four that were tried and killed.
+
+## Design
+
+### Class A mechanism
+
+Every write site that persists a voice override or emotion-variant slot gains
+a **predicate re-check, re-run at write time, inside the same per-book lock
+the write already takes**, reading the just-locked, fresh cast.json. The
+existing upfront checks (before GPU work, before any lock) are unchanged and
+remain a fast-path.
+
+**Scoped narrowly**, addressing the shared-walker entanglement a fresh read of
+the code surfaced: `forEachMatchingCastCharacter`'s `mutate` callback is
+`(character: CastCharacter) => CastCharacter` and is shared by
+`applyOverrideToCastFiles`, `applyTierToCastFiles` (tier pin only — never
+touches voice fields), and `ensureCharacterVoiceUuid`'s own `stamp` (uuid
+only). The re-check must not become a blanket property of the walker, or a
+tier pin and a uuid mint both start refusing on an unrelated character's
+clone status. Add an **optional** `guard?: (character: CastCharacter) =>
+{ ok: true } | { ok: false; reason: string }` parameter to
+`forEachMatchingCastCharacter`; when present, it runs on the freshly-locked
+character immediately before `mutate`, and a `{ ok: false }` skips that
+character (recording book + reason) instead of calling `mutate`. Only
+`applyOverrideToCastFiles` and `persistEmotionVariant`'s callers pass a guard;
+`applyTierToCastFiles` and `ensureCharacterVoiceUuid`'s stamp pass none and
+are structurally unaffected.
+
+The guard predicate for the SET branch is `hasClonedProvenance(fresh, engine)`
+for any clone-capable engine other than the one being written — generalising
+`voices.ts:927`'s existing same-engine preservation logic to also gate the
+write. For the CLEAR branch, `single-design.ts`, `qwen-voice.ts`'s base
+design, and `cast-design.ts`: `characterHasClonedSlot(fresh)`.
+
+### Refusal semantics, per site
+
+- **`voices.ts` fan-out (workspace/series scope):** skip-and-continue, never
+  abort mid-walk. `forEachMatchingCastCharacter` returns which books were
+  skipped; `PUT /:voiceId/override` maps the result: all matches skipped → 409
+  (unchanged from today's pre-check refusal); some written, some skipped → a
+  new partial-success shape; none skipped → unchanged from today. (Today's
+  success status is **204**, not 200 — corrected from the superseded draft;
+  the partial-success shape needs a body, so it becomes 200 + `skipped`, and
+  the pure-success path stays 204 as today, `skipped` omitted. The existing
+  404 — no character with that voiceId found anywhere — is a fourth,
+  unchanged case: `updatedBookDirs`/`skippedCloneBookDirs` both empty.)
+- **`single-design.ts` / `qwen-voice.ts` / `cast-design.ts`, own-book write:**
+  the write-time guard fires **after** GPU work, from a context that has
+  already committed to a success path. Resolving the "hollow terminal event"
+  tension directly rather than by silent reuse: this is **not** the same
+  event as the existing pre-GPU-work 409/`character_skipped`. It gets its own
+  identifier —
+  - `single-design.ts`: a new SSE code, `code: 'clone_protected_race'`,
+    documented in `openapi.yaml` as distinct from the existing pre-check
+    `clone_protected` 409, with prose stating plainly that it is the rare
+    write-time catch, not a duplicate of the upfront check, and that a
+    "hollow" hit here means real GPU work was discarded to avoid a worse
+    outcome (a muted clone).
+  - `qwen-voice.ts`'s own-book (non-series) write: response not yet sent, so
+    it refuses with the existing 409 `code: 'clone_protected'` — this one
+    genuinely is the same contract as the upfront check, just caught later,
+    because the JSON route never flushes early.
+  - `qwen-voice.ts`'s series-propagation branch and `cast-design.ts`'s bulk
+    job: skip-and-continue-and-report — `cast-design.ts` reuses its own
+    existing `character_skipped` / `reason: 'already_cloned'` event verbatim
+    (no new event needed, no UI change needed — confirmed against
+    `cast-design-stream-middleware.ts`); `qwen-voice.ts`'s response body gains
+    a `propagationSkipped: string[]` field for books skipped during
+    propagation, parallel to `voices.ts`'s `skipped`.
+
+### Class B mechanism — `cast-link-prior.ts`
+
+The clone check itself needs no change (already race-free). The fix targets
+only the missing `library-voice:<uuid>` participation:
+
+1. **Peek** `target.overrideTtsVoices` for candidate library uuids
+   *before* taking any lock (a plain unlocked read — this is only to learn
+   which key(s) to request; it commits to nothing).
+2. **Acquire** `library-voice:<uuid>` for each candidate, then the two cast
+   locks (`withCastLocks`), preserving the global `design → library-voice →
+   cast` order.
+3. **Re-verify inside the lock**: re-read the target fresh; if its current
+   library uuid(s) differ from what was peeked, release and retry from step 1
+   (bounded retry count, same shape as any optimistic-peek-then-lock pattern;
+   the window between peek and lock acquisition is small and this is not a
+   hot path). If they match, proceed exactly as today.
+
+This closes the gap without changing the existing `withCastLocks` span's
+internal logic at all — it only adds a library-voice acquisition around it,
+conditional on what the peek found.
+
+### Class E mechanism — the voiceUuid double-mint
+
+Per the design-of-record's own §12.2 suggestion: wrap
+`ensureCharacterVoiceUuid`'s **entire body** (not just its per-book branch) in
+a `withKeyLock('series-mint:<author>/<series>')` when `seriesFilter` is
+present, serialising concurrent mints for the same linked character across a
+series. Acknowledged limitation, stated plainly rather than silently: this
+only reaches books already in the propagation match set at request time
+(`voices.ts:811`-equivalent skips any book where `!state.castConfirmed`), so a
+book that confirms its cast mid-mint is not covered. Not fixed further here —
+named as a residual, matching this repo's convention for recording rather
+than silently absorbing a known-remaining gap.
+
+## Plumbing changes
+
+- `forEachMatchingCastCharacter`: add the optional `guard` parameter; return
+  type becomes `{ updatedBookDirs: string[]; skippedBookDirs: Array<{
+  bookDir: string; reason: string }> }` **only when a guard was passed** —
+  callers with no guard keep receiving the current `Promise<number>` shape
+  (a discriminated overload on whether `guard` is present), so
+  `applyTierToCastFiles` and `ensureCharacterVoiceUuid`'s stamp need no
+  changes at their call sites.
+- `persistEmotionVariant`: corrected from the superseded draft's false
+  premise — it currently returns `Promise<void>`, not `Promise<number>`. It
+  changes to `Promise<{ updated: boolean; skippedClone: boolean;
+  propagationSkipped: string[] }>` so its two callers (the route handler,
+  `cast-design.ts`'s variant branch) can each apply their own refusal
+  semantic above.
+- `openapi.yaml` / `src/lib/api-types.ts`: `PUT /:voiceId/override`'s 204
+  response gains a sibling 200 (partial success, `skipped` field);
+  `SingleDesignEvent.code` enum gains `clone_protected_race`; `qwen-voice.ts`'s
+  design-voice response schema gains `propagationSkipped`. Regenerate via
+  `npm run openapi:types` and commit the diff alongside.
+
+## Testing
+
+Every Class A/B site needs a paired test that:
+
+1. Passes the upfront check with no clone present.
+2. Injects a clone (or, for the cross-engine SET case, a clone on a different
+   engine; for Class B, a concurrent `DELETE /voice-library/:uuid`) **between**
+   the upfront check and the write, directly manipulating cast.json inside the
+   write-time lock window.
+3. Asserts the write-time guard catches it, via the exact refusal channel
+   named above for that site — not a silently-applied write.
+4. Is mutation-verified: weakening or deleting the guard must turn the test
+   red, with the observed failure output captured.
+
+A fan-out test (`voices.ts` workspace scope, `qwen-voice.ts` series
+propagation) additionally asserts non-conflicting books still get written — a
+skip must not abort siblings. A guard-scoping test asserts `applyTierToCastFiles`
+and `ensureCharacterVoiceUuid`'s stamp are unaffected by a cloned character
+elsewhere in the same walk (the walker-entanglement regression this design
+exists to avoid).
+
+## Out of scope
+
+- Class D sites (`cast-series-patch.ts`, `cast-add-from-roster.ts`) — found to
+  carry no clone-consent risk; no change proposed.
+- Class C (`voice-override-linked.ts`) — found to already be correct for the
+  consent decision; its separate write-list staleness (non-consent) is not
+  addressed here.
+- Any change to lock granularity or acquisition order beyond Class B's
+  `library-voice` participation fix (`#2000` §3.2 stands).
+- Caching/replaying GPU output discarded by a `clone_protected_race` refusal.
+- The Class E residual named above (a book confirming its cast mid-mint).

--- a/docs/superpowers/specs/2026-08-21-clone-consent-write-time-refusal-design.md
+++ b/docs/superpowers/specs/2026-08-21-clone-consent-write-time-refusal-design.md
@@ -1,6 +1,21 @@
 ---
-status: draft
+status: superseded
 ---
+
+> **SUPERSEDED — this is mechanism #1 of a family already tried and rejected.**
+> Written without first reading #2006's own comment history, which records
+> "Four mechanisms designed, four failures" — this design is a re-derivation of
+> failure #1 ("fold into the lock / re-validate inside the write's scope"),
+> already rejected specifically for `voices.ts`'s cross-book veto, and it does
+> not address the reason the *best* of the four (a sha256 fingerprint) died:
+> `ensureCharacterVoiceUuid` writes cast.json **between** the clone-consent
+> gates' read and their guarded write, in both detached-job paths, with zero
+> concurrency required. Also scoped to 4 of the real 5 sites — `cast-link-prior.ts`
+> and the `voice-override-linked.ts`/`cast-series-patch.ts`/`cast-add-from-roster.ts`
+> trio are missing. See #2006's comment thread and
+> `docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md` §7/§12.2/§13
+> for the full prior-attempt record. Kept here, not deleted, as a record of the
+> fifth failed attempt for whoever reads this next.
 
 # Clone-consent gates: write-time refusal (closes #2006 / srv-81)
 

--- a/docs/superpowers/specs/2026-08-21-clone-consent-write-time-refusal-design.md
+++ b/docs/superpowers/specs/2026-08-21-clone-consent-write-time-refusal-design.md
@@ -1,0 +1,205 @@
+---
+status: draft
+---
+
+# Clone-consent gates: write-time refusal (closes #2006 / srv-81)
+
+## Problem
+
+Three clone-consent gates read cast.json, decide a refusal, and then write in
+a **different scope** — after GPU work, after `res.flushHeaders()`, or after
+walking to a different book — than the scope the decision was made in. A
+concurrent write landing in that gap makes the decision stale, and the guard
+silently passes: a character gets retargeted off a consented cloned voice
+(a real person's voice) with its marker intact but its resolution muted.
+
+| Gate | Reads / decides | Writes |
+|---|---|---|
+| `voices.ts` `PUT /:voiceId/override` | `hasClonedSlotAmongMatches` (`:615-645`), an unlocked cross-book workspace/series walk, before any write | `applyOverrideToCastFiles` → `forEachMatchingCastCharacter` (`:779-940`), per book inside its own `withCastLock` |
+| `single-design.ts` `POST /:bookId/cast/:characterId/design-voice/stream` | `characterHasClonedSlot(character)` (`:273`), before the SSE stream starts, before GPU work | `applyOverrideToCastFiles` (`:179`) inside `runSingleDesign`, detached after `res.flushHeaders()` and after GPU work completes |
+| `qwen-voice.ts` `POST /:bookId/cast/:characterId/design-voice` (variant) | `characterHasClonedSlot(character)` (`:600`), before GPU work | `persistEmotionVariant` (`:671` / `:144-209`), after GPU work; own-book branch is still pre-response, series-propagation branch touches other books entirely |
+| `cast-design.ts` bulk "Design full cast" job | `characterHasClonedSlot(character)` (`:402`, `:430`), re-checked fresh each loop iteration, before that character's GPU work | same write primitives as above, after that character's GPU work, inside the same detached SSE job |
+
+`cast-design.ts` was not named in the original issue but carries the identical
+shape (found while reading the code for this design) — its own comment at
+`:387-401` already states the applicable policy in miniature ("skip this
+character and report it — refusing the whole sweep would let one cloned
+character block designing the rest") and is folded into this design rather
+than filed as a separate issue, since it's the same defect at the same root
+cause.
+
+## Why the existing per-book lock (#2000/#2118) doesn't already cover this
+
+`forEachMatchingCastCharacter` already takes each book's `withCastLock`
+individually and reads cast.json fresh **inside** that lock (`:779-825`) — the
+per-book read-modify-write is race-free. What's stale is the *decision to
+write at all*: the workspace-wide veto scan and the pre-GPU-work check both
+run **outside and before** any lock, so a clone that appears after the check
+but before the (possibly much later) write is invisible to it. This is not a
+locking gap — #2000 §3.2 correctly rejected workspace-scoped lock acquisition,
+and nothing here reopens that. It's a **validation-staleness** gap: the check
+and the write are correct in isolation but not re-synchronized with each
+other.
+
+## Design
+
+### Mechanism
+
+Every write site that persists a voice override or emotion-variant slot gains
+a **second clone-safety check, re-run at write time, inside the same per-book
+lock the write already takes**, reading the just-locked, fresh cast.json.
+
+- The existing upfront checks (`hasClonedSlotAmongMatches`,
+  `characterHasClonedSlot` before GPU work) are **unchanged** — they remain a
+  fast-path that fails before wasting GPU work in the common case.
+- The **write-time check is the new authoritative one**. Whatever the upfront
+  check decided, the write-time check is what actually gates the write.
+- No new lock, no rollback, no workspace-wide acquisition. Each book's
+  read-decide-write stays exactly one lock span, matching the existing
+  same-engine check already living inside `forEachMatchingCastCharacter`'s
+  mutate step (`voices.ts:927`), which is precedent for this exact pattern —
+  this design generalises it from "same engine only" to "any clone-capable
+  engine other than the one being written."
+
+### Refusal semantics, per unit of work
+
+Refusal is never "abort an in-flight multi-book operation" and never "silently
+mute a clone." It is scoped to the smallest unit that can still refuse
+honestly:
+
+1. **The request's own/primary book, response not yet sent** — `voices.ts`
+   single-book case, `qwen-voice.ts`'s own-book (non-series) write. Refuse
+   with the existing 409, potentially thrown *after* GPU work completed for
+   the qwen-voice.ts case (see "Accepted trade-off" below).
+2. **A fan-out write to another book in the same request** — `voices.ts`
+   workspace/series scope, `qwen-voice.ts`'s series-propagation branch of
+   `persistEmotionVariant`. Skip that book, keep going, report which books
+   were skipped. The response body gains a `skipped: string[]` field
+   (book dirs) alongside the existing `updates`/success count. This is a
+   **new response shape** for both routes — additive, not a breaking change
+   to the success path when nothing is skipped (`skipped: []`).
+3. **A detached SSE job** — `single-design.ts`'s stream,
+   `cast-design.ts`'s bulk job. Emit `type: 'character_skipped', reason:
+   'already_cloned'` (the event `cast-design.ts` already uses at `:405-410`
+   for the pre-GPU-work case — reused verbatim, not a new event type) instead
+   of the success event (`designed` / `character_designed` /
+   `variant_designed`).
+
+Because a fan-out or bulk-job skip is reported rather than thrown, "all
+children/books processed" no longer implies "no clone was ever at risk" —
+callers (UI) must read the `skipped`/`character_skipped` signal, not just
+absence of a 4xx.
+
+### Plumbing change
+
+`forEachMatchingCastCharacter` and `persistEmotionVariant` currently return
+`Promise<number>` — a bare count of books updated. They change to return
+which books were skipped for clone-safety, not just how many succeeded:
+
+```ts
+type ClonePersistResult = {
+  updatedBookDirs: string[];
+  skippedCloneBookDirs: string[];
+};
+```
+
+Every caller reacts to `skippedCloneBookDirs` on its own transport per the
+rules above; no caller re-derives the reason itself. The single-book
+`onlyBookDir` branch of `forEachMatchingCastCharacter` (`:809-826`) and the
+book-scoped branch of `persistEmotionVariant` (`:200-208`) both populate the
+same shape with at most one entry each, so callers that only ever touch one
+book (single-design.ts, qwen-voice.ts's own-book write) don't need a separate
+code path — they just check `skippedCloneBookDirs.length > 0` for their own
+`bookDir`.
+
+### What counts as "the write would silently mute a clone" at write time
+
+Same predicate the upfront checks already use, applied to the freshly-locked
+character instead of the pre-GPU-work snapshot:
+
+- `voices.ts`'s SET branch: `hasClonedProvenance(fresh, engine)` for any
+  clone-capable engine other than the one being written (generalising the
+  existing same-engine-only check at `:927` to also gate the write, not just
+  decide what to preserve inside it).
+- `voices.ts`'s CLEAR branch, `single-design.ts`, `qwen-voice.ts`'s base
+  design, `cast-design.ts`: `characterHasClonedSlot(fresh)`, unchanged
+  predicate, just re-evaluated on fresh data at write time.
+- `qwen-voice.ts` / `cast-design.ts` variant path: `characterHasClonedSlot`
+  gates the variant slot exactly as the existing pre-GPU-work check does.
+
+### Accepted trade-off
+
+A write-time refusal after GPU work discards that GPU work
+(`single-design.ts`, `qwen-voice.ts`'s own-book write, `cast-design.ts`'s
+per-character GPU work). This only fires inside the race window itself —
+small and rare — and matches this wave's existing philosophy everywhere else
+in the codebase: refuse loudly rather than silently corrupt, even at a real
+cost. No caching or replay of the discarded GPU output is in scope here.
+
+## Components touched
+
+- `server/src/routes/voices.ts` — `forEachMatchingCastCharacter`'s mutate
+  step gains the write-time cross-engine check; its two branches
+  (`onlyBookDir`, workspace/series walk) both surface
+  `skippedCloneBookDirs`. `PUT /:voiceId/override` maps the result to a
+  status precisely: `updatedBookDirs.length === 0 &&
+  skippedCloneBookDirs.length > 0` (every match was clone-protected, nothing
+  written) → 409, same as today's pre-check refusal; `updatedBookDirs.length
+  > 0 && skippedCloneBookDirs.length > 0` (some written, some skipped) → 200
+  + `skipped` field, a new partial-success shape; `skippedCloneBookDirs.length
+  === 0` → 200, unchanged from today.
+- `server/src/routes/single-design.ts` — `runSingleDesign` checks
+  `skippedCloneBookDirs` after `applyOverrideToCastFiles` returns and emits
+  `type: 'error', code: 'clone_protected'` (reusing the existing pre-check's
+  code, `:274-277`) instead of `designed` when the job's own book was
+  skipped.
+- `server/src/routes/qwen-voice.ts` — `persistEmotionVariant` gains the
+  write-time check in both its series-propagation branch (`:168-190`) and its
+  book-scoped branch (`:200-208`); the route handler (`:671-681`) checks the
+  result for its own book before returning 200, and includes propagated-skip
+  book dirs in the JSON body when the series branch was used.
+- `server/src/routes/cast-design.ts` — the bulk job's two post-GPU-work write
+  calls, `applyOverrideToCastFiles` (base path, `:544-549`) and
+  `persistEmotionVariant` (variant path, `:555`), both check the returned
+  skip set for `job.bookDir` before broadcasting success and emit
+  `character_skipped` / `reason: 'already_cloned'` (matching the existing
+  pre-GPU-work skip at `:405-410`/`:433-438`) instead of
+  `character_designed` (`:551`) / `variant_designed` (`:557`) when it was
+  skipped. `job.skipped` increments and `job.clonedSkips` gains the entry,
+  same bookkeeping the pre-GPU-work skip already does, so the UI's existing
+  "already cloned: <names>" summary (`src/store/cast-design-stream-middleware.ts`)
+  covers both the fast-path and write-time skip without a UI change.
+- `docs/superpowers/specs/2026-07-31-cast-json-write-lock-design.md` §7 —
+  gains a note that the write-time re-check documented here is the mechanism
+  that closes the TOCTOU window §7 flagged as open, cross-referencing this
+  spec.
+
+## Testing
+
+Every write site above needs a paired test that:
+
+1. Sets up a character with no clone, passes the upfront check.
+2. Injects a clone onto that character (or, for the cross-engine case, on a
+   different engine) **between the upfront check and the write** — i.e.
+   directly manipulates cast.json inside the write-time lock window, not just
+   before the request starts.
+3. Asserts the write-time check catches it: 409 / `skipped` entry /
+   `character_skipped` event, per the site's refusal semantic above — **not**
+   a silently-applied write with the clone marker muted.
+4. Is mutation-verified: deleting or weakening the write-time check must turn
+   the test red, with the observed failure output captured, per this repo's
+   "mutate the fix, watch it fail" acceptance bar.
+
+A fan-out test (`voices.ts` workspace scope, `qwen-voice.ts` series
+propagation) additionally asserts the **other, non-conflicting books still
+get written** — a skip must not abort siblings.
+
+## Out of scope
+
+- Any change to lock granularity or acquisition order (`#2000` §3.2 stands).
+- Caching/replaying GPU output discarded by a write-time refusal.
+- The fourth gate (`voice-library.ts` DELETE) — already fixed in #2000 with a
+  library-voice-scoped lock, per the original issue.
+- `cast-lock.guard.test.ts`'s static-scan coverage of the touched functions —
+  no new unlocked write site is introduced by this design, so the guard
+  needs no change.

--- a/docs/superpowers/specs/2026-08-22-clone-consent-voices-override-refusal-design.md
+++ b/docs/superpowers/specs/2026-08-22-clone-consent-voices-override-refusal-design.md
@@ -2,157 +2,321 @@
 status: draft
 ---
 
-# `voices.ts` clone-consent refusal: documented partial-success (part of #2006 / srv-81)
+# `voices.ts` clone-consent refusal: series-wide veto (part of #2006 / srv-81)
 
 Scope note up front, because the two prior attempts at this issue
 (`2026-08-21-clone-consent-write-time-refusal-design.md`,
 `2026-08-21-clone-consent-toctou-full-scope-design.md`, both superseded —
 see their headers) failed partly by overclaiming scope. **This spec resolves
-one site only: `voices.ts` `PUT /:voiceId/override` (via
-`applyOverrideToCastFiles`), and its one downstream consumer,
-`single-design.ts`'s single-book call.** It does not touch, and makes no
-claim about, `qwen-voice.ts`'s series-propagation branch, `cast-design.ts`'s
-bulk job, `cast-link-prior.ts`, or the `voiceUuid` double-mint — those remain
-open, undesigned, and tracked on #2006 as before. Do not read "closes #2006"
-into this document; it closes one gate of several.
+`voices.ts` `PUT /:voiceId/override` (via `applyOverrideToCastFiles`), its
+downstream consumers `single-design.ts`'s single-book call and
+`cast-design.ts`'s bulk-job base-voice call, and the two frontend gates that
+mirror this same predicate.** It does not touch `qwen-voice.ts`'s emotion-
+variant path (see the sibling `2026-08-26-clone-consent-qwen-voice-refusal-
+design.md`, which resolves that gate on the same series-wide model this
+document now uses), `cast-link-prior.ts`, or the `voiceUuid` double-mint —
+those remain open, undesigned, and tracked on #2006 as before.
+
+**Revision note (v2).** v1 chose a "documented partial-success contract":
+each book's own write was race-free for its own decision, with no atomicity
+across the propagation as a whole. While implementing the sibling
+`qwen-voice.ts` spec, that same per-book-independence question was raised
+explicitly to the user as a judgment call — clone consent is recorded
+per-book (`voice-library.ts`'s clone-assign writes the marker to exactly one
+book) while the character's identity and artifact key are series-wide, so a
+per-book-independent check can silently write a new assignment for a linked
+character elsewhere in the series while correctly refusing the book that
+prompted the request. The user decided the same way for this gate:
+**clone-consent refusal is scoped to the linked voice identity (series-wide),
+not to a single book's marker or a single book's independent decision** — a
+clone anywhere in the series refuses the whole propagation, implemented as a
+**best-effort** (not fully atomic) fresh scan immediately before the write,
+for the same reason the sibling spec gives: full atomicity needs #2000 §3.2's
+rejected workspace-lock model reopened, which stays out of scope here too.
+
+This revision also adds the sibling's other two follow-on decisions, made by
+the same user at the same time: `cast-design.ts`'s own base-voice call site
+(a third caller of `applyOverrideToCastFiles` the v1 draft scoped out) is
+brought into the same reporting shape as its emotion-variant sibling, and both
+frontend clone gates are upgraded to mirror the series-wide rule rather than
+staying book-local.
 
 ## The decision this spec finalizes
 
-#2006's own design history (see the two superseded specs for the full
-citation trail) established that `voices.ts`'s cross-book veto
-(`hasClonedSlotAmongMatches`) cannot be made atomic with its per-book write
-without reopening `#2000` §3.2 (workspace-scoped lock acquisition, rejected
-for holding a lock across a full directory walk). Two options were on the
-table:
+#2006's own design history established that `voices.ts`'s cross-book veto
+(`hasClonedSlotAmongMatches`) cannot be made *fully atomic* with its per-book
+write without reopening `#2000` §3.2 (workspace-scoped lock acquisition,
+rejected for holding a lock across a full directory walk). That remains true
+in v2. What changes is which of the two non-atomic options is chosen:
 
 - **A bounded N-book lock** — after the unlocked scan produces a concrete
   match list, take `withCastLocks` on exactly those N books (sorted), hold it
   for the whole re-check-and-write. Real atomicity, cost bounded by the
-  propagation's own size rather than the workspace. Not chosen — deferred as
-  more work than this pass needs.
-- **A documented partial-success contract** (chosen) — no atomicity across
-  books. Each book's own write is race-free for its own decision; the
-  operation as a whole is not one atomic yes/no. This trades a weaker
-  guarantee for materially less implementation risk, and is stated at exactly
-  that strength below — not as "closing the window."
+  propagation's own size rather than the workspace. Still not chosen — this
+  is a strictly bigger change than the one below and was not what the user
+  asked for.
+- **A best-effort series-wide veto** (chosen, v2) — re-run
+  `hasClonedSlotAmongMatches` **fresh, immediately before the write**,
+  replacing the stale pre-scan the caller already did. If it finds a clone
+  anywhere in the match set, refuse the *entire* propagation: no book is
+  written. If it finds none, proceed with the existing per-book walk, which
+  keeps its own predicate re-check as a residual-window backstop (below) —
+  not because partial success is now the intended contract, but because the
+  walk itself still takes nonzero time after the fresh scan passes, and a
+  clone landing in that narrower window needs *something* to catch it.
+
+  This is a strictly bigger refusal than v1's per-book contract (an unrelated
+  sibling's own write can now be refused because of a clone on a *different*
+  book), not a smaller one — the trade the user is making is "protect the
+  linked identity more broadly" against "occasionally refuse a book that,
+  taken alone, would have been fine to write."
 
 ## Mechanism
 
-The fix lives entirely inside `applyOverrideToCastFiles`
-(`server/src/routes/voices.ts:875-953`) and does **not** change
-`forEachMatchingCastCharacter`'s shared signature. This is deliberate: round
-2 of adversarial review found a prior draft's `guard` parameter on the shared
-walker would have made `applyTierToCastFiles` and `ensureCharacterVoiceUuid`'s
-own `stamp` — both also callers of that walker, both unrelated to
-clone-consent — start participating in a check that has nothing to do with
-their own write. Scoping the fix to `applyOverrideToCastFiles`'s own mutate
-closure makes that entanglement structurally impossible rather than merely
-avoided by care.
+The fix still lives entirely inside `applyOverrideToCastFiles`
+(`server/src/routes/voices.ts:875-953`) and still does **not** change
+`forEachMatchingCastCharacter`'s shared signature — v1's reasoning for that
+holds unchanged: `applyTierToCastFiles` and `ensureCharacterVoiceUuid`'s own
+`stamp`, both also callers of that walker, both unrelated to clone-consent,
+must not start participating in a check that has nothing to do with their own
+write. `hasClonedSlotAmongMatches` (`voices.ts:615-645`) needs no signature
+change either — it already takes exactly the arguments this needs
+(`voiceId`, `seriesFilter?`, `otherThanEngine?`), since it is the same
+function the upfront check already calls (`voices.ts:712`/`:723`); this
+document's fresh call simply re-runs it at write time instead of trusting the
+scan the caller already did before this function was invoked.
 
-**Predicate re-check, immune to unrelated intermediate writes.** The mutate
-closure already runs per-book, inside that book's `withCastLock`, on a
-freshly-read character (`forEachMatchingCastCharacter`'s existing behaviour,
-`voices.ts:809-861`). It gains: before applying the override, re-evaluate the
-same clone predicate the upfront `hasClonedSlotAmongMatches` check used —
-`hasClonedProvenance(fresh, engine)` for other-engine SET,
-`characterHasClonedSlot(fresh)` for CLEAR — against this fresh read, not the
-pre-scan snapshot. Confirmed immune to `ensureCharacterVoiceUuid`'s
-intermediate write (`qwen-voice.ts:235`/`:258`, both `{ ...c, voiceUuid: uuid
-}` only) in round 2 of review: the predicate reads `overrideTtsVoices`, which
-that write never touches.
+**Fresh series-wide check, before any write:**
 
-**On a positive re-check:** the closure returns the character **unchanged**
-(no field mutation) rather than applying the override. This is a harmless
-idempotent rewrite from `forEachMatchingCastCharacter`'s point of view — the
-walker still writes the book's cast.json (it cannot tell mutate declined),
-but the bytes are identical to what was already on disk, so there is no data
-consequence, only a wasted disk write in the rare skip case. The skip itself
-is recorded in a side-channel `skipped: Array<{ bookDir: string; characterId:
-string; reason: string }>` array that `applyOverrideToCastFiles` owns and
-closes over — not derived from the walker's own return value, which is not
-trustworthy for this purpose (it counts a no-op "skip" write the same as a
-real one). `applyOverrideToCastFiles` tracks its own `updated` count
-independently, incrementing only when the predicate passes.
+```ts
+export async function applyOverrideToCastFiles(
+  voiceId: string,
+  override: { engine: TtsEngine; name: string } | null,
+  seriesFilter?: { author: string; series: string },
+  onlyBookDir?: string,
+): Promise<{ updated: number; skipped: Array<{ bookDir: string; characterId: string; reason: string }> }> {
+  const otherThanEngine = override === null ? undefined : override.engine;
+  const stillCloned = await hasClonedSlotAmongMatches(voiceId, seriesFilter, otherThanEngine);
+  if (stillCloned) {
+    return {
+      updated: 0,
+      skipped: [{ bookDir: onlyBookDir ?? '(series-wide)', characterId: voiceId, reason: 'already_cloned' }],
+    };
+  }
+  // ... proceed to the walk below, unchanged from v1 except for the count/skip bookkeeping already there
+}
+```
+
+The synthetic single entry (`bookDir: '(series-wide)'`) is deliberate, not a
+placeholder: enumerating every individual matched `(bookDir, characterId)`
+pair for a refusal that touched none of them would need a second, purely
+read-only walk beyond what `hasClonedSlotAmongMatches` already returns (it
+answers `boolean`, not the match list), and no caller of this function
+distinguishes *which* book carried the clone from *that* one did — both
+`voices.ts`'s response mapping and `single-design.ts`'s single-book collapse
+only test `skipped.length > 0`. Building that enumeration purely to populate
+an unused level of detail would be speculative machinery this repo's
+"simplicity first" convention argues against. `onlyBookDir` is threaded
+through when present (the `single-design.ts` caller) so that caller's own
+existing "was *my* book in `skipped`" logic still works unchanged — it
+already collapses to "is `skipped` non-empty at all" for a single-book match
+set, which the synthetic entry still satisfies.
+
+**Predicate re-check, residual-window backstop (unchanged from v1):** the
+mutate closure passed to `forEachMatchingCastCharacter` keeps its own
+per-book re-check, immune to unrelated intermediate writes exactly as v1
+documented — `hasClonedProvenance(fresh, engine)` for other-engine SET,
+`characterHasClonedSlot(fresh)` for CLEAR, evaluated against the fresh
+per-book read inside that book's own `withCastLock`. On a positive, the
+closure returns the character unchanged (harmless idempotent rewrite,
+`voices.ts:844-853`'s `dirty = true` fires regardless, exactly as v1 already
+noted) and the entry is added to the same `skipped` array — now genuinely
+rare (the fresh series-wide check above already caught the routine case),
+rather than the primary mechanism v1 relied on.
 
 ## Signature change
 
-`applyOverrideToCastFiles` changes from `Promise<number>` to:
+`applyOverrideToCastFiles` keeps the `Promise<{ updated, skipped }>` shape v1
+introduced — no further change to the return type. **Three** call sites now
+need updating (v1 listed two; this revision adds the third):
 
-```ts
-Promise<{ updated: number; skipped: Array<{ bookDir: string; characterId: string; reason: string }> }>
-```
-
-Two call sites, both updated in this change:
-
-- `voices.ts:731` (`PUT /:voiceId/override`) — maps the result per the table
-  below.
+- `voices.ts:731` (`PUT /:voiceId/override`) — maps the result per the
+  response table below, unchanged from v1.
 - `single-design.ts:179` (`runSingleDesign`, single-book via `onlyBookDir`) —
-  a non-empty `skipped` for its own book means refuse that job. This is not a
-  new design question: it is single-book by construction
-  (`onlyBookDir` is passed, so at most one book's worth of entries can appear
-  in `skipped`), so it collapses to the same refusal the existing pre-GPU-work
-  check already performs, just reachable at write time too. **How that
-  refusal reaches the SSE stream is not decided by this spec** — round 2 found
-  the previous draft invented an OpenAPI enum field (`SingleDesignEvent.code`)
-  that does not exist in the schema, and this document does not repeat that
-  mistake. `single-design.ts`'s own refusal channel is out of scope here and
-  remains open, same as the other undesigned sites listed above.
+  unchanged from v1: a non-empty `skipped` for its own book means refuse that
+  job.
+- **`cast-design.ts:544-549` (new in v2)** — the SSE bulk job's base-voice
+  path currently discards the return value entirely (`await
+  applyOverrideToCastFiles(...)`, then unconditionally `job.done += 1;
+  broadcast(... 'character_designed' ...)`). This is the exact gap the
+  sibling `qwen-voice.ts` spec flagged without fixing (v1 of that document
+  named it as a question for this spec's author; the user has now answered
+  it: mirror the variant branch's existing pattern). Updated to:
+
+  ```ts
+  const { updated, skipped } = await applyOverrideToCastFiles(
+    matchKey,
+    { engine: 'qwen', name: voiceId },
+    seriesFilter,
+    job.bookDir,
+  );
+  if (updated === 0 && skipped.length > 0) {
+    job.skipped += 1;
+    job.clonedSkips.push({ characterId, name: character.name ?? characterId });
+    broadcast(job, { type: 'character_skipped', characterId, name: character.name ?? characterId, reason: 'already_cloned' });
+  } else {
+    job.done += 1;
+    broadcast(job, { type: 'character_designed', characterId, voiceId });
+  }
+  ```
+
+  Same channel the emotion-variant branch already uses two lines below this
+  one (`cast-design.ts:555` in the sibling spec) — one bulk job, one
+  `clonedSkips` reporting shape for both its base-voice and variant paths,
+  not two.
 
 ## Response contract for `voices.ts` `PUT /:voiceId/override`
 
-All four cases distinguished explicitly (a prior draft's mapping silently
-collapsed two of them):
+Unchanged from v1 — the four-case table still holds, since the *shape* of
+the response didn't change, only *when* `skipped` gets populated (series-wide
+scan vs. per-book independent decisions):
 
 | `updated` | `skipped.length` | Status | Body | Change from today |
 |---|---|---|---|---|
 | >0 | 0 | 204 | none | unchanged |
-| >0 | >0 | 200 | `{ updated, skipped }` | **new** — today has no partial-success shape |
-| 0 | >0 | 409 | `{ error, skipped }` | status unchanged (matches today's pre-check 409); body gains `skipped` |
+| >0 | >0 | 200 | `{ updated, skipped }` | **new** — today has no partial-success shape. Now rare: only the residual-window backstop produces this, not the routine case. |
+| 0 | >0 | 409 | `{ error, skipped }` | status unchanged (matches today's pre-check 409); body gains `skipped`. Now the routine outcome for "cloned somewhere in the series," not just "cloned in every matched book." |
 | 0 | 0 | 404 | `{ error }` | unchanged |
 
-The 0/0 → 404 case is unaffected by this change: it's the existing
-"no character with this voiceId found anywhere" branch (`voices.ts:732-739`),
-computed the same way it is today (`updated === 0`, now also requiring
-`skipped.length === 0` to distinguish it from the new all-skipped 409 case).
+The 0/0 → 404 case is unaffected: it's the existing "no character with this
+voiceId found anywhere" branch (`voices.ts:732-739`).
 
 **Noted, not fixed here:** `openapi.yaml` currently documents only
 204/400/404 for this route — the 409 exists in code (`voices.ts:713`,
-`:724`) but was never added to the spec. Touching this response block is a
-natural place to close that gap too, but it is a distinct, smaller fix from
-the partial-success shape this document adds, and should be called out as
-such in whatever PR implements this (not silently folded in as if it were
-part of the new behaviour).
+`:724`) but was never added to the spec. Unchanged from v1; still a distinct,
+smaller fix to call out in whatever PR implements this.
+
+## Frontend series-awareness (new in v2)
+
+Two frontend gates currently mirror this predicate but read only the
+*current book's own* character data, matching v1's per-book model:
+
+- `src/modals/profile-drawer.tsx:1102-1111` — the base-voice "Design" button's
+  own client-side gate (`character.overrideTtsVoices?.qwen?.provenance ===
+  'cloned' || character.overrideTtsVoices?.coqui?.provenance === 'cloned'`).
+- `src/components/emotion-variant-designer.tsx:125-135` — the emotion-variant
+  designer's gate (identical shape, gates the whole component rather than one
+  button).
+
+Per the user's decision, both should mirror the new series-wide rule rather
+than staying book-local. This requires the backend to expose "cloned
+somewhere in this character's linked series" as data the frontend can read,
+since the frontend only ever has the current book's own cast in hand — a
+genuine API surface addition, not a client-only change:
+
+- Add a computed, read-only field to the `Character` shape (`openapi.yaml`'s
+  `Character` schema, regenerated into `src/lib/api-types.ts` via `npm run
+  openapi:types`) — e.g. `clonedElsewhereInSeries: boolean` — **true** when
+  `hasClonedSlotAmongMatches` (this document's own function, reused again)
+  finds a clone on some *other* linked book, **false** when the only clone
+  (if any) is on this book's own copy (which the existing
+  `overrideTtsVoices.*.provenance` fields already expose) or there is none.
+  Excluding the caller's own book from this specific field avoids a
+  redundant/confusing "double true" when both this book and a sibling are
+  independently cloned.
+- **Implementation task, not resolved here:** locate the cast-read path that
+  serves the confirm/cast views their `Character[]` (the route that turns
+  `cast.json` into the API-shaped response the frontend's `characters` slice
+  consumes) and compute the field there, once per character, for a
+  series-linked book. This document does not cite a specific file:line for
+  that site — verify it against the actual working tree at implementation
+  time rather than trusting a citation written without reading it, per this
+  whole spec's own review history.
+- Both frontend gates change from:
+  ```ts
+  character.overrideTtsVoices?.qwen?.provenance === 'cloned' ||
+  character.overrideTtsVoices?.coqui?.provenance === 'cloned'
+  ```
+  to:
+  ```ts
+  character.overrideTtsVoices?.qwen?.provenance === 'cloned' ||
+  character.overrideTtsVoices?.coqui?.provenance === 'cloned' ||
+  character.clonedElsewhereInSeries === true
+  ```
+- The user-facing copy at both sites (`profile-drawer.tsx:1107-1109`,
+  `emotion-variant-designer.tsx:130-133`) currently says "X already has a
+  cloned voice" / "X uses a cloned voice" — both false when the clone is on a
+  sibling book. Reword to the same book-agnostic phrasing this spec's sibling
+  document already gives `clonedVariantRefusal` (`qwen-voice.ts:99`, v2 of
+  that spec): the clone is on *this linked character*, not necessarily *this
+  book's copy* of them.
+- This is additive to, not a replacement for, the backend series-wide checks
+  above — the frontend gate is a UX convenience (disable/hide before a round
+  trip), the backend checks are what actually enforce consent. A stale or
+  unpropagated `clonedElsewhereInSeries` value degrades to "the button is
+  offered when it shouldn't be," never to "the write happens when it
+  shouldn't" — the backend's own fresh check is authoritative regardless of
+  what the frontend believed.
 
 ## What this does not claim
 
-- No atomicity across books touched by one request. A client cannot tell,
-  from the 200/`skipped` shape alone, whether the skip is "harmless, the
-  clone was always there" or "a clone appeared during this exact request" —
-  both look identical. If that distinction ever matters to a caller, it is
-  not available here.
-- Does not address `qwen-voice.ts`, `cast-design.ts`, `cast-link-prior.ts`, or
-  the `voiceUuid` double-mint. Each remains exactly as open as the
-  design-of-record and #2006's comment history already recorded it.
+- **Not fully atomic**, same reasoning as the sibling spec: the residual
+  window between `hasClonedSlotAmongMatches` passing and the walk reaching
+  each book is real, though far smaller than v1's original per-book-only
+  window. A true atomic veto needs #2000 §3.2's workspace-lock reopened — out
+  of scope here.
+- A client cannot tell, from the 200/`skipped` shape alone, whether a
+  residual-window skip is "a clone appeared during this exact request" vs.
+  some other cause — same limitation v1 already named, now covering a
+  narrower (rarer) case.
+- Does not address `qwen-voice.ts`'s own mechanism in detail (see that
+  sibling spec directly), `cast-link-prior.ts`, or the `voiceUuid`
+  double-mint.
 - Does not change `#2000` §3.2's lock-granularity decision.
+- Does not implement the frontend field's exact backend wiring — named as an
+  implementation task above, not designed to the file:line level here.
 
 ## Testing
 
-Paired test for `applyOverrideToCastFiles`:
+Paired tests for `applyOverrideToCastFiles`:
 
-1. Two (or more) matching books, no clone on either — request succeeds,
-   `updated === 2`, `skipped === []`, 204.
-2. Inject a clone into book B **between** the upfront scan and book B's own
-   write (direct cast.json manipulation inside the write-time lock window,
-   not before the request starts) — book A still gets `updated`, book B
-   lands in `skipped` with a stated reason, response is 200.
-3. All matching books cloned at write time — `updated === 0`,
-   `skipped.length > 0`, 409.
-4. No matching book at all — unchanged 404, `skipped` never appears (this
+1. Two (or more) matching books, no clone anywhere in the match set — request
+   succeeds, `updated === 2`, `skipped === []`, 204.
+2. Clone present on a book **not** in the caller's own request path (e.g. a
+   sibling book, for a request whose `bookId`/`onlyBookDir` context is a
+   different book) at call time — the *entire* propagation refuses:
+   `updated === 0`, `skipped` contains the synthetic series-wide entry, 409.
+   This is the corrected version of v1's test 2, which asserted "book A
+   applied, book B skipped" as the expected 200 partial-success outcome — v2
+   makes that the *wrong* expectation; a clone anywhere refuses everywhere.
+3. **Residual-window case (new in v2):** clone injected into a specific book
+   *after* the fresh `hasClonedSlotAmongMatches` call has already returned
+   `false`, but *before* the walk reaches that specific book (the narrower
+   race v1's mechanism is now reserved for) — that book lands in `skipped`
+   with `reason: 'already_cloned'` from the per-book closure backstop, other
+   matched books still get `updated`, response is 200 with a non-empty
+   `skipped` — the one remaining path that produces this "genuine" partial
+   shape.
+4. All matching books cloned at write time — `updated === 0`, `skipped`
+   non-empty (either via the fresh series-wide check short-circuiting, or,
+   in the unlikely case every book's own clone appeared only in the residual
+   window, via the per-book backstop populating one entry per book), 409.
+5. No matching book at all — unchanged 404, `skipped` never appears (this
    path doesn't reach the new code).
-5. Mutation-verified: deleting the write-time predicate re-check must turn
-   test 2 red (the clone gets silently overwritten instead of skipped), with
-   the observed failure output captured.
-6. A guard-scoping regression test: a concurrent `applyTierToCastFiles` or
+6. Mutation-verified: deleting the fresh series-wide check must turn test 2
+   red; deleting the per-book closure backstop must turn test 3 red — two
+   separate mutations, two separate assertions, since v2 has two distinct
+   layers where v1 had one.
+7. A guard-scoping regression test: a concurrent `applyTierToCastFiles` or
    `ensureCharacterVoiceUuid` call against a book with a cloned character in
-   this same walk is unaffected — proving the fix's closure-scoping, not the
-   shared walker, is what changed.
+   this same walk is unaffected — unchanged from v1, still proving the fix's
+   closure-scoping, not the shared walker, is what changed.
+8. `cast-design.ts:544`'s new branch: mock `applyOverrideToCastFiles` to
+   return `{updated: 0, skipped: [...]}`  — assert `job.skipped` incremented,
+   `job.clonedSkips` gains the entry, and the broadcast matches the existing
+   `character_skipped`/`already_cloned` shape the variant branch already
+   uses two lines below it.
+9. Frontend: with `clonedElsewhereInSeries: true` and no book-local clone
+   provenance, both gated components render their refusal state (button
+   disabled / variant designer replaced by its hint), matching the existing
+   book-local-clone test coverage's shape but keyed on the new field instead.

--- a/docs/superpowers/specs/2026-08-22-clone-consent-voices-override-refusal-design.md
+++ b/docs/superpowers/specs/2026-08-22-clone-consent-voices-override-refusal-design.md
@@ -1,0 +1,158 @@
+---
+status: draft
+---
+
+# `voices.ts` clone-consent refusal: documented partial-success (part of #2006 / srv-81)
+
+Scope note up front, because the two prior attempts at this issue
+(`2026-08-21-clone-consent-write-time-refusal-design.md`,
+`2026-08-21-clone-consent-toctou-full-scope-design.md`, both superseded —
+see their headers) failed partly by overclaiming scope. **This spec resolves
+one site only: `voices.ts` `PUT /:voiceId/override` (via
+`applyOverrideToCastFiles`), and its one downstream consumer,
+`single-design.ts`'s single-book call.** It does not touch, and makes no
+claim about, `qwen-voice.ts`'s series-propagation branch, `cast-design.ts`'s
+bulk job, `cast-link-prior.ts`, or the `voiceUuid` double-mint — those remain
+open, undesigned, and tracked on #2006 as before. Do not read "closes #2006"
+into this document; it closes one gate of several.
+
+## The decision this spec finalizes
+
+#2006's own design history (see the two superseded specs for the full
+citation trail) established that `voices.ts`'s cross-book veto
+(`hasClonedSlotAmongMatches`) cannot be made atomic with its per-book write
+without reopening `#2000` §3.2 (workspace-scoped lock acquisition, rejected
+for holding a lock across a full directory walk). Two options were on the
+table:
+
+- **A bounded N-book lock** — after the unlocked scan produces a concrete
+  match list, take `withCastLocks` on exactly those N books (sorted), hold it
+  for the whole re-check-and-write. Real atomicity, cost bounded by the
+  propagation's own size rather than the workspace. Not chosen — deferred as
+  more work than this pass needs.
+- **A documented partial-success contract** (chosen) — no atomicity across
+  books. Each book's own write is race-free for its own decision; the
+  operation as a whole is not one atomic yes/no. This trades a weaker
+  guarantee for materially less implementation risk, and is stated at exactly
+  that strength below — not as "closing the window."
+
+## Mechanism
+
+The fix lives entirely inside `applyOverrideToCastFiles`
+(`server/src/routes/voices.ts:875-953`) and does **not** change
+`forEachMatchingCastCharacter`'s shared signature. This is deliberate: round
+2 of adversarial review found a prior draft's `guard` parameter on the shared
+walker would have made `applyTierToCastFiles` and `ensureCharacterVoiceUuid`'s
+own `stamp` — both also callers of that walker, both unrelated to
+clone-consent — start participating in a check that has nothing to do with
+their own write. Scoping the fix to `applyOverrideToCastFiles`'s own mutate
+closure makes that entanglement structurally impossible rather than merely
+avoided by care.
+
+**Predicate re-check, immune to unrelated intermediate writes.** The mutate
+closure already runs per-book, inside that book's `withCastLock`, on a
+freshly-read character (`forEachMatchingCastCharacter`'s existing behaviour,
+`voices.ts:809-861`). It gains: before applying the override, re-evaluate the
+same clone predicate the upfront `hasClonedSlotAmongMatches` check used —
+`hasClonedProvenance(fresh, engine)` for other-engine SET,
+`characterHasClonedSlot(fresh)` for CLEAR — against this fresh read, not the
+pre-scan snapshot. Confirmed immune to `ensureCharacterVoiceUuid`'s
+intermediate write (`qwen-voice.ts:235`/`:258`, both `{ ...c, voiceUuid: uuid
+}` only) in round 2 of review: the predicate reads `overrideTtsVoices`, which
+that write never touches.
+
+**On a positive re-check:** the closure returns the character **unchanged**
+(no field mutation) rather than applying the override. This is a harmless
+idempotent rewrite from `forEachMatchingCastCharacter`'s point of view — the
+walker still writes the book's cast.json (it cannot tell mutate declined),
+but the bytes are identical to what was already on disk, so there is no data
+consequence, only a wasted disk write in the rare skip case. The skip itself
+is recorded in a side-channel `skipped: Array<{ bookDir: string; characterId:
+string; reason: string }>` array that `applyOverrideToCastFiles` owns and
+closes over — not derived from the walker's own return value, which is not
+trustworthy for this purpose (it counts a no-op "skip" write the same as a
+real one). `applyOverrideToCastFiles` tracks its own `updated` count
+independently, incrementing only when the predicate passes.
+
+## Signature change
+
+`applyOverrideToCastFiles` changes from `Promise<number>` to:
+
+```ts
+Promise<{ updated: number; skipped: Array<{ bookDir: string; characterId: string; reason: string }> }>
+```
+
+Two call sites, both updated in this change:
+
+- `voices.ts:731` (`PUT /:voiceId/override`) — maps the result per the table
+  below.
+- `single-design.ts:179` (`runSingleDesign`, single-book via `onlyBookDir`) —
+  a non-empty `skipped` for its own book means refuse that job. This is not a
+  new design question: it is single-book by construction
+  (`onlyBookDir` is passed, so at most one book's worth of entries can appear
+  in `skipped`), so it collapses to the same refusal the existing pre-GPU-work
+  check already performs, just reachable at write time too. **How that
+  refusal reaches the SSE stream is not decided by this spec** — round 2 found
+  the previous draft invented an OpenAPI enum field (`SingleDesignEvent.code`)
+  that does not exist in the schema, and this document does not repeat that
+  mistake. `single-design.ts`'s own refusal channel is out of scope here and
+  remains open, same as the other undesigned sites listed above.
+
+## Response contract for `voices.ts` `PUT /:voiceId/override`
+
+All four cases distinguished explicitly (a prior draft's mapping silently
+collapsed two of them):
+
+| `updated` | `skipped.length` | Status | Body | Change from today |
+|---|---|---|---|---|
+| >0 | 0 | 204 | none | unchanged |
+| >0 | >0 | 200 | `{ updated, skipped }` | **new** — today has no partial-success shape |
+| 0 | >0 | 409 | `{ error, skipped }` | status unchanged (matches today's pre-check 409); body gains `skipped` |
+| 0 | 0 | 404 | `{ error }` | unchanged |
+
+The 0/0 → 404 case is unaffected by this change: it's the existing
+"no character with this voiceId found anywhere" branch (`voices.ts:732-739`),
+computed the same way it is today (`updated === 0`, now also requiring
+`skipped.length === 0` to distinguish it from the new all-skipped 409 case).
+
+**Noted, not fixed here:** `openapi.yaml` currently documents only
+204/400/404 for this route — the 409 exists in code (`voices.ts:713`,
+`:724`) but was never added to the spec. Touching this response block is a
+natural place to close that gap too, but it is a distinct, smaller fix from
+the partial-success shape this document adds, and should be called out as
+such in whatever PR implements this (not silently folded in as if it were
+part of the new behaviour).
+
+## What this does not claim
+
+- No atomicity across books touched by one request. A client cannot tell,
+  from the 200/`skipped` shape alone, whether the skip is "harmless, the
+  clone was always there" or "a clone appeared during this exact request" —
+  both look identical. If that distinction ever matters to a caller, it is
+  not available here.
+- Does not address `qwen-voice.ts`, `cast-design.ts`, `cast-link-prior.ts`, or
+  the `voiceUuid` double-mint. Each remains exactly as open as the
+  design-of-record and #2006's comment history already recorded it.
+- Does not change `#2000` §3.2's lock-granularity decision.
+
+## Testing
+
+Paired test for `applyOverrideToCastFiles`:
+
+1. Two (or more) matching books, no clone on either — request succeeds,
+   `updated === 2`, `skipped === []`, 204.
+2. Inject a clone into book B **between** the upfront scan and book B's own
+   write (direct cast.json manipulation inside the write-time lock window,
+   not before the request starts) — book A still gets `updated`, book B
+   lands in `skipped` with a stated reason, response is 200.
+3. All matching books cloned at write time — `updated === 0`,
+   `skipped.length > 0`, 409.
+4. No matching book at all — unchanged 404, `skipped` never appears (this
+   path doesn't reach the new code).
+5. Mutation-verified: deleting the write-time predicate re-check must turn
+   test 2 red (the clone gets silently overwritten instead of skipped), with
+   the observed failure output captured.
+6. A guard-scoping regression test: a concurrent `applyTierToCastFiles` or
+   `ensureCharacterVoiceUuid` call against a book with a cloned character in
+   this same walk is unaffected — proving the fix's closure-scoping, not the
+   shared walker, is what changed.

--- a/docs/superpowers/specs/2026-08-26-clone-consent-qwen-voice-refusal-design.md
+++ b/docs/superpowers/specs/2026-08-26-clone-consent-qwen-voice-refusal-design.md
@@ -7,133 +7,430 @@ status: draft
 Sibling to `2026-08-22-clone-consent-voices-override-refusal-design.md`, which
 resolves the `voices.ts`/`single-design.ts` gate. **This spec resolves the third
 gate: `persistEmotionVariant` (`server/src/routes/qwen-voice.ts:144-209`),
-shared by the JSON `design-voice` route and the SSE bulk "Design full cast"
-job.** It does not touch `cast-design.ts`'s base-voice path
-(`applyOverrideToCastFiles`), `cast-link-prior.ts`, or the `voiceUuid`
-double-mint — those remain exactly as open as #2006's history already
-recorded them.
+shared by the JSON `design-voice` route (call site `qwen-voice.ts:671`) and the
+SSE bulk "Design full cast" job (call site `cast-design.ts:555`).** It does not
+touch `cast-design.ts`'s base-voice path (`applyOverrideToCastFiles`),
+`cast-link-prior.ts`, or the `voiceUuid` double-mint — those remain exactly as
+open as #2006's history already recorded them.
+
+**Line numbers below are cited against this worktree's own
+`server/src/routes/qwen-voice.ts`** (branch `docs/docs-2006-clone-consent-refusal-spec`),
+verified directly, not against `main` — this branch is currently ~12 lines
+behind `main` in that file (missing #2246's `language_unset` block), so a
+citation that looks off by roughly that much elsewhere is a sign the reader is
+comparing against `main`, not an error in this spec. Rebase before
+implementation and re-verify if the gap has grown.
+
+**Revision history.** Four rounds of the mandatory adversarial review
+(`assumption-checker`, Opus/xhigh) — three as the capped review loop, a fourth
+as a fresh check warranted by how much the mechanism changed after a
+judgment call was resolved:
+
+- **v1 → v2:** fixed a two-boolean return shape that silently mislabeled
+  "character not found" as success; added artifact teardown on refusal.
+- **v2 → v3:** removed the teardown and a walker-signature-extension idea,
+  because round 2 found both dangerous — the teardown could delete a
+  deterministically-named artifact a sibling book's independent successful
+  write still referenced; the signature extension contradicted the sibling
+  spec's explicit commitment not to touch `forEachMatchingCastCharacter`.
+- **v3 → v4:** round 3 found that v3's "per-book independence is intentional"
+  framing rested on a false premise — clone consent is recorded per-book
+  (`voice-library.ts`'s clone-assign writes the marker to exactly one book),
+  but the character's identity and artifact key are series-wide. This was
+  raised to the user as a genuine product decision rather than resolved
+  unilaterally. The user decided: **clone-consent refusal is scoped to the
+  linked voice identity (series-wide), not to a single book's marker** — a
+  clone anywhere in the series refuses the whole propagation — implemented as
+  a **best-effort** (not fully atomic) fresh scan immediately before the write
+  walk, explicitly declining to reopen #2000 §3.2's rejected workspace-lock
+  model for full atomicity.
+- **v4 → v5 (this revision):** a fresh round-4 check of the new mechanism
+  found two real defects in v4's implementation of the user's decision (not
+  further judgment calls):
+  1. v4 made only the *write-time* re-check series-wide. All four gates
+     upstream of it — the frontend's own gate, both routes' upfront 409s, and
+     the design core's #1954 guard — stayed book-local. For any character
+     cloned on a sibling book (a stable configuration, not a race), that meant
+     every design attempt would run full GPU synthesis and *then* refuse,
+     deterministically, every time — the exact case this spec exists to make
+     cheap to refuse. Fixed by making both callers' upfront checks series-wide
+     too (§"Upfront checks" below), reusing the same exported function.
+  2. v4 cited the `voices.ts` sibling as precedent for silently discarding a
+     residual mid-walk skip — but the sibling built its `skipped` array
+     specifically to report that exact case, not to swallow it. Fixed by
+     threading `forEachMatchingCastCharacter`'s own returned count through
+     instead of discarding it, and logging (not silently absorbing) the rare
+     residual-skip case. See §"Series branch" below.
+
+  Two smaller corrections: `clonedVariantRefusal`'s message assumed the
+  refusal was always caused by *this* book's own copy, which a series-wide
+  refusal can make false; reworded to be accurate regardless of which linked
+  book carries the marker. `hasClonedSlotAmongMatches`'s doc comment is scoped
+  to its one existing caller; exporting it for a second caller makes that
+  comment stale, which this spec fixes in the same round per CLAUDE.md's
+  incidental-findings rule rather than filing it separately.
 
 ## The problem, restated after reading the current code
 
 The issue as filed frames this as one TOCTOU gap (read-then-decide in one
-scope, write in another). Reading the code surfaces a second, independent gap
-in the same function that the write-time fix below closes for free:
+scope, write in another). Reading the code surfaces a second, independent gap:
 
-1. **TOCTOU.** Both callers check `characterHasClonedSlot` once, before the
-   (slow) GPU design call, then call `persistEmotionVariant` afterward with no
-   re-check. A clone can land on the character during GPU synthesis and the
-   stale decision persists anyway.
-2. **Propagation never checks clone status per target book at all.**
-   `persistEmotionVariant`'s `seriesFilter` branch propagates the variant to
-   every linked-cast character across the series via
+1. **TOCTOU.** Both callers check `characterHasClonedSlot` once
+   (`qwen-voice.ts:600-605`, `cast-design.ts:430-440`), before the (slow) GPU
+   design call, then call `persistEmotionVariant` afterward with no re-check. A
+   clone can land on the character during GPU synthesis and the stale decision
+   persists anyway.
+2. **The check was never series-wide.** Both upfront checks, and the design
+   core's own #1954 guard, test only the *originating* book's own character.
+   `persistEmotionVariant`'s `seriesFilter` branch then propagates the variant
+   to every linked-cast character across the series via
    `forEachMatchingCastCharacter`'s mutate closure (`qwen-voice.ts:186-188`),
-   unconditionally. Only the *originating* book's character was ever checked
-   (once, by the caller, upfront) — a sibling book where the same linked
-   character carries its own independent cloned slot gets the variant applied
-   regardless.
+   unconditionally — so a linked character cloned in a *different* book than
+   the one the request came from was never checked at all, anywhere, until
+   this spec.
 
-A per-book write-time predicate re-check, done the way the `voices.ts` sibling
-does it, fixes both: it closes the TOCTOU window, and because it runs inside
-the walker's mutate closure it naturally re-evaluates *each* target book's own
-current clone status rather than the source's.
+**Why gap #2 is not a rare edge case — it is a routine, deterministic failure
+mode without the upfront fix.** A character cloned on a sibling book is a
+stable, steady-state configuration (someone recorded consent-refusal once, for
+that book), not a timing coincidence. Every one of the four existing
+book-local gates — the frontend's `cloned` check
+(`src/components/emotion-variant-designer.tsx:125-127`), both routes' upfront
+409s, and the core guard below — passes for a character in this state, every
+time, because none of them looks past the caller's own book. Without also
+fixing the upfront checks, a write-time-only fix would make the correct
+refusal happen *after* a full GPU design round completed, deterministically,
+for every attempt — not occasionally, under a race. §"Upfront checks" below
+closes this at the cheap end instead of only the expensive one.
+
+**Not this spec's problem, confirmed by reading the code:** `addVariant`
+(`qwen-voice.ts:157-166`) stamps `baseVoiceId` onto a sibling that has no
+existing qwen slot at all. That is the intended base-propagation behaviour —
+the whole point of the series branch is that a linked character's qwen
+identity travels — and is orthogonal to clone-consent: a sibling with no qwen
+slot at all is not itself evidence of anything; the clone check is what
+determines refusal, not the presence/absence of a prior qwen slot.
+
+**The core's own #1954 guard remains a book-local backstop, not a gate this
+spec upgrades.** `designQwenVoiceForCharacter`'s guard (`qwen-voice.ts:424-425`,
+inside `server/src/routes/qwen-voice.ts:372`) reads `p.character` — the
+caller's own snapshot, built at `qwen-voice.ts:649` (`characterForDesign`) and
+passed in at `:653`. Once both callers' upfront checks are series-wide (below),
+this guard becomes redundant-but-harmless for the normal path — GPU work is
+never reached for a series-wide-cloned character in the first place — and is
+left as-is rather than given a `seriesFilter` parameter of its own, since its
+only remaining job is guarding the narrow residual window between the
+upfront check and this same GPU call, which is small and already covered by
+the upfront check having *just* run.
+
+**Why the just-minted artifact is left alone rather than torn down.** The
+emotion-variant embedding id is deterministic —
+`` `${baseVoiceId}__${emotion}` `` (`qwen-voice.ts:428`) — not unique per
+design attempt. Tearing it down on refusal risks deleting something a
+different book's successful write or a pre-existing consented design still
+references. This spec does not attempt artifact cleanup on refusal: the
+consent guarantee is that no clone-protected linked character's `cast.json`
+ever points at the newly-minted embedding, which the series-wide refusal
+below fully delivers by not writing to *any* book when a clone is found
+anywhere. An unreferenced `.pt`/`.json` sitting on disk (or, on the audition
+side, a cached MP3 — a pre-existing gap this codebase doesn't solve anywhere,
+including for the redesign-invalidation path at `qwen-voice.ts:878-880`) is a
+storage-hygiene question, not a fresh consent violation, once the
+cast.json-write guarantee holds for every linked book rather than only the
+caller's own.
 
 ## The decision this spec finalizes
 
-**Signal shape: return-value tracking, not a thrown error** — matching the
-`voices.ts` sibling exactly, for the same reason: neither caller needs to
-unwind normal control flow to react to a refusal, and a new error class would
-be one more entry in this file's already-dense error-mapping surface.
+### 1. Return contract
 
 `persistEmotionVariant` changes from `Promise<void>` to:
 
 ```ts
-Promise<{ applied: boolean; skippedClone: boolean }>
+type PersistEmotionVariantOutcome =
+  | 'applied'        // the variant was propagated to at least one book (book-scoped:
+                      // the caller's own book; series-scoped: series-wide, no clone
+                      // found anywhere, at least one matching confirmed-cast book existed)
+  | 'skippedClone'   // refused: a clone was found — the caller's own character
+                      // (book-scoped) or ANY linked character in the series
+                      // (series-scoped) — no book was written
+  | 'notFound';      // no-op: unknown character, vanished mid-write, or (series-scoped)
+                      // no confirmed-cast book matched at all — nothing written and no
+                      // clone was the reason. Existing silent-no-op disposition, named
+                      // rather than expanded.
+
+Promise<PersistEmotionVariantOutcome>
 ```
 
-`applied`/`skippedClone` reflect **only the caller's own `(bookDir,
-characterId)`** — not the aggregate across the whole series propagation. This
-mirrors the `single-design.ts` sibling's collapse-to-single-book approach:
-neither caller here has (or needs) infrastructure to report per-linked-book
-detail; each only acts on its own book's outcome.
+Both callers branch **only** on `'skippedClone'` vs. everything else, so
+`'applied'` and `'notFound'` collapse to the same caller-visible behaviour —
+today's existing behaviour, preserved exactly. The series branch derives
+`'applied'` vs. `'notFound'` from `forEachMatchingCastCharacter`'s own
+returned count (`Promise<number>`, `voices.ts:795`/`:860`) rather than
+discarding it — `count > 0` is `'applied'`, `count === 0` is `'notFound'` (no
+confirmed-cast book in the series matched this character at all, a state the
+series-wide clone scan already ruled out as the reason).
 
-**Bulk-job skip channel: reused, not new.** When the SSE job's write-time
-re-check catches a clone that appeared during GPU synthesis, it reports
-through the *exact same* channel as today's upfront skip —
+### 2. Upfront checks: also series-wide, not just the write-time re-check
+
+**Both callers' pre-GPU checks are upgraded to call the same exported,
+series-wide scan** (§3 below), replacing their current book-local
+`characterHasClonedSlot(character)` test:
+
+- **JSON route** (`qwen-voice.ts:600-605`): this check currently runs
+  *before* `isStandalone`/`seriesInfo` are computed (`:638-639`), so making it
+  series-wide requires moving that computation earlier in the handler — a
+  reordering with no behavioural effect on anything else in the function,
+  since neither depends on work done between the current two positions.
+  ```ts
+  const isStandalone = located.state?.isStandalone === true;
+  const seriesInfo = isStandalone ? null : await findAuthorSeriesForBookId(bookId);
+  if (emotion && await hasClonedSlotAmongMatches(character.voiceId ?? character.id, seriesInfo ?? undefined)) {
+    return res.status(409).json({
+      error: clonedVariantRefusal(character.name ?? characterId),
+      code: 'clone_protected',
+    });
+  }
+  ```
+- **SSE bulk job** (`cast-design.ts:430-440`): `seriesFilter` is already in
+  scope at this point (`runDesignJob`'s own parameter, threaded in from the
+  job's start) — no reordering needed, just swap the predicate:
+  ```ts
+  if (await hasClonedSlotAmongMatches(character.voiceId ?? character.id, seriesFilter)) {
+    job.skipped += 1;
+    job.clonedSkips.push({ characterId, name: character.name ?? characterId });
+    broadcast(job, { type: 'character_skipped', characterId, name: character.name ?? characterId, reason: 'already_cloned' });
+    continue;
+  }
+  ```
+
+This turns the routine, deterministic "full GPU round then refuse" case
+(named above) into a cheap pre-GPU 409/skip — the same cost this spec already
+pays to make the *write-time* check series-wide, just spent before GPU work
+instead of after. **The frontend's own book-local `cloned` gate
+(`emotion-variant-designer.tsx:125-127`) is not changed by this spec** — it
+would need the character prop to carry cross-book clone state, which is a
+frontend/API surface change this backend spec doesn't make. Until that
+follow-up lands, a user whose character is cloned only on a sibling book can
+still click "Design" and get a 409 rather than the button being disabled or
+hidden — but the 409 now arrives immediately, not after a full GPU round.
+
+### 3. Series-wide check, reused, not reimplemented
+
+**Export `hasClonedSlotAmongMatches`** (`voices.ts:615-645`, currently
+module-private) — no change to its logic or its two-parameter-plus-optional
+signature (`voiceId`, `seriesFilter?`, `otherThanEngine?`), only its
+visibility. Both this spec's call sites pass `otherThanEngine` as `undefined`,
+matching the existing plain `characterHasClonedSlot`-based checks it
+replaces — the `otherThanEngine` parameter stays specific to `voices.ts`'s own
+SET-branch asymmetry (`voices.ts:723`) and is irrelevant here. **Update the
+function's doc comment** (`voices.ts:588-614`), which currently describes it
+as scoped to "the clear branch below" and one SET-branch caller — both false
+once this spec adds a second, unrelated caller. This is a chore this spec's
+own change makes owed, fixed in the same round rather than filed separately.
+
+`persistEmotionVariant`'s series branch calls it **fresh, at write time**,
+before any book is touched — in addition to the callers now also calling it
+**before GPU work**, per §2:
+
+```ts
+if (seriesFilter) {
+  const stillCloned = await hasClonedSlotAmongMatches(character.voiceId ?? character.id, seriesFilter);
+  if (stillCloned) return 'skippedClone'; // whole propagation refused — no book written
+  // ... proceed to the walk below
+}
+```
+
+This replaces the caller's stale pre-GPU snapshot with a fresh, series-wide
+read at the moment of writing — shrinking the residual TOCTOU window from
+"GPU synthesis duration" (closed by §2) down further to "the time between
+this specific check and the walk actually reaching each book."
+
+**Residual window, named rather than hidden — this is not full atomicity.**
+Between this check passing and an individual book's own write inside the walk
+below, a clone can still appear on that specific book (the same reasoning
+#2006's issue body gives for why a true atomic veto needs #2000 §3.2's
+workspace-lock reopened, which this spec does not do). The walk's own mutate
+closure keeps a defensive per-book re-check as a second layer, and — unlike
+v4 — this revision does not discard what that layer learns:
+
+```ts
+let residualSkip = false;
+const updated = await forEachMatchingCastCharacter(character.voiceId ?? character.id, seriesFilter, (c) => {
+  if (characterHasClonedSlot(c)) {
+    residualSkip = true;
+    return c; // unchanged — this book's own write correctly declined
+  }
+  return addVariant(c, baseVoiceId);
+});
+if (residualSkip) {
+  console.warn(
+    `[persistEmotionVariant] residual-window skip: a clone appeared on a linked book for ${characterId} between the series-wide scan and this walk reaching it (${updated} book(s) still received the variant).`,
+  );
+}
+return updated > 0 ? 'applied' : 'notFound';
+```
+
+**Why this is a logged, not a reported, outcome.** The user-facing contract
+(§1) still resolves to `'applied'`/`'skippedClone'`/`'notFound'` — adding a
+fourth, partial-success outcome would require both callers to handle a shape
+neither the JSON 409 nor the SSE `clonedSkips` channel currently has room for,
+and would reopen exactly the "how much per-book detail does a caller need"
+question the review process already spent three rounds narrowing down. The
+residual case is: (a) rare — it requires a clone to land in the specific
+window between a passing series-wide scan and the walk reaching that one
+book, not the routine sibling-already-cloned case §2 now closes cheaply; (b)
+still fully protected on cast.json — the affected book's own write is
+correctly declined by the same predicate, it just isn't reflected in the
+return value's granularity. `console.warn` makes it observable to an operator
+reading server logs without inventing new plumbing for a residual window this
+spec's own stated scope (best-effort, not fully atomic) already discloses.
+**This differs from v4's disposition of the same case**, which asserted it
+needed no visibility at all; this revision's position is narrower — no
+*caller-facing* reporting, but not silent either.
+
+This function never needs to distinguish the caller's own book from any
+other matched book, so no signature change to `forEachMatchingCastCharacter`
+or its mutate parameter is needed anywhere in this design — it stays exactly
+as it is today, and its three other callers (`applyOverrideToCastFiles`,
+`applyTierToCastFiles`, `ensureCharacterVoiceUuid`'s `stamp`) are untouched.
+
+### 4. Refusal message: book-agnostic wording
+
+`clonedVariantRefusal` (`qwen-voice.ts:99`) currently reads: `` `"${name}" uses
+a cloned voice, so emotion variants are unavailable … Assign a designed voice
+to this character to use emotion variants.` `` Under series-wide scoping, the
+refusal can fire for a character that, *in this book*, is not cloned and
+already has a designed voice — making both the claim and the remedy false.
+Reworded to be accurate regardless of which linked book carries the marker:
+
+```ts
+export function clonedVariantRefusal(name: string): string {
+  return (
+    `"${name}" is linked to a cloned voice somewhere in this series, so emotion variants are unavailable — ` +
+    `they are only offered for a designed voice. Minting one would re-derive a ` +
+    `new performance of a real person's voice under a key their consent record ` +
+    `does not cover and revoking consent does not erase. Remove the clone from ` +
+    `every linked book to use emotion variants for this character.`
+  );
+}
+```
+
+Used identically at the upfront checks (§2), the write-time series check
+(§3), and the core's own #1954 guard (`qwen-voice.ts:424-425`) — one message,
+accurate at every call site regardless of which book triggered it.
+
+### 5. Bulk-job skip channel: reused, not new
+
+Confirmed against `cast-design.ts:430-440`: both the upgraded upfront check
+(§2) and the write-time re-check report through the *exact same* channel —
 `job.skipped += 1; job.clonedSkips.push({characterId, name}); broadcast(job,
 {type: 'character_skipped', characterId, name, reason: 'already_cloned'})` —
-not a new reason or counter. The user-visible meaning ("this character kept
-its clone, no variant applied") is identical whether the clone was caught
-before or after the wasted GPU work.
+not a new reason or counter. `character.name` is in scope at both the upfront
+site and the write-time call site (`cast-design.ts:555`), and the existing
+`break` at `:560` is unaffected (it sits inside the `for (;;)` retry loop
+above the persist call, not inside the outcome branch this spec adds).
 
 ## Mechanism
 
 ### Book-scoped branch (no `seriesFilter`, `qwen-voice.ts:200-208`)
 
-Already re-reads fresh inside its own `withCastLock`. Add a
+Unchanged from the series question above — there is no series to scan for a
+standalone book. Already re-reads fresh inside its own `withCastLock`. Add a
 `characterHasClonedSlot(freshCharacter)` re-check immediately before
-`addVariant`. On a positive: skip the write entirely (no idempotent-rewrite
-concern here, unlike the shared-walker branch below — there is no walker
-forcing an unconditional write in this branch), and return `{applied: false,
-skippedClone: true}`.
+`addVariant`. On a positive: skip the write entirely and return
+`'skippedClone'`. Otherwise apply and return `'applied'`. The existing `if
+(!fresh || idx === -1) return;` at `:203` returns `'notFound'`.
 
 ### Series branch (`forEachMatchingCastCharacter`, `qwen-voice.ts:168-189`)
 
-Do **not** change `forEachMatchingCastCharacter`'s shared signature — same
-reasoning as the `voices.ts` sibling: it is also used by
-`applyOverrideToCastFiles` and `ensureCharacterVoiceUuid`'s `stamp`, neither of
-which has anything to do with clone-consent, and round 2 of that sibling's
-review found a `guard`-parameter approach on the shared walker entangled
-those unrelated callers.
-
-Wrap the mutate closure passed into the walker:
-
 ```ts
-const skipped: Array<{ bookDir: string; characterId: string; reason: string }> = [];
-await forEachMatchingCastCharacter(character.voiceId ?? character.id, seriesFilter, (c, bookDir) => {
+const baseVoiceId = qwenStorageKey(character, characterId);
+
+const stillCloned = await hasClonedSlotAmongMatches(character.voiceId ?? character.id, seriesFilter);
+if (stillCloned) return 'skippedClone';
+
+let residualSkip = false;
+const updated = await forEachMatchingCastCharacter(character.voiceId ?? character.id, seriesFilter, (c) => {
   if (characterHasClonedSlot(c)) {
-    skipped.push({ bookDir, characterId: c.id, reason: 'already_cloned' });
-    return c; // unchanged — harmless idempotent rewrite, same as the voices.ts sibling
+    residualSkip = true;
+    return c; // unchanged — this book's own write correctly declined
   }
   return addVariant(c, baseVoiceId);
 });
+if (residualSkip) {
+  console.warn(
+    `[persistEmotionVariant] residual-window skip: a clone appeared on a linked book for ${characterId} between the series-wide scan and this walk reaching it (${updated} book(s) still received the variant).`,
+  );
+}
+return updated > 0 ? 'applied' : 'notFound';
 ```
 
-(Note: `forEachMatchingCastCharacter`'s mutate signature is currently
-`(character: CastCharacter) => CastCharacter` and does not pass `bookDir` to
-the closure. This spec's closure needs it to build the `skipped` entries. The
-implementation task must check whether the closure can capture `bookDir` from
-its own enclosing loop some other way, or whether the walker needs a minimal,
-backward-compatible signature extension — e.g. an optional second callback
-parameter — that the two *other* callers can simply ignore. Either resolution
-is acceptable; picking one is implementation, not a design decision, since it
-doesn't change either caller's observable behaviour.)
+`hasClonedSlotAmongMatches` needs importing into `qwen-voice.ts` alongside the
+existing `forEachMatchingCastCharacter` import (`qwen-voice.ts:47`).
 
-After the walk, `persistEmotionVariant` determines its own return value by
-checking whether `(bookDir, characterId)` — its own parameters — appear in
-`skipped`:
+### JSON route (`qwen-voice.ts:600-605` upfront, `:671` write-time)
+
+Upfront (moved after `isStandalone`/`seriesInfo`, per §2):
 
 ```ts
-const own = skipped.find((s) => s.bookDir === bookDir && s.characterId === characterId);
-return { applied: !own, skippedClone: !!own };
+const isStandalone = located.state?.isStandalone === true;
+const seriesInfo = isStandalone ? null : await findAuthorSeriesForBookId(bookId);
+if (emotion && await hasClonedSlotAmongMatches(character.voiceId ?? character.id, seriesInfo ?? undefined)) {
+  return res.status(409).json({
+    error: clonedVariantRefusal(character.name ?? characterId),
+    code: 'clone_protected',
+  });
+}
 ```
 
-### JSON route (`qwen-voice.ts:683`)
+Write-time:
 
 ```ts
-const result = await persistEmotionVariant(bookDir, characterId, emotion, voiceId, seriesInfo ?? undefined);
-if (result.skippedClone) {
+const outcome = await persistEmotionVariant(bookDir, characterId, emotion, voiceId, seriesInfo ?? undefined);
+if (outcome === 'skippedClone') {
   return res.status(409).json({ error: clonedVariantRefusal(character.name ?? characterId), code: 'clone_protected' });
 }
 ```
 
-Same message/code as the existing upfront check at line 612 — this makes it
-reachable at write time too, instead of the current silent no-recheck.
+The frontend consumer (`src/components/emotion-variant-designer.tsx`'s
+`designOne`, lines 145-167) catches any thrown error generically (`catch (e) {
+setError(...) }`) with no assumption about *when* the error arrives relative
+to GPU progress, so a 409 landing after a previously-always-200 GPU
+round-trip needs no frontend change to avoid crashing. With §2's upfront fix,
+the *routine* sibling-cloned case never reaches that point at all — it 409s
+immediately, before `designOne` even starts its GPU round.
 
-### SSE bulk job (`cast-design.ts:555`)
+**Noted, not fixed here — a frontend visibility gap for the *residual*
+case only.** That same component's `designAll` (`:190-193`) awaits `designOne`
+per emotion in sequence, and each iteration's `setError(null)` (`:147`)
+clears the previous emotion's error before its own attempt starts — so a
+`clone_protected` 409 on one emotion is overwritten by the next emotion's
+attempt before the user can read it. With §2's fix in place, this only
+matters for the residual-window case (§3) or a genuine mid-GPU-synthesis
+clone (§1's original TOCTOU) — no longer the routine "already cloned
+elsewhere" case, which now 409s before `designAll`'s loop does any GPU work
+per emotion. Flagging as a smaller-scope UI follow-up than v4 identified:
+fixing it needs its own UI decision (a persistent per-emotion error list vs.
+a toast vs. something else) that a backend consent-gate spec shouldn't make
+unilaterally.
+
+### SSE bulk job (`cast-design.ts:430-440` upfront, `:555` write-time)
+
+Upfront:
 
 ```ts
-const result = await persistEmotionVariant(job.bookDir, characterId, emotion, voiceId, seriesFilter);
-if (result.skippedClone) {
+if (await hasClonedSlotAmongMatches(character.voiceId ?? character.id, seriesFilter)) {
+  job.skipped += 1;
+  job.clonedSkips.push({ characterId, name: character.name ?? characterId });
+  broadcast(job, { type: 'character_skipped', characterId, name: character.name ?? characterId, reason: 'already_cloned' });
+  continue;
+}
+```
+
+Write-time:
+
+```ts
+const outcome = await persistEmotionVariant(job.bookDir, characterId, emotion, voiceId, seriesFilter);
+if (outcome === 'skippedClone') {
   job.skipped += 1;
   job.clonedSkips.push({ characterId, name: character.name ?? characterId });
   broadcast(job, { type: 'character_skipped', characterId, name: character.name ?? characterId, reason: 'already_cloned' });
@@ -146,62 +443,112 @@ if (result.skippedClone) {
 
 ## What this does not claim
 
-- No cross-book atomicity for the propagation as a whole. A concurrent
-  redesign of the *source* character between `persistEmotionVariant`'s
-  unlocked outer read (`qwen-voice.ts:185`, `baseVoiceId`) and a given target
-  book's write still propagates the OLD key — this is the existing `I4`
-  staleness window, already tracked on #2006, not addressed here.
+- **Not fully atomic.** The residual window between `hasClonedSlotAmongMatches`
+  passing and the walk reaching each book is real, though far smaller than the
+  window this spec closes (GPU-synthesis duration → this function's own walk
+  duration). A true atomic veto needs #2000 §3.2's workspace-lock reopened —
+  out of scope here, named explicitly rather than silently accepted, per the
+  user's own decision above.
+- The residual-window case is logged (`console.warn`), not surfaced to either
+  caller's user-facing outcome — see §3's rationale for why that's a
+  deliberate, narrower disclosure than full per-book reporting, not an
+  oversight.
+- A concurrent redesign of the *source* character between
+  `persistEmotionVariant`'s unlocked outer read (`qwen-voice.ts:185`,
+  `baseVoiceId`) and a given target book's write still propagates the OLD key
+  — the existing `I4` staleness window, already tracked on #2006, not
+  addressed here.
+- Does not tear down the just-minted artifact on refusal — see the rationale
+  above.
+- Does not purge the cached audition MP3 in any case (pre-existing gap,
+  shared with the redesign-invalidation path).
+- Does not change the frontend's own book-local `cloned` gate
+  (`emotion-variant-designer.tsx:125-127`) to be series-aware — see §2.
+- Does not fix the frontend's error-visibility gap for the residual/TOCTOU
+  case in a `designAll` run (flagged above as a follow-up, not fixed here).
 - Does not address `cast-design.ts`'s base-voice path
   (`applyOverrideToCastFiles`), `cast-link-prior.ts`, or the `voiceUuid`
   double-mint.
-- Does not change `#2000` §3.2's lock-granularity decision.
+- Does not change `#2000` §3.2's lock-granularity decision — reopening it for
+  full atomicity is named as a real, larger option above, not taken here.
+- **Does not revisit whether `voices.ts`'s own write-time re-check (the
+  finalized sibling design, `2026-08-22-...md`) should also become
+  series-wide.** That design's per-book re-check has a materially different
+  risk profile than this one had in v1-v3: a base-voice *override* is
+  deliberately about not silently retargeting a book's *own* existing clone
+  marker away, not about whether a design action anywhere in the series should
+  be gated by a clone anywhere in the series. Whether the same series-wide
+  reasoning applies there is a question for that spec's own author, not
+  answered here — flagging it as a question worth asking, not a finding
+  against that document.
 
 ## Noted, not fixed here — a gap in the `voices.ts` sibling design
 
 `applyOverrideToCastFiles` (`voices.ts:875`, current signature
 `Promise<number>`) has a **third call site** the sibling design doc
-(`2026-08-22-clone-consent-voices-override-refusal-design.md`) does not
-account for: `cast-design.ts:544`, the SSE bulk job's own base-voice path. That
-doc lists only `voices.ts:731` and `single-design.ts:179` as call sites needing
-the signature-change update. When that sibling spec is implemented,
-`cast-design.ts:544` will need the same `{updated, skipped}`-aware handling
-this spec gives `persistEmotionVariant`'s call sites — otherwise it silently
-narrows to reading a stale `number` shape (or a type error, depending on how
-the signature changes). Flagging here since this design pass is what surfaced
-it; the sibling spec's author should decide whether to amend that document or
-handle it as an implementation-time addendum.
+(`2026-08-22-clone-consent-voices-override-refusal-design.md`) scopes out but
+whose consequence is worth naming precisely: `cast-design.ts:544-549`
+discards the function's return value entirely today (`await
+applyOverrideToCastFiles(...)`, then unconditionally `job.done += 1;
+broadcast(... 'character_designed' ...)`). Once that sibling spec's
+`{updated, skipped}` signature ships, this call site will **silently report
+`character_designed` for a base-voice write the new signature refused** — no
+type error, since discarding a changed return type compiles cleanly. The
+decision the sibling spec's implementation needs to make: should
+`cast-design.ts:544` route a non-empty `skipped` into `job.clonedSkips` the
+same way this spec's variant branch does, or something else? Naming that
+question is this note's job; deciding it belongs to whoever implements the
+sibling spec.
 
 ## Testing
 
 Paired tests for `persistEmotionVariant`:
 
-1. Book-scoped, no clone — `applied: true`, `skippedClone: false`, variant
-   slot recorded.
-2. Book-scoped, clone injected between the function's entry and its own
-   `withCastLock` re-read (direct cast.json manipulation inside the lock
-   window, not before the call starts) — `applied: false, skippedClone: true`,
-   no field mutation.
-3. Series-scoped, two+ linked books, no clones — both get the variant,
-   `applied: true` for the caller's own book.
-4. Series-scoped, clone injected into a **different** linked book (not the
-   caller's own) between the walk's start and that book's own write — that
-   book's write is skipped (verify via direct read of that book's cast.json
-   after the call), while the caller's own book still gets `applied: true` —
-   proves the per-book independence gap (problem #2 above) is closed, not just
-   the TOCTOU window.
-5. Series-scoped, clone injected into the caller's OWN linked book — `applied:
-   false, skippedClone: true` for the caller.
-6. Mutation-verified: deleting the write-time predicate re-check in either
-   branch must turn tests 2/4/5 red (the clone gets silently overwritten
-   instead of skipped), with the observed failure output captured.
+1. Book-scoped, no clone — `'applied'`, variant slot recorded.
+2. Book-scoped, clone present at call time — `'skippedClone'`, no field
+   mutation. (The achievable race window is between the unlocked read at
+   `:151` and lock acquisition at `:200` — a concurrent writer respecting
+   `withCastLock` cannot land inside the lock's own critical section by
+   definition, so this test injects the clone before the call. For the
+   genuine concurrent-write race, follow the existing pattern at
+   `qwen-voice.test.ts:1632-1640`.)
+3. Series-scoped, two+ linked books, no clones anywhere — all get the
+   variant, `'applied'`.
+4. Series-scoped, clone present on a **different** linked book (not the
+   caller's own) at call time — `'skippedClone'` for the caller, and **no
+   book gets the variant, including the un-cloned ones** (verify via direct
+   read of every matched book's cast.json).
+5. Series-scoped, clone present on the caller's OWN linked book, siblings not
+   cloned — `'skippedClone'`, same series-wide no-write assertion as test 4.
+6. Series-scoped, no confirmed-cast book matches at all (e.g. every candidate
+   fails `state.castConfirmed`) — `'notFound'`, distinguishing this from
+   `'applied'` via the walker's own returned count being `0`.
+7. Series-scoped, residual-window case: clone appears on one linked book
+   *after* `hasClonedSlotAmongMatches` has already returned `false` but
+   *before* the walk reaches that specific book (inject directly, simulating
+   a race the fresh scan couldn't see) — that one book's write is skipped by
+   the closure's defensive re-check, `persistEmotionVariant` still returns
+   `'applied'` (since `updated > 0` from the other matched books), and
+   `console.warn` is called with a message naming the character.
+8. Mutation-verified: deleting the write-time predicate re-check (either the
+   series-wide scan call, or the per-book closure backstop) must turn the
+   corresponding test red, with the observed failure output captured.
 
 Paired tests for the two call sites:
 
-7. JSON route: mock `persistEmotionVariant` to return `skippedClone: true` —
-   assert 409 `clone_protected` with the existing `clonedVariantRefusal`
-   message.
-8. SSE bulk job: mock the same — assert `job.skipped` incremented,
-   `job.clonedSkips` gains the entry, and the broadcast event matches the
-   existing upfront-skip shape exactly (same `type`/`reason` fields) so the
-   frontend's existing handling (`src/store/cast-design-stream-middleware.ts`)
-   needs no changes.
+9. JSON route, upfront: character not cloned in this book but cloned on a
+   sibling — asserts a 409 `clone_protected` **before** `designQwenVoiceForCharacter`
+   is called at all (mock it and assert zero invocations) — this is the test
+   that pins §2's fix and would have failed on v4.
+10. JSON route, write-time: mock `persistEmotionVariant` to return
+    `'skippedClone'` — assert 409 `clone_protected` with the (new, §4) message.
+11. SSE bulk job, upfront: same sibling-cloned setup — asserts `job.skipped`
+    incremented and `job.clonedSkips` gains the entry **before** any GPU design
+    call for that character (mock `designQwenVoiceForCharacter` and assert zero
+    invocations for that character).
+12. SSE bulk job, write-time: mock `persistEmotionVariant` to return
+    `'skippedClone'` — assert `job.skipped` incremented, `job.clonedSkips`
+    gains the entry, and the broadcast event matches the existing
+    upfront-skip shape exactly (same `type`/`reason` fields) so the frontend's
+    existing handling (`src/store/cast-design-stream-middleware.ts`) needs no
+    changes.

--- a/docs/superpowers/specs/2026-08-26-clone-consent-qwen-voice-refusal-design.md
+++ b/docs/superpowers/specs/2026-08-26-clone-consent-qwen-voice-refusal-design.md
@@ -1,0 +1,207 @@
+---
+status: draft
+---
+
+# `qwen-voice.ts` clone-consent refusal: write-time re-check (part of #2006 / srv-81)
+
+Sibling to `2026-08-22-clone-consent-voices-override-refusal-design.md`, which
+resolves the `voices.ts`/`single-design.ts` gate. **This spec resolves the third
+gate: `persistEmotionVariant` (`server/src/routes/qwen-voice.ts:144-209`),
+shared by the JSON `design-voice` route and the SSE bulk "Design full cast"
+job.** It does not touch `cast-design.ts`'s base-voice path
+(`applyOverrideToCastFiles`), `cast-link-prior.ts`, or the `voiceUuid`
+double-mint — those remain exactly as open as #2006's history already
+recorded them.
+
+## The problem, restated after reading the current code
+
+The issue as filed frames this as one TOCTOU gap (read-then-decide in one
+scope, write in another). Reading the code surfaces a second, independent gap
+in the same function that the write-time fix below closes for free:
+
+1. **TOCTOU.** Both callers check `characterHasClonedSlot` once, before the
+   (slow) GPU design call, then call `persistEmotionVariant` afterward with no
+   re-check. A clone can land on the character during GPU synthesis and the
+   stale decision persists anyway.
+2. **Propagation never checks clone status per target book at all.**
+   `persistEmotionVariant`'s `seriesFilter` branch propagates the variant to
+   every linked-cast character across the series via
+   `forEachMatchingCastCharacter`'s mutate closure (`qwen-voice.ts:186-188`),
+   unconditionally. Only the *originating* book's character was ever checked
+   (once, by the caller, upfront) — a sibling book where the same linked
+   character carries its own independent cloned slot gets the variant applied
+   regardless.
+
+A per-book write-time predicate re-check, done the way the `voices.ts` sibling
+does it, fixes both: it closes the TOCTOU window, and because it runs inside
+the walker's mutate closure it naturally re-evaluates *each* target book's own
+current clone status rather than the source's.
+
+## The decision this spec finalizes
+
+**Signal shape: return-value tracking, not a thrown error** — matching the
+`voices.ts` sibling exactly, for the same reason: neither caller needs to
+unwind normal control flow to react to a refusal, and a new error class would
+be one more entry in this file's already-dense error-mapping surface.
+
+`persistEmotionVariant` changes from `Promise<void>` to:
+
+```ts
+Promise<{ applied: boolean; skippedClone: boolean }>
+```
+
+`applied`/`skippedClone` reflect **only the caller's own `(bookDir,
+characterId)`** — not the aggregate across the whole series propagation. This
+mirrors the `single-design.ts` sibling's collapse-to-single-book approach:
+neither caller here has (or needs) infrastructure to report per-linked-book
+detail; each only acts on its own book's outcome.
+
+**Bulk-job skip channel: reused, not new.** When the SSE job's write-time
+re-check catches a clone that appeared during GPU synthesis, it reports
+through the *exact same* channel as today's upfront skip —
+`job.skipped += 1; job.clonedSkips.push({characterId, name}); broadcast(job,
+{type: 'character_skipped', characterId, name, reason: 'already_cloned'})` —
+not a new reason or counter. The user-visible meaning ("this character kept
+its clone, no variant applied") is identical whether the clone was caught
+before or after the wasted GPU work.
+
+## Mechanism
+
+### Book-scoped branch (no `seriesFilter`, `qwen-voice.ts:200-208`)
+
+Already re-reads fresh inside its own `withCastLock`. Add a
+`characterHasClonedSlot(freshCharacter)` re-check immediately before
+`addVariant`. On a positive: skip the write entirely (no idempotent-rewrite
+concern here, unlike the shared-walker branch below — there is no walker
+forcing an unconditional write in this branch), and return `{applied: false,
+skippedClone: true}`.
+
+### Series branch (`forEachMatchingCastCharacter`, `qwen-voice.ts:168-189`)
+
+Do **not** change `forEachMatchingCastCharacter`'s shared signature — same
+reasoning as the `voices.ts` sibling: it is also used by
+`applyOverrideToCastFiles` and `ensureCharacterVoiceUuid`'s `stamp`, neither of
+which has anything to do with clone-consent, and round 2 of that sibling's
+review found a `guard`-parameter approach on the shared walker entangled
+those unrelated callers.
+
+Wrap the mutate closure passed into the walker:
+
+```ts
+const skipped: Array<{ bookDir: string; characterId: string; reason: string }> = [];
+await forEachMatchingCastCharacter(character.voiceId ?? character.id, seriesFilter, (c, bookDir) => {
+  if (characterHasClonedSlot(c)) {
+    skipped.push({ bookDir, characterId: c.id, reason: 'already_cloned' });
+    return c; // unchanged — harmless idempotent rewrite, same as the voices.ts sibling
+  }
+  return addVariant(c, baseVoiceId);
+});
+```
+
+(Note: `forEachMatchingCastCharacter`'s mutate signature is currently
+`(character: CastCharacter) => CastCharacter` and does not pass `bookDir` to
+the closure. This spec's closure needs it to build the `skipped` entries. The
+implementation task must check whether the closure can capture `bookDir` from
+its own enclosing loop some other way, or whether the walker needs a minimal,
+backward-compatible signature extension — e.g. an optional second callback
+parameter — that the two *other* callers can simply ignore. Either resolution
+is acceptable; picking one is implementation, not a design decision, since it
+doesn't change either caller's observable behaviour.)
+
+After the walk, `persistEmotionVariant` determines its own return value by
+checking whether `(bookDir, characterId)` — its own parameters — appear in
+`skipped`:
+
+```ts
+const own = skipped.find((s) => s.bookDir === bookDir && s.characterId === characterId);
+return { applied: !own, skippedClone: !!own };
+```
+
+### JSON route (`qwen-voice.ts:683`)
+
+```ts
+const result = await persistEmotionVariant(bookDir, characterId, emotion, voiceId, seriesInfo ?? undefined);
+if (result.skippedClone) {
+  return res.status(409).json({ error: clonedVariantRefusal(character.name ?? characterId), code: 'clone_protected' });
+}
+```
+
+Same message/code as the existing upfront check at line 612 — this makes it
+reachable at write time too, instead of the current silent no-recheck.
+
+### SSE bulk job (`cast-design.ts:555`)
+
+```ts
+const result = await persistEmotionVariant(job.bookDir, characterId, emotion, voiceId, seriesFilter);
+if (result.skippedClone) {
+  job.skipped += 1;
+  job.clonedSkips.push({ characterId, name: character.name ?? characterId });
+  broadcast(job, { type: 'character_skipped', characterId, name: character.name ?? characterId, reason: 'already_cloned' });
+} else {
+  job.done += 1;
+  broadcast(job, { type: 'variant_designed', characterId, emotion, voiceId,
+    ...(fellBackToDesignVoice ? { viaFallback: true, fallbackReason } : {}) });
+}
+```
+
+## What this does not claim
+
+- No cross-book atomicity for the propagation as a whole. A concurrent
+  redesign of the *source* character between `persistEmotionVariant`'s
+  unlocked outer read (`qwen-voice.ts:185`, `baseVoiceId`) and a given target
+  book's write still propagates the OLD key — this is the existing `I4`
+  staleness window, already tracked on #2006, not addressed here.
+- Does not address `cast-design.ts`'s base-voice path
+  (`applyOverrideToCastFiles`), `cast-link-prior.ts`, or the `voiceUuid`
+  double-mint.
+- Does not change `#2000` §3.2's lock-granularity decision.
+
+## Noted, not fixed here — a gap in the `voices.ts` sibling design
+
+`applyOverrideToCastFiles` (`voices.ts:875`, current signature
+`Promise<number>`) has a **third call site** the sibling design doc
+(`2026-08-22-clone-consent-voices-override-refusal-design.md`) does not
+account for: `cast-design.ts:544`, the SSE bulk job's own base-voice path. That
+doc lists only `voices.ts:731` and `single-design.ts:179` as call sites needing
+the signature-change update. When that sibling spec is implemented,
+`cast-design.ts:544` will need the same `{updated, skipped}`-aware handling
+this spec gives `persistEmotionVariant`'s call sites — otherwise it silently
+narrows to reading a stale `number` shape (or a type error, depending on how
+the signature changes). Flagging here since this design pass is what surfaced
+it; the sibling spec's author should decide whether to amend that document or
+handle it as an implementation-time addendum.
+
+## Testing
+
+Paired tests for `persistEmotionVariant`:
+
+1. Book-scoped, no clone — `applied: true`, `skippedClone: false`, variant
+   slot recorded.
+2. Book-scoped, clone injected between the function's entry and its own
+   `withCastLock` re-read (direct cast.json manipulation inside the lock
+   window, not before the call starts) — `applied: false, skippedClone: true`,
+   no field mutation.
+3. Series-scoped, two+ linked books, no clones — both get the variant,
+   `applied: true` for the caller's own book.
+4. Series-scoped, clone injected into a **different** linked book (not the
+   caller's own) between the walk's start and that book's own write — that
+   book's write is skipped (verify via direct read of that book's cast.json
+   after the call), while the caller's own book still gets `applied: true` —
+   proves the per-book independence gap (problem #2 above) is closed, not just
+   the TOCTOU window.
+5. Series-scoped, clone injected into the caller's OWN linked book — `applied:
+   false, skippedClone: true` for the caller.
+6. Mutation-verified: deleting the write-time predicate re-check in either
+   branch must turn tests 2/4/5 red (the clone gets silently overwritten
+   instead of skipped), with the observed failure output captured.
+
+Paired tests for the two call sites:
+
+7. JSON route: mock `persistEmotionVariant` to return `skippedClone: true` —
+   assert 409 `clone_protected` with the existing `clonedVariantRefusal`
+   message.
+8. SSE bulk job: mock the same — assert `job.skipped` incremented,
+   `job.clonedSkips` gains the entry, and the broadcast event matches the
+   existing upfront-skip shape exactly (same `type`/`reason` fields) so the
+   frontend's existing handling (`src/store/cast-design-stream-middleware.ts`)
+   needs no changes.

--- a/docs/superpowers/specs/2026-08-26-clone-consent-qwen-voice-refusal-design.md
+++ b/docs/superpowers/specs/2026-08-26-clone-consent-qwen-voice-refusal-design.md
@@ -462,8 +462,6 @@ if (outcome === 'skippedClone') {
   above.
 - Does not purge the cached audition MP3 in any case (pre-existing gap,
   shared with the redesign-invalidation path).
-- Does not change the frontend's own book-local `cloned` gate
-  (`emotion-variant-designer.tsx:125-127`) to be series-aware — see §2.
 - Does not fix the frontend's error-visibility gap for the residual/TOCTOU
   case in a `designAll` run (flagged above as a follow-up, not fixed here).
 - Does not address `cast-design.ts`'s base-voice path
@@ -471,34 +469,33 @@ if (outcome === 'skippedClone') {
   double-mint.
 - Does not change `#2000` §3.2's lock-granularity decision — reopening it for
   full atomicity is named as a real, larger option above, not taken here.
-- **Does not revisit whether `voices.ts`'s own write-time re-check (the
-  finalized sibling design, `2026-08-22-...md`) should also become
-  series-wide.** That design's per-book re-check has a materially different
-  risk profile than this one had in v1-v3: a base-voice *override* is
-  deliberately about not silently retargeting a book's *own* existing clone
-  marker away, not about whether a design action anywhere in the series should
-  be gated by a clone anywhere in the series. Whether the same series-wide
-  reasoning applies there is a question for that spec's own author, not
-  answered here — flagging it as a question worth asking, not a finding
-  against that document.
 
-## Noted, not fixed here — a gap in the `voices.ts` sibling design
+## Resolved via the `voices.ts` sibling design (v2)
 
-`applyOverrideToCastFiles` (`voices.ts:875`, current signature
-`Promise<number>`) has a **third call site** the sibling design doc
-(`2026-08-22-clone-consent-voices-override-refusal-design.md`) scopes out but
-whose consequence is worth naming precisely: `cast-design.ts:544-549`
-discards the function's return value entirely today (`await
-applyOverrideToCastFiles(...)`, then unconditionally `job.done += 1;
-broadcast(... 'character_designed' ...)`). Once that sibling spec's
-`{updated, skipped}` signature ships, this call site will **silently report
-`character_designed` for a base-voice write the new signature refused** — no
-type error, since discarding a changed return type compiles cleanly. The
-decision the sibling spec's implementation needs to make: should
-`cast-design.ts:544` route a non-empty `skipped` into `job.clonedSkips` the
-same way this spec's variant branch does, or something else? Naming that
-question is this note's job; deciding it belongs to whoever implements the
-sibling spec.
+Three questions this spec originally left open for the sibling's own author
+are now decided by the user and implemented in
+`2026-08-22-clone-consent-voices-override-refusal-design.md`'s v2 revision —
+noted here rather than left dangling as still-open follow-ups:
+
+- **The sibling's own write-time re-check is now series-wide too**, using the
+  same `hasClonedSlotAmongMatches`-fresh-scan model this spec uses, not the
+  narrower per-book independent check v1 of that document chose. See that
+  document's "Revision note (v2)".
+- **`cast-design.ts:544`'s base-voice call site now mirrors this spec's
+  variant branch** — its previously-discarded `{updated, skipped}` return
+  routes into the same `job.clonedSkips`/`character_skipped` channel. See
+  that document's "Signature change" section.
+- **The frontend's book-local `cloned` gate — in both
+  `emotion-variant-designer.tsx:125-127` (this spec's own frontend consumer)
+  and `profile-drawer.tsx:1102-1111` (the sibling's) — is upgraded to a new
+  `clonedElsewhereInSeries` field**, computed via the same
+  `hasClonedSlotAmongMatches` function, rather than staying book-local. See
+  that document's "Frontend series-awareness" section for the field, the
+  call-site diffs, and the reworded user-facing copy. This spec's own
+  §"Upfront checks" note above ("does not change the frontend gate") is
+  superseded by that section — the frontend gate does change, just via the
+  sibling document rather than this one, since the same field serves both
+  consumers.
 
 ## Testing
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2138,8 +2138,50 @@ paths:
           description: Override written (or cleared) on every matching cast.json entry
         '400':
           description: Body is missing or malformed (override must be a BaseVoice or null)
+        '200':
+          description: >-
+            Applied to at least one linked character, but at least one other
+            linked character was skipped (a residual-window clone, or —
+            pre-existing — a same-book conflict). See `skipped`.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [updated, skipped]
+                properties:
+                  updated: { type: integer }
+                  skipped:
+                    type: array
+                    items:
+                      type: object
+                      required: [bookDir, characterId, reason]
+                      properties:
+                        bookDir: { type: string }
+                        characterId: { type: string }
+                        reason: { type: string }
         '404':
           description: No character with that voiceId exists in any confirmed cast
+        '409':
+          description: >-
+            Refused entirely — a consented cloned voice exists on this
+            linked character somewhere in the series (or, for a SET, on a
+            different clone-capable engine). No book was written.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [error]
+                properties:
+                  error: { type: string }
+                  skipped:
+                    type: array
+                    items:
+                      type: object
+                      required: [bookDir, characterId, reason]
+                      properties:
+                        bookDir: { type: string }
+                        characterId: { type: string }
+                        reason: { type: string }
 
   # --- Voice library (fs-38 Wave 1) --------------------------------
   /api/voice-library:

--- a/server/src/routes/cast-design.ts
+++ b/server/src/routes/cast-design.ts
@@ -541,12 +541,20 @@ async function runDesignJob(
                ONLY this book instead of sweeping every book in the workspace
                sharing the same bare character id (e.g. "narrator"). */
             const matchKey = character.voiceId ?? character.id;
-            await applyOverrideToCastFiles(
+            const overrideResult = await applyOverrideToCastFiles(
               matchKey,
               { engine: 'qwen', name: voiceId },
               seriesFilter,
               job.bookDir,
             );
+            /* Series-wide veto: a cloned slot exists somewhere in the scope.
+               Refuse the propagation and report this character as failed —
+               the UI will surface the refusal. */
+            if (overrideResult.skipped.length > 0) {
+              throw new Error(
+                `Propagation refused: a cloned slot already occupies this voice (${overrideResult.skipped.length} book(s) skipped).`,
+              );
+            }
             job.done += 1;
             broadcast(job, { type: 'character_designed', characterId, voiceId });
           } else {

--- a/server/src/routes/single-design.test.ts
+++ b/server/src/routes/single-design.test.ts
@@ -28,7 +28,7 @@ vi.mock('./qwen-voice.js', async (orig) => ({
   }),
 }));
 
-const applyOverrideStub = vi.fn(async () => 1);
+const applyOverrideStub = vi.fn(async () => ({ updated: 1, skipped: [] }));
 vi.mock('./voices.js', async (orig) => {
   const real = await orig<typeof import('./voices.js')>();
   return {
@@ -125,7 +125,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   applyOverrideStub.mockReset();
-  applyOverrideStub.mockResolvedValue(1);
+  applyOverrideStub.mockResolvedValue({ updated: 1, skipped: [] });
   writeBookOnDisk(bookDir, BOOK_ID);
 });
 

--- a/server/src/routes/single-design.ts
+++ b/server/src/routes/single-design.ts
@@ -176,12 +176,20 @@ async function runSingleDesign(
        book instead of sweeping every book in the workspace sharing the
        same bare character id (e.g. "narrator"). */
     const matchKey = character.voiceId ?? character.id;
-    await applyOverrideToCastFiles(
+    const overrideResult = await applyOverrideToCastFiles(
       matchKey,
       { engine: 'qwen', name: voiceId },
       seriesFilter,
       job.bookDir,
     );
+    /* Series-wide veto: a cloned slot exists somewhere in the scope.
+       Refuse the propagation and report this character as failed —
+       the UI will surface the refusal. */
+    if (overrideResult.skipped.length > 0) {
+      throw new Error(
+        `Propagation refused: a cloned slot already occupies this voice (${overrideResult.skipped.length} book(s) skipped).`,
+      );
+    }
     endJob(job, {
       type: 'designed',
       characterId: job.characterId,

--- a/server/src/routes/voices.test.ts
+++ b/server/src/routes/voices.test.ts
@@ -2236,7 +2236,6 @@ describe('applyOverrideToCastFiles — series-wide veto (v2)', () => {
   const VETO_SERIES = 'The Amber Coast';
   const VETO_BOOK_ONE = 'First Light';
   const VETO_BOOK_TWO = 'Second Light';
-  let bookOneDir: string;
   let bookTwoDir: string;
 
   function seedVetoBooks(bookOneCloned: boolean, bookTwoCloned: boolean) {
@@ -2249,7 +2248,7 @@ describe('applyOverrideToCastFiles — series-wide veto (v2)', () => {
       },
       { id: 'uncloned', name: 'Uncloned', voiceId: 'uncloned-voice-id' },
     ];
-    bookOneDir = writeBookOnDisk(
+    writeBookOnDisk(
       workspaceRoot, VETO_AUTHOR, VETO_SERIES, VETO_BOOK_ONE, 'book-veto-one',
       charFor(bookOneCloned),
     );

--- a/server/src/routes/voices.test.ts
+++ b/server/src/routes/voices.test.ts
@@ -51,6 +51,7 @@ const BETA_AUTHOR = 'Beta Author';
 const BETA_TITLE = 'Beta Book';
 const ALPHA_QWEN_OVERRIDE_NAME = 'qwen-ALPHAUUID1';
 const BETA_QWEN_OVERRIDE_NAME = 'qwen-BETAUUID1';
+const SCOPE_TEST_AUTHOR = 'Ines Halvorsen';
 
 let workspaceRoot: string;
 let app: Express;
@@ -63,6 +64,7 @@ let applyTierToCastFiles: (
   seriesFilter?: { author: string; series: string },
 ) => Promise<number>;
 let applyOverrideToCastFiles: typeof import('./voices.js').applyOverrideToCastFiles;
+let hasClonedSlotAmongMatches: typeof import('./voices.js').hasClonedSlotAmongMatches;
 let writeVoiceStylePersona: typeof import('./cast-design.js').writeVoiceStylePersona;
 let standaloneA: { bookDir: string };
 let standaloneB: { bookDir: string };
@@ -144,13 +146,14 @@ beforeAll(async () => {
   workspaceRoot = mkdtempSync(join(tmpdir(), 'audiobook-voices-test-'));
   process.env.WORKSPACE_DIR = workspaceRoot;
 
-  const { voicesRouter, applyTierToCastFiles: atcf, applyOverrideToCastFiles: aotcf } =
+  const { voicesRouter, applyTierToCastFiles: atcf, applyOverrideToCastFiles: aotcf, hasClonedSlotAmongMatches: hcsam } =
     await import('./voices.js');
   const paths = await import('../workspace/paths.js');
   const baseVoices = await import('../tts/base-voices.js');
   const castDesign = await import('./cast-design.js');
   applyTierToCastFiles = atcf;
   applyOverrideToCastFiles = aotcf;
+  hasClonedSlotAmongMatches = hcsam;
   writeVoiceStylePersona = castDesign.writeVoiceStylePersona;
   invalidateBaseVoiceCache = baseVoices.invalidateBaseVoiceCache;
   bookOneId = paths.makeBookId(AUTHOR, SERIES, BOOK_ONE);
@@ -2183,5 +2186,32 @@ describe('#1981 Task 9 — forEachMatchingCastCharacter locks per book', () => {
         ?.name,
     ).toBe('qwen-hoist-check');
     expect(targetNarrator.voiceStyle).toBe('a hoist-check persona');
+  });
+});
+
+it('hasClonedSlotAmongMatches is exported for reuse by qwen-voice.ts and single-design.ts', async () => {
+  const mod = await import('./voices.js');
+  expect(typeof mod.hasClonedSlotAmongMatches).toBe('function');
+});
+
+describe('hasClonedSlotAmongMatches — onlyBookDir scope (found under review)', () => {
+  let bookOneDir: string;
+
+  beforeEach(() => {
+    bookOneDir = writeBookOnDisk(
+      workspaceRoot, SCOPE_TEST_AUTHOR, 'Standalones', 'Onyx Reach', 'book-onyx',
+      [{ id: 'narrator', name: 'Narrator' }], // no clone
+      true,
+    );
+    writeBookOnDisk(
+      workspaceRoot, SCOPE_TEST_AUTHOR, 'Standalones', 'Salt Line', 'book-salt',
+      [{ id: 'narrator', name: 'Narrator', overrideTtsVoices: { coqui: { name: 'clone-x', provenance: 'cloned' } } }],
+      true,
+    );
+  });
+
+  it('with no seriesFilter but an onlyBookDir, scopes the scan to that one book — a clone in an unrelated standalone book sharing the same bare id must not cause a false refusal', async () => {
+    const result = await hasClonedSlotAmongMatches('narrator', undefined, undefined, bookOneDir);
+    expect(result).toBe(false);
   });
 });

--- a/server/src/routes/voices.test.ts
+++ b/server/src/routes/voices.test.ts
@@ -1790,13 +1790,13 @@ describe('applyOverrideToCastFiles — standalone book-scoping (fs-61)', () => {
   });
 
   it('with no seriesFilter but an onlyBookDir, touches only that book', async () => {
-    const n = await applyOverrideToCastFiles(
+    const { updated } = await applyOverrideToCastFiles(
       'narrator',
       { engine: 'qwen', name: 'qwen-standalone-a-voice' },
       undefined,
       standaloneA.bookDir,
     );
-    expect(n).toBe(1);
+    expect(updated).toBe(1);
 
     const a = readCastFromDisk(workspaceRoot, 'Castwright', 'Standalones', 'Standalone A');
     expect(
@@ -1811,7 +1811,7 @@ describe('applyOverrideToCastFiles — standalone book-scoping (fs-61)', () => {
   });
 
   it('with neither seriesFilter nor onlyBookDir, still sweeps the whole workspace (unchanged default)', async () => {
-    const n = await applyOverrideToCastFiles('narrator', {
+    const { updated } = await applyOverrideToCastFiles('narrator', {
       engine: 'qwen',
       name: 'qwen-workspace-wide',
     });
@@ -1819,9 +1819,9 @@ describe('applyOverrideToCastFiles — standalone book-scoping (fs-61)', () => {
        genuinely-global scope (only used by PUT /:voiceId/override's
        'workspace' scope) still matches every one, deliberately. (Other
        unrelated fixtures elsewhere in this file also use the bare id
-       "narrator" and share this workspace, so `n` counts more than just
+       "narrator" and share this workspace, so `updated` counts more than just
        our two — assert our two specifically, not the total.) */
-    expect(n).toBeGreaterThanOrEqual(2);
+    expect(updated).toBeGreaterThanOrEqual(2);
     const a = readCastFromDisk(workspaceRoot, 'Castwright', 'Standalones', 'Standalone A');
     const b = readCastFromDisk(workspaceRoot, 'Castwright', 'Standalones', 'Standalone B');
     expect(
@@ -1920,7 +1920,7 @@ describe('#1981 Task 9 — forEachMatchingCastCharacter locks per book', () => {
     let wrote: boolean;
     // Hoisted so the `finally` below can await them on the failure path
     // instead of leaving them orphaned and still running past the test.
-    let overridePromise: Promise<number> | undefined;
+    let overridePromise: Promise<{ updated: number; skipped: Array<{ bookDir: string; characterId: string; reason: string }> }> | undefined;
     let personaPromise: Promise<boolean> | undefined;
     try {
       overridePromise = applyOverrideToCastFiles(
@@ -1947,7 +1947,9 @@ describe('#1981 Task 9 — forEachMatchingCastCharacter locks per book', () => {
       await new Promise((r) => setTimeout(r, 50));
 
       released();
-      [n, wrote] = await Promise.all([overridePromise, personaPromise]);
+      const [overrideResult, wroteResult] = await Promise.all([overridePromise, personaPromise]);
+      n = overrideResult.updated;
+      wrote = wroteResult;
     } finally {
       // Idempotent: also fires here so a throw ANYWHERE above (before the
       // happy-path call) still releases a held `readJson` rather than
@@ -2009,7 +2011,7 @@ describe('#1981 Task 9 — forEachMatchingCastCharacter locks per book', () => {
     let wrote: boolean;
     // Hoisted so the `finally` below can await them on the failure path
     // instead of leaving them orphaned and still running past the test.
-    let walkPromise: Promise<number> | undefined;
+    let walkPromise: Promise<{ updated: number; skipped: Array<{ bookDir: string; characterId: string; reason: string }> }> | undefined;
     let personaPromise: Promise<boolean> | undefined;
     try {
       walkPromise = applyOverrideToCastFiles('narrator', {
@@ -2031,7 +2033,9 @@ describe('#1981 Task 9 — forEachMatchingCastCharacter locks per book', () => {
       await new Promise((r) => setTimeout(r, 50));
 
       released();
-      [n, wrote] = await Promise.all([walkPromise, personaPromise]);
+      const [walkResult, wroteResult] = await Promise.all([walkPromise, personaPromise]);
+      n = walkResult.updated;
+      wrote = wroteResult;
     } finally {
       // Idempotent: also fires here so a throw ANYWHERE above (before the
       // happy-path call) still releases a held `readJson` rather than
@@ -2117,7 +2121,7 @@ describe('#1981 Task 9 — forEachMatchingCastCharacter locks per book', () => {
     let writerSettled = false;
     // Hoisted so the `finally` below can await them on the failure path
     // instead of leaving them orphaned and still running past the test.
-    let walkPromise: Promise<number> | undefined;
+    let walkPromise: Promise<{ updated: number; skipped: Array<{ bookDir: string; characterId: string; reason: string }> }> | undefined;
     let writerPromise: Promise<boolean> | undefined;
     try {
       walkPromise = applyOverrideToCastFiles('narrator', {
@@ -2152,7 +2156,8 @@ describe('#1981 Task 9 — forEachMatchingCastCharacter locks per book', () => {
       expect(writerSettled).toBe(true);
 
       released();
-      n = await walkPromise;
+      const walkResult = await walkPromise;
+      n = walkResult.updated;
       await writerPromise;
     } finally {
       // Idempotent — see the finally block above for why.
@@ -2213,5 +2218,138 @@ describe('hasClonedSlotAmongMatches — onlyBookDir scope (found under review)',
   it('with no seriesFilter but an onlyBookDir, scopes the scan to that one book — a clone in an unrelated standalone book sharing the same bare id must not cause a false refusal', async () => {
     const result = await hasClonedSlotAmongMatches('narrator', undefined, undefined, bookOneDir);
     expect(result).toBe(false);
+  });
+});
+
+describe('applyOverrideToCastFiles — series-wide veto (v2)', () => {
+  /* Fresh, dedicated fixture — do NOT reuse AUTHOR/SERIES/BOOK_ONE/BOOK_TWO
+     (voices.test.ts:30-33): those books' cast.json already has fixed
+     characters (char-brann / v_brann) seeded once in this file's top-level
+     beforeAll and read by ~8 other describes; `setOverrideOnDisk` can only
+     rewrite an EXISTING character's override, it cannot mint a character
+     with a NEW voiceId like 'shared-voice-id'. This describe mints its own
+     two books via this file's `writeBookOnDisk` helper (:70-102), each
+     seeded with two characters whose ids/voiceIds this describe controls
+     directly, and rewrites both books fresh in `beforeEach` so no test can
+     leak state into another. */
+  const VETO_AUTHOR = 'Petra Solberg';
+  const VETO_SERIES = 'The Amber Coast';
+  const VETO_BOOK_ONE = 'First Light';
+  const VETO_BOOK_TWO = 'Second Light';
+  let bookOneDir: string;
+  let bookTwoDir: string;
+
+  function seedVetoBooks(bookOneCloned: boolean, bookTwoCloned: boolean) {
+    const charFor = (cloned: boolean) => [
+      {
+        id: 'shared',
+        name: 'Shared',
+        voiceId: 'shared-voice-id',
+        ...(cloned ? { overrideTtsVoices: { coqui: { name: 'clone-x', provenance: 'cloned' } } } : {}),
+      },
+      { id: 'uncloned', name: 'Uncloned', voiceId: 'uncloned-voice-id' },
+    ];
+    bookOneDir = writeBookOnDisk(
+      workspaceRoot, VETO_AUTHOR, VETO_SERIES, VETO_BOOK_ONE, 'book-veto-one',
+      charFor(bookOneCloned),
+    );
+    bookTwoDir = writeBookOnDisk(
+      workspaceRoot, VETO_AUTHOR, VETO_SERIES, VETO_BOOK_TWO, 'book-veto-two',
+      charFor(bookTwoCloned),
+    );
+  }
+
+  beforeEach(() => {
+    seedVetoBooks(false, false);
+  });
+
+  it('refuses the ENTIRE propagation when a clone exists on a sibling book, not just that book', async () => {
+    seedVetoBooks(true, false); // book one's 'shared' is cloned; book two's is not
+    const result = await applyOverrideToCastFiles(
+      'shared-voice-id',
+      { engine: 'qwen', name: 'qwen-shared' },
+      { author: VETO_AUTHOR, series: VETO_SERIES },
+    );
+    expect(result.updated).toBe(0);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].reason).toBe('already_cloned');
+    expect(result.skipped[0].bookDir).toBe('(series-wide)');
+
+    // CRITICAL: book two was NOT written either — the whole propagation was refused
+    const two = readCastFromDisk(workspaceRoot, VETO_AUTHOR, VETO_SERIES, VETO_BOOK_TWO);
+    expect(two.characters[0].overrideTtsVoices).toBeUndefined();
+  });
+
+  it('propagates normally when no clone exists anywhere in the series', async () => {
+    seedVetoBooks(false, false);
+    const result = await applyOverrideToCastFiles(
+      'shared-voice-id',
+      { engine: 'qwen', name: 'qwen-shared' },
+      { author: VETO_AUTHOR, series: VETO_SERIES },
+    );
+    expect(result.updated).toBe(2);
+    expect(result.skipped).toHaveLength(0);
+
+    const one = readCastFromDisk(workspaceRoot, VETO_AUTHOR, VETO_SERIES, VETO_BOOK_ONE);
+    const two = readCastFromDisk(workspaceRoot, VETO_AUTHOR, VETO_SERIES, VETO_BOOK_TWO);
+    expect(
+      (one.characters[0].overrideTtsVoices as Record<string, { name?: string }>)?.qwen?.name,
+    ).toBe('qwen-shared');
+    expect(
+      (two.characters[0].overrideTtsVoices as Record<string, { name?: string }>)?.qwen?.name,
+    ).toBe('qwen-shared');
+  });
+
+  it('reports the refusal with a workspace-wide sentinel when no seriesFilter is given', async () => {
+    seedVetoBooks(true, false);
+    const result = await applyOverrideToCastFiles(
+      'shared-voice-id',
+      { engine: 'qwen', name: 'qwen-shared' },
+    );
+    expect(result.updated).toBe(0);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].bookDir).toBe('(workspace-wide)');
+  });
+
+  it('catches a clone injected during the walk (residual-window backstop)', async () => {
+    /* Seeds NEITHER book cloned. Injects a clone into book two's cast
+       DURING the walk's own read of book one — so the fresh upfront scan
+       passes (nothing cloned yet) but the per-book residual backstop
+       inside the mutate closure sees the injection. */
+    seedVetoBooks(false, false);
+
+    const stateIo = await import('../workspace/state-io.js');
+    const actual = await vi.importActual<typeof import('../workspace/state-io.js')>(
+      '../workspace/state-io.js',
+    );
+    let intercepted = false;
+    const spy = vi.mocked(stateIo.readJson).mockImplementation(async (path: string) => {
+      const value = await actual.readJson(path);
+      if (!intercepted && path.includes(VETO_BOOK_ONE)) {
+        intercepted = true;
+        // Inject a clone into book two WHILE the walk is reading book one
+        const castPath = join(bookTwoDir, '.audiobook', 'cast.json');
+        const cast = JSON.parse(readFileSync(castPath, 'utf8'));
+        cast.characters[0].overrideTtsVoices = {
+          coqui: { name: 'clone-x', provenance: 'cloned' },
+        };
+        writeFileSync(castPath, JSON.stringify(cast));
+      }
+      return value;
+    });
+
+    try {
+      const result = await applyOverrideToCastFiles(
+        'shared-voice-id',
+        { engine: 'qwen', name: 'qwen-shared' },
+        { author: VETO_AUTHOR, series: VETO_SERIES },
+      );
+      expect(intercepted).toBe(true);
+      // The upfront scan passed (nothing cloned yet), but the residual
+      // backstop inside the walk caught the injection on book two
+      expect(result.skipped.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      spy.mockImplementation(actual.readJson);
+    }
   });
 });

--- a/server/src/routes/voices.ts
+++ b/server/src/routes/voices.ts
@@ -585,38 +585,58 @@ voicesRouter.put('/:voiceId/pin', async (req: Request, res: Response) => {
   }
 });
 
-/* fs-38 Wave 3c Task 4 — read-only pre-check for the clear branch below.
-   `applyOverrideToCastFiles(voiceId, null, ...)` wipes overrideTtsVoices
-   entirely for every matching character — including any OTHER engine slot
-   that carries a consented clone (`provenance: 'cloned'`), silently
-   reverting a real person's voice to a catalog voice. Walks the SAME
-   (workspace- or series-scoped) match set `forEachMatchingCastCharacter`
-   does, but read-only — it must run BEFORE any write so the caller can
-   refuse the whole clear atomically instead of wiping some books before
-   discovering a conflict in another. Deliberately NOT implemented by
-   reusing `forEachMatchingCastCharacter` itself (which always persists,
-   even for a no-op mutate) — a validation pass must not touch disk.
+/* Read-only scan: does any confirmed-cast character matching `voiceId`
+   (optionally scoped to a series, optionally excluding one engine) carry a
+   consented cloned voice? Exported — reused by:
+     - this file's own PUT /:voiceId/override (both the CLEAR and SET
+       upfront checks, and applyOverrideToCastFiles's own fresh write-time
+       check, all below);
+     - single-design.ts's upfront gate;
+     - qwen-voice.ts's persistEmotionVariant (write-time) and its two
+       callers' upfront checks.
+   Walks the SAME (workspace- or series-scoped) match set
+   forEachMatchingCastCharacter does, but read-only — deliberately NOT
+   implemented by reusing forEachMatchingCastCharacter itself (which always
+   persists, even for a no-op mutate) — a validation pass must not touch disk.
 
-   GATE 2 I-B1 — `otherThanEngine` serves the SET branch, which had no
-   pre-check at all. A SET does not only fill a slot: it pins
-   `replacement.ttsEngine = override.engine` (see applyOverrideToCastFiles)
-   across every matching book in scope. A character cloned on a DIFFERENT
-   clone-capable engine was therefore silently retargeted off its clone —
-   the marker survives on disk but goes inert, because
-   `resolveCharacterEngine` now routes its lines to the incoming engine.
-   Same shape Task 6a closed in cast-link-prior.ts and this wave closed in
-   `voice-override-linked.ts`'s applyToBook, which is why the predicate is
-   the same fail-safe provenance test.
+   `otherThanEngine` serves ONLY voices.ts's own SET-branch asymmetry (a SET
+   pins `ttsEngine` to the incoming engine, so a clone on a DIFFERENT
+   clone-capable engine would go inert — see the SET branch below); every
+   other caller passes it as `undefined`, meaning "any clone-capable engine
+   counts".
 
-   Scoped to the OTHER engines deliberately: a SET on the engine that
-   carries the clone is the documented [DELTA-I5] wart — the slot's
-   libraryUuid/provenance are preserved and the clone still renders, so
-   there is nothing to mute and nothing to refuse. */
-async function hasClonedSlotAmongMatches(
+   `onlyBookDir` scopes the scan to exactly one book when `seriesFilter` is
+   absent — mirrors forEachMatchingCastCharacter's own special case
+   (voices.ts:809) so a caller with no series context (a standalone book)
+   gets a book-scoped check instead of an accidental workspace-wide one on a
+   bare shared id (fs-61). Ignored whenever `seriesFilter` is present, same
+   as forEachMatchingCastCharacter. */
+export async function hasClonedSlotAmongMatches(
   voiceId: string,
   seriesFilter?: { author: string; series: string },
   otherThanEngine?: TtsEngine,
+  onlyBookDir?: string,
 ): Promise<boolean> {
+  const cloned = (c: CastCharacter): boolean =>
+    otherThanEngine
+      ? CLONE_ENGINE_LIST.some((e) => e !== otherThanEngine && hasClonedProvenance(c, e))
+      : characterHasClonedSlot(c);
+
+  /* Mirrors forEachMatchingCastCharacter's own onlyBookDir special case
+     (voices.ts:809) exactly: a caller with no series context must not fall
+     through to a workspace-wide scan on a bare character id (fs-61) — that
+     would make THIS predicate refuse across unrelated standalone books even
+     though the write it gates stays correctly single-book-scoped. */
+  if (!seriesFilter && onlyBookDir) {
+    const cast = await readJson<CastJson>(castJsonPath(onlyBookDir));
+    if (!cast?.characters?.length) return false;
+    for (const c of cast.characters) {
+      if ((c.voiceId ?? c.id) !== voiceId) continue;
+      if (cloned(c)) return true;
+    }
+    return false;
+  }
+
   for (const authorName of listDirs(BOOKS_ROOT)) {
     for (const seriesName of listDirs(join(BOOKS_ROOT, authorName))) {
       for (const titleName of listDirs(join(BOOKS_ROOT, authorName, seriesName))) {
@@ -631,12 +651,7 @@ async function hasClonedSlotAmongMatches(
         if (!cast?.characters?.length) continue;
         for (const c of cast.characters) {
           if ((c.voiceId ?? c.id) !== voiceId) continue;
-          const cloned = otherThanEngine
-            ? CLONE_ENGINE_LIST.some(
-                (e) => e !== otherThanEngine && hasClonedProvenance(c, e),
-              )
-            : characterHasClonedSlot(c);
-          if (cloned) return true;
+          if (cloned(c)) return true;
         }
       }
     }

--- a/server/src/routes/voices.ts
+++ b/server/src/routes/voices.ts
@@ -743,14 +743,25 @@ voicesRouter.put('/:voiceId/override', async (req: Request, res: Response) => {
           `Reassign that character directly instead.`,
       });
     }
-    const updates = await applyOverrideToCastFiles(voiceId, parsed, seriesFilter);
-    if (updates === 0) {
+    const { updated, skipped } = await applyOverrideToCastFiles(voiceId, parsed, seriesFilter);
+    if (updated === 0 && skipped.length === 0) {
       const where = seriesFilter
         ? `in series "${seriesFilter.author} / ${seriesFilter.series}"`
         : 'in any confirmed cast';
       return res
         .status(404)
         .json({ error: `No character with voiceId "${voiceId}" found ${where}.` });
+    }
+    if (updated === 0 && skipped.length > 0) {
+      return res.status(409).json({
+        error:
+          `Voice "${voiceId}" has a consented cloned voice on a linked character — ` +
+          `propagation refused. Reassign that character directly instead.`,
+        skipped,
+      });
+    }
+    if (skipped.length > 0) {
+      return res.status(200).json({ updated, skipped });
     }
     res.status(204).end();
   } catch (e) {
@@ -903,11 +914,62 @@ export async function applyOverrideToCastFiles(
      workspace sharing the same bare character id. Only the genuinely-global
      PUT /:voiceId/override 'workspace' scope should omit both. */
   onlyBookDir?: string,
-): Promise<number> {
+): Promise<{ updated: number; skipped: Array<{ bookDir: string; characterId: string; reason: string }> }> {
+  const otherThanEngine = override === null ? undefined : override.engine;
+  /* Which sentinel a caller gets right: forEachMatchingCastCharacter's own
+     branch at voices.ts:809 only honours `onlyBookDir` when `seriesFilter`
+     is ABSENT — with a seriesFilter present it always runs the general
+     multi-book walk regardless of onlyBookDir (voices.ts:827-861). Both
+     single-design.ts and cast-design.ts pass BOTH a seriesFilter AND
+     job.bookDir, so `onlyBookDir` does NOT mean "this call touches exactly
+     that book" whenever seriesFilter is set — using it as a per-entry label
+     in that case would name the WRONG book (the caller's own, when the
+     clone could be on any matched sibling). Only compute a real single-book
+     label when seriesFilter is absent, matching forEachMatchingCastCharacter's
+     own condition exactly. */
+  const singleBookDir = !seriesFilter ? onlyBookDir : undefined;
+  /* v2 — fresh, series-wide re-check immediately before any write, replacing
+     the caller's stale pre-scan. Refuses the WHOLE propagation on a hit —
+     no book is written — rather than the v1 per-book-independent contract.
+     See docs/superpowers/specs/2026-08-22-clone-consent-voices-override-
+     refusal-design.md "The decision this spec finalizes". This IS a
+     genuinely series-wide (or workspace-wide) verdict, not a per-book one —
+     labelled accordingly rather than with the residual backstop's
+     "(unknown)" sentinel below. */
+  if (await hasClonedSlotAmongMatches(voiceId, seriesFilter, otherThanEngine, onlyBookDir)) {
+    return {
+      updated: 0,
+      skipped: [{
+        bookDir: singleBookDir ?? (seriesFilter ? '(series-wide)' : '(workspace-wide)'),
+        characterId: voiceId,
+        reason: 'already_cloned',
+      }],
+    };
+  }
+  const skipped: Array<{ bookDir: string; characterId: string; reason: string }> = [];
   const updated = await forEachMatchingCastCharacter(
     voiceId,
     seriesFilter,
     (original) => {
+      /* Residual-window backstop: the walk still takes nonzero time after
+         the fresh scan above passed. Immune to unrelated intermediate
+         writes because it re-checks the FRESH per-book read
+         forEachMatchingCastCharacter already did before calling this
+         closure. `singleBookDir` names this entry's book ONLY in the
+         genuinely single-book case (no seriesFilter, onlyBookDir set) —
+         the same case forEachMatchingCastCharacter itself treats as
+         single-book. Every other case (a series or workspace walk touching
+         possibly-many books) can't attribute a specific book from inside
+         this closure, so it uses '(unknown)' — no caller of this function
+         reads `skipped[].bookDir` for logic, only `skipped.length`, so this
+         is for human/API-consumer legibility, not correctness. */
+      const cloned = override === null
+        ? characterHasClonedSlot(original)
+        : CLONE_ENGINE_LIST.some((e) => e !== override.engine && hasClonedProvenance(original, e));
+      if (cloned) {
+        skipped.push({ bookDir: singleBookDir ?? '(unknown)', characterId: voiceId, reason: 'already_cloned' });
+        return original; // unchanged — dirty=true still fires (harmless idempotent rewrite)
+      }
       const normalised = normaliseCastCharacter(original);
       const replacement: CastCharacter = { ...normalised };
       if (override === null) {
@@ -965,7 +1027,7 @@ export async function applyOverrideToCastFiles(
      this anyway so a future invocation refreshes /speakers cleanly if the
      sidecar was bounced in between. Cheap and side-effect free. */
   if (updated > 0) invalidateBaseVoiceCache();
-  return updated;
+  return { updated, skipped };
 }
 
 /* Set or clear the per-character Qwen quality tier (ttsModelKey) across every

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1999,6 +1999,24 @@ async function realGetBaseVoices(): Promise<{ voices: BaseVoice[] }> {
   return res.json();
 }
 
+/* Shape of the 409 Conflict body returned by PUT /api/voices/:voiceId/override
+   when a cloned slot blocks propagation. Exported so the UI can render the
+   refusal (e.g. a toast listing the affected books). */
+export interface VoiceOverrideRefusedError {
+  error: 'already_cloned';
+  skipped: Array<{ bookDir: string; characterId: string; reason: string }>;
+}
+
+export class VoiceOverrideRefused extends Error {
+  readonly status = 409;
+  readonly body: VoiceOverrideRefusedError;
+  constructor(body: VoiceOverrideRefusedError) {
+    super('Voice override refused: a cloned slot already occupies this voice.');
+    this.name = 'VoiceOverrideRefused';
+    this.body = body;
+  }
+}
+
 async function realSetVoiceOverride(
   voiceId: string,
   override: BaseVoice | null,
@@ -2012,6 +2030,10 @@ async function realSetVoiceOverride(
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
+  if (res.status === 409) {
+    const refused = (await res.json()) as VoiceOverrideRefusedError;
+    throw new VoiceOverrideRefused(refused);
+  }
   if (!res.ok)
     throw new Error(
       `Voice override update failed (${res.status}): ${(await res.text()) || res.statusText}`,


### PR DESCRIPTION
## Summary

- `applyOverrideToCastFiles` (`server/src/routes/voices.ts`) now runs a fresh, series-wide clone-consent check immediately before any write: if a clone exists anywhere in the linked series (or the whole workspace, when no series filter applies), the WHOLE propagation is refused — no book gets written, not even the ones that were clean.
- Return type changed from `Promise<number>` to `Promise<{ updated, skipped }>` so callers can distinguish a refusal from a no-op.
- Residual-window backstop: a per-book check inside the mutate closure catches a clone injected mid-walk.
- `openapi.yaml` documents the 200-partial and 409 responses for `PUT /api/voices/{voiceId}/override`.
- `runDesignJob` (`cast-design.ts`) and `runSingleDesign` (`single-design.ts`) updated for the new return shape: both now surface the series-wide veto as an explicit refusal (thrown error, caught by the existing per-character failure path) instead of silently reporting success on a partial propagation.
- `src/lib/api.ts` updated for the new response shape.

## Landing note

This PR was queued through the Open Engine agent pipeline (`cline-qwen-cloud`). The lane's code changes were correct but it repeatedly failed to land them: a bug in its detached-commit script (`Start-Process -ArgumentList` word-splitting a multi-word `-m` message) caused every commit attempt to fail with pathspec errors while the worker polled an unrelated process believing the commit was still running — fixed upstream in [open-engine#57](https://github.com/dudarenok-maker/open-engine/pull/57). Landing this PR by hand also caught one real defect the lane's own commit had missed: three caller files (`cast-design.ts`, `single-design.ts`, `single-design.test.ts`) were edited but never staged in the same commit as the return-type change, which `tsc --noEmit` failed on (`bookOneDir` declared but unused, plus the missing caller updates) — both are fixed here as separate commits on this branch.

## Test plan

- [x] `npm run typecheck` passes (frontend + server)
- [x] `npm run test:server` — 533 files / 7892 tests passed, 1 file / 9 tests skipped
- [x] New `applyOverrideToCastFiles — series-wide veto (v2)` describe block in `voices.test.ts` covers: refusal on a sibling-book clone, no partial writes, and the residual-window backstop
- [x] `hasClonedSlotAmongMatches — onlyBookDir scope` describe covers the single-book scoping this veto relies on

Closes #2668