### PR TITLE
docs(docs): decide docs/superpowers/plans and specs lifecycle, finish the review-gate sweep

### DIFF
--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -25,6 +25,19 @@ Each plan's frontmatter `status:` is one of:
 
 When a plan reaches **stable** AND has a filled **Ship notes** section, move it to [`archive/`](archive/README.md) in the same PR — the top-level index is the working set, not a changelog. See `archive/README.md` for the move checklist.
 
+### `docs/superpowers/plans/` and `specs/`
+
+These directories hold the design-thread artifacts (implementation plans from
+`writing-plans` and specs from `brainstorming`), not the regression plans
+above — they carry no `status:` frontmatter, so their lifecycle is tracked at
+the **checkbox level**, not the file level. An unchecked `- [ ]` step is still
+actionable and must never point at a retired mechanism; a checked step, or
+narrative/decision-record prose describing what was already decided or done,
+is historical and is never rewritten to "fix" it — that would falsify the
+record (see CLAUDE.md's "Surgical changes"). Anyone sweeping a retired
+mechanism across these directories (e.g. the `code-review`→`pr-review-gate`
+rename) fixes unchecked steps only.
+
 ## How to run a plan
 
 1. Pick a plan from the index.

--- a/docs/superpowers/plans/2026-07-03-fs54-audiobookshelf-export-and-status-pill.md
+++ b/docs/superpowers/plans/2026-07-03-fs54-audiobookshelf-export-and-status-pill.md
@@ -2326,5 +2326,5 @@ git commit -m "docs(docs): fs-54 release notes + BACKLOG row removal"
 
 1. Run `npm run verify` (full battery: typecheck + all tests + e2e + build) — catches anything the per-task runs missed.
 2. Open the PR with `Closes #978` in the body (per `CLAUDE.md`'s PR-gate issue-verification rule).
-3. Per `CLAUDE.md`'s model-routing rules, this PR is multi-scope (`server` + `frontend`) → **`high`** effort for the mandatory `code-review` pass once fully staged.
+3. Per `CLAUDE.md`'s model-routing rules, this PR is multi-scope (`server` + `frontend`) → **`high`** effort for the mandatory `pr-review-gate` pass once fully staged.
 4. Explicitly call out the breaking sync-folder layout change (Task 6) in the PR description, not just in the release notes.

--- a/docs/superpowers/plans/2026-07-03-setup-checker-defense-in-depth-diagnosis.md
+++ b/docs/superpowers/plans/2026-07-03-setup-checker-defense-in-depth-diagnosis.md
@@ -2746,4 +2746,4 @@ git commit -m "docs(docs): add regression plan and release notes for the setup c
 
 - [ ] **Step 6: Push and open the PR**
 
-Per CLAUDE.md's PR-gate: title matches the commit convention, body links `Closes #NN`, and — since this is a multi-scope (`fe`+`srv`) feature PR — the mandatory `code-review` pass runs at `high` effort once everything above is pushed, before merge.
+Per CLAUDE.md's PR-gate: title matches the commit convention, body links `Closes #NN`, and — since this is a multi-scope (`fe`+`srv`) feature PR — the mandatory `pr-review-gate` pass runs at `high` effort once everything above is pushed, before merge.

--- a/docs/superpowers/plans/2026-07-03-srv50-sidecar-stall-autorecycle.md
+++ b/docs/superpowers/plans/2026-07-03-srv50-sidecar-stall-autorecycle.md
@@ -874,4 +874,4 @@ Expected: PASS — typecheck + all tests + e2e + build.
   1. This plan file itself + the spec under `docs/superpowers/specs/` already serve as the regression documentation for this change — no separate `docs/features/*.md` entry is needed (this is a small, localized reliability fix, not a new feature surface).
   2. Append an entry to `docs/release-notes-next.md` (technical register) and a matching brand-voice line to `RELEASE_NOTES.md`'s in-progress version section.
   3. Confirm the PR body includes `Closes #1243`.
-  4. Run the mandatory `code-review` pass (medium effort — single-scope `feat`, per this repo's model-routing table) before merge.
+  4. Run the mandatory `pr-review-gate` pass (medium effort — single-scope `feat`, per this repo's model-routing table) before merge.

--- a/docs/superpowers/plans/2026-07-04-castwright-local-port-cert.md
+++ b/docs/superpowers/plans/2026-07-04-castwright-local-port-cert.md
@@ -1171,11 +1171,11 @@ EOF
 )"
 ```
 
-This is a multi-scope PR (server + frontend + docs) per `CONTRIBUTING.md`'s commit-convention vocabulary — per the model-routing skill, it gets the `high` effort tier for the mandatory independent `code-review` pass (no `--fix`) once fully staged, before merge. File/link a GitHub issue per the PR-gate issue-verification convention if one doesn't already exist for this work.
+This is a multi-scope PR (server + frontend + docs) per `CONTRIBUTING.md`'s commit-convention vocabulary — per the model-routing skill, it gets the `high` effort tier for the mandatory independent `pr-review-gate` pass (no `--fix`) once fully staged, before merge. File/link a GitHub issue per the PR-gate issue-verification convention if one doesn't already exist for this work.
 
-- [ ] **Step 3: Run the mandatory code-review gate**
+- [ ] **Step 3: Run the mandatory `pr-review-gate` gate**
 
-Once pushed, run the `code-review` skill at `high` effort against the full diff (no `--fix`). Triage findings by hand per `CLAUDE.md`: clear-cut bugs get fixed and pushed (which re-triggers one more review pass, capped at 2 re-review rounds); judgment-call findings route through a normal ask-first conversation with the user rather than being auto-applied.
+Once pushed, run the mandatory gate via the `pr-review-gate` skill at `high` effort against the full diff (no `--fix`). Triage findings by hand per `CLAUDE.md`: clear-cut bugs get fixed and pushed (which re-triggers one more review pass, capped at 2 re-review rounds); judgment-call findings route through a normal ask-first conversation with the user rather than being auto-applied.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-04-fs38-wave1-voice-library-store.md
+++ b/docs/superpowers/plans/2026-07-04-fs38-wave1-voice-library-store.md
@@ -484,7 +484,7 @@ if (qwenSlot?.libraryUuid) return `qwen-${qwenSlot.libraryUuid}`
 - [ ] **Step 1: Make the doc edits** (PR body will carry `Refs #624` — partial delivery; fs-12's #419 is already closed into #624).
 - [ ] **Step 2: Run `npm run verify`** — full battery green.
 - [ ] **Step 3: Commit** — `docs(docs): fs-38 wave-1 ship notes + release notes`
-- [ ] **Step 4:** Push branch, open PR titled `feat(frontend,server): fs-38 wave 1 — voice-library store, #/voices restructure, designed authoring` with `Refs #624`, run the mandatory code-review gate (`high` effort — multi-scope PR), fold findings, merge per repo flow.
+- [ ] **Step 4:** Push branch, open PR titled `feat(frontend,server): fs-38 wave 1 — voice-library store, #/voices restructure, designed authoring` with `Refs #624`, run the mandatory `pr-review-gate` gate (`high` effort — multi-scope PR), fold findings, merge per repo flow.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-04-fs60-xtts-language-eligibility.md
+++ b/docs/superpowers/plans/2026-07-04-fs60-xtts-language-eligibility.md
@@ -2203,6 +2203,6 @@ git commit -m "docs(docs): fs-60 regression plan + release notes"
 ## After all tasks: verify, review, ship
 
 1. Run `npm run verify` (typecheck + all tests + e2e + build) from the repo root.
-2. Run the mandatory adversarial review on THIS plan before implementation starts (per CLAUDE.md's model-routing skill — Opus-tier `assumption-checker` pass), and again the mandatory `code-review` pass (medium effort — single-scope `feat`, per CONTRIBUTING.md's commit-convention-based effort table) once the branch is fully staged, before opening the PR.
+2. Run the mandatory adversarial review on THIS plan before implementation starts (per CLAUDE.md's model-routing skill — Opus-tier `assumption-checker` pass), and again the mandatory `pr-review-gate` pass (medium effort — single-scope `feat`, per CONTRIBUTING.md's commit-convention-based effort table) once the branch is fully staged, before opening the PR.
 3. Open the PR with `Closes #1005` in the body (this plan delivers the XTTS-only slice fs-60 was narrowed to — a full delivery of the narrowed scope, not a partial wave).
 4. Cut the branch as `feat/server-fs60-xtts-eligibility` (multi-scope: server + frontend + sidecar — per CONTRIBUTING.md's multi-scope syntax, consider `feat/server,frontend-fs60-xtts-eligibility` if this repo's convention requires listing every touched scope).

--- a/docs/superpowers/plans/2026-07-04-github-wiki-user-guide.md
+++ b/docs/superpowers/plans/2026-07-04-github-wiki-user-guide.md
@@ -16,7 +16,7 @@
 - Every screenshot is captured against the **real running app** (`npm start`, real analyzer/sidecar, no mocks), using **The Coalfall Commission** demo book as the content source — never fabricated/mocked UI states (spec "Screenshot workflow").
 - File convention: `docs/wiki/images/<page-slug>/NN-caption.png`, numbered in on-page order (spec "Screenshot workflow").
 - Desktop-viewport screenshots by default; add phone/tablet only where the mobile layout genuinely differs (spec "Screenshot workflow").
-- Waves 1–4 are pure `docs/**`/root `*.md` changes and get the **docs-only CI fast-path and code-review exemption**. **Wave 0 ships `scripts/sync-wiki.mjs`, a `chore`/`build`-shaped change** — it does NOT qualify for the exemption and gets a real (`low`-effort) `code-review` pass per CLAUDE.md's model-routing table.
+- Waves 1–4 are pure `docs/**`/root `*.md` changes and get the **docs-only CI fast-path and `pr-review-gate` exemption**. **Wave 0 ships `scripts/sync-wiki.mjs`, a `chore`/`build`-shaped change** — it does NOT qualify for the exemption and gets a real (`low`-effort) `pr-review-gate` pass per CLAUDE.md's model-routing table.
 - One integration branch, `docs/docs-github-wiki`, off `main`, **pushed to origin** so every task branch can target it as a PR base. Every task below branches off that integration branch (not off `main` directly) and merges back into it via its own small PR. Rebase onto the latest `docs/docs-github-wiki` before opening each PR.
 - **`fe-46` (issue #1262) is a DEFERRED DRAFT, not in-flight work** — plan `docs/features/240-cast-first-landing-and-voice-readiness-gate.md` is `status: draft`, implementation has not started, and it's explicitly deferred until post-v1.10.0 (already cut). This corrects the spec's "landing in parallel" premise. Tasks 4 and 10 (pages 7, 11, 12) do NOT block or wait on it — both capture the current (pre-fe-46) flow now and file a re-shoot follow-up issue, re-checking fe-46's status at capture time in case it has since shipped.
 - **Image-path convention propagation:** the Wave-0 spike (Task 1) records its outcome in a committed file, `docs/wiki/.image-path-convention` (contents: literal string `relative` or `raw-main`). Every content task (2–10) reads this file before writing any image reference and substitutes the path form it specifies — this is a file check, not reliance on a human re-reading this plan's prose, so it holds even when each task is executed by a fresh subagent with no memory of Task 1.
@@ -410,7 +410,7 @@ EOF
 )"
 ```
 
-This PR is `chore`/`build`-shaped, NOT docs-only — run the mandatory `low`-effort `code-review` pass on it before merge (Global Constraints).
+This PR is `chore`/`build`-shaped, NOT docs-only — run the mandatory `low`-effort `pr-review-gate` pass on it before merge (Global Constraints).
 
 ---
 
@@ -510,7 +510,7 @@ git push -u origin docs/docs-github-wiki-wave1a-getting-started
 gh pr create --base docs/docs-github-wiki --title "docs(docs): Getting Started + Installing Castwright wiki pages" --body "Refs #1276"
 ```
 
-Pure `docs/**` change — docs-only CI fast-path and code-review exemption apply (Global Constraints).
+Pure `docs/**` change — docs-only CI fast-path and `pr-review-gate` exemption apply (Global Constraints).
 
 ---
 
@@ -1225,7 +1225,7 @@ git switch docs/docs-github-wiki && git pull
 gh pr create --base main --title "docs(docs): GitHub wiki user guide (all waves)" --body "Closes #1276"
 ```
 
-This PR's diff includes Wave 0's `scripts/sync-wiki.mjs`/`package.json` change, so by the doc-only file-set test it is technically not a pure-docs PR — but that diff already went through its own mandatory `low`-effort `code-review` pass in Task 1's PR. Don't re-run a full review here; just diff this PR against Task 1's already-reviewed PR to confirm no new non-docs changes crept in during integration, and merge via "Create a merge commit" per the repo's PR convention.
+This PR's diff includes Wave 0's `scripts/sync-wiki.mjs`/`package.json` change, so by the doc-only file-set test it is technically not a pure-docs PR — but that diff already went through its own mandatory `low`-effort `pr-review-gate` pass in Task 1's PR. Don't re-run a full review here; just diff this PR against Task 1's already-reviewed PR to confirm no new non-docs changes crept in during integration, and merge via "Create a merge commit" per the repo's PR convention.
 
 Run `npm run wiki:sync` one final time after this merges to `main`, to publish the final README-linked state.
 

--- a/docs/superpowers/plans/2026-07-05-admin-model-manager-advanced-settings-wiki.md
+++ b/docs/superpowers/plans/2026-07-05-admin-model-manager-advanced-settings-wiki.md
@@ -13,7 +13,7 @@
 ## Global Constraints
 
 - No changes to real (non-mock) application behavior. Touched source is limited to `e2e/marketing/scenes.ts`, `e2e/marketing/capture.spec.ts`, `src/mocks/marketing/hollow-tide.ts`, `src/lib/api.ts`'s `mockGetModelInventory` (Task 12) and `mockGetListenProgress` (Task 11 — adds a `DEMO_CAPTURE` branch following the exact pattern already used by ~8 other mock functions in that file), and `e2e/model-manager-health.spec.ts` (Task 12, fixing assertions the mock flip breaks).
-- This PR is **not docs-only** (it edits `e2e/marketing/scenes.ts`, outside the `docs/**` glob) — the full `npm run verify` battery is required before merge, and it's a **high**-effort `code-review` gate (multi-scope: docs + test/fixture code + one shared-mock change).
+- This PR is **not docs-only** (it edits `e2e/marketing/scenes.ts`, outside the `docs/**` glob) — the full `npm run verify` battery is required before merge, and it's a **high**-effort `pr-review-gate` gate (multi-scope: docs + test/fixture code + one shared-mock change).
 - No new knobs, no changed defaults/behavior in `server/src/config/registry.ts` or `model-settings-form.tsx` — this is descriptive documentation of what already ships.
 - No product-code change to add a Model Manager pill for Qwen VoiceDesign — #1318's "Qwen's row" means the Qwen3-TTS Base row only.
 - PR body: `Closes #1319` and `Closes #1318`.
@@ -2003,6 +2003,6 @@ EOF
 )"
 ```
 
-- [ ] **Step 8: Run the mandatory high-effort `code-review` pass**
+- [ ] **Step 8: Run the mandatory high-effort `pr-review-gate` pass**
 
 Per CLAUDE.md's model-routing skill (multi-scope PR: docs + test/fixture code + one shared-mock change → `high` effort), once the PR is fully staged and pushed.

--- a/docs/superpowers/plans/2026-07-05-github-issues-kanban-board.md
+++ b/docs/superpowers/plans/2026-07-05-github-issues-kanban-board.md
@@ -1977,7 +1977,7 @@ npm run verify
 Expected: PASS. This is a mixed docs+code PR (new scripts, a modified
 `package.json`, `CONTRIBUTING.md`, `docs/BACKLOG.md`, two feature-plan
 docs) — **not** docs-only, so it does NOT qualify for the docs-only
-exemption from the mandatory `code-review` gate below, and pre-push `verify`
+exemption from the mandatory `pr-review-gate` gate below, and pre-push `verify`
 runs in full (no docs-only fast-path).
 
 - [ ] **Step 4: Mandatory independent PR review**
@@ -1986,7 +1986,7 @@ Per CLAUDE.md's model-routing table: this PR mixes `feat`/`chore`/`docs`
 commits across a single scope (`ops`) — multi-type-in-one-PR takes the
 highest tier any single commit would earn, but none of these commits are
 `refactor`/`perf` and it's single-scope, so effort level is **medium**
-(single-scope `feat`/`chore`). Run the `code-review` skill at `medium`
+(single-scope `feat`/`chore`). Run the mandatory gate via the `pr-review-gate` skill at `medium`
 effort, without `--fix`, once every task above is committed and pushed.
 Triage findings per the usual convention (clear-cut fixes applied directly
 and pushed — retriggers exactly one re-review round per the correctness-bug

--- a/docs/superpowers/plans/2026-07-05-gpu-semaphore-device-aware-cost.md
+++ b/docs/superpowers/plans/2026-07-05-gpu-semaphore-device-aware-cost.md
@@ -1012,17 +1012,11 @@ EOF
 
 - [ ] **Step 8: Mandatory independent review**
 
-Per `CLAUDE.md`'s model-routing skill: this PR is a single-scope `fix` touching only `server` (the sidecar lives under `server/tts-sidecar/`, same scope) — **medium** effort. Run:
-
-```
-/code-review medium
-```
-
-(without `--fix`). Triage findings by hand per the skill's rules: clear-cut correctness bugs get fixed, committed, and pushed (re-triggering a review pass); cleanup-only findings can be fixed without a mandatory re-review; genuinely ambiguous findings route through a judgment call with the user rather than being auto-resolved.
+Per `CLAUDE.md`'s model-routing skill: this PR is a single-scope `fix` touching only `server` (the sidecar lives under `server/tts-sidecar/`, same scope) — **medium** effort. Run the mandatory `pr-review-gate` pass at medium effort (without `--fix`). Triage findings by hand per the skill's rules: clear-cut correctness bugs get fixed, committed, and pushed (re-triggering a review pass); cleanup-only findings can be fixed without a mandatory re-review; genuinely ambiguous findings route through a judgment call with the user rather than being auto-resolved.
 
 - [ ] **Step 9: Confirm mergeable state**
 
-Once `npm run verify` is green, the PR is open with a linked issue, and the code-review pass has come back clean (or its findings are resolved), the branch is in mergeable state. Report the PR URL and a one-paragraph summary back to the user — do not merge without their go-ahead.
+Once `npm run verify` is green, the PR is open with a linked issue, and the `pr-review-gate` pass has come back clean (or its findings are resolved), the branch is in mergeable state. Report the PR URL and a one-paragraph summary back to the user — do not merge without their go-ahead.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-05-quality-gate-marketing-screenshots.md
+++ b/docs/superpowers/plans/2026-07-05-quality-gate-marketing-screenshots.md
@@ -825,9 +825,9 @@ git commit -m "docs(docs): fill in PR number in release notes"
 git push
 ```
 
-- [ ] **Step 4: Request the mandatory code-review gate**
+- [ ] **Step 4: Request the mandatory `pr-review-gate` pass**
 
-Per `.claude/skills/model-routing/SKILL.md`, this PR is single-scope `docs`+`feat` touching `src/mocks/`, `src/lib/api.ts`, `e2e/marketing/`, `docs/wiki/` — run the `code-review` skill at `medium` effort before merge.
+Per `.claude/skills/model-routing/SKILL.md`, this PR is single-scope `docs`+`feat` touching `src/mocks/`, `src/lib/api.ts`, `e2e/marketing/`, `docs/wiki/` — run the mandatory gate via the `pr-review-gate` skill at `medium` effort before merge.
 
 - [ ] **Step 5: STOP and ask before syncing the wiki**
 

--- a/docs/superpowers/plans/2026-07-06-verify-ci-rebalance.md
+++ b/docs/superpowers/plans/2026-07-06-verify-ci-rebalance.md
@@ -1048,7 +1048,7 @@ Working practice:
 - Default loop for non-trivial work: finalize the change → run
   `npm run verify:fast:branch` (same branch-scoped check pre-push now runs)
   → open the PR → cloud `verify.yml` (required, opt-out) and the mandatory
-  code-review pass run independently → merge once both are green. Run the
+  `pr-review-gate` pass run independently → merge once both are green. Run the
   full `npm run verify` manually only when you specifically want the full
   local battery (e.g. before a release cut, or debugging something scope-
   filtering might be hiding).

--- a/docs/superpowers/plans/2026-07-07-srv36-audition-centroid-reference.md
+++ b/docs/superpowers/plans/2026-07-07-srv36-audition-centroid-reference.md
@@ -1226,9 +1226,9 @@ EOF
 
 Per CLAUDE.md's "Mandatory review gates": this PR is `refactor(server)`, single-scope — the model-routing skill's effort table puts `refactor` at **`high`** regardless of scope count.
 
-- [ ] Once pushed and the PR is open, run the `code-review` skill at `high` effort (no `--fix`) against this branch.
+- [ ] Once pushed and the PR is open, run the mandatory gate via the `pr-review-gate` skill at `high` effort (findings only, never auto-applied) against this branch.
 - [ ] Triage findings per the skill's Findings handling: fix clear-cut correctness bugs directly, commit, push (re-triggers review per the loop rules); route genuine judgment calls back to the user rather than auto-resolving.
 
 ### Step 5: Merge
 
-- [ ] Once cloud `verify.yml` and the code-review pass are both green and any findings are resolved, merge via `gh pr merge --merge` (repo merges are "Create a merge commit" only — squash/rebase disabled).
+- [ ] Once cloud `verify.yml` and the `pr-review-gate` pass are both green and any findings are resolved, merge via `gh pr merge --merge` (repo merges are "Create a merge commit" only — squash/rebase disabled).

--- a/docs/superpowers/plans/2026-07-08-marketing-screenshots-refresh.md
+++ b/docs/superpowers/plans/2026-07-08-marketing-screenshots-refresh.md
@@ -1126,9 +1126,9 @@ EOF
 
 (Replace `#NN` with the real issue number.)
 
-- [ ] **Step 4: Request the mandatory code-review gate**
+- [ ] **Step 4: Request the mandatory `pr-review-gate` pass**
 
-Per this plan's Global Constraints and `.claude/skills/model-routing/SKILL.md`: this PR is multi-scope (`e2e`, `mocks`, `scripts`, `frontend`), not docs-only — run the `code-review` skill at **`high`** effort before merge. Triage and fix any correctness findings; a fix commit re-triggers one re-review round, per the skill's own re-review rule.
+Per this plan's Global Constraints and `.claude/skills/model-routing/SKILL.md`: this PR is multi-scope (`e2e`, `mocks`, `scripts`, `frontend`), not docs-only — run the mandatory gate via the `pr-review-gate` skill at **`high`** effort before merge. Triage and fix any correctness findings; a fix commit re-triggers one re-review round, per the skill's own re-review rule.
 
 - [ ] **Step 5: Surface the result**
 

--- a/docs/superpowers/plans/2026-07-09-dialogue-structure-attribution.md
+++ b/docs/superpowers/plans/2026-07-09-dialogue-structure-attribution.md
@@ -887,7 +887,7 @@ Routing: `'local'` → the already-selected analyzer instance; `'cloud'` → con
 ### Task 14: PR + review gate + acceptance handoff
 
 - [ ] Push branch; open PR titled `feat(server): dialogue-structure attribution engine (plan 247)`, body: mini release notes + `Closes #<srv-59 issue number>` (literal, not backticked) + link spec + plan + regression plan.
-- [ ] Mandatory independent `code-review` pass (effort `high` — multi-scope feat: server + skills + docs) once fully staged; triage and fold findings before merge.
+- [ ] Mandatory independent `pr-review-gate` pass (effort `high` — multi-scope feat: server + skills + docs) once fully staged; triage and fold findings before merge.
 - [ ] Cloud `verify.yml` green (required check).
 - [ ] Merge (merge commit; auto-delete branch). **Owed after merge (record in the issue before closing):** on-box acceptance per regression plan §acceptance — re-analyze _Ночной дозор_ on the default pipeline and compare against the baseline numbers.
 

--- a/docs/superpowers/plans/2026-07-10-fs52-caption-srt-export.md
+++ b/docs/superpowers/plans/2026-07-10-fs52-caption-srt-export.md
@@ -3196,4 +3196,4 @@ git commit -m "docs(docs): add fs-52 regression plan, release notes, and backlog
 
 1. Run the full local battery: `npm run verify:fast:branch` (or `npm run verify` for the complete local suite, given this branch touches `server/tts-sidecar/**` — `test:sidecar` is scope-gated to fire).
 2. Push the branch, open the PR with `Closes #975` in the body.
-3. Run the mandatory `code-review` pass (per CLAUDE.md's model-routing table — this is a multi-scope `feat` PR spanning sidecar/server/frontend, so `high` effort) before merge.
+3. Run the mandatory `pr-review-gate` pass (per CLAUDE.md's model-routing table — this is a multi-scope `feat` PR spanning sidecar/server/frontend, so `high` effort) before merge.

--- a/docs/superpowers/plans/2026-07-10-script-review-cancellation-reattach-hardening.md
+++ b/docs/superpowers/plans/2026-07-10-script-review-cancellation-reattach-hardening.md
@@ -1787,5 +1787,5 @@ Once all 7 tasks are committed on the implementation branch (cut per CLAUDE.md's
 2. Append an entry to `docs/release-notes-next.md` and a matching user-facing line to the in-progress version section of `RELEASE_NOTES.md`.
 3. Open the PR with `Closes #1481` in the body.
 4. Run `npm run verify:fast:branch` locally.
-5. Once pushed and `verify.yml` is green, run the mandatory `code-review` pass (this PR is multi-scope — server + frontend + e2e + docs — so `high` effort per the model-routing table's PR-review-effort rule).
+5. Once pushed and `verify.yml` is green, run the mandatory `pr-review-gate` pass (this PR is multi-scope — server + frontend + e2e + docs — so `high` effort per the model-routing table's PR-review-effort rule).
 6. Merge.

--- a/docs/superpowers/plans/2026-07-11-cast-design-job-hardening.md
+++ b/docs/superpowers/plans/2026-07-11-cast-design-job-hardening.md
@@ -934,8 +934,8 @@ scoped (as done above) while the PR title itself picks the dominant scope — us
 cast design job against GPU contention` as the PR title, with the frontend/sidecar detail in the PR
 body's Summary section.
 
-- [ ] **Step 5: Mandatory independent code-review pass**
+- [ ] **Step 5: Mandatory independent pr-review-gate pass**
 
 Per CLAUDE.md's Model routing → Mandatory independent review gate: this is a multi-scope PR (sidecar +
-server + frontend), so it gets **high** effort. Run the `code-review` skill (no `--fix`) once the branch
+server + frontend), so it gets **high** effort. Run the mandatory gate via the `pr-review-gate` skill (findings only, never auto-applied) once the branch
 is pushed, before merge. Triage and fold findings.

--- a/docs/superpowers/plans/2026-07-12-app-10-lan-loopback-proxy.md
+++ b/docs/superpowers/plans/2026-07-12-app-10-lan-loopback-proxy.md
@@ -1545,7 +1545,7 @@ git commit -m "docs(docs): reconcile app-10 to the loopback proxy + release note
 
 - All of Tasks 1-8 green under `cd apps/android && flutter test` and `flutter analyze` clean (the `app.yml` gate).
 - Docs reconciled (Task 9); the `app-10` row no longer claims a false "closed."
-- PR body carries `Closes #553`; mandatory `code-review` pass (single-scope `feat(app)` → `medium` effort per model-routing) triaged before merge.
+- PR body carries `Closes #553`; mandatory `pr-review-gate` pass (single-scope `feat(app)` → `medium` effort per model-routing) triaged before merge.
 - **On-device Android smoke test is owed to the owner post-merge** (standard app-* "live device acceptance owed"). Reopen #553 only if it fails on a real phone.
 
 ## Self-review (writing-plans)

--- a/docs/superpowers/plans/2026-07-13-narrator-localized-folkloric-identity.md
+++ b/docs/superpowers/plans/2026-07-13-narrator-localized-folkloric-identity.md
@@ -558,7 +558,7 @@ git commit -m "docs(server): regression plan + release notes for narrator identi
 - [ ] `npm run typecheck` — clean.
 - [ ] `npm run verify:fast:branch` — branch-scoped battery green.
 - [ ] Open the PR with `Closes #NNNN` (file/link a GitHub issue — `type:feature` + `area:server` — at PR time per the PR-gate), fill Summary + Test plan, link the spec and regression plan.
-- [ ] Mandatory `code-review` pass (medium — single-scope `feat`) before merge.
+- [ ] Mandatory `pr-review-gate` pass (medium — single-scope `feat`) before merge.
 
 ## Self-Review
 

--- a/docs/superpowers/plans/2026-07-14-fe49-analyzer-wizard-split.md
+++ b/docs/superpowers/plans/2026-07-14-fe49-analyzer-wizard-split.md
@@ -1016,7 +1016,7 @@ git commit -m "test(e2e): 7-step wizard order + Ollama pull path"
 - **Regression plan:** create `docs/features/<n>-fe49-analyzer-wizard-split.md` from `TEMPLATE.md` (frontmatter `status: active`), documenting the tri-state gate invariant + the two regression guards; add its `docs/features/INDEX.md` entry.
 - **Release notes (both):** append a technical entry to `docs/release-notes-next.md` (PR-refed) AND a brand-voice user line to the in-progress version at the top of `RELEASE_NOTES.md`.
 - **Admin follow-up (spec §7):** file a Backlog-item issue — "Mirror fe-49 analyzer/voice split + tri-state badge in `model-settings-form.tsx`/`model-manager.tsx`" (labels `area:fe`, `type:chore`, `moscow:should`) — and add the thin `docs/BACKLOG.md` row linking it.
-- **PR:** title `feat(frontend): split setup analyzer/voice steps + primary-backup analyzer signal`; body `Closes #1610`; link the regression plan. Run `npm run verify:fast:branch` locally; cloud `verify.yml` + the mandatory `code-review` pass gate the merge.
+- **PR:** title `feat(frontend): split setup analyzer/voice steps + primary-backup analyzer signal`; body `Closes #1610`; link the regression plan. Run `npm run verify:fast:branch` locally; cloud `verify.yml` + the mandatory `pr-review-gate` pass gate the merge.
 
 ## Self-review
 

--- a/docs/superpowers/plans/2026-07-14-help-troubleshooting-reorg-and-wiki-links.md
+++ b/docs/superpowers/plans/2026-07-14-help-troubleshooting-reorg-and-wiki-links.md
@@ -1057,7 +1057,7 @@ Expected: green (or, if the GPU is pinned and local legs contend, push and let c
 
 - [ ] **Step 3: File issues + open PR**
 
-File a `type:feature` + `area:frontend` issue for the Troubleshooting reorg and (if not folded into one) a second for the wiki-link surface; add thin rows to `docs/BACKLOG.md` if they represent net-new backlog items. Open the PR with `Closes #NN` for each, title `feat(frontend): reorganize troubleshooting help and add wiki links`, filling `## Summary` + `## Test plan` and linking the plan. Then run the mandatory `code-review` pass (medium effort — single-scope `feat`) before merge.
+File a `type:feature` + `area:frontend` issue for the Troubleshooting reorg and (if not folded into one) a second for the wiki-link surface; add thin rows to `docs/BACKLOG.md` if they represent net-new backlog items. Open the PR with `Closes #NN` for each, title `feat(frontend): reorganize troubleshooting help and add wiki links`, filling `## Summary` + `## Test plan` and linking the plan. Then run the mandatory `pr-review-gate` pass (medium effort — single-scope `feat`) before merge.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-14-mock-script-review-dedup.md
+++ b/docs/superpowers/plans/2026-07-14-mock-script-review-dedup.md
@@ -525,4 +525,4 @@ git commit -m "docs: release notes for mock script-review dedup (#1496)"
 
 ## Execution Handoff
 
-Plan complete. This will be executed via subagent-driven-development per the controlling thread's mandate (fresh implementer per task + two-stage review), then the ship task (verify, PR, code-review gate).
+Plan complete. This will be executed via subagent-driven-development per the controlling thread's mandate (fresh implementer per task + two-stage review), then the ship task (verify, PR, pr-review-gate pass).

--- a/docs/superpowers/plans/2026-07-15-fe51-language-aware-engine-recommendation.md
+++ b/docs/superpowers/plans/2026-07-15-fe51-language-aware-engine-recommendation.md
@@ -898,7 +898,7 @@ git commit -m "test(frontend): e2e for wizard engine recommendation + regression
 - [ ] **Step 6: Full branch verification**
 
 Run: `npm run verify:fast:branch`
-Expected: PASS. Then open the PR (`Closes #1614`), let cloud `verify.yml` + the mandatory Premium `code-review` (single-scope `feat` → `medium` effort) run, triage findings, merge.
+Expected: PASS. Then open the PR (`Closes #1614`), let cloud `verify.yml` + the mandatory Premium `pr-review-gate` pass (single-scope `feat` → `medium` effort) run, triage findings, merge.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-15-wizard-help-wiki-links.md
+++ b/docs/superpowers/plans/2026-07-15-wizard-help-wiki-links.md
@@ -814,9 +814,9 @@ BODY
 Run: `gh pr view --json title,body,url`
 Expected: body contains `Closes #1615` and `Closes #1616`; `verify.yml` starts on the push.
 
-- [ ] **Step 5: Run the mandatory independent code-review gate**
+- [ ] **Step 5: Run the mandatory independent pr-review-gate pass**
 
-Per CLAUDE.md, a single-scope `feat` PR gets a **`low`-effort** `code-review` pass (no `--fix`) once fully staged. Triage and fold findings before merge.
+Per CLAUDE.md, a single-scope `feat` PR gets a **`low`-effort** `pr-review-gate` pass (no `--fix`) once fully staged. Triage and fold findings before merge.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-16-tier3-alias-coreference-merge.md
+++ b/docs/superpowers/plans/2026-07-16-tier3-alias-coreference-merge.md
@@ -543,7 +543,7 @@ git commit -m "docs(server): release notes + cast-view comment for Tier-3 alias 
 
 1. Push the branch and open a PR titled `fix(server): merge same-character-different-name cast rows (Tier-3 alias coreference)` with `Closes #1662` in the body, linking the spec `docs/superpowers/specs/2026-07-16-character-coreference-alias-merge-design.md`.
 2. Run `npm run verify:fast:branch` locally.
-3. Mandatory `code-review` gate — single-scope `fix` ⇒ **medium** effort (per model-routing). Triage and fold findings before merge.
+3. Mandatory `pr-review-gate` pass — single-scope `fix` ⇒ **medium** effort (per model-routing). Triage and fold findings before merge.
 4. This is a localized change (one source file + tests); per the Before-shipping checklist, the spec + paired tests are the regression record — no separate `docs/features/` plan doc is required. Note that explicitly in the PR body.
 
 ---

--- a/docs/superpowers/plans/2026-07-17-cast-alias-repoint-on-unlink.md
+++ b/docs/superpowers/plans/2026-07-17-cast-alias-repoint-on-unlink.md
@@ -977,7 +977,7 @@ git commit -m "docs(docs): fold alias-repoint (b) into regression plan + release
 Run: `npm run verify:fast:branch`
 Expected: lint + typecheck + config:check + test:hooks + test + test:server + build all green (each scope-gated).
 
-- [ ] **Open the PR.** Body: `Refs #1676` (this issue stays open only if further parts remain; part (b) completes the issue → use `Closes #1676`). Fill Summary + Test plan. Then run the mandatory `code-review` gate (medium effort — multi-scope `feat`), fold findings, merge.
+- [ ] **Open the PR.** Body: `Refs #1676` (this issue stays open only if further parts remain; part (b) completes the issue → use `Closes #1676`). Fill Summary + Test plan. Then run the mandatory `pr-review-gate` pass (medium effort — multi-scope `feat`), fold findings, merge.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-17-cast-bulk-line-reassignment.md
+++ b/docs/superpowers/plans/2026-07-17-cast-bulk-line-reassignment.md
@@ -1750,7 +1750,7 @@ git commit -m "test(frontend): e2e for bulk reassign + regression plan + release
 - [ ] **Step 5: Full fast branch verify**
 
 Run: `npm run verify:fast:branch`
-Expected: PASS. Then open the PR (`Closes #1676` — note part (b) is a separate follow-up, so use `Refs #1676` if the issue must remain open for part b; confirm with the issue's scope before choosing) and let cloud `verify.yml` + the mandatory `code-review` gate run.
+Expected: PASS. Then open the PR (`Closes #1676` — note part (b) is a separate follow-up, so use `Refs #1676` if the issue must remain open for part b; confirm with the issue's scope before choosing) and let cloud `verify.yml` + the mandatory `pr-review-gate` pass run.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-17-cloud-request-sizing.md
+++ b/docs/superpowers/plans/2026-07-17-cloud-request-sizing.md
@@ -846,4 +846,4 @@ git commit -m "docs(docs): analyzer cloud request-sizing regression plan + relea
 - [ ] **Knob-parity check:** every new env var (`ANALYZER_MAX_INPUT_TOKENS_PER_REQUEST`, `ANALYZER_STAGE1_LOCAL_INPUT_FRACTION`, `ANALYZER_STAGE2_LOCAL_INPUT_FRACTION`, `GEMINI_RPM_GEMMA_4_26B_A4B_IT`, `GEMINI_TPM_GEMMA_4_26B_A4B_IT`, `GEMINI_RPD_GEMMA_4_26B_A4B_IT`) appears in BOTH `registry.ts` (as a knob) AND `server/.env.example`. Grep each name in both files; no env-only reads. (The 26b now has full RPM/TPM/RPD parity with the 31b.)
 - [ ] `npm run verify:fast:branch` — the pre-push battery.
 - [ ] Manual (on-box, owner): free-tier Gemma re-analysis of *Ночной дозор* completes without dropped chapters or hang; calibrate `analyzer.stage2.localInputFraction` against a Qwen local truncation trace.
-- [ ] Open PR: `fix/server-cloud-request-sizing` → `main`, body `Closes #1682`, link this plan + the spec; run the mandatory `code-review` gate.
+- [ ] Open PR: `fix/server-cloud-request-sizing` → `main`, body `Closes #1682`, link this plan + the spec; run the mandatory gate via the `pr-review-gate` skill.

--- a/docs/superpowers/plans/2026-07-17-per-model-keepalive.md
+++ b/docs/superpowers/plans/2026-07-17-per-model-keepalive.md
@@ -723,4 +723,4 @@ git commit -m "docs(server): regression plan + local-llm sweep + release notes f
 - [ ] `npm run config:check` → PASS (no `.env.example` drift)
 - [ ] `git grep -n 'RESIDENT_MODELS\|resolveAnalyzerKeepAlive\|analyzer.ollama.keepAlive' -- server/src src` → only archived-doc matches, no live code
 - [ ] `npm run verify:fast:branch` → PASS (only when no GPU generation is active — check `nvidia-smi`)
-- [ ] Open the PR with `Closes #NN`; run the mandatory `code-review` gate before merge.
+- [ ] Open the PR with `Closes #NN`; run the mandatory gate via the `pr-review-gate` skill before merge.

--- a/docs/superpowers/plans/2026-07-18-vram-aware-gpu-placement.md
+++ b/docs/superpowers/plans/2026-07-18-vram-aware-gpu-placement.md
@@ -372,7 +372,7 @@ def test_idle_evict_then_place():
 - [ ] **Step 1:** Write the regression plan — invariants (per-call peak reservation held only as ledger bookkeeping, `min(...)` admit formula, up-only ratchet, sidecar-down fallback, eGPU-drop reconcile, analyzer-evict-only-when-it-helps, **analyzer↔heavy-TTS temporal separation per device**, **poll-cap fails with a toast not a hang**, and the **global lock order** ledger→threading-load-lock→`_synth_lock`) + the manual acceptance walkthrough on the 1-card and 2-card boxes (attach eGPU mid-run, drop it mid-run; run an analysis and a render together on the 8 GB card and confirm they take turns with no OOM and no permanent hang).
 - [ ] **Step 2:** Append the technical + brand-voice release-notes lines.
 - [ ] **Step 3:** `npm run verify:fast:branch`; then `npm run test:sidecar` (the new pytest tiers).
-- [ ] **Step 4:** Push the branch, open the PR (`Closes #<issue>`), run the mandatory `code-review` gate (`high` — multi-scope refactor).
+- [ ] **Step 4:** Push the branch, open the PR (`Closes #<issue>`), run the mandatory gate via the `pr-review-gate` skill (`high` — multi-scope refactor).
 - [ ] **Step 5: Commit** — `git commit -m "docs(server): regression plan + release notes for capacity-aware placement"`
 
 ---

--- a/docs/superpowers/plans/2026-07-20-script-review-summary-and-create-once.md
+++ b/docs/superpowers/plans/2026-07-20-script-review-summary-and-create-once.md
@@ -1196,7 +1196,7 @@ File/confirm a GitHub issue for this feature (title `fs-58 — script-review who
 - [ ] `npx vitest run src/store/script-review-slice.test.ts src/lib/apply-proposed.test.ts src/components/script-review-diff.test.tsx` — all green.
 - [ ] `npm run verify:fast:branch` from the worktree root — lint + typecheck + scoped tests + build.
 - [ ] Manual: at phone width (<640px) the accordion is single-column, chapter/type controls are ≥44px, and expanding works by tap.
-- [ ] Open the mandatory `code-review` pass (medium effort — single-scope `feat`) once pushed.
+- [ ] Open the mandatory `pr-review-gate` pass (medium effort — single-scope `feat`) once pushed.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-21-target-c-stage2-attribution-prompt.md
+++ b/docs/superpowers/plans/2026-07-21-target-c-stage2-attribution-prompt.md
@@ -358,7 +358,7 @@ Run from this worktree (corpus present); export `GEMINI_API_KEY` first (it lives
 
 ## After acceptance passes
 
-- **Whole-branch `code-review`** (Premium tier — `feat` multi-file, medium/high effort), fold findings.
+- **Whole-branch `pr-review-gate` pass** (Premium tier — `feat` multi-file, medium/high effort), fold findings.
 - **PR** `feat(server): …` with `Closes #<new issue>` (file a `type:feature`/`area:srv` issue if none exists — the auto-file gate). Fill `## Summary` + `## Test plan` (the three unit tests + the on-box eval numbers).
 - **Docs:** update `docs/features/265-attribution-eval-tuning.md` with the Target C cycle and the captured numbers; append the two release-notes entries (a raw-attribution lift is a user-visible delta).
 - **Tracked follow-up (same round):** file the RU/DE non-English eval fixture issue (hand-label one Russian + one German chapter, re-run the gate) + its thin `docs/BACKLOG.md` row.

--- a/docs/superpowers/plans/2026-07-22-attribution-ch44-addressee-tag-fix.md
+++ b/docs/superpowers/plans/2026-07-22-attribution-ch44-addressee-tag-fix.md
@@ -515,7 +515,7 @@ perception-verb frame survive the treatment replay; record outcomes (do not fix 
   being *spoken to* instead of the speaker").
 - [ ] File the GitHub issue (`srv-…`, `bug` label — a real wrong-voice defect); PR body
   `Closes #NN`.
-- [ ] `npm run verify:fast:branch`; open PR; mandatory `code-review` (medium — single-
+- [ ] `npm run verify:fast:branch`; open PR; mandatory `pr-review-gate` pass (medium — single-
   scope `fix`) before merge.
 
 ## Self-Review

--- a/docs/superpowers/plans/2026-07-24-fs10-listen-title-segment.md
+++ b/docs/superpowers/plans/2026-07-24-fs10-listen-title-segment.md
@@ -973,4 +973,4 @@ EOF
 
 - [ ] **Step 7: Run the mandatory review gate**
 
-Per `CLAUDE.md`'s before-shipping checklist step 9 and the model-routing skill: this is a multi-scope PR, so the `code-review` pass runs at `high` effort. Triage and fold findings before merge. Confirm `pr-title-lint`, `pr-issue-link`, and `verify.yml` are all green — including the `e2e-visual` job, which needs the linux baselines from Task 6 Step 7 merged in first.
+Per `CLAUDE.md`'s before-shipping checklist step 9 and the model-routing skill: this is a multi-scope PR, so the `pr-review-gate` pass runs at `high` effort. Triage and fold findings before merge. Confirm `pr-title-lint`, `pr-issue-link`, and `verify.yml` are all green — including the `e2e-visual` job, which needs the linux baselines from Task 6 Step 7 merged in first.

--- a/docs/superpowers/plans/2026-07-24-fs35-per-chapter-detect-emotions.md
+++ b/docs/superpowers/plans/2026-07-24-fs35-per-chapter-detect-emotions.md
@@ -816,7 +816,7 @@ git commit -m "docs(docs): fs-35 regression plan + release notes"
 
 - [ ] **V1:** `npm run verify:fast:branch` (same battery pre-push runs) — lint, typecheck, config:check, test:hooks, test, test:server, build, each scope-gated to the branch diff. Expected: green.
 - [ ] **V2:** Confirm `manuscript.tsx` is unchanged in the diff (`git diff main --stat -- src/views/manuscript.tsx` → empty) — the store-selector design means it must not appear.
-- [ ] **V3:** Open the PR with `Closes #592`, fill Summary + Test plan, link the regression plan. Then run the mandatory `code-review` pass (medium effort — multi-scope `feat`) and fold findings before merge.
+- [ ] **V3:** Open the PR with `Closes #592`, fill Summary + Test plan, link the regression plan. Then run the mandatory `pr-review-gate` pass (medium effort — multi-scope `feat`) and fold findings before merge.
 
 ## Self-review notes (author)
 

--- a/docs/superpowers/plans/2026-07-25-fs38-wave3a-ingest-consent-recorder.md
+++ b/docs/superpowers/plans/2026-07-25-fs38-wave3a-ingest-consent-recorder.md
@@ -1483,7 +1483,7 @@ git commit -m "docs(docs): fs-38 3a regression plan + release notes + doc-194 up
 - [ ] **Typecheck:** `npm run typecheck` — green (proves the api registration + generated types line up).
 - [ ] **Branch-scoped gate:** `npm run verify:fast:branch`.
 - [ ] **E2E (add one spec):** an upload-path phase-1 golden path is deferred with the wizard to 3b1 (3a ships no wired wizard entry point). If time allows, add a component-level RTL test that a cloned fixture appears in My voices with a working Revoke — already covered by Task 13. No new Playwright spec is required for 3a; note this explicitly in the PR ("e2e lands with the wizard in 3b1").
-- [ ] **PR:** body links `Refs #624` (partial delivery — 3a of four sub-waves), links the regression plan and the spec, and states the disclosed behind-flag scope (consent guard / revoke / cloned UI have no reachable caller until 3b1). Run the mandatory `code-review` pass (medium effort — multi-scope `feat`).
+- [ ] **PR:** body links `Refs #624` (partial delivery — 3a of four sub-waves), links the regression plan and the spec, and states the disclosed behind-flag scope (consent guard / revoke / cloned UI have no reachable caller until 3b1). Run the mandatory `pr-review-gate` pass (medium effort — multi-scope `feat`).
 
 ## Self-review notes (author)
 

--- a/docs/superpowers/plans/2026-07-26-audition-engine-and-tier-fidelity.md
+++ b/docs/superpowers/plans/2026-07-26-audition-engine-and-tier-fidelity.md
@@ -1655,7 +1655,7 @@ follow on its own branch.
 
 - [ ] **Step 4: Mandatory independent review**
 
-Run the `code-review` gate (no `--fix`) per CLAUDE.md's Before-shipping checklist step 9, effort `medium` (single-concern `fix`, but multi-scope). Ask it specifically to re-check the one-cache-key invariant across all nine call sites — that is this change's failure mode.
+Run the mandatory `pr-review-gate` pass per CLAUDE.md's Before-shipping checklist step 9, effort `medium` (single-concern `fix`, but multi-scope). Ask it specifically to re-check the one-cache-key invariant across all nine call sites — that is this change's failure mode.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-28-coqui-residency-eviction.md
+++ b/docs/superpowers/plans/2026-07-28-coqui-residency-eviction.md
@@ -1394,5 +1394,5 @@ PR body must contain `Closes #1894`, a `## Summary` and a `## Test plan` section
 
 - [ ] **Step 7: Run the mandatory independent code review**
 
-Per CLAUDE.md's Before-shipping checklist step 10 and the model-routing skill: dispatch a `code-review` pass at the tier the PR's scope calls for. This PR is multi-scope (`sidecar,server`) → **high** effort, Premium tier. Triage and fold findings before merge. Do not merge on a Critical finding without re-review.
+Per CLAUDE.md's Before-shipping checklist step 10 and the model-routing skill: dispatch a `pr-review-gate` pass at the tier the PR's scope calls for. This PR is multi-scope (`sidecar,server`) → **high** effort, Premium tier. Triage and fold findings before merge. Do not merge on a Critical finding without re-review.
 

--- a/docs/superpowers/plans/2026-07-31-cast-json-write-lock.md
+++ b/docs/superpowers/plans/2026-07-31-cast-json-write-lock.md
@@ -1357,6 +1357,6 @@ git commit -m "docs(docs): record the cast.json lock convention and release note
       four failed staleness mechanisms; auto-closing them discards the brief the
       next attempt starts from. Declare Task 8's `library-cast-override` same-book fix and
       Task 3's #2001 fix under "Also fixed, found in passing".
-- [ ] Mandatory `code-review` pass at `high` effort — multi-scope, 17 modules.
+- [ ] Mandatory `pr-review-gate` pass at `high` effort — multi-scope, 17 modules.
 
 ---

--- a/docs/superpowers/plans/2026-07-31-xtts-clone-torchcodec-ffmpeg.md
+++ b/docs/superpowers/plans/2026-07-31-xtts-clone-torchcodec-ffmpeg.md
@@ -1013,7 +1013,7 @@ Title: `fix(side,server): derive XTTS cloned voices without torchcodec`. Body mu
 
 - [ ] **Step 6: Mandatory independent review**
 
-Dispatch the `code-review` gate at Premium tier — multi-scope PR, so `high` effort. Triage and fold findings before merge.
+Dispatch the `pr-review-gate` gate at Premium tier — multi-scope PR, so `high` effort. Triage and fold findings before merge.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-01-cast-character-identity.md
+++ b/docs/superpowers/plans/2026-08-01-cast-character-identity.md
@@ -1068,7 +1068,7 @@ a stamp either: the "auto-reconciled" list would be empty by construction
 - [ ] **Step 1:** `npm run verify` (full local battery) → green.
 - [ ] **Step 2:** Push and open the PR with `Closes #2040`.
 - [ ] **Step 3:** Confirm cloud `verify.yml` and `pr-issue-link.yml` are green.
-- [ ] **Step 4:** Run the mandatory independent `code-review` pass, triage findings, fold before merge.
+- [ ] **Step 4:** Run the mandatory independent `pr-review-gate` pass, triage findings, fold before merge.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-05-device-token-scope.md
+++ b/docs/superpowers/plans/2026-08-05-device-token-scope.md
@@ -699,7 +699,7 @@ PR body must also state: *"On-box acceptance: F2 added. PR B (server
 enforcement) follows and must not merge until an APK built from this branch is
 installed on the acceptance phone."*
 
-- [ ] **Step 7: The mandatory `code-review` gate**
+- [ ] **Step 7: The mandatory `pr-review-gate` gate**
 
 Not a docs-only PR, single-scope `fix` ⇒ **medium** effort, Premium tier. Fold
 findings before merge.
@@ -1455,7 +1455,7 @@ Before pushing, run
 the only issue trailers are the ones you intend — a `Closes` in a commit fires
 regardless of the PR body.
 
-- [ ] **Step 7: The mandatory `code-review` gate**
+- [ ] **Step 7: The mandatory `pr-review-gate` gate**
 
 Not docs-only, single-scope `feat` ⇒ **medium** effort, Premium tier. Triage and
 fold findings before merge.

--- a/docs/superpowers/plans/2026-08-06-cast-merge-base-serialise-and-detect.md
+++ b/docs/superpowers/plans/2026-08-06-cast-merge-base-serialise-and-detect.md
@@ -1711,7 +1711,7 @@ Body must contain:
 - Any incidental findings fixed in passing, per CLAUDE.md ("Also fixed, found in
   passing: …").
 
-- [ ] **Step 5: Mandatory `code-review` gate**
+- [ ] **Step 5: Mandatory `pr-review-gate` gate**
 
 Multi-scope (`server` + `frontend` + `api`) → **`high`** effort, Premium tier.
 Triage and fold findings before merge.

--- a/docs/superpowers/plans/2026-08-07-rename-midrun-bookdir-pinning.md
+++ b/docs/superpowers/plans/2026-08-07-rename-midrun-bookdir-pinning.md
@@ -1562,7 +1562,7 @@ readable sentence in the existing error toast.
     pre-rename path, disabling the analysis↔bulk-design exclusion for that book
     until the run ends; the run's own disk writes are unaffected). A reviewer
     must not have to find that in the plan.
-  - **Review gate:** a `code-review` pass at `medium` effort (single-scope
+  - **Review gate:** a `pr-review-gate` pass at `medium` effort (single-scope
     `fix` semantics, multi-scope diff → treat as `high` if the reviewer's
     routing table says so), dispatched to the Premium tier, before merge.
   - **Merge:** "Create a merge commit" only.


### PR DESCRIPTION
## Summary

Records a durable lifecycle rule for `docs/superpowers/plans/**` and `docs/superpowers/specs/**` (checkbox-level, not file-level, since these directories carry no `status:` frontmatter) as a new subsection under `docs/features/INDEX.md`'s "## Plan lifecycle", then sweeps every unchecked/actionable `code-review` reference in those directories to `pr-review-gate`, leaving checked steps and historical/narrative prose untouched. Closes #2243.

## Test plan

Verified as a read-only pass (this ticket is a verify step, no code to test):

- [x] `docs/features/INDEX.md` states the checkbox-based lifecycle rule for `docs/superpowers/plans/**` and `specs/**` — confirmed present at lines 28-39.
- [x] Re-ran `grep -rn "code-review" docs/superpowers/plans/ docs/superpowers/specs/` myself — output matches step 1's receipt exactly (8 plan files, 13 spec files); every hit is either a checked/narrative reference, or one of the two explicitly-flagged left-unchanged cases (the `code-reviewer`-role wording in `2026-06-12-companion-marketing-capture.md:1502`, and the separate, still-live `/code-review ultra` command in `2026-08-14-model-effort-routing.md:238`).
- [x] Spot-checked the ambiguous-looking hits in `2026-07-01-model-routing-and-review-gates.md` (line 311 is inside a literal patch block being applied to CLAUDE.md at the time it was written, not a live instruction for this plan) and `2026-07-04-github-wiki-user-guide.md:1254` (past-tense "fixed" narrative) — both correctly left unchanged.
- [x] `git diff main...HEAD --stat` touches only `docs/features/INDEX.md` and files under `docs/superpowers/plans/**` — no source files, no `docs/superpowers/specs/**` edits (matches the receipt's claim that all spec hits were narrative and needed no changes).
- [x] No `docs/superpowers/plans/README.md` or `docs/superpowers/specs/README.md` was created.
- [x] `CLAUDE.md`, `.claude/skills/model-routing/SKILL.md`, and every other `docs/features/*.md` file are untouched by this branch.
- [x] Working tree is clean on `docs/docs-2243-plans-lifecycle-sweep`, commit `8d86ae92`, already pushed.

Docs-only change; exempt from the mandatory `pr-review-gate` pass per CLAUDE.md's Model-routing section.
