### PR TITLE
docs(sidecar): state the Coqui residency policy and guard its cross-references

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -290,18 +290,17 @@ jobs:
       # `--changed <base>` narrows both server configs to diff-affected tests
       # (CI cost round 2). The slow config still serial-runs ONLY the hot files
       # the diff actually touched. Run from server/ so the per-dir vitest
-      # config loads. A sidecar-only PR touches no server TS graph → 0 tests
-      # run here, which is correct (server tests mock the Python sidecar).
-      # See docs/features/118-ci-cost-round-2.md.
+      # config loads. A typical sidecar-only diff (touching only .py files
+      # outside main.py) touches no server TS graph → 0 tests run here, which
+      # is correct (server tests mock the Python sidecar). See
+      # docs/features/118-ci-cost-round-2.md. EXCEPTION: a
+      # server/tts-sidecar/main.py-only diff DOES schedule test:server now (via
+      # extraFiles in verify-cache.mjs + forceRerunTriggers in vitest.config.ts,
+      # since coqui-residency-policy.guard.test.ts reads it at runtime as part
+      # of the Coqui eviction cross-reference guard, #1932).
       # test:server AND test:server-slow share this one step, so the
       # condition is the union of both steps' keys. Drops the old `sidecar`
-      # disjunct deliberately: a typical sidecar-only diff (touching only
-      # .py files outside main.py) used to run this job for zero tests —
-      # but EXCEPTION: a server/tts-sidecar/main.py-only diff DOES schedule
-      # test:server now (via extraFiles in verify-cache.mjs + forceRerunTriggers
-      # in vitest.config.ts, since coqui-residency-policy.guard.test.ts reads
-      # it at runtime as part of the Coqui eviction cross-reference guard,
-      # #1932), so behaviour is mostly behaviour-neutral for the general case.
+      # disjunct deliberately.
       # (was: server || sidecar || shared).
       # leg: test:server
       - name: Server tests (fast + slow)

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -295,10 +295,14 @@ jobs:
       # See docs/features/118-ci-cost-round-2.md.
       # test:server AND test:server-slow share this one step, so the
       # condition is the union of both steps' keys. Drops the old `sidecar`
-      # disjunct deliberately: a sidecar-only diff used to run this job for
-      # zero tests (server tests mock the Python sidecar, per the comment
-      # above), so skipping the job entirely for that diff is behaviour-
-      # neutral, not a narrowing (was: server || sidecar || shared).
+      # disjunct deliberately: a typical sidecar-only diff (touching only
+      # .py files outside main.py) used to run this job for zero tests —
+      # but EXCEPTION: a server/tts-sidecar/main.py-only diff DOES schedule
+      # test:server now (via extraFiles in verify-cache.mjs + forceRerunTriggers
+      # in vitest.config.ts, since coqui-residency-policy.guard.test.ts reads
+      # it at runtime as part of the Coqui eviction cross-reference guard,
+      # #1932), so behaviour is mostly behaviour-neutral for the general case.
+      # (was: server || sidecar || shared).
       # leg: test:server
       - name: Server tests (fast + slow)
         if: fromJSON(needs.detect.outputs.scopes).step_test_server || fromJSON(needs.detect.outputs.scopes).step_test_server_slow || fromJSON(needs.detect.outputs.scopes).shared

--- a/docs/features/264-vram-aware-gpu-placement.md
+++ b/docs/features/264-vram-aware-gpu-placement.md
@@ -354,9 +354,9 @@ single statement of that ruling so the question is not reopened.
 
 `evictEngineForPhase` (`server/src/tts/synthesise-chapter.ts:1015`) POSTs
 `/unload` to the sidecar for a named engine. The Coqui-facing wrappers are
-`evictCoquiForQwenPhase` (`:1041`) and the symmetric `evictQwenForCoquiPhase`
-(`:1029`). The leading evict fires at `:2912` before a mixed chapter's Coqui
-phase; the trailing evict fires at `:2976` at its end.
+`evictCoquiForQwenPhase` (`:1049`) and the symmetric `evictQwenForCoquiPhase`
+(`:1029`). The leading evict fires at `:2920` before a mixed chapter's Coqui
+phase; the trailing evict fires at `:2987` at its end.
 
 It is driven by the **generation plan** — Node knows which engine each
 remaining chapter needs, so it can free the VRAM at a boundary where "no
@@ -370,10 +370,10 @@ should not break a whole chapter if a transient sidecar hiccup occurs.
 
 ### Mechanism B — sidecar, demand-driven, reactive
 
-`_idle_evict_steps` (`server/tts-sidecar/main.py:5019-5048`) is a
+`_idle_evict_steps` (`server/tts-sidecar/main.py:4989-5064`) is a
 **five-step, cross-engine ladder** — `spk`, `asr`, `qwen.design`,
 `qwen.base17`, `coqui` — run by `PlacementController` on the admission path
-when an op is VRAM-starved. Coqui is *one step of it* (`:5047`), calling
+when an op is VRAM-starved. Coqui is *one step of it* (`:5063`), calling
 `CoquiEngine.maybe_free_idle` (`:2273`). This is **not** a Coqui-specific
 idle evict: it is one entry in a generic ladder that every engine has a step
 in.
@@ -381,11 +381,11 @@ in.
 Two Coqui-specific qualifications distinguish the Coqui step from the others:
 
 1. **Self-admission skip.** The step is omitted entirely when the admitting
-   op is itself Coqui (`server/tts-sidecar/main.py:5044`, `if engine !=
+   op is itself Coqui (`server/tts-sidecar/main.py:5053`, `if engine !=
    "coqui"`) — evicting would unload the model that op is about to reload.
 2. **Real idle TTL.** It is the only step that uses a non-zero idle TTL —
-   `_coqui_idle_ttl()` (`:8272`, 30 s default, env `COQUI_IDLE_TTL`,
-   registry key `sidecar.coquiIdleTtl` at `server/src/config/registry.ts:849`)
+   `_coqui_idle_ttl()` (`:8288`, 30 s default, env `COQUI_IDLE_TTL`,
+   registry key `sidecar.coquiIdleTtl` at `server/src/config/registry.ts:848`)
    — rather than the `0.0` the transient models (SPK, ASR, Qwen design,
    Qwen base17) take. Coqui deliberately has **no** background watchdog,
    unlike Qwen/ASR/ECAPA, so this only ever runs under genuine VRAM

--- a/docs/features/264-vram-aware-gpu-placement.md
+++ b/docs/features/264-vram-aware-gpu-placement.md
@@ -361,10 +361,12 @@ phase; the trailing evict fires at `:2976` at its end.
 It is driven by the **generation plan** — Node knows which engine each
 remaining chapter needs, so it can free the VRAM at a boundary where "no
 further Coqui work is queued" is a *fact* rather than a prediction. Each call
-is bounded by `withCallTimeout` and carries the chapter's abort signal. The
-trailing evict is deliberately **fail-soft** — every group is already
-synthesised by then, so throwing would destroy completed work purely to free
-VRAM. The leading one is not fail-soft.
+is bounded by `withCallTimeout` and carries the chapter's abort signal. Both
+evicts are deliberately **fail-soft** — only abort signals are rethrown; other
+failures (socket errors, timeouts) are logged as warnings and execution
+continues. This is correct for both the leading and trailing positions: the
+trailing evict destroys synthesised work if it throws, and the leading evict
+should not break a whole chapter if a transient sidecar hiccup occurs.
 
 ### Mechanism B — sidecar, demand-driven, reactive
 
@@ -416,11 +418,13 @@ outside the current book's render.
 ### Lock caveats — invariants any future change must preserve
 
 1. **Mechanism A's timeout and abort.** Each `/unload` call is bounded by
-   `withCallTimeout` and carries the chapter's abort signal. The trailing
-   evict must remain fail-soft: every group is already synthesised when it
-   runs, so an exception there destroys completed work purely to free VRAM.
-   The leading evict must remain fail-hard: the Coqui phase has not started
-   yet, so a failure there is a genuine precondition not met.
+   `withCallTimeout` and carries the chapter's abort signal. Both evicts must
+   remain fail-soft (aborting only on genuine abort signals, not transient
+   errors): only abort signals rethrow; other failures are logged as warnings
+   and execution continues. The trailing evict is already-synthesised work
+   that would be lost on exception. The leading evict must not break the
+   chapter if a transient sidecar hiccup (socket error, timeout) occurs
+   mid-evict.
 
 2. **Mechanism B's lock-guarded idle check.** `maybe_free_idle`
    (`server/tts-sidecar/main.py:2273`) re-validates the idle condition under

--- a/docs/features/264-vram-aware-gpu-placement.md
+++ b/docs/features/264-vram-aware-gpu-placement.md
@@ -362,11 +362,14 @@ It is driven by the **generation plan** — Node knows which engine each
 remaining chapter needs, so it can free the VRAM at a boundary where "no
 further Coqui work is queued" is a *fact* rather than a prediction. Each call
 is bounded by `withCallTimeout` and carries the chapter's abort signal. Both
-evicts are deliberately **fail-soft** — only abort signals are rethrown; other
-failures (socket errors, timeouts) are logged as warnings and execution
-continues. This is correct for both the leading and trailing positions: the
-trailing evict destroys synthesised work if it throws, and the leading evict
-should not break a whole chapter if a transient sidecar hiccup occurs.
+evicts are deliberately **fail-soft** on non-abort errors: socket errors and
+timeouts are logged as warnings and execution continues. The leading evict
+additionally rethrows abort signals for pause detection (`routes/generation.ts`
+names its own `AbortError`); the trailing evict swallows aborts too, since by
+the time it fires the chapter's synthesis work is already complete. This
+asymmetry is correct: the trailing evict's abort swallow does not lose
+synthesised work (all groups are done), while the leading evict's abort rethrow
+ensures a paused generation is visible to the pause-detection path.
 
 ### Mechanism B — sidecar, demand-driven, reactive
 
@@ -419,12 +422,13 @@ outside the current book's render.
 
 1. **Mechanism A's timeout and abort.** Each `/unload` call is bounded by
    `withCallTimeout` and carries the chapter's abort signal. Both evicts must
-   remain fail-soft (aborting only on genuine abort signals, not transient
-   errors): only abort signals rethrow; other failures are logged as warnings
-   and execution continues. The trailing evict is already-synthesised work
-   that would be lost on exception. The leading evict must not break the
-   chapter if a transient sidecar hiccup (socket error, timeout) occurs
-   mid-evict.
+   remain fail-soft on transient errors (socket errors, timeouts are logged as
+   warnings and execution continues), but they differ on aborts: the leading
+   evict rethrows `AbortError` for pause detection (`routes/generation.ts`
+   names its own `AbortError`), while the trailing evict swallows abort signals
+   too since by that point all synthesis work is done. The trailing evict
+   cannot lose synthesised audio by failing, and the leading evict must signal
+   a pause through its abort path if the generation is cancelled mid-evict.
 
 2. **Mechanism B's lock-guarded idle check.** `maybe_free_idle`
    (`server/tts-sidecar/main.py:2273`) re-validates the idle condition under
@@ -432,14 +436,22 @@ outside the current book's render.
    never free the model out from under an active forward. Any change to
    `maybe_free_idle` must preserve this re-validation-under-lock.
 
-3. **Mechanism B's non-reentrant lock.** `_drop_model_locked()` must not be
+3. **Mechanism B's non-reentrant lock.** `_drop_model_locked()` MUST be
    called while already holding `_synth_lock` (it is a non-reentrant
-   `threading.Lock`) — only the `/unload` route calls `unload()` without
-   the lock. Internal holders that need the same teardown call
-   `_drop_model_locked()` and then `_reclaim_after_drop()` after releasing
-   the lock; `maybe_free_idle` is the one such caller
-   (`server/tts-sidecar/main.py:2051-2055`). Any future caller must follow
-   the same release-then-reclaim sequence.
+   `threading.Lock`); by contrast, the public `unload()` method MUST NOT be
+   called while holding the lock — it acquires the lock itself. Internal
+   callers that need the same teardown (e.g., `maybe_free_idle` at
+   `server/tts-sidecar/main.py:2273`) acquire the lock, call
+   `_drop_model_locked()` inside it, then release the lock and call
+   `_reclaim_after_drop()` afterwards. This sequence is critical: releasing
+   the lock BEFORE reclaim allows a concurrent forward to complete its own
+   reference-drop, which is essential for the actual VRAM reclamation to work.
+   Any future internal caller must follow the same acquire-drop-release-reclaim
+   sequence; any future code that nulls or reassigns a model field must mirror
+   `_drop_model_locked()`'s full teardown (including the device restoration
+   that `_drop_model_locked()` already handles) to avoid the double-allocation
+   race documented in `unload()`'s own docstring
+   (`server/tts-sidecar/main.py:2040-2049`).
 
 ## Ship notes
 

--- a/docs/features/264-vram-aware-gpu-placement.md
+++ b/docs/features/264-vram-aware-gpu-placement.md
@@ -354,30 +354,33 @@ single statement of that ruling so the question is not reopened.
 
 `evictEngineForPhase` (`server/src/tts/synthesise-chapter.ts:1015`) POSTs
 `/unload` to the sidecar for a named engine. The Coqui-facing wrappers are
-`evictCoquiForQwenPhase` (`:1049`) and the symmetric `evictQwenForCoquiPhase`
+`evictCoquiForQwenPhase` (`:1050`) and the symmetric `evictQwenForCoquiPhase`
 (`:1029`). 
 
 The eviction wrappers have **four call sites**, not two:
 
 1. **Pre-pass invocations (memoised, resolver-mediated):** `beforeFirstCoquiDerive`
-   (`:1882-1899`) evicts `evictQwenForCoquiPhase` before the first Coqui derive
-   in the chapter; `beforeFirstQwenDerive` (`:1943-1953`) evicts
+   (`:1883-1900`) evicts `evictQwenForCoquiPhase` before the first Coqui derive
+   in the chapter; `beforeFirstQwenDerive` (`:1944-1954`) evicts
    `evictCoquiForQwenPhase` before the first Qwen derive (when Coqui is present).
    **Two of the three pre-pass sites are called from *inside* voice-resolver
    try/catch blocks (`clone-voice-resolver.ts`), inheriting the resolver's own
    fail-loud (cloned voices) / fail-soft (designed voices) semantics — no local
    try/catch wraps them at those call sites.** However, **a third pre-pass site**
-   exists at `:2114-2122`, also in `synthesise-chapter.ts`, which primes
-   `beforeFirstQwenDerive` before any Qwen render-phase work when only Qwen
-   voices with no derive are present (no resolver call to hang the hook off).
-   This third site **is wrapped in a local try/catch** (lines 2114-2122) that
+   exists at `:2115-2123`, also in `synthesise-chapter.ts`, which primes
+   `beforeFirstQwenDerive` before any Qwen render-phase work when Coqui is present
+   AND any Qwen work is present (either groups or derives). This third site shares
+   the memoised promise with the resolver-mediated call sites, so while it fires in
+   more cases than "no derive needed", the resolver calls still apply their own
+   fail-loud (cloned) / fail-soft (designed) policy on top.
+   This third site **is wrapped in a local try/catch** (lines 2115-2123) that
    unconditionally swallows the error and logs a warning — deliberately best-effort
-   fail-soft, covering the "Qwen render with no derive needed" case where a
-   sidecar recycle window at this priming call cannot abort the chapter.
+   fail-soft, covering cases where a sidecar recycle window at this priming call
+   cannot abort the chapter.
 
 2. **Render-phase pair (top-level, plan-driven):** The leading evict fires at
-   `:2920` before a mixed chapter's Coqui phase; the trailing evict fires at
-   `:2988` at its end. Each call is bounded by `withCallTimeout` and carries
+   `:2921` before a mixed chapter's Coqui phase; the trailing evict fires at
+   `:2989` at its end. Each call is bounded by `withCallTimeout` and carries
    the chapter's abort signal.
 
 The render-phase pair is driven by the **generation plan** — Node knows which
@@ -457,18 +460,20 @@ outside the current book's render.
      signal a pause through its abort path if the generation is cancelled
      mid-evict.
    
-   - **Pre-pass pair — two resolver-mediated, one render-prep best-effort:**
-     `beforeFirstCoquiDerive` and `beforeFirstQwenDerive` have **three distinct
-     invocation patterns**, each with different failure semantics that must be
-     preserved independently:
+   - **Pre-pass pair — four resolver-mediated, one render-prep best-effort:**
+     `beforeFirstCoquiDerive` and `beforeFirstQwenDerive` have **five distinct
+     invocation sites across three failure-semantics patterns**, each with different
+     failure semantics that must be preserved independently:
      
-     - **Two resolver-mediated sites (voice-type-dependent):** Called from
+     - **Four resolver-mediated sites (voice-type-dependent):** Called from
        *inside* voice-resolver try/catch blocks in `clone-voice-resolver.ts`,
-       with no separate local try/catch wrapping them. A failure is reported
-       through the resolver's own existing, already-differentiated policy: the
-       cloned resolver's catch treats it as an ordinary derive failure (fail-loud —
-       `broken` accumulates, `UnresolvableClonedVoiceError` still throws), while
-       the designed resolver's catch treats it as an ordinary self-heal failure
+       with no separate local try/catch wrapping them. The cloned resolver calls
+       both hooks (coqui arm at ~line 547, qwen arm at ~line 548); the designed
+       resolver also calls both (coqui arm at ~line 996, qwen arm at ~line 1073).
+       A failure is reported through the resolver's own existing, already-differentiated
+       policy: the cloned resolver's catch treats it as an ordinary derive failure
+       (fail-loud — `broken` accumulates, `UnresolvableClonedVoiceError` still throws),
+       while the designed resolver's catch treats it as an ordinary self-heal failure
        (fail-soft — `softFailedUuids`/keep-stale, never rethrown). This voice-type-dependent
        semantics is intentional: a pre-pass evict failure on a cloned voice is
        unrecoverable (the cloned resolver's own identity depends on that model
@@ -476,14 +481,18 @@ outside the current book's render.
        the stale version.
      
      - **One render-prep best-effort site (unconditional fail-soft):** A third
-       pre-pass invocation at `:2114-2122` in `synthesise-chapter.ts` primes
-       `beforeFirstQwenDerive` before any Qwen render-phase work when only
-       healthy/catalogue Qwen voices are present (no resolver call to hang the
-       hook off). This site **is deliberately wrapped in a local try/catch**
-       that unconditionally swallows errors and logs warnings, covering the case
-       where a sidecar recycle window at this priming call cannot abort the
-       chapter (fix for a §2.3 chapter-abort regression). This best-effort wrapper
-       is distinct from the resolver-mediated invocations and correct by design.
+       pre-pass invocation at `:2115-2123` in `synthesise-chapter.ts` primes
+       `beforeFirstQwenDerive` before any Qwen render-phase work when Coqui is
+       present AND any Qwen work is pending (either groups or derives; no resolver
+       call to hang the hook off for the render-only case). This site shares the
+       memoised promise with the four resolver-mediated calls, so when they later
+       await the same hook, they get the already-settled result and apply their own
+       fail-loud/fail-soft policy on top.
+       This site **is deliberately wrapped in a local try/catch** that unconditionally
+       swallows errors and logs warnings, covering the case where a sidecar recycle
+       window at this priming call cannot abort the chapter (fix for a §2.3
+       chapter-abort regression). This best-effort wrapper is distinct from the
+       resolver-mediated invocations and correct by design.
      
      Any future change to the pre-pass evicts must **preserve all three
      invocation patterns independently**: the two resolver-mediated sites must

--- a/docs/features/264-vram-aware-gpu-placement.md
+++ b/docs/features/264-vram-aware-gpu-placement.md
@@ -355,21 +355,37 @@ single statement of that ruling so the question is not reopened.
 `evictEngineForPhase` (`server/src/tts/synthesise-chapter.ts:1015`) POSTs
 `/unload` to the sidecar for a named engine. The Coqui-facing wrappers are
 `evictCoquiForQwenPhase` (`:1049`) and the symmetric `evictQwenForCoquiPhase`
-(`:1029`). The leading evict fires at `:2920` before a mixed chapter's Coqui
-phase; the trailing evict fires at `:2987` at its end.
+(`:1029`). 
 
-It is driven by the **generation plan** — Node knows which engine each
-remaining chapter needs, so it can free the VRAM at a boundary where "no
-further Coqui work is queued" is a *fact* rather than a prediction. Each call
-is bounded by `withCallTimeout` and carries the chapter's abort signal. Both
-evicts are deliberately **fail-soft** on non-abort errors: socket errors and
-timeouts are logged as warnings and execution continues. The leading evict
-additionally rethrows abort signals for pause detection (`routes/generation.ts`
-names its own `AbortError`); the trailing evict swallows aborts too, since by
-the time it fires the chapter's synthesis work is already complete. This
-asymmetry is correct: the trailing evict's abort swallow does not lose
-synthesised work (all groups are done), while the leading evict's abort rethrow
-ensures a paused generation is visible to the pause-detection path.
+The eviction wrappers have **four call sites**, not two:
+
+1. **Pre-pass pair (memoised, demand-driven):** `beforeFirstCoquiDerive`
+   (`:1882-1899`) evicts `evictQwenForCoquiPhase` before the first Coqui derive
+   in the chapter; `beforeFirstQwenDerive` (`:1943-1953`) evicts
+   `evictCoquiForQwenPhase` before the first Qwen derive (when Coqui is present).
+   These are called from *inside* voice-resolver try/catch blocks
+   (`clone-voice-resolver.ts`), so they inherit the resolver's own fail-loud
+   (cloned voices) / fail-soft (designed voices) semantics — **no local
+   try/catch wraps them, by design.**
+
+2. **Render-phase pair (top-level, plan-driven):** The leading evict fires at
+   `:2920` before a mixed chapter's Coqui phase; the trailing evict fires at
+   `:2988` at its end. Each call is bounded by `withCallTimeout` and carries
+   the chapter's abort signal.
+
+The render-phase pair is driven by the **generation plan** — Node knows which
+engine each remaining chapter needs, so it can free the VRAM at a boundary
+where "no further Coqui work is queued" is a *fact* rather than a prediction
+(this scope applies to the **render-phase pair only**, not the pre-pass pair,
+which is memoised and runs *before* any derive). The render-phase evicts are
+deliberately **fail-soft** on non-abort errors: socket errors and timeouts are
+logged as warnings and execution continues. The leading evict additionally
+rethrows abort signals for pause detection (`routes/generation.ts` names its
+own `AbortError`); the trailing evict swallows aborts too, since by the time it
+fires the chapter's synthesis work is already complete. This asymmetry is
+correct: the trailing evict's abort swallow does not lose synthesised work (all
+groups are done), while the leading evict's abort rethrow ensures a paused
+generation is visible to the pause-detection path.
 
 ### Mechanism B — sidecar, demand-driven, reactive
 
@@ -420,15 +436,33 @@ outside the current book's render.
 
 ### Lock caveats — invariants any future change must preserve
 
-1. **Mechanism A's timeout and abort.** Each `/unload` call is bounded by
-   `withCallTimeout` and carries the chapter's abort signal. Both evicts must
-   remain fail-soft on transient errors (socket errors, timeouts are logged as
-   warnings and execution continues), but they differ on aborts: the leading
-   evict rethrows `AbortError` for pause detection (`routes/generation.ts`
-   names its own `AbortError`), while the trailing evict swallows abort signals
-   too since by that point all synthesis work is done. The trailing evict
-   cannot lose synthesised audio by failing, and the leading evict must signal
-   a pause through its abort path if the generation is cancelled mid-evict.
+1. **Mechanism A's failure semantics differ by call site.**
+   
+   - **Render-phase pair (bounded by `withCallTimeout`, fail-soft):** Each
+     `/unload` call carries the chapter's abort signal. Both evicts must remain
+     fail-soft on transient errors (socket errors, timeouts are logged as
+     warnings and execution continues). They differ on aborts: the leading
+     evict rethrows `AbortError` for pause detection (`routes/generation.ts`
+     names its own `AbortError`), while the trailing evict swallows abort
+     signals too since by that point all synthesis work is done. The trailing
+     evict cannot lose synthesised audio by failing, and the leading evict must
+     signal a pause through its abort path if the generation is cancelled
+     mid-evict.
+   
+   - **Pre-pass pair (memoised, resolver-dependent):** `beforeFirstCoquiDerive`
+     and `beforeFirstQwenDerive` are called from *inside* voice-resolver
+     try/catch blocks in `clone-voice-resolver.ts`, with no separate local
+     try/catch wrapping them. A failure is therefore reported through the
+     resolver's own existing, already-differentiated policy: the cloned
+     resolver's catch treats it as an ordinary derive failure (fail-loud —
+     `broken` accumulates, `UnresolvableClonedVoiceError` still throws), while
+     the designed resolver's catch treats it as an ordinary self-heal failure
+     (fail-soft — `softFailedUuids`/keep-stale, never rethrown). This
+     voice-type-dependent semantics is intentional and must be preserved: a
+     pre-pass evict failure on a cloned voice is unrecoverable (the cloned
+     resolver's own identity depends on that model running), while a failure
+     on a designed voice can be healed by keeping the stale version. Any future
+     change to the pre-pass evicts must maintain this asymmetry.
 
 2. **Mechanism B's lock-guarded idle check.** `maybe_free_idle`
    (`server/tts-sidecar/main.py:2273`) re-validates the idle condition under
@@ -444,8 +478,15 @@ outside the current book's render.
    `server/tts-sidecar/main.py:2273`) acquire the lock, call
    `_drop_model_locked()` inside it, then release the lock and call
    `_reclaim_after_drop()` afterwards. This sequence is critical: releasing
-   the lock BEFORE reclaim allows a concurrent forward to complete its own
-   reference-drop, which is essential for the actual VRAM reclamation to work.
+   the lock BEFORE reclaim is necessary for throughput — holding `_synth_lock`
+   across the multi-second `gc.collect()` + `torch.cuda.empty_cache()` in
+   `_reclaim_after_drop()` would unnecessarily block concurrent synth calls that
+   only need the lock briefly, for no correctness benefit (the reference-drop
+   whose safety depends on the lock is guaranteed by ACQUIRING it, not
+   releasing it — `_synth_lock` waits for any in-flight forward to finish and
+   release its own reference before `_drop_model_locked()` runs). See
+   `_reclaim_after_drop()`'s docstring at `server/tts-sidecar/main.py:2127-2134`
+   for the full rationale.
    Any future internal caller must follow the same acquire-drop-release-reclaim
    sequence; any future code that nulls or reassigns a model field must mirror
    `_drop_model_locked()`'s full teardown (including the device restoration

--- a/docs/features/264-vram-aware-gpu-placement.md
+++ b/docs/features/264-vram-aware-gpu-placement.md
@@ -340,6 +340,103 @@ cold-load, Coqui load-steer) are tracked together in **#1730**.
 > acceptance (with `SEG_CAPACITY_ADMISSION=1`) still owed before the
 > concurrent-multi-card flag flip.
 
+## Coqui residency policy (side-18)
+
+<!-- COQUI-RESIDENCY-POLICY -->
+
+Two independent mechanisms free VRAM held by a resident Coqui XTTS model (~3.5 GB).
+Both are correct, both are tested, and neither knows the other exists. The fork
+#1932 offered — collapse to one, or keep both with explicit cross-references —
+is **closed: both are kept**, for the two reasons below. This section is the
+single statement of that ruling so the question is not reopened.
+
+### Mechanism A — Node, plan-driven, proactive
+
+`evictEngineForPhase` (`server/src/tts/synthesise-chapter.ts:1015`) POSTs
+`/unload` to the sidecar for a named engine. The Coqui-facing wrappers are
+`evictCoquiForQwenPhase` (`:1041`) and the symmetric `evictQwenForCoquiPhase`
+(`:1029`). The leading evict fires at `:2912` before a mixed chapter's Coqui
+phase; the trailing evict fires at `:2976` at its end.
+
+It is driven by the **generation plan** — Node knows which engine each
+remaining chapter needs, so it can free the VRAM at a boundary where "no
+further Coqui work is queued" is a *fact* rather than a prediction. Each call
+is bounded by `withCallTimeout` and carries the chapter's abort signal. The
+trailing evict is deliberately **fail-soft** — every group is already
+synthesised by then, so throwing would destroy completed work purely to free
+VRAM. The leading one is not fail-soft.
+
+### Mechanism B — sidecar, demand-driven, reactive
+
+`_idle_evict_steps` (`server/tts-sidecar/main.py:5019-5048`) is a
+**five-step, cross-engine ladder** — `spk`, `asr`, `qwen.design`,
+`qwen.base17`, `coqui` — run by `PlacementController` on the admission path
+when an op is VRAM-starved. Coqui is *one step of it* (`:5047`), calling
+`CoquiEngine.maybe_free_idle` (`:2273`). This is **not** a Coqui-specific
+idle evict: it is one entry in a generic ladder that every engine has a step
+in.
+
+Two Coqui-specific qualifications distinguish the Coqui step from the others:
+
+1. **Self-admission skip.** The step is omitted entirely when the admitting
+   op is itself Coqui (`server/tts-sidecar/main.py:5044`, `if engine !=
+   "coqui"`) — evicting would unload the model that op is about to reload.
+2. **Real idle TTL.** It is the only step that uses a non-zero idle TTL —
+   `_coqui_idle_ttl()` (`:8272`, 30 s default, env `COQUI_IDLE_TTL`,
+   registry key `sidecar.coquiIdleTtl` at `server/src/config/registry.ts:849`)
+   — rather than the `0.0` the transient models (SPK, ASR, Qwen design,
+   Qwen base17) take. Coqui deliberately has **no** background watchdog,
+   unlike Qwen/ASR/ECAPA, so this only ever runs under genuine VRAM
+   pressure.
+
+### Ownership
+
+**A owns known plan boundaries; B owns unpredicted demand pressure. Neither
+is a superset of the other.**
+
+A fires at the exact points where Node's generation plan guarantees no
+further Coqui work remains in the current dispatch. B fires whenever an
+unrelated admission is VRAM-starved and Coqui happens to be idle long enough
+to reclaim — a situation Node's plan cannot predict because it arrives from
+outside the current book's render.
+
+### Why both are kept
+
+1. **Removing B** would delete one step from a five-step cross-engine ladder
+   that stays regardless. The only effect is that a starved *non-Coqui*
+   admission can no longer reclaim XTTS's ~3.5 GB on an 8 GB card. That is a
+   regression, not a consolidation.
+
+2. **Removing A** would require the sidecar to know Node's generation plan
+   across a process boundary, which it cannot. And B cannot substitute for
+   A: B fires only *after* an admission is already starved, and only past a
+   30 s TTL — so a Qwen load arriving 5 s after the Coqui phase ends finds
+   Coqui resident, the step returns `False`, and nothing is reclaimed.
+
+### Lock caveats — invariants any future change must preserve
+
+1. **Mechanism A's timeout and abort.** Each `/unload` call is bounded by
+   `withCallTimeout` and carries the chapter's abort signal. The trailing
+   evict must remain fail-soft: every group is already synthesised when it
+   runs, so an exception there destroys completed work purely to free VRAM.
+   The leading evict must remain fail-hard: the Coqui phase has not started
+   yet, so a failure there is a genuine precondition not met.
+
+2. **Mechanism B's lock-guarded idle check.** `maybe_free_idle`
+   (`server/tts-sidecar/main.py:2273`) re-validates the idle condition under
+   `_synth_lock` and skips while a synth is in flight, so admission can
+   never free the model out from under an active forward. Any change to
+   `maybe_free_idle` must preserve this re-validation-under-lock.
+
+3. **Mechanism B's non-reentrant lock.** `_drop_model_locked()` must not be
+   called while already holding `_synth_lock` (it is a non-reentrant
+   `threading.Lock`) — only the `/unload` route calls `unload()` without
+   the lock. Internal holders that need the same teardown call
+   `_drop_model_locked()` and then `_reclaim_after_drop()` after releasing
+   the lock; `maybe_free_idle` is the one such caller
+   (`server/tts-sidecar/main.py:2051-2055`). Any future caller must follow
+   the same release-then-reclaim sequence.
+
 ## Ship notes
 
 (Filled when status flips to `stable` after the on-box acceptance above passes and

--- a/docs/features/264-vram-aware-gpu-placement.md
+++ b/docs/features/264-vram-aware-gpu-placement.md
@@ -359,14 +359,21 @@ single statement of that ruling so the question is not reopened.
 
 The eviction wrappers have **four call sites**, not two:
 
-1. **Pre-pass pair (memoised, demand-driven):** `beforeFirstCoquiDerive`
+1. **Pre-pass invocations (memoised, resolver-mediated):** `beforeFirstCoquiDerive`
    (`:1882-1899`) evicts `evictQwenForCoquiPhase` before the first Coqui derive
    in the chapter; `beforeFirstQwenDerive` (`:1943-1953`) evicts
    `evictCoquiForQwenPhase` before the first Qwen derive (when Coqui is present).
-   These are called from *inside* voice-resolver try/catch blocks
-   (`clone-voice-resolver.ts`), so they inherit the resolver's own fail-loud
-   (cloned voices) / fail-soft (designed voices) semantics — **no local
-   try/catch wraps them, by design.**
+   **Two of the three pre-pass sites are called from *inside* voice-resolver
+   try/catch blocks (`clone-voice-resolver.ts`), inheriting the resolver's own
+   fail-loud (cloned voices) / fail-soft (designed voices) semantics — no local
+   try/catch wraps them at those call sites.** However, **a third pre-pass site**
+   exists at `:2114-2122`, also in `synthesise-chapter.ts`, which primes
+   `beforeFirstQwenDerive` before any Qwen render-phase work when only Qwen
+   voices with no derive are present (no resolver call to hang the hook off).
+   This third site **is wrapped in a local try/catch** (lines 2114-2122) that
+   unconditionally swallows the error and logs a warning — deliberately best-effort
+   fail-soft, covering the "Qwen render with no derive needed" case where a
+   sidecar recycle window at this priming call cannot abort the chapter.
 
 2. **Render-phase pair (top-level, plan-driven):** The leading evict fires at
    `:2920` before a mixed chapter's Coqui phase; the trailing evict fires at
@@ -374,18 +381,19 @@ The eviction wrappers have **four call sites**, not two:
    the chapter's abort signal.
 
 The render-phase pair is driven by the **generation plan** — Node knows which
-engine each remaining chapter needs, so it can free the VRAM at a boundary
+engine the **current dispatch** needs, so it can free the VRAM at a boundary
 where "no further Coqui work is queued" is a *fact* rather than a prediction
-(this scope applies to the **render-phase pair only**, not the pre-pass pair,
-which is memoised and runs *before* any derive). The render-phase evicts are
-deliberately **fail-soft** on non-abort errors: socket errors and timeouts are
-logged as warnings and execution continues. The leading evict additionally
-rethrows abort signals for pause detection (`routes/generation.ts` names its
-own `AbortError`); the trailing evict swallows aborts too, since by the time it
-fires the chapter's synthesis work is already complete. This asymmetry is
-correct: the trailing evict's abort swallow does not lose synthesised work (all
-groups are done), while the leading evict's abort rethrow ensures a paused
-generation is visible to the pause-detection path.
+(this scope applies to the **render-phase pair only** and the current dispatch,
+not future chapters or the pre-pass pair, which is memoised and runs *before*
+any derive). The render-phase evicts are deliberately **fail-soft** on non-abort
+errors: socket errors and timeouts are logged as warnings and execution
+continues. The leading evict additionally rethrows abort signals for pause
+detection (`routes/generation.ts` names its own `AbortError`); the trailing
+evict swallows aborts too, since by the time it fires the chapter's synthesis
+work is already complete. This asymmetry is correct: the trailing evict's abort
+swallow does not lose synthesised work (all groups are done), while the leading
+evict's abort rethrow ensures a paused generation is visible to the pause-detection
+path.
 
 ### Mechanism B — sidecar, demand-driven, reactive
 
@@ -449,20 +457,39 @@ outside the current book's render.
      signal a pause through its abort path if the generation is cancelled
      mid-evict.
    
-   - **Pre-pass pair (memoised, resolver-dependent):** `beforeFirstCoquiDerive`
-     and `beforeFirstQwenDerive` are called from *inside* voice-resolver
-     try/catch blocks in `clone-voice-resolver.ts`, with no separate local
-     try/catch wrapping them. A failure is therefore reported through the
-     resolver's own existing, already-differentiated policy: the cloned
-     resolver's catch treats it as an ordinary derive failure (fail-loud —
-     `broken` accumulates, `UnresolvableClonedVoiceError` still throws), while
-     the designed resolver's catch treats it as an ordinary self-heal failure
-     (fail-soft — `softFailedUuids`/keep-stale, never rethrown). This
-     voice-type-dependent semantics is intentional and must be preserved: a
-     pre-pass evict failure on a cloned voice is unrecoverable (the cloned
-     resolver's own identity depends on that model running), while a failure
-     on a designed voice can be healed by keeping the stale version. Any future
-     change to the pre-pass evicts must maintain this asymmetry.
+   - **Pre-pass pair — two resolver-mediated, one render-prep best-effort:**
+     `beforeFirstCoquiDerive` and `beforeFirstQwenDerive` have **three distinct
+     invocation patterns**, each with different failure semantics that must be
+     preserved independently:
+     
+     - **Two resolver-mediated sites (voice-type-dependent):** Called from
+       *inside* voice-resolver try/catch blocks in `clone-voice-resolver.ts`,
+       with no separate local try/catch wrapping them. A failure is reported
+       through the resolver's own existing, already-differentiated policy: the
+       cloned resolver's catch treats it as an ordinary derive failure (fail-loud —
+       `broken` accumulates, `UnresolvableClonedVoiceError` still throws), while
+       the designed resolver's catch treats it as an ordinary self-heal failure
+       (fail-soft — `softFailedUuids`/keep-stale, never rethrown). This voice-type-dependent
+       semantics is intentional: a pre-pass evict failure on a cloned voice is
+       unrecoverable (the cloned resolver's own identity depends on that model
+       running), while a failure on a designed voice can be healed by keeping
+       the stale version.
+     
+     - **One render-prep best-effort site (unconditional fail-soft):** A third
+       pre-pass invocation at `:2114-2122` in `synthesise-chapter.ts` primes
+       `beforeFirstQwenDerive` before any Qwen render-phase work when only
+       healthy/catalogue Qwen voices are present (no resolver call to hang the
+       hook off). This site **is deliberately wrapped in a local try/catch**
+       that unconditionally swallows errors and logs warnings, covering the case
+       where a sidecar recycle window at this priming call cannot abort the
+       chapter (fix for a §2.3 chapter-abort regression). This best-effort wrapper
+       is distinct from the resolver-mediated invocations and correct by design.
+     
+     Any future change to the pre-pass evicts must **preserve all three
+     invocation patterns independently**: the two resolver-mediated sites must
+     remain unwrapped at those call sites (inheriting resolver semantics), and
+     the render-prep site must retain its local fail-soft wrapper to prevent
+     chapter aborts on transient sidecar errors.
 
 2. **Mechanism B's lock-guarded idle check.** `maybe_free_idle`
    (`server/tts-sidecar/main.py:2273`) re-validates the idle condition under

--- a/scripts/tests/verify-cache.test.mjs
+++ b/scripts/tests/verify-cache.test.mjs
@@ -422,6 +422,11 @@ test("stepTouchedByDiff: server/tts-sidecar/main.py diff matches test:server via
   assert.equal(stepTouchedByDiff(stepByName['test:hooks'], diff), false);
 });
 
+test("stepTouchedByDiff: docs/features/264-vram-aware-gpu-placement.md diff matches test:server via extraFiles (coqui-residency-policy.guard.test.ts reads it at runtime, #2715)", () => {
+  const diff = ['docs/features/264-vram-aware-gpu-placement.md'];
+  assert.equal(stepTouchedByDiff(stepByName['test:server'], diff), true);
+});
+
 test('stepTouchedByDiff: a frontend diff is in scope for test, not test:server', () => {
   const diff = ['src/views/listen.tsx'];
   assert.equal(stepTouchedByDiff(stepByName['test'], diff), true);

--- a/scripts/tests/verify-cache.test.mjs
+++ b/scripts/tests/verify-cache.test.mjs
@@ -415,10 +415,10 @@ test('stepName participates in the hash (different steps with same inputs differ
 
 const stepByName = Object.fromEntries(STEPS.map((s) => [s.name, s]));
 
-test('stepTouchedByDiff: a sidecar-only diff leaves the fast legs out of scope', () => {
+test("stepTouchedByDiff: server/tts-sidecar/main.py diff matches test:server via extraFiles (coqui-residency-policy.guard.test.ts reads it at runtime, #2715), but not frontend/hooks", () => {
   const diff = ['server/tts-sidecar/main.py'];
   assert.equal(stepTouchedByDiff(stepByName['test'], diff), false); // frontend
-  assert.equal(stepTouchedByDiff(stepByName['test:server'], diff), false);
+  assert.equal(stepTouchedByDiff(stepByName['test:server'], diff), true);
   assert.equal(stepTouchedByDiff(stepByName['test:hooks'], diff), false);
 });
 

--- a/scripts/verify-cache.mjs
+++ b/scripts/verify-cache.mjs
@@ -422,6 +422,14 @@ export const STEPS = [
         'pinokio-scripts/lib/resolve-release.js',
         'e2e/global-teardown.ts',
         '.gitattributes',
+        /* #1932 (side-18): coqui-residency-policy.guard.test.ts (server suite) reads both
+           of these at RUNTIME to guard cross-reference rot across Coqui eviction mechanisms
+           and their policy doc — no module-graph edge, same #1847 runtime-read trap as
+           openapi.yaml/scripts/** above. Without these entries, a diff confined to either
+           (exactly the shape that could break the Coqui eviction contract) reports [cached]
+           and the guard never re-runs. */
+        'server/tts-sidecar/main.py',
+        'docs/features/264-vram-aware-gpu-placement.md',
       ],
       includeLockfiles: ['server'],
     },

--- a/server/src/force-rerun-triggers.test.ts
+++ b/server/src/force-rerun-triggers.test.ts
@@ -135,10 +135,11 @@ const MAIN_COVERED = [
   },
   /* #1932 (side-18) — coqui-residency-policy.guard.test.ts reads these three
      files at RUNTIME to catch cross-reference rot across the two eviction
-     mechanisms and their policy doc. No module-graph edges, so a diff confined
-     to any of them selected zero tests under `vitest run --changed` before these
-     entries existed — the same consequence spelled out above for openapi.yaml/
-     scripts/**. */
+     mechanisms and their policy doc. The sidecar main.py and docs file have no
+     module-graph edges (same #1847 runtime-read trap); synthesise-chapter.ts
+     IS importable but is included here for consistency with the guard's uniform
+     readFileSync approach rather than being split into two separate tracking
+     mechanisms. */
   { rel: 'src/tts/synthesise-chapter.ts', file: 'the Node Coqui eviction mechanism', base: SERVER_ROOT },
   {
     rel: 'server/tts-sidecar/main.py',

--- a/server/src/force-rerun-triggers.test.ts
+++ b/server/src/force-rerun-triggers.test.ts
@@ -133,6 +133,23 @@ const MAIN_COVERED = [
     file: 'a server/tts-sidecar/requirements/** file',
     base: REPO_ROOT,
   },
+  /* #1932 (side-18) — coqui-residency-policy.guard.test.ts reads these three
+     files at RUNTIME to catch cross-reference rot across the two eviction
+     mechanisms and their policy doc. No module-graph edges, so a diff confined
+     to any of them selected zero tests under `vitest run --changed` before these
+     entries existed — the same consequence spelled out above for openapi.yaml/
+     scripts/**. */
+  { rel: 'src/tts/synthesise-chapter.ts', file: 'the Node Coqui eviction mechanism', base: SERVER_ROOT },
+  {
+    rel: 'server/tts-sidecar/main.py',
+    file: 'the sidecar Coqui eviction mechanism (via the server/tts-sidecar/main.py trigger)',
+    base: REPO_ROOT,
+  },
+  {
+    rel: 'docs/features/264-vram-aware-gpu-placement.md',
+    file: 'the Coqui residency policy doc',
+    base: REPO_ROOT,
+  },
 ];
 
 const SLOW_COVERED = [

--- a/server/src/tts/coqui-residency-policy.guard.test.ts
+++ b/server/src/tts/coqui-residency-policy.guard.test.ts
@@ -5,7 +5,7 @@
    sidecar's `_idle_evict_steps` `coqui` step) without noticing the other
    side, or the policy doc, still exists. This guard fails loudly if that
    happens: it is a literal marker-presence check, not a source-text
-   scanner — it does not parse anything, it greps four files for one token
+   scanner — it does not parse anything, it greps three files for one token
    and one heading.
 
    Line numbers are asserted NOWHERE here on purpose: they rot (this repo's
@@ -21,6 +21,11 @@ const REPO_ROOT = join(process.cwd(), '..');
 
 const SYNTHESISE_CHAPTER_PATH = join(process.cwd(), 'src', 'tts', 'synthesise-chapter.ts');
 const SIDECAR_MAIN_PATH = join(process.cwd(), 'tts-sidecar', 'main.py');
+/* NOTE: When plan 264 is archived (status → stable), this path will move to
+   docs/features/archive/264-vram-aware-gpu-placement.md. Keep the path
+   hardcoded so the guard fails-closed if archival forgets to update it;
+   also update the cross-reference comments in synthesise-chapter.ts and
+   main.py that point at this doc in the same commit. */
 const POLICY_DOC_PATH = join(REPO_ROOT, 'docs', 'features', '264-vram-aware-gpu-placement.md');
 
 function occurrences(haystack: string, needle: string): number {

--- a/server/src/tts/coqui-residency-policy.guard.test.ts
+++ b/server/src/tts/coqui-residency-policy.guard.test.ts
@@ -24,8 +24,12 @@ const SIDECAR_MAIN_PATH = join(process.cwd(), 'tts-sidecar', 'main.py');
 /* NOTE: When plan 264 is archived (status → stable), this path will move to
    docs/features/archive/264-vram-aware-gpu-placement.md. Keep the path
    hardcoded so the guard fails-closed if archival forgets to update it.
-   On archival, update all FIVE of these in the same commit (two code comments
-   fail loudly on archival when forgotten; three CI entries fail silently):
+   On archival, update all FIVE of these in the same commit. ITEMS 1-5 all fail
+   SILENTLY when archival forgets them (stale comments stay stale, CI entries
+   stay stale, the guard just keeps checking the old path). The ONE exception
+   that fails LOUDLY is this file's own POLICY_DOC_PATH constant below — if
+   this path is wrong or missing, the readFileSync call in this test's "keeps
+   the policy section" spec will throw immediately.
    1. The cross-reference comment in synthesise-chapter.ts (search for the TOKEN)
    2. The cross-reference comments in main.py (search for the TOKEN)
    3. server/vitest.config.ts forceRerunTriggers entry (will miss config-only diffs)

--- a/server/src/tts/coqui-residency-policy.guard.test.ts
+++ b/server/src/tts/coqui-residency-policy.guard.test.ts
@@ -1,0 +1,67 @@
+/* #1932 (side-18) — static guard against cross-reference rot.
+   A comment alone rots: nothing stops the next person touching Coqui
+   residency from deleting one side of the cross-reference between the two
+   independent eviction mechanisms (Node's `evictCoquiForQwenPhase` and the
+   sidecar's `_idle_evict_steps` `coqui` step) without noticing the other
+   side, or the policy doc, still exists. This guard fails loudly if that
+   happens: it is a literal marker-presence check, not a source-text
+   scanner — it does not parse anything, it greps four files for one token
+   and one heading.
+
+   Line numbers are asserted NOWHERE here on purpose: they rot (this repo's
+   register row IDs already did, tree-wide), so this guard keys on the
+   `COQUI-RESIDENCY-POLICY` token and the doc heading text only. */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const TOKEN = 'COQUI-RESIDENCY-POLICY';
+const REPO_ROOT = join(process.cwd(), '..');
+
+const SYNTHESISE_CHAPTER_PATH = join(process.cwd(), 'src', 'tts', 'synthesise-chapter.ts');
+const SIDECAR_MAIN_PATH = join(process.cwd(), 'tts-sidecar', 'main.py');
+const POLICY_DOC_PATH = join(REPO_ROOT, 'docs', 'features', '264-vram-aware-gpu-placement.md');
+
+function occurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+describe('Coqui residency policy cross-references (side-18, #1932)', () => {
+  it('keeps the cross-reference in synthesise-chapter.ts (mechanism A)', () => {
+    const source = readFileSync(SYNTHESISE_CHAPTER_PATH, 'utf8');
+    expect(
+      source.includes(TOKEN),
+      `the ${TOKEN} cross-reference at synthesise-chapter.ts is gone; the two Coqui ` +
+        'eviction mechanisms are documented in docs/features/264-vram-aware-gpu-placement.md ' +
+        '— restore the pointer or update the policy',
+    ).toBe(true);
+  });
+
+  it('keeps both cross-references in main.py (mechanism B)', () => {
+    const source = readFileSync(SIDECAR_MAIN_PATH, 'utf8');
+    expect(
+      occurrences(source, TOKEN),
+      `expected 2 occurrences of ${TOKEN} in main.py (maybe_free_idle's docstring and the ` +
+        "coqui EvictStep); the two Coqui eviction mechanisms are documented in " +
+        'docs/features/264-vram-aware-gpu-placement.md — restore the missing pointer(s) or ' +
+        'update the policy',
+    ).toBe(2);
+  });
+
+  it('keeps the policy section in docs/features/264-vram-aware-gpu-placement.md', () => {
+    const doc = readFileSync(POLICY_DOC_PATH, 'utf8');
+    expect(
+      doc.includes(TOKEN),
+      `the ${TOKEN} marker is gone from docs/features/264-vram-aware-gpu-placement.md — the ` +
+        'Coqui residency policy section (side-18) has been removed or altered; restore it or ' +
+        'update the code-site cross-references that point at it',
+    ).toBe(true);
+    expect(
+      doc.includes('## Coqui residency policy (side-18)'),
+      'the "## Coqui residency policy (side-18)" heading is gone from ' +
+        'docs/features/264-vram-aware-gpu-placement.md — the two Coqui eviction mechanisms ' +
+        '(synthesise-chapter.ts and main.py) cross-reference this section by name',
+    ).toBe(true);
+  });
+});

--- a/server/src/tts/coqui-residency-policy.guard.test.ts
+++ b/server/src/tts/coqui-residency-policy.guard.test.ts
@@ -36,11 +36,11 @@ describe('Coqui residency policy cross-references (side-18, #1932)', () => {
   it('keeps the cross-reference in synthesise-chapter.ts (mechanism A)', () => {
     const source = readFileSync(SYNTHESISE_CHAPTER_PATH, 'utf8');
     expect(
-      source.includes(TOKEN),
-      `the ${TOKEN} cross-reference at synthesise-chapter.ts is gone; the two Coqui ` +
-        'eviction mechanisms are documented in docs/features/264-vram-aware-gpu-placement.md ' +
+      occurrences(source, TOKEN),
+      `expected 1 occurrence of ${TOKEN} in synthesise-chapter.ts (the Coqui residency policy cross-reference); ` +
+        'the two Coqui eviction mechanisms are documented in docs/features/264-vram-aware-gpu-placement.md ' +
         '— restore the pointer or update the policy',
-    ).toBe(true);
+    ).toBe(1);
   });
 
   it('keeps both cross-references in main.py (mechanism B)', () => {

--- a/server/src/tts/coqui-residency-policy.guard.test.ts
+++ b/server/src/tts/coqui-residency-policy.guard.test.ts
@@ -23,9 +23,17 @@ const SYNTHESISE_CHAPTER_PATH = join(process.cwd(), 'src', 'tts', 'synthesise-ch
 const SIDECAR_MAIN_PATH = join(process.cwd(), 'tts-sidecar', 'main.py');
 /* NOTE: When plan 264 is archived (status → stable), this path will move to
    docs/features/archive/264-vram-aware-gpu-placement.md. Keep the path
-   hardcoded so the guard fails-closed if archival forgets to update it;
-   also update the cross-reference comments in synthesise-chapter.ts and
-   main.py that point at this doc in the same commit. */
+   hardcoded so the guard fails-closed if archival forgets to update it.
+   On archival, update all FIVE of these in the same commit (two code comments
+   fail loudly on archival when forgotten; three CI entries fail silently):
+   1. The cross-reference comment in synthesise-chapter.ts (search for the TOKEN)
+   2. The cross-reference comments in main.py (search for the TOKEN)
+   3. server/vitest.config.ts forceRerunTriggers entry (will miss config-only diffs)
+   4. server/src/force-rerun-triggers.test.ts MAIN_COVERED row (guard goes stale)
+   5. scripts/verify-cache.mjs test:server extraFiles entry (fails SILENTLY if
+      forgotten — hashFile returns a sentinel for a missing path rather than
+      throwing, so a docs-only PR would just silently stop invalidating the
+      verify cache, reopen the bug this PR #2715 fixed, and never error) */
 const POLICY_DOC_PATH = join(REPO_ROOT, 'docs', 'features', '264-vram-aware-gpu-placement.md');
 
 function occurrences(haystack: string, needle: string): number {

--- a/server/src/tts/synthesise-chapter.ts
+++ b/server/src/tts/synthesise-chapter.ts
@@ -1033,11 +1033,12 @@ async function evictQwenForCoquiPhase(signal?: AbortSignal): Promise<void> {
 /* fs-38 Wave 3c, Task 22 [FAB-I2] — the mirror of `evictQwenForCoquiPhase`
    above: evicts Coqui so a subsequent Qwen derive/render doesn't run with
    XTTS (~3.5 GB) still resident, the same co-residency hazard mirrored the
-   other direction. Used ONLY by the cloned/designed-voice resolver pre-pass
-   (below) to hand off from "coqui derive phase" back to "qwen phase" — see
-   the pre-pass's own Task 22 comment for why this fires only when a qwen
-   load is about to happen afterward (evicting XTTS unconditionally would
-   unload it right before every Coqui-only chapter's groups reload it).
+   other direction. Used by the cloned/designed-voice resolver pre-pass (below)
+   to hand off from "coqui derive phase" back to "qwen phase", and also by the
+   render-phase trailing evict (line ~2988) to reclaim VRAM after all groups
+   have been synthesised. See the pre-pass's own Task 22 comment for the
+   pre-pass semantics (evicting XTTS unconditionally would unload it right
+   before every Coqui-only chapter's groups reload it).
 
    COQUI-RESIDENCY-POLICY — this is mechanism A (Node, plan-driven,
    proactive). A second, independent mechanism can also free XTTS VRAM:

--- a/server/src/tts/synthesise-chapter.ts
+++ b/server/src/tts/synthesise-chapter.ts
@@ -2967,13 +2967,14 @@ export async function synthesiseChapter(
        Task 11 clears on unload) once per mixed dispatch — and is accepted
        deliberately: 3.5 GB held across an entire book is the worse trade.
 
-       Fail-SOFT, same as the leading evict (see lines 2919-2943 above):
-       every group is already synthesised by the time this runs, so letting a
-       sidecar recycle window (502/ECONNREFUSED on `/unload`) throw would
-       destroy a chapter's completed work purely to free VRAM — the exact
-       §2.3 shape #1893 and Task 22 fix round 2 each closed elsewhere. Both
-       evicts catch non-abort errors and log warnings, preserving chapter
-       completion over VRAM reclamation. The main addition this trailing evict
+       Fail-SOFT on ALL errors (including aborts), unlike the leading evict:
+       every group is already synthesised by the time this runs, so letting any
+       error throw would destroy a chapter's completed work purely to free VRAM — the exact
+       §2.3 shape #1893 and Task 22 fix round 2 each closed elsewhere. This
+       asymmetry is correct: the leading evict rethrows AbortError for pause
+       detection (routes/generation.ts), but at this point (end of synthesis
+       work), swallowing the abort doesn't lose audio, and the chapter must not
+       fail on VRAM-cleanup housekeeping. The main addition this trailing evict
        brings is the `withCallTimeout` bounded ceiling that matches the leading
        one: previously unbounded, it could stall a chapter whose groups are
        all already synthesised. */

--- a/server/src/tts/synthesise-chapter.ts
+++ b/server/src/tts/synthesise-chapter.ts
@@ -1037,7 +1037,15 @@ async function evictQwenForCoquiPhase(signal?: AbortSignal): Promise<void> {
    (below) to hand off from "coqui derive phase" back to "qwen phase" — see
    the pre-pass's own Task 22 comment for why this fires only when a qwen
    load is about to happen afterward (evicting XTTS unconditionally would
-   unload it right before every Coqui-only chapter's groups reload it). */
+   unload it right before every Coqui-only chapter's groups reload it).
+
+   COQUI-RESIDENCY-POLICY — this is mechanism A (Node, plan-driven,
+   proactive). A second, independent mechanism can also free XTTS VRAM:
+   the sidecar's admission ladder (`_idle_evict_steps` in
+   `server/tts-sidecar/main.py`), which reclaims idle Coqui when an
+   unrelated op is VRAM-starved. Neither mechanism knows the other exists;
+   the keep-both ruling and the full cross-reference are in
+   `docs/features/264-vram-aware-gpu-placement.md`. */
 async function evictCoquiForQwenPhase(signal?: AbortSignal): Promise<void> {
   return evictEngineForPhase('coqui', signal);
 }

--- a/server/src/tts/synthesise-chapter.ts
+++ b/server/src/tts/synthesise-chapter.ts
@@ -2967,13 +2967,16 @@ export async function synthesiseChapter(
        Task 11 clears on unload) once per mixed dispatch — and is accepted
        deliberately: 3.5 GB held across an entire book is the worse trade.
 
-       Fail-SOFT, deliberately and unlike the leading evict: every group is
-       already synthesised by the time this runs, so letting a sidecar
-       recycle window (502/ECONNREFUSED on `/unload`) throw here would
+       Fail-SOFT, same as the leading evict (see lines 2919-2943 above):
+       every group is already synthesised by the time this runs, so letting a
+       sidecar recycle window (502/ECONNREFUSED on `/unload`) throw would
        destroy a chapter's completed work purely to free VRAM — the exact
-       §2.3 shape #1893 and Task 22 fix round 2 each closed elsewhere. The
-       leading evict's own bare `await` is untouched here; it is a separate
-       finding with its own reconciliation against main. */
+       §2.3 shape #1893 and Task 22 fix round 2 each closed elsewhere. Both
+       evicts catch non-abort errors and log warnings, preserving chapter
+       completion over VRAM reclamation. The main addition this trailing evict
+       brings is the `withCallTimeout` bounded ceiling that matches the leading
+       one: previously unbounded, it could stall a chapter whose groups are
+       all already synthesised. */
     try {
       /* #1893 reconciliation (main merge) — bounded + cancellable, matching
          the leading `qwen-evict-for-coqui` call above. The fail-soft policy

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -2288,6 +2288,15 @@ class CoquiEngine(Engine):
         The reclaim runs AFTER the lock is released, and this method is called
         synchronously on the event loop by `_idle_evict_steps` — see
         `_reclaim_after_drop`.
+
+        COQUI-RESIDENCY-POLICY — this is mechanism B (sidecar, demand-driven,
+        reactive): one step in the generic `_idle_evict_steps` admission
+        ladder. Node also evicts Coqui proactively at generation-plan phase
+        boundaries via `evictCoquiForQwenPhase` / `evictQwenForCoquiPhase`
+        in `server/src/tts/synthesise-chapter.ts` — this method is therefore
+        not the only path that drops the model. The keep-both ruling and the
+        full cross-reference are in
+        `docs/features/264-vram-aware-gpu-placement.md`.
         """
         # Cheap, lock-free fast-outs first: nothing loaded, mid-forward, or
         # used recently. Skipping the lock here matters — a forward can run
@@ -5044,6 +5053,13 @@ def _idle_evict_steps(device_key: str, engine: str) -> list["EvictStep"]:
     if engine != "coqui":
         coqui = ENGINES.get("coqui")
         if isinstance(coqui, CoquiEngine) and _same_card(getattr(coqui, "_device", None), device_key):
+            # COQUI-RESIDENCY-POLICY — this step is one entry in the generic
+            # cross-engine admission ladder above; it is not a Coqui-specific
+            # idle evict. Node also evicts Coqui proactively at generation-plan
+            # phase boundaries (`evictCoquiForQwenPhase` in
+            # `server/src/tts/synthesise-chapter.ts`). The keep-both ruling
+            # and the full cross-reference are in
+            # `docs/features/264-vram-aware-gpu-placement.md`.
             steps.append(EvictStep("coqui", "coqui", lambda: coqui.maybe_free_idle(_coqui_idle_ttl())))
     return steps
 

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -225,7 +225,10 @@ export default defineConfig({
       '{**/server/tts-sidecar/requirements/**,**/.*/**/server/tts-sidecar/requirements/**}',
       /* coqui-residency-policy.guard.test.ts (#1932 side-18): reads three files at
          RUNTIME to catch cross-reference rot across the two Coqui eviction mechanisms
-         and their policy doc — no module-graph edges, same #1847 runtime-read trap. */
+         and their policy doc. The sidecar main.py and docs file have no module-graph
+         edges (same #1847 runtime-read trap); synthesise-chapter.ts IS importable
+         but is included here for consistency with the guard's uniform readFileSync
+         approach rather than being split into two separate tracking mechanisms. */
       '{**/server/src/tts/synthesise-chapter.ts,**/.*/**/server/src/tts/synthesise-chapter.ts}',
       '{**/server/tts-sidecar/main.py,**/.*/**/server/tts-sidecar/main.py}',
       '{**/docs/features/264-vram-aware-gpu-placement.md,**/.*/**/docs/features/264-vram-aware-gpu-placement.md}',

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -223,6 +223,12 @@ export default defineConfig({
          consequence spelled out above for openapi.yaml/scripts/**. */
       '{**/.gitattributes,**/.*/**/.gitattributes}',
       '{**/server/tts-sidecar/requirements/**,**/.*/**/server/tts-sidecar/requirements/**}',
+      /* coqui-residency-policy.guard.test.ts (#1932 side-18): reads three files at
+         RUNTIME to catch cross-reference rot across the two Coqui eviction mechanisms
+         and their policy doc — no module-graph edges, same #1847 runtime-read trap. */
+      '{**/server/src/tts/synthesise-chapter.ts,**/.*/**/server/src/tts/synthesise-chapter.ts}',
+      '{**/server/tts-sidecar/main.py,**/.*/**/server/tts-sidecar/main.py}',
+      '{**/docs/features/264-vram-aware-gpu-placement.md,**/.*/**/docs/features/264-vram-aware-gpu-placement.md}',
     ],
     pool: 'forks',
     /* Vitest 4 removed `poolOptions`; `poolOptions.forks.maxForks` is now the


### PR DESCRIPTION
## Summary

States the Coqui VRAM residency policy (side-18, #1932): two independent eviction mechanisms — Node's plan-driven `evictCoquiForQwenPhase`/`evictQwenForCoquiPhase` and the sidecar's demand-driven `_idle_evict_steps` `coqui` step — are both kept, with the ownership split and rationale documented in `docs/features/264-vram-aware-gpu-placement.md`. Adds `COQUI-RESIDENCY-POLICY` cross-reference comments at the code sites and a static guard test (`server/src/tts/coqui-residency-policy.guard.test.ts`) that fails if any of them is removed. Closes #1932.

**Also fixed, found in passing** (across four independent PR-review rounds; see PR comments for the full findings):
- The guard test had no CI-selection wiring: a diff touching only `server/tts-sidecar/main.py` or only the policy doc didn't schedule the `test:server` CI leg, and a `synthesise-chapter.ts`-only diff scheduled the leg but `vitest run --changed` never selected the guard. Wired all three into `server/vitest.config.ts`'s `forceRerunTriggers`, `server/src/force-rerun-triggers.test.ts`'s coverage list, and `scripts/verify-cache.mjs`'s `test:server` `extraFiles` — each now regression-tested.
- Several factual corrections to the policy doc against the actual sidecar/Node code: an inverted lock invariant (`_drop_model_locked()` vs `unload()`'s hold-the-lock rules), a false claim that both eviction paths symmetrically rethrow aborts (only the leading one does), a wrong rationale for why the lock is released before VRAM reclaim, missing enumeration of two of four real eviction call sites (a voice-prepare pre-pass pair with different, voice-type-dependent fail semantics), and a third pre-pass invocation with its own local fail-soft wrapper that the doc's original wording would have licensed deleting.
- A regression test (`scripts/tests/verify-cache.test.mjs`) that the CI-wiring fix broke (an invariant asserting sidecar-only diffs stay out of `test:server` scope) was updated to reflect the new, deliberate exception rather than reverted.
- Several stale/duplicated-claim code comments corrected (`.github/workflows/verify.yml`, `server/src/force-rerun-triggers.test.ts`, `server/src/tts/synthesise-chapter.ts`).

## Test plan

- [x] `npm run test:server -- coqui-residency-policy.guard` — green
- [x] Mutation check: deleted the `COQUI-RESIDENCY-POLICY` token from `synthesise-chapter.ts`, re-ran the guard — went red as expected; restored and confirmed green again.
- [x] `npm run test:hooks` — full battery green (1600+ tests), including the new `scripts/tests/verify-cache.test.mjs` coverage for the CI-wiring fix.
- [x] `npm run test:server` — full suite green (8000+ tests).
- [x] `npm run typecheck` — clean.
- [x] `npm run verify:fast:branch` — green on every push (pre-push hook).

No release-notes entry: no shippable delta, this is docs, comments, and CI-selection wiring only — no product behaviour change.
No on-box acceptance row: no new behaviour.
