### PR TITLE
feat(ops,scripts,docs): seed the live view's publish token + stamper

### DIFF
--- a/docs/testing/onbox-acceptance-register-live-view.html
+++ b/docs/testing/onbox-acceptance-register-live-view.html
@@ -161,6 +161,12 @@
 
   <p class="eyebrow">Castwright · docs/testing/onbox-acceptance-register.md</p>
   <h1>On-box acceptance register</h1>
+
+  <!-- Publish token. NEVER hand-edit: run `npm run stamp:publish-token`.
+       The counter orders publishes; the id proves which branch produced one.
+       Attributes, not a comment: checkLiveView blanks comments before reading. -->
+  <div hidden data-published-as="1" data-publish-id="25f4dfb810b6"></div>
+
   <p class="lede">
     Shipped behaviour that only real hardware can prove — a live GPU, a real sidecar, a real
     analyzer, a real book, a real phone — and that was <strong>not</strong> proven at PR time.

--- a/docs/testing/onbox-acceptance-register-live-view.html
+++ b/docs/testing/onbox-acceptance-register-live-view.html
@@ -164,7 +164,7 @@
 
   <!-- Publish token. NEVER hand-edit: run `npm run stamp:publish-token`.
        The counter orders publishes; the id proves which branch produced one.
-       Attributes, not a comment: checkLiveView blanks comments before reading. -->
+       Attributes, not a comment: checkLiveView removes comments before reading. -->
   <div hidden data-published-as="1" data-publish-id="25f4dfb810b6"></div>
 
   <p class="lede">

--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -48,6 +48,41 @@ and concluded they had complied. The live view is tracked in this repo — rathe
 than living in whichever session scratchpad last built it — precisely so the
 right file is always to hand.
 
+### The publish token — never hand-edit it
+
+The live view carries a **publish token** just under its `<h1>`:
+
+```html
+<div hidden data-published-as="<counter>" data-publish-id="<nonce>"></div>
+```
+
+The counter orders publishes; the id says *which branch produced this one*. Both
+are machine-written. **Do not type either value.** Run:
+
+```
+npm run stamp:publish-token              # bumps the counter AND mints a fresh id
+npm run stamp:publish-token -- --check   # report only, changes nothing
+```
+
+**Stamp, then commit, then publish** — in that order. An uncommitted stamp
+cannot be found in git history, which is where its freshness is verified.
+
+Why a command rather than an instruction to bump the number: a token that a
+human maintains goes stale, and a stale one fails in the **green** direction —
+a competing lane whose value happens to match yours reads as your *own* earlier
+publish, so the check waves through exactly the overwrite it exists to stop.
+Bumping the counter without minting a new id is that same failure with an extra
+step. Two of the eight designs considered for this token died on precisely that,
+which is why the stamper does both halves or neither.
+
+The token is inert today: nothing reads it yet. The check that does — a
+comparison against the live page's own token, to catch a lane publishing over
+work it never saw — lands separately (#2599). It is seeded first and on its own
+because a guard cannot ship in the same change as the data it requires: the
+checker validates `origin/main`'s copy, so the data has to be on `main` already
+or the guard's first run fails on its own delivery. That is the same
+data-then-guard split the stable row IDs needed (#2629).
+
 The live view carries derived figures — owed count, per-group counts, oldest
 debt — that must be **recomputed** on every edit. Rows can be right while the
 summary strip lies. `npm run check:onbox-register` verifies the owed total, the

--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -83,6 +83,16 @@ checker validates `origin/main`'s copy, so the data has to be on `main` already
 or the guard's first run fails on its own delivery. That is the same
 data-then-guard split the stable row IDs needed (#2629).
 
+**One more thing has to happen before that check can pass, and it is easy to
+miss because it is not a code change: the live view must be PUBLISHED at least
+once with a token on it.** The comparator reads three copies — the tracked file,
+`origin/main`'s, and the *saved live page* — and the live page only acquires a
+token when someone publishes after this change merged. Until then the check
+reports that the published page carries none while `origin/main` does, and
+names the transition explicitly rather than guessing. So the first publish after
+this merges clears it, and the wording of that error is written for exactly that
+window.
+
 The live view carries derived figures — owed count, per-group counts, oldest
 debt — that must be **recomputed** on every edit. Rows can be right while the
 summary strip lies. `npm run check:onbox-register` verifies the owed total, the
@@ -129,6 +139,12 @@ CI check — the same call this design already made for the tracked-pair
 comparison, see the edge list above). The merge step that closes this, run
 **immediately before every publish**, not only after a suspected race:
 
+0. **If your change touched the live view, stamp it and commit the stamp** —
+   `npm run stamp:publish-token`, then commit. It goes *before* step 2, not
+   after step 4, for two reasons: the check reads the token, and an
+   **uncommitted** stamp cannot be found in git history, which is where its
+   freshness is verified. See "The publish token" above for why this is a
+   command rather than an instruction to edit a number.
 1. Fetch the page currently live at the canonical URL above and save it to a
    local file — this is the CURRENTLY-published register, which may be ahead
    of what you are about to publish.

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "test:quarantine": "cross-env RUN_QUARANTINE=1 npm run test && cross-env RUN_QUARANTINE=1 npm --prefix server run test && cross-env RUN_QUARANTINE=1 npm --prefix server run test:slow",
     "quarantine:health": "node scripts/quarantine-health.mjs",
     "check:onbox-register": "node scripts/check-onbox-register.mjs",
+    "stamp:publish-token": "node scripts/stamp-publish-token.mjs",
     "check:register-citations": "node scripts/check-register-citations.mjs",
     "check:cycles": "node scripts/check-import-cycles.mjs",
     "capture:marketing": "playwright test --config=playwright.marketing.config.ts --project=desktop",

--- a/scripts/check-onbox-register.mjs
+++ b/scripts/check-onbox-register.mjs
@@ -449,8 +449,11 @@ export function checkRegister(text) {
 // directions matter and both were wrong without it (PR #2080 review round 2):
 // a commented-out row was counted as a real one, and commenting out a whole
 // group section — which removes it from the published page — was invisible.
-// Blanking rather than deleting keeps the comment's own `<section>`/`<span>`
-// text from being read while leaving the surrounding structure intact.
+// Removing the comment entirely keeps its own `<section>`/`<span>` text from
+// being read while leaving the surrounding structure intact. (This said
+// "blanking rather than deleting" and the code has always done the latter —
+// `.replace(..., '')` removes the span rather than substituting whitespace.
+// Corrected because the distinction is the kind a reader would reason from.)
 export function stripHtmlComments(html) {
   let out = html;
   for (;;) {

--- a/scripts/publish-token.mjs
+++ b/scripts/publish-token.mjs
@@ -1,0 +1,341 @@
+// Publish-token comparator — executable draft for #2599.
+//
+// SEVEN designs preceded this. Three per-row content rules; a bare counter
+// (cannot tell your re-publish from a rival's — same number); a branch name
+// (inherited, renamed, degenerate under detached HEAD); a hand-minted nonce
+// (goes stale, fails GREEN); and a nonce whose freshness was tested against
+// `b.nonce` rather than against history (closed the hole by exactly one commit).
+//
+// The freshness question is NOT "does the page's nonce differ from main's". It
+// is: **is the page's nonce already in the baseline's history while its counter
+// is ahead of the baseline?** That is the signature of "somebody bumped without
+// minting", at any depth, and it is what closes the class.
+
+export const PUBLISH_TOKEN_BASELINE_ERROR =
+  "Cannot verify the publish token: origin/main's live view is unavailable or " +
+  'unreadable. Do not publish until this passes.';
+
+export const PUBLISH_TOKEN_PUBLISHED_ERROR =
+  'Cannot verify the publish token: the saved copy of the published page could ' +
+  'not be read. Re-save it from the artifact URL and re-run.';
+
+export const PUBLISH_TOKEN_WORKING_ERROR =
+  'Cannot verify the publish token: the tracked live view could not be read.';
+
+// A factory, not a shared mutable object. A `/g` regex carries `lastIndex`, and
+// one stray `.test()` on a shared instance makes the next `matchAll` return zero
+// matches — i.e. "this file has no token" for a file that has one.
+export const publishTokenRegex = () =>
+  /data-published-as="([^"]*)"\s+data-publish-id="([^"]*)"/g;
+
+export function parsePublishToken(rawHtml) {
+  if (typeof rawHtml !== 'string') return null;
+  const matches = [...rawHtml.matchAll(publishTokenRegex())];
+  if (matches.length === 0) return null;
+  if (matches.length > 1) {
+    return { malformed: `the publish token appears more than once (${matches.length} times)` };
+  }
+  const [, n, nonce] = matches[0];
+  // Digit cap, not just "is an integer": past 2^53 `Number()` collapses
+  // neighbouring counters onto one value, and `p.n > b.n` silently goes false —
+  // losing the stale-nonce STOP. It also makes bumpToken's `+ 1` a no-op, so a
+  // typo'd counter in main would tell every operator to bump, forever.
+  if (!/^\d{1,15}$/.test(n)) {
+    return { malformed: `the counter "${n}" is not a bare integer of 1-15 digits` };
+  }
+  // The nonce is interpolated into a `git log -S data-publish-id="<nonce>"`
+  // anchor, so its charset is a correctness constraint, not a style one: a
+  // quote or a space breaks out of the anchor. The 6-char floor keeps it from
+  // matching half the repository. The leading-`-` clause is defence in depth
+  // ONLY — the anchor prepends `data-publish-id="`, so the argv element always
+  // starts with `d` and a nonce can never be read as a git flag. It is kept
+  // against a future caller that searches the bare nonce; it is not what makes
+  // today's call safe, and the earlier comment claiming otherwise was wrong.
+  if (!/^[A-Za-z0-9_-]{6,64}$/.test(nonce) || /^-/.test(nonce)) {
+    return {
+      malformed: `the nonce "${nonce}" must be 6-64 chars of [A-Za-z0-9_-] and may not start with "-"`,
+    };
+  }
+  return { n: Number(n), nonce };
+}
+
+// `lookups` supplies the FOUR history answers, so the comparator stays pure:
+//   inBaseline        — is the PUBLISHED nonce in the BASELINE COMMIT's history?
+//   inMine            — is the PUBLISHED nonce in HEAD's history?
+//   baselineInMine    — is the BASELINE's OWN nonce in HEAD's history?
+//                       i.e. does my branch contain main's live view? Green
+//                       REQUIRES this. It is the working-side half of the
+//                       invariant, and its absence was pass 5's Critical.
+//   workingInBaseline — is the WORKING nonce in the baseline's history?
+//                       (consulted only when w.n > b.n; see its guard below)
+// Each is true | false | null, and null (the lookup itself failed) is never
+// treated as false. Count them here whenever one is added: this comment said
+// "two" while the code read three, and the third went unguarded because of it.
+export function comparePublishTokens({
+  working,
+  published,
+  baseline,
+  lookups = {},
+  allowBehind = false,
+}) {
+  // `= {}` only defaults `undefined`. A caller batching failed lookups can hand
+  // us `null`, and destructuring that throws — which becomes whatever an
+  // enclosing catch decides, including a pass.
+  if (lookups === null || typeof lookups !== 'object') lookups = {};
+  if (baseline === null || baseline === undefined) return [PUBLISH_TOKEN_BASELINE_ERROR];
+  if (published === null || published === undefined) return [PUBLISH_TOKEN_PUBLISHED_ERROR];
+  if (working === null || working === undefined) return [PUBLISH_TOKEN_WORKING_ERROR];
+
+  const w = parsePublishToken(working);
+  const p = parsePublishToken(published);
+  const b = parsePublishToken(baseline);
+
+  const malformed = [];
+  for (const [label, parsed] of [
+    ['tracked', w],
+    ['published', p],
+    ['origin/main', b],
+  ]) {
+    if (parsed && parsed.malformed) {
+      malformed.push(`Publish token (${label}): ${parsed.malformed}. Fix it before publishing.`);
+    }
+  }
+  if (malformed.length > 0) return malformed;
+
+  if (!b) {
+    return [
+      'Publish token: origin/main carries none. It was seeded before this check shipped, so this is a revert or a deletion — do not publish; investigate.',
+    ];
+  }
+  if (!w) return ['Publish token: the tracked live view has none. Restore it before publishing.'];
+  if (!p) {
+    return [
+      'Publish token: the published page carries no publish token, but origin/main does. Most likely it was published from a branch that predates the token — check whether a lane branched before it landed. Otherwise the wrong file was published to this URL, or the page was clobbered. Do not publish over it until you know which.',
+    ];
+  }
+
+  const behind = p.n < b.n;
+
+  // Flag misuse is an invocation error, refused rather than ignored — the
+  // --discharging unconsumed-name property.
+  if (allowBehind && !behind) {
+    return [
+      `Publish token: --live-page-behind-main was passed, but the live page (${p.n}) is not behind origin/main (${b.n}). Remove the flag.`,
+    ];
+  }
+
+  const { inBaseline, inMine, baselineInMine } = lookups;
+  if (inBaseline === null || inBaseline === undefined || inMine === null || inMine === undefined) {
+    return [
+      "Publish token: could not search history for the published page's nonce. Do not publish until this passes.",
+    ];
+  }
+  if (baselineInMine === null || baselineInMine === undefined) {
+    return [
+      "Publish token: could not search history for origin/main's own nonce. Do not publish until this passes.",
+    ];
+  }
+
+  // Lookup consistency. If my branch contains origin/main's live view
+  // (`baselineInMine`), then it contains main's history for that path, so
+  // anything in main's history is in mine: `inBaseline && baselineInMine`
+  // IMPLIES `inMine`. A caller reporting otherwise has wired a lookup to the
+  // wrong ref or the wrong nonce — the live hazard here, since the delivery
+  // plan currently wires ONE lookup where this function consumes four. Fail
+  // closed: every downstream verdict is derived from these three answers, so a
+  // contradiction among them makes all of them untrustworthy, not just one.
+  if (inBaseline && baselineInMine && !inMine) {
+    return [
+      'Publish token: the history lookups contradict each other — the published nonce is in origin/main\'s history and origin/main\'s own nonce is in this branch\'s, yet the published nonce is reported absent here. A lookup is wired to the wrong ref or nonce. Fix the wiring; do not publish on these answers.',
+    ];
+  }
+
+  // THE stale-nonce check, at any depth. A nonce already in the baseline's
+  // history cannot legitimately carry a counter ahead of the baseline: that
+  // means a lane bumped without minting, and every counter comparison below
+  // would misattribute their publish to you.
+  if (inBaseline && p.n > b.n) {
+    return [
+      `Publish token: the live page is at ${p.n}, ahead of origin/main (${b.n}), but its nonce ("${p.nonce}") is already in origin/main's history. A lane published without minting a new id. Do not publish over it — find that publish first.`,
+    ];
+  }
+  // THE WORKING-SIDE invariant, and the one this design spent five review
+  // passes without. Every other check governs the PUBLISHED nonce; nothing
+  // related the working file to the baseline except a counter that the stale
+  // lane increments itself — and the remedy at `w.n === b.n` told it to.
+  //
+  // The failure it closes, with no operator error anywhere in it: two lanes
+  // branch from main at 47 and each stamps once (47 -> 48). B merges and
+  // publishes. A runs the check for the first time, is told "the same as
+  // origin/main — bump", obeys, and gets GREEN over a page it never saw. The
+  // summary strip and footer revert; the ROWS are identical, so every existing
+  // mechanical check is blind. That is the 2026-07-31/08-01 incident.
+  //
+  // `!baselineInMine` is that staleness, stated positively: origin/main's own
+  // live-view nonce is not in my history, so my branch does not contain the
+  // page I am about to publish over. It is checked BEFORE the counters because
+  // it is the stronger fact — counters are the thing being lied to — and
+  // before `!inBaseline && !inMine` so a stale lane hears "rebase" rather than
+  // a rival-publish diagnosis it cannot act on.
+  //
+  // NOT a rejected design: this is the same history-backed question the
+  // surviving invariant already asks, pointed at (b.nonce, HEAD) instead of
+  // (p.nonce, baseline). No branch name, no hand-maintained value.
+  if (!baselineInMine) {
+    return [
+      `Publish token: origin/main's live-view nonce ("${b.nonce}") is not in this branch's history — your branch does not contain the live view that is currently on main. REBASE; do not bump. Bumping past it publishes your copy over whatever landed in between.`,
+    ];
+  }
+
+  if (!inBaseline && !inMine) {
+    if (p.nonce === w.nonce) {
+      return [
+        `Publish token: the live page carries this branch's nonce ("${p.nonce}") but it is not committed yet, so it cannot be found in history. Commit the bump, then re-run.`,
+      ];
+    }
+    return [
+      `Publish token: the live page's nonce ("${p.nonce}") is in neither origin/main's history nor this branch's — another lane published since your baseline. Rebase, re-read the live page, and re-run. Do not publish.`,
+    ];
+  }
+
+  // Production side of the same invariant: if the working file's nonce is
+  // already in the baseline's history, it was not freshly minted.
+  //
+  // `workingInBaseline` is the THIRD lookup, and it gets the same fail-closed
+  // treatment as the other two. It is guarded HERE rather than beside them
+  // because it is only consulted in this state; hoisting it would demand a git
+  // call the other branches never need. Reading it bare — as `&& lookups.x` —
+  // made a FAILED lookup indistinguishable from "the nonce is fresh", so a git
+  // error turned this STOP into a silent pass. That is the same fail-green
+  // shape this file's header claims is closed, and the header said "the two
+  // history answers" while the code consulted three.
+  if (w.n > b.n) {
+    const { workingInBaseline } = lookups;
+    if (workingInBaseline === null || workingInBaseline === undefined) {
+      return [
+        "Publish token: could not search history for the tracked live view's nonce. Do not publish until this passes.",
+      ];
+    }
+    if (workingInBaseline) {
+      return [
+        `Publish token: the tracked live view bumped the counter to ${w.n} but its nonce ("${w.nonce}") is already in origin/main's history — it was not freshly minted. Run \`node scripts/stamp-publish-token.mjs\`.`,
+      ];
+    }
+  }
+
+  // Un-minted, detectable with NO history lookup at all: the counter advanced
+  // while the nonce did not. This is the same corruption guard 15 exists to
+  // catch, one commit earlier — reachable before either nonce has been
+  // committed, which is exactly when history cannot see it.
+  if (p.nonce === w.nonce && w.n > p.n) {
+    return [
+      `Publish token: the tracked live view advanced the counter to ${w.n} but kept the published page's nonce ("${w.nonce}") — the counter was bumped without minting. Run \`node scripts/stamp-publish-token.mjs\`, which does both.`,
+    ];
+  }
+
+  // Rebase OUTRANKS behind: in the overlap state the other order hands the
+  // operator the mute flag while un-rebased.
+  if (w.n < b.n) {
+    return [
+      `Publish token: the tracked live view is at ${w.n} but origin/main is at ${b.n} — your branch predates main. REBASE; do not bump. Publishing from here would overwrite whatever landed in between.`,
+    ];
+  }
+  if (w.n === b.n) {
+    return [
+      `Publish token: the tracked live view is at ${w.n}, the same as origin/main. Run \`node scripts/stamp-publish-token.mjs\` to bump the counter and mint a new id — an unbumped publish is untracked.`,
+    ];
+  }
+  if (behind && !allowBehind) {
+    return [
+      `Publish token: the live page is at ${p.n} but origin/main is at ${b.n} — the page is BEHIND main. A bump merged without publishing, or a publish was reverted. Confirm which, then re-run with --live-page-behind-main.`,
+    ];
+  }
+  if (w.n <= p.n) {
+    return [
+      `Publish token: the tracked live view is at ${w.n}, not ahead of your own last publish (${p.n}). Run \`node scripts/stamp-publish-token.mjs\` again.`,
+    ];
+  }
+  return [];
+}
+
+// true = nonce is in <ref>'s history for that path. false = it is not.
+// null = the lookup itself failed. HEAD/<sha> explicitly, never --all: the
+// baseline fetch means --all would see a rival's freshly-fetched commit.
+//
+// THREE git semantics here are load-bearing, and getting any of them wrong
+// flips the answer in the PERMISSIVE direction for every STOP this gates.
+// (Two were found by pass 5 and the third by pass 6, in this same call — count
+// them here whenever one is added, and see the four-lookup comment above for
+// why an out-of-date count in a comment is not a cosmetic defect.)
+//
+//   --full-history — a pathspec'd `git log` applies default history
+//   simplification: at a merge that is TREESAME to one parent for that path,
+//   only that parent is walked. Resolving a live-view conflict by taking one
+//   side wholesale — the single most likely resolution, and the exact accident
+//   this ticket exists for — makes the merge TREESAME and PRUNES the other
+//   lane's commit out of the answer. `false` then means "pruned", not "absent".
+//
+//   the anchor — `-S` is a SUBSTRING search, not a whole-value match. A bare
+//   six-hex nonce collides with the abbreviated commit SHAs this very file
+//   quotes in its own changelog prose, so a rival's nonce could be "found" in
+//   your history because you cited an unrelated SHA that contains it. Searching
+//   for the full `data-publish-id="<nonce>"` makes the match positional as well
+//   as textual. `parsePublishToken` constrains the nonce charset so the anchor
+//   cannot be broken out of.
+//   --diff-merges=first-parent — `git log` computes NO diff for a merge commit
+//   unless asked, so pickaxe never inspects one. A nonce born in a CONFLICT
+//   RESOLUTION therefore reads as absent from the very history that contains
+//   it. That is not exotic here: this repo mandates merge commits (squash and
+//   rebase merge are disabled), the live view is the file lanes race, and the
+//   natural resolution IS a re-stamp — so the token ends up in neither parent.
+//   `--full-history` does not cover this; it cures pruning, not merge diffing.
+//   Paired with `-s`, which suppresses the patch body while leaving pickaxe
+//   SELECTION untouched — without it every lookup streams a full diff of a
+//   250 KB file through stdout.
+export function nonceInHistory(repoRoot, liveViewPath, nonce, ref, gitRunner) {
+  const anchored = `data-publish-id="${nonce}"`;
+  const result = gitRunner(
+    [
+      'log',
+      '--oneline',
+      '-s',
+      '--full-history',
+      '--diff-merges=first-parent',
+      '-S',
+      anchored,
+      ref,
+      '--',
+      liveViewPath,
+    ],
+    repoRoot,
+  );
+  if (result.error) return null;
+  if (result.status !== 0) return null;
+  if (typeof result.stdout !== 'string') return null;
+  return result.stdout.trim() !== '';
+}
+
+export function bumpToken(html, mintNonce) {
+  const parsed = parsePublishToken(html);
+  if (parsed === null) throw new Error('stamp-publish-token: no publish token found in the live view.');
+  if (parsed.malformed) throw new Error(`stamp-publish-token: ${parsed.malformed}`);
+  const n = parsed.n + 1;
+  const nonce = mintNonce();
+  // Validate the MINTED value against the same rule the parser enforces, or a
+  // stamper can write a token its own reader rejects — and `mintNonce` is
+  // caller-supplied, so nothing else constrains it.
+  if (typeof nonce !== 'string' || !/^[A-Za-z0-9_-]{6,64}$/.test(nonce) || /^-/.test(nonce)) {
+    throw new Error(`stamp-publish-token: minted nonce ${JSON.stringify(nonce)} is not 6-64 chars of [A-Za-z0-9_-].`);
+  }
+  // A FUNCTION replacement, not a string. String.replace expands `$&`, `$'`,
+  // "$`" and `$1` in its replacement, so a minted nonce containing any of them
+  // would splice the surrounding markup back into the attribute — corrupting
+  // the file into a token that still parses. The charset check above already
+  // excludes `$`; this makes the corruption unreachable rather than merely
+  // unlikely, because the two constraints are independent.
+  const next = html.replace(
+    publishTokenRegex(),
+    () => `data-published-as="${n}" data-publish-id="${nonce}"`,
+  );
+  return { html: next, n, nonce };
+}

--- a/scripts/publish-token.mjs
+++ b/scripts/publish-token.mjs
@@ -320,6 +320,16 @@ export function bumpToken(html, mintNonce) {
   if (parsed === null) throw new Error('stamp-publish-token: no publish token found in the live view.');
   if (parsed.malformed) throw new Error(`stamp-publish-token: ${parsed.malformed}`);
   const n = parsed.n + 1;
+  // The counter is capped at 15 digits by the parser, so a bump AT the cap
+  // would write a 16-digit token that this module's own reader then rejects —
+  // wedging the check permanently, because stamping again needs a parseable
+  // token to bump. Refuse instead, while the file is still valid. Unreachable
+  // with an honest counter; reachable via a typo'd counter that merged.
+  if (!/^\d{1,15}$/.test(String(n))) {
+    throw new Error(
+      `stamp-publish-token: bumping ${parsed.n} would exceed the 15-digit counter cap. Fix the counter in the file first.`,
+    );
+  }
   const nonce = mintNonce();
   // Validate the MINTED value against the same rule the parser enforces, or a
   // stamper can write a token its own reader rejects — and `mintNonce` is

--- a/scripts/stamp-publish-token.mjs
+++ b/scripts/stamp-publish-token.mjs
@@ -16,6 +16,9 @@
 //   node scripts/stamp-publish-token.mjs            # stamp the live view
 //   node scripts/stamp-publish-token.mjs --check    # report, change nothing
 //   node scripts/stamp-publish-token.mjs --file X   # stamp some other file
+//   node scripts/stamp-publish-token.mjs --file=X   # same, = form
+// Any other argument is REFUSED rather than ignored -- the default action is a
+// write, so a typo must not fall through to it.
 //
 // Exit codes: 0 stamped (or --check found a token), 1 refused.
 
@@ -27,7 +30,7 @@ import { bumpToken, parsePublishToken } from './publish-token.mjs';
 import { isDirectlyInvoked } from './lib/is-main-module.mjs';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const DEFAULT_FILE = 'docs/testing/onbox-acceptance-register-live-view.html';
+export const DEFAULT_FILE = 'docs/testing/onbox-acceptance-register-live-view.html';
 
 // 12 lowercase hex. The parser admits [A-Za-z0-9_-]{6,64}; 12 is chosen well
 // above the floor so a nonce is not plausibly confusable with the abbreviated
@@ -51,6 +54,17 @@ export function seedToken(html, mint = mintNonce) {
     throw new Error('stamp-publish-token: no <h1> found to anchor the seed token to.');
   }
   const nonce = mint();
+  // The same two hardenings bumpToken applies at the identical seam. They were
+  // missing here, which is the shape where a divergence hides: the seed path
+  // runs once per file and so is the one least likely to be exercised again.
+  // A seed the parser rejects would wedge the check permanently — and unlike a
+  // bad bump it cannot be re-stamped away, because stamping needs a parseable
+  // token to bump.
+  if (typeof nonce !== 'string' || !/^[A-Za-z0-9_-]{6,64}$/.test(nonce) || /^-/.test(nonce)) {
+    throw new Error(
+      `stamp-publish-token: minted nonce ${JSON.stringify(nonce)} is not 6-64 chars of [A-Za-z0-9_-].`,
+    );
+  }
   // A hidden <div>, not a <meta>: this file is a body fragment (the publisher
   // supplies <html>/<head>), and <meta> is not valid outside <head>. And an
   // ATTRIBUTE pair rather than an HTML comment, because checkLiveView's first
@@ -60,18 +74,50 @@ export function seedToken(html, mint = mintNonce) {
   const marker =
     `\n  <!-- Publish token. NEVER hand-edit: run \`npm run stamp:publish-token\`.\n` +
     `       The counter orders publishes; the id proves which branch produced one.\n` +
-    `       Attributes, not a comment: checkLiveView blanks comments before reading. -->\n` +
+    `       Attributes, not a comment: checkLiveView removes comments before reading. -->\n` +
     `  <div hidden data-published-as="1" data-publish-id="${nonce}"></div>\n`;
-  return { html: html.replace(SEED_AFTER, `$1\n${marker}`), n: 1, nonce };
+  // A function replacement, like bumpToken's. This one legitimately needs the
+  // captured heading, so it uses `match` rather than a `$1` in a template
+  // string — which also means a `$` pattern in the minted nonce cannot splice
+  // surrounding markup into the attribute. The charset check above already
+  // excludes `$`; the two constraints are independent on purpose.
+  return { html: html.replace(SEED_AFTER, (match) => `${match}\n${marker}`), n: 1, nonce };
+}
+
+// Parse strictly, and REFUSE anything unrecognised. The default action of this
+// script is a WRITE to a tracked file, so a permissive parser turns a typo into
+// a silent mutation: `--chek` (for `--check`) used to stamp the live view and
+// exit 0, and `--file=other.html` used to stamp the DEFAULT file while leaving
+// `other.html` untouched. A stray bump that then gets committed manufactures
+// the "live page is BEHIND main" state the comparator keeps a manual escape
+// hatch for. Refusing is what scripts/wt-new.mjs does, for the same reason.
+export function parseArgs(argv) {
+  let check = false;
+  let file = null;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--check') {
+      check = true;
+    } else if (arg === '--file') {
+      file = argv[++i];
+      if (file === undefined) return { error: '--file needs a path.' };
+    } else if (arg.startsWith('--file=')) {
+      file = arg.slice('--file='.length);
+      if (file === '') return { error: '--file= needs a path.' };
+    } else {
+      return { error: `unknown argument ${JSON.stringify(arg)}. Use --check and/or --file <path>.` };
+    }
+  }
+  return { check, file: file ?? DEFAULT_FILE };
 }
 
 function main(argv) {
-  const fileArg = argv.indexOf('--file');
-  const rel = fileArg !== -1 ? argv[fileArg + 1] : DEFAULT_FILE;
-  if (fileArg !== -1 && !rel) {
-    process.stderr.write('stamp-publish-token: --file needs a path.\n');
+  const parsed = parseArgs(argv);
+  if (parsed.error) {
+    process.stderr.write(`stamp-publish-token: ${parsed.error}\n`);
     return 1;
   }
+  const rel = parsed.file;
   const abs = resolve(REPO_ROOT, rel);
 
   let html;
@@ -84,7 +130,7 @@ function main(argv) {
 
   const existing = parsePublishToken(html);
 
-  if (argv.includes('--check')) {
+  if (parsed.check) {
     if (existing === null) {
       process.stdout.write(`stamp-publish-token: ${rel} has NO publish token (needs seeding).\n`);
       return 1;

--- a/scripts/stamp-publish-token.mjs
+++ b/scripts/stamp-publish-token.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+// Stamp the on-box register live view's publish token: bump the counter and
+// mint a fresh id, atomically, in one command.
+//
+// WHY THIS EXISTS AT ALL. The token is `data-published-as="<counter>"
+// data-publish-id="<nonce>"`. Two of the eight designs that preceded it failed
+// because a human was expected to maintain part of that pair by hand — and a
+// hand-maintained identity goes stale, which fails in the GREEN direction: a
+// competing lane whose stale value happens to match yours reads as your own
+// earlier publish. Bumping the counter without minting a new id is the same
+// failure with an extra step. So the rule is: nothing hand-edits this token.
+// Run this instead. `scripts/check-onbox-register.mjs`'s remedies name this
+// command precisely so no runbook line ever says "bump it by one".
+//
+// Usage:
+//   node scripts/stamp-publish-token.mjs            # stamp the live view
+//   node scripts/stamp-publish-token.mjs --check    # report, change nothing
+//   node scripts/stamp-publish-token.mjs --file X   # stamp some other file
+//
+// Exit codes: 0 stamped (or --check found a token), 1 refused.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { randomBytes } from 'node:crypto';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { bumpToken, parsePublishToken } from './publish-token.mjs';
+import { isDirectlyInvoked } from './lib/is-main-module.mjs';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const DEFAULT_FILE = 'docs/testing/onbox-acceptance-register-live-view.html';
+
+// 12 lowercase hex. The parser admits [A-Za-z0-9_-]{6,64}; 12 is chosen well
+// above the floor so a nonce is not plausibly confusable with the abbreviated
+// commit SHAs this page quotes in its own changelog prose. The history lookup
+// anchors on `data-publish-id="<nonce>"` so a collision is not a correctness
+// bug, but keeping the two shapes distinct keeps the logs readable.
+export const mintNonce = () => randomBytes(6).toString('hex');
+
+// The genesis case: the file has no token yet, so there is nothing to bump.
+// This is the ONLY path that creates a token, and it exists so that even the
+// first one is machine-written — an operator typing the seed by hand is how a
+// malformed or too-short id would enter the file, and the seed is the one
+// value every later comparison is anchored to.
+const SEED_AFTER = /(<h1[^>]*>[\s\S]*?<\/h1>)/;
+
+export function seedToken(html, mint = mintNonce) {
+  if (parsePublishToken(html) !== null) {
+    throw new Error('stamp-publish-token: this file already has a token; stamp it, do not seed it.');
+  }
+  if (!SEED_AFTER.test(html)) {
+    throw new Error('stamp-publish-token: no <h1> found to anchor the seed token to.');
+  }
+  const nonce = mint();
+  // A hidden <div>, not a <meta>: this file is a body fragment (the publisher
+  // supplies <html>/<head>), and <meta> is not valid outside <head>. And an
+  // ATTRIBUTE pair rather than an HTML comment, because checkLiveView's first
+  // action is stripHtmlComments — a comment-carried token is invisible to the
+  // very function that has to read it. The explanatory comment beside it is
+  // stripped harmlessly; the attributes are not.
+  const marker =
+    `\n  <!-- Publish token. NEVER hand-edit: run \`npm run stamp:publish-token\`.\n` +
+    `       The counter orders publishes; the id proves which branch produced one.\n` +
+    `       Attributes, not a comment: checkLiveView blanks comments before reading. -->\n` +
+    `  <div hidden data-published-as="1" data-publish-id="${nonce}"></div>\n`;
+  return { html: html.replace(SEED_AFTER, `$1\n${marker}`), n: 1, nonce };
+}
+
+function main(argv) {
+  const fileArg = argv.indexOf('--file');
+  const rel = fileArg !== -1 ? argv[fileArg + 1] : DEFAULT_FILE;
+  if (fileArg !== -1 && !rel) {
+    process.stderr.write('stamp-publish-token: --file needs a path.\n');
+    return 1;
+  }
+  const abs = resolve(REPO_ROOT, rel);
+
+  let html;
+  try {
+    html = readFileSync(abs, 'utf8');
+  } catch (err) {
+    process.stderr.write(`stamp-publish-token: cannot read ${rel}: ${err.message}\n`);
+    return 1;
+  }
+
+  const existing = parsePublishToken(html);
+
+  if (argv.includes('--check')) {
+    if (existing === null) {
+      process.stdout.write(`stamp-publish-token: ${rel} has NO publish token (needs seeding).\n`);
+      return 1;
+    }
+    if (existing.malformed) {
+      process.stderr.write(`stamp-publish-token: ${rel} token is malformed — ${existing.malformed}\n`);
+      return 1;
+    }
+    process.stdout.write(
+      `stamp-publish-token: ${rel} is at ${existing.n} (id ${existing.nonce}).\n`,
+    );
+    return 0;
+  }
+
+  let result;
+  try {
+    result = existing === null ? seedToken(html) : bumpToken(html, mintNonce);
+  } catch (err) {
+    process.stderr.write(`${err.message}\n`);
+    return 1;
+  }
+
+  writeFileSync(abs, result.html);
+  const verb = existing === null ? 'SEEDED' : 'stamped';
+  process.stdout.write(
+    `stamp-publish-token: ${verb} ${rel} -> ${result.n} (id ${result.nonce}).\n` +
+      `Commit this before running check:onbox-register --against-published — an\n` +
+      `uncommitted stamp cannot be found in history, and the check says so.\n`,
+  );
+  return 0;
+}
+
+// Via the shared helper, not a hand-rolled comparison: a naive form silently
+// evaluates false through a junction (this repo junctions worktrees), so main()
+// would never run and the process would exit 0 with no output — a vacuous
+// green rather than a visible failure. See scripts/lib/is-main-module.mjs (#2291).
+//
+// And `process.exitCode = ...` rather than `process.exit(main())`: exit()
+// terminates before Node flushes pending async stdout, which is synchronous on
+// Windows but ASYNCHRONOUS on POSIX — this script prints three lines, so
+// exit() would truncate its own tail on a Linux/macOS runner while looking
+// perfect locally.
+if (isDirectlyInvoked(import.meta.url)) {
+  process.exitCode = main(process.argv.slice(2));
+}

--- a/scripts/tests/publish-token-git.test.mjs
+++ b/scripts/tests/publish-token-git.test.mjs
@@ -16,30 +16,55 @@ import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { nonceInHistory } from '../publish-token.mjs';
+import { scrubGitEnv } from '../git-env.mjs';
 
 const LIVE = 'docs/live.html';
 
-// EVERY git spawn in this file MUST use this env. Passing `cwd` is NOT enough.
+// EVERY git spawn in this file MUST use this env. Passing `cwd` is NOT enough:
+// git resolves the repository from the environment BEFORE falling back to
+// discovery from `cwd`, so `git -C <tmp>` does not protect you.
 //
-// git exports GIT_DIR, GIT_INDEX_FILE, GIT_WORK_TREE and friends to processes
-// it runs — hooks above all. A child `git` that inherits them ignores its own
-// cwd and operates on the EXPORTED repository instead. These tests run under
-// `npm run test:hooks`, which runs from pre-commit, so without this scrub the
-// throwaway repositories' init/add/commit land on the REAL repo: they replace
-// its index with a one-entry index holding this file's fixture path, and
-// commit a fixture commit onto the checked-out branch. That is not
-// theoretical — it happened twice while this file was being written, taking
-// 3,979 tracked files down to 1 and moving the branch to a commit called
-// "base". `git -C <path>` does NOT override GIT_DIR; only the environment does.
+// Without it, these throwaway repositories' init/add/commit reach the REAL
+// repository. Not theoretical — it happened twice while this file was being
+// written, replacing a 3,979-entry index with a one-entry index holding this
+// file's fixture path, and leaving a fixture commit named "base" as HEAD.
 //
-// It is a FUNCTION, evaluated per spawn, not a constant snapshot taken at
-// import. As a constant it was computed before any test could inject a GIT_*
-// variable, so the self-check below PASSED with the scrub deleted — the
-// snapshot never contained the variable it was meant to strip, and the
-// instrument could not fail. Read the environment at call time.
+// TWO groups of keys, and they are scrubbed for different reasons:
+//
+//   1. REPOSITORY REDIRECTION — GIT_DIR, GIT_WORK_TREE, GIT_OBJECT_DIRECTORY,
+//      GIT_COMMON_DIR. Delegated to `scrubGitEnv` (scripts/git-env.mjs, #2169
+//      / #2216) rather than re-listed here, so this file inherits any later
+//      addition instead of becoming a third divergent copy. That helper also
+//      matches case-INSENSITIVELY, which matters and is easy to get wrong:
+//      Windows preserves whatever casing a variable was stored under, env
+//      lookup there is case-insensitive, and git honours a lowercase `git_dir`
+//      exactly as it honours `GIT_DIR` (measured on git 2.54.0.windows.1 —
+//      `git rev-parse --absolute-git-dir` from an unrelated cwd resolved to
+//      the `git_dir` target). A `startsWith('GIT_')` filter leaves that
+//      survivor in place, which is a no-op fix for the one case the scrub
+//      exists to close.
+//
+//   2. GIT_INDEX_FILE — deliberately NOT in that helper's list, and
+//      deliberately scrubbed HERE. Its exclusion there is correct and
+//      measured: a hook exports it (an ordinary hook does NOT export GIT_DIR —
+//      that is the header's own #2216 correction), git re-anchors it to the
+//      discovered toplevel, and a command whose job is to read the in-flight
+//      staged set must honour whichever index git is actually using. This file
+//      is the opposite case: nothing here reads the staged set, every spawn
+//      builds a disposable repository, and an inherited index is precisely
+//      what turned the real one into a one-entry file. So the general rule is
+//      right and this site is its exception — stated rather than assumed,
+//      because deleting this line looks like tidying.
+//
+// A FUNCTION, evaluated per spawn, not a constant snapshot taken at import. As
+// a constant it was computed before any test could inject a variable, so the
+// self-check below PASSED with the scrub deleted — the snapshot never held the
+// variable it was meant to strip, and the instrument could not fail.
 const cleanEnv = () => {
-  const env = { ...process.env };
-  for (const key of Object.keys(env)) if (key.startsWith('GIT_')) delete env[key];
+  const env = scrubGitEnv(process.env);
+  for (const key of Object.keys(env)) {
+    if (key.toUpperCase() === 'GIT_INDEX_FILE') delete env[key];
+  }
   return env;
 };
 
@@ -84,34 +109,43 @@ test('git: the env scrub actually isolates the throwaway repo (self-check)', () 
   // repository and destroy it, which is far worse than a red test. So assert
   // the isolation directly, with GIT_DIR/GIT_INDEX_FILE deliberately set to
   // the values a hook would export.
-  const decoy = newRepo();
-  const repo = newRepo();
-  try {
-    const saved = { dir: process.env.GIT_DIR, index: process.env.GIT_INDEX_FILE };
-    process.env.GIT_DIR = join(decoy, '.git');
-    process.env.GIT_INDEX_FILE = join(decoy, '.git', 'index');
+  // BOTH casings. git honours a lowercase `git_dir` exactly as it honours
+  // `GIT_DIR`, and Windows preserves whatever casing a variable was stored
+  // under — so an uppercase-only injection leaves a case-sensitive scrub
+  // looking correct while the survivor it misses is the live hazard.
+  for (const [dirKey, indexKey] of [
+    ['GIT_DIR', 'GIT_INDEX_FILE'],
+    ['git_dir', 'git_index_file'],
+  ]) {
+    const decoy = newRepo();
+    const repo = newRepo();
     try {
-      writeToken(repo, 1, 'nISOLATE');
-      git(repo, 'add', '-A');
-      git(repo, 'commit', '-qm', 'isolated');
-      // The work landed in `repo`...
-      assert.equal(ask(repo, 'nISOLATE'), true);
-      // ...and the decoy that GIT_DIR pointed at is untouched.
-      const decoyFiles = execFileSync('git', ['ls-files'], {
-        cwd: decoy,
-        encoding: 'utf8',
-        env: cleanEnv(),
-      });
-      assert.equal(decoyFiles.trim(), '', 'GIT_DIR leaked: the decoy repo was written to');
+      const saved = { dir: process.env[dirKey], index: process.env[indexKey] };
+      process.env[dirKey] = join(decoy, '.git');
+      process.env[indexKey] = join(decoy, '.git', 'index');
+      try {
+        writeToken(repo, 1, 'nISOLATE');
+        git(repo, 'add', '-A');
+        git(repo, 'commit', '-qm', 'isolated');
+        // The work landed in `repo`...
+        assert.equal(ask(repo, 'nISOLATE'), true, `${dirKey}: work did not land in the temp repo`);
+        // ...and the decoy the env pointed at is untouched.
+        const decoyFiles = execFileSync('git', ['ls-files'], {
+          cwd: decoy,
+          encoding: 'utf8',
+          env: cleanEnv(),
+        });
+        assert.equal(decoyFiles.trim(), '', `${dirKey} leaked: the decoy repo was written to`);
+      } finally {
+        for (const [k, v] of [[dirKey, saved.dir], [indexKey, saved.index]]) {
+          if (v === undefined) delete process.env[k];
+          else process.env[k] = v;
+        }
+      }
     } finally {
-      if (saved.dir === undefined) delete process.env.GIT_DIR;
-      else process.env.GIT_DIR = saved.dir;
-      if (saved.index === undefined) delete process.env.GIT_INDEX_FILE;
-      else process.env.GIT_INDEX_FILE = saved.index;
+      rmSync(repo, { recursive: true, force: true });
+      rmSync(decoy, { recursive: true, force: true });
     }
-  } finally {
-    rmSync(repo, { recursive: true, force: true });
-    rmSync(decoy, { recursive: true, force: true });
   }
 });
 

--- a/scripts/tests/publish-token-git.test.mjs
+++ b/scripts/tests/publish-token-git.test.mjs
@@ -1,0 +1,321 @@
+// REAL-GIT coverage for nonceInHistory.
+//
+// Why this file exists: of the five green-direction Criticals found in review
+// passes 5 and 6, FOUR lived in this one nine-line function — --full-history,
+// the -S anchor, and merge diffing. None of them is visible from JavaScript.
+// The unit suite stubs the runner, so it can pin the argv and nothing about
+// what git does with it; every one of those defects passed a green unit suite.
+//
+// These tests build throwaway repositories and ask the real binary. They are
+// the only thing standing between a git-semantics change and a silent
+// fail-green, so treat a failure here as a correctness alarm, not a flake.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { nonceInHistory } from '../publish-token.mjs';
+
+const LIVE = 'docs/live.html';
+
+// EVERY git spawn in this file MUST use this env. Passing `cwd` is NOT enough.
+//
+// git exports GIT_DIR, GIT_INDEX_FILE, GIT_WORK_TREE and friends to processes
+// it runs — hooks above all. A child `git` that inherits them ignores its own
+// cwd and operates on the EXPORTED repository instead. These tests run under
+// `npm run test:hooks`, which runs from pre-commit, so without this scrub the
+// throwaway repositories' init/add/commit land on the REAL repo: they replace
+// its index with a one-entry index holding this file's fixture path, and
+// commit a fixture commit onto the checked-out branch. That is not
+// theoretical — it happened twice while this file was being written, taking
+// 3,979 tracked files down to 1 and moving the branch to a commit called
+// "base". `git -C <path>` does NOT override GIT_DIR; only the environment does.
+//
+// It is a FUNCTION, evaluated per spawn, not a constant snapshot taken at
+// import. As a constant it was computed before any test could inject a GIT_*
+// variable, so the self-check below PASSED with the scrub deleted — the
+// snapshot never contained the variable it was meant to strip, and the
+// instrument could not fail. Read the environment at call time.
+const cleanEnv = () => {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) if (key.startsWith('GIT_')) delete env[key];
+  return env;
+};
+
+// The same shape check-onbox-register.mjs's runGitCommand returns.
+const runner = (args, cwd) => {
+  try {
+    const stdout = execFileSync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      stdio: 'pipe',
+      env: cleanEnv(),
+    });
+    return { status: 0, stdout };
+  } catch (err) {
+    return { status: err.status ?? 1, stdout: err.stdout ?? '', error: err };
+  }
+};
+
+const git = (repo, ...args) =>
+  execFileSync('git', args, { cwd: repo, stdio: 'pipe', env: cleanEnv() });
+const token = (n, nonce) => `<p data-published-as="${n}" data-publish-id="${nonce}">x</p>\n`;
+
+function writeToken(repo, n, nonce) {
+  mkdirSync(join(repo, 'docs'), { recursive: true });
+  writeFileSync(join(repo, LIVE), token(n, nonce));
+}
+
+function newRepo() {
+  const repo = mkdtempSync(join(tmpdir(), 'nonce-git-'));
+  git(repo, 'init', '-q', '-b', 'main');
+  git(repo, 'config', 'user.email', 'test@example.com');
+  git(repo, 'config', 'user.name', 'Test');
+  git(repo, 'config', 'commit.gpgsign', 'false');
+  return repo;
+}
+
+const ask = (repo, nonce, ref = 'HEAD') => nonceInHistory(repo, LIVE, nonce, ref, runner);
+
+test('git: the env scrub actually isolates the throwaway repo (self-check)', () => {
+  // The instrument-check for every other test in this file. If the scrub ever
+  // regresses, these tests do not fail — they silently operate on the real
+  // repository and destroy it, which is far worse than a red test. So assert
+  // the isolation directly, with GIT_DIR/GIT_INDEX_FILE deliberately set to
+  // the values a hook would export.
+  const decoy = newRepo();
+  const repo = newRepo();
+  try {
+    const saved = { dir: process.env.GIT_DIR, index: process.env.GIT_INDEX_FILE };
+    process.env.GIT_DIR = join(decoy, '.git');
+    process.env.GIT_INDEX_FILE = join(decoy, '.git', 'index');
+    try {
+      writeToken(repo, 1, 'nISOLATE');
+      git(repo, 'add', '-A');
+      git(repo, 'commit', '-qm', 'isolated');
+      // The work landed in `repo`...
+      assert.equal(ask(repo, 'nISOLATE'), true);
+      // ...and the decoy that GIT_DIR pointed at is untouched.
+      const decoyFiles = execFileSync('git', ['ls-files'], {
+        cwd: decoy,
+        encoding: 'utf8',
+        env: cleanEnv(),
+      });
+      assert.equal(decoyFiles.trim(), '', 'GIT_DIR leaked: the decoy repo was written to');
+    } finally {
+      if (saved.dir === undefined) delete process.env.GIT_DIR;
+      else process.env.GIT_DIR = saved.dir;
+      if (saved.index === undefined) delete process.env.GIT_INDEX_FILE;
+      else process.env.GIT_INDEX_FILE = saved.index;
+    }
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(decoy, { recursive: true, force: true });
+  }
+});
+
+test('git: a nonce on an ordinary commit is found, an absent one is not', () => {
+  const repo = newRepo();
+  try {
+    writeToken(repo, 1, 'nBASE0');
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-qm', 'base');
+    assert.equal(ask(repo, 'nBASE0'), true);
+    assert.equal(ask(repo, 'nNEVER'), false, 'an absent nonce must be false, or every STOP dies');
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('git: a nonce born in a MERGE CONFLICT RESOLUTION is found (pass 6 / F1)', () => {
+  // The routine shape in this repo: two lanes edit the live view, the merge
+  // conflicts, and the resolution re-stamps — so the surviving token exists in
+  // NEITHER parent. Without --diff-merges git computes no diff for the merge
+  // and reports the nonce absent from the history that literally contains it.
+  const repo = newRepo();
+  try {
+    writeToken(repo, 1, 'nBASE0');
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-qm', 'base');
+
+    git(repo, 'checkout', '-q', '-b', 'lane');
+    writeToken(repo, 2, 'nLANEA');
+    git(repo, 'commit', '-qam', 'lane');
+
+    git(repo, 'checkout', '-q', 'main');
+    writeToken(repo, 2, 'nMAIN0');
+    git(repo, 'commit', '-qam', 'main');
+
+    git(repo, 'checkout', '-q', 'lane');
+    try {
+      git(repo, 'merge', '--no-commit', 'main');
+    } catch {
+      /* the conflict is the point */
+    }
+    writeToken(repo, 3, 'nRESOLV'); // the re-stamp that resolves it
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-qm', 'merge + restamp');
+
+    // Ground truth: the nonce IS the current content.
+    assert.match(
+      execFileSync('git', ['show', `HEAD:${LIVE}`], {
+        cwd: repo,
+        encoding: 'utf8',
+        env: cleanEnv(),
+      }),
+      /nRESOLV/,
+    );
+    assert.equal(ask(repo, 'nRESOLV'), true, 'a merge-born nonce must be visible to the lookup');
+    // and the other lane's pre-merge nonce is still reachable
+    assert.equal(ask(repo, 'nMAIN0'), true);
+    assert.equal(ask(repo, 'nNEVER'), false, 'merge diffing must not make everything true');
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('git: a nonce PRUNED by default history simplification is found (pass 5 / C2)', () => {
+  // Two lanes diverge; the merge resolves by taking one side wholesale, so the
+  // result is TREESAME to that parent for this path and default simplification
+  // walks only it — pruning the other lane's commit out of the answer. Taking
+  // one side wholesale is the most likely resolution for this file, which is
+  // what makes `false` meaning "pruned" rather than "absent" dangerous.
+  const repo = newRepo();
+  try {
+    writeToken(repo, 1, 'nBASE0');
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-qm', 'base');
+
+    git(repo, 'checkout', '-q', '-b', 'laneB');
+    writeToken(repo, 2, 'nLANEB');
+    git(repo, 'commit', '-qam', 'B');
+
+    git(repo, 'checkout', '-q', 'main');
+    writeToken(repo, 2, 'nLANEA');
+    git(repo, 'commit', '-qam', 'A');
+
+    try {
+      git(repo, 'merge', '--no-commit', 'laneB');
+    } catch {
+      /* conflict expected */
+    }
+    writeToken(repo, 2, 'nLANEA'); // take ours wholesale -> TREESAME to main
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-qm', 'merge, took ours');
+
+    // Ground truth: B is an ancestor, so its nonce IS in this history.
+    assert.doesNotThrow(() => git(repo, 'merge-base', '--is-ancestor', 'laneB', 'HEAD'));
+    assert.equal(ask(repo, 'nLANEB'), true, 'a pruned nonce must still be found');
+
+    // HONEST LIMIT of this test. Measured on this exact repo:
+    //   plain                                  -> 0   (pruned; C2 is real)
+    //   --full-history                         -> 1
+    //   --diff-merges=first-parent             -> 1
+    //   --full-history --diff-merges=first-parent -> 1
+    // So with the merge-diff flag present, DELETING --full-history leaves this
+    // test green — the two overlap here, and this scenario cannot isolate
+    // --full-history's own contribution. It is kept because it is free and
+    // because no one has shown the overlap is total; the unit suite asserts it
+    // stays in the argv so it cannot be dropped silently. If you can build a
+    // case where --full-history matters and --diff-merges does not, add it —
+    // that is the missing half of this test, and its absence is why the
+    // corresponding mutant survives rather than because the flag is dead.
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('git: --diff-merges alone does NOT rescue the plain-default pruning', () => {
+  // The control for the note above: proves the pruning it describes is real
+  // rather than an artifact, by showing the unflagged query genuinely misses.
+  const repo = newRepo();
+  try {
+    writeToken(repo, 1, 'nBASE0');
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-qm', 'base');
+    git(repo, 'checkout', '-q', '-b', 'laneB');
+    writeToken(repo, 2, 'nLANEB');
+    git(repo, 'commit', '-qam', 'B');
+    git(repo, 'checkout', '-q', 'main');
+    writeToken(repo, 2, 'nLANEA');
+    git(repo, 'commit', '-qam', 'A');
+    try {
+      git(repo, 'merge', '--no-commit', 'laneB');
+    } catch {
+      /* conflict expected */
+    }
+    writeToken(repo, 2, 'nLANEA');
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-qm', 'merge, took ours');
+
+    const bare = runner(
+      ['log', '--oneline', '-s', '-S', 'data-publish-id="nLANEB"', 'HEAD', '--', LIVE],
+      repo,
+    );
+    assert.equal(bare.status, 0);
+    assert.equal(
+      bare.stdout.trim(),
+      '',
+      'the UNFLAGGED query must miss it — otherwise this whole test proves nothing',
+    );
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('git: the -S query is anchored — a nonce inside a longer string does not match', () => {
+  // -S is a substring search. A six-hex nonce collides with the abbreviated
+  // SHAs this very page quotes in its changelog prose; an unanchored query
+  // would report a rival's publish as your own.
+  const repo = newRepo();
+  try {
+    writeToken(repo, 1, 'nBASE0');
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-qm', 'base');
+    // A commit that mentions ab12cd — a superstring of the rival nonce ab12cd
+    // is not enough; use a nonce that is a strict substring of unrelated text.
+    writeFileSync(join(repo, LIVE), token(2, 'nBASE0') + '<p>see commit abc123def for detail</p>\n');
+    git(repo, 'commit', '-qam', 'cite a sha');
+    assert.equal(
+      ask(repo, 'abc123'),
+      false,
+      'a nonce appearing only inside prose must NOT count as published',
+    );
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('git: the ref is honoured — a sibling lane\'s nonce is not in my history', () => {
+  const repo = newRepo();
+  try {
+    writeToken(repo, 1, 'nBASE0');
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-qm', 'base');
+
+    git(repo, 'checkout', '-q', '-b', 'rival');
+    writeToken(repo, 2, 'nRIVAL');
+    git(repo, 'commit', '-qam', 'rival');
+
+    git(repo, 'checkout', '-q', 'main');
+    writeToken(repo, 2, 'nMINE0');
+    git(repo, 'commit', '-qam', 'mine');
+
+    // This is THE question the whole feature turns on.
+    assert.equal(ask(repo, 'nRIVAL', 'HEAD'), false, "a rival's nonce must be absent from mine");
+    assert.equal(ask(repo, 'nRIVAL', 'rival'), true, 'and present on theirs');
+    assert.equal(ask(repo, 'nMINE0', 'HEAD'), true);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('git: a real failure returns null, never false', () => {
+  const repo = newRepo(); // no commits at all -> git log fails
+  try {
+    assert.equal(ask(repo, 'nBASE0'), null, 'a failed lookup must not read as "absent"');
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});

--- a/scripts/tests/publish-token.test.mjs
+++ b/scripts/tests/publish-token.test.mjs
@@ -1,0 +1,526 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  comparePublishTokens,
+  parsePublishToken,
+  nonceInHistory,
+  bumpToken,
+  publishTokenRegex,
+  PUBLISH_TOKEN_BASELINE_ERROR,
+  PUBLISH_TOKEN_PUBLISHED_ERROR,
+  PUBLISH_TOKEN_WORKING_ERROR,
+} from '../publish-token.mjs';
+
+// Nonces are padded to the parser's 6-char floor so cases stay readable as
+// 'aaa'/'zzz' while remaining legal values. Padding is deterministic, so
+// equality and inequality between cases are preserved exactly.
+const T = (n, nonce) => TRAW(n, String(nonce).padEnd(6, 'x'));
+// Unpadded, for the malformed-input cases that must reach the parser as-is.
+const TRAW = (n, nonce) => `<p data-published-as="${n}" data-publish-id="${nonce}">x</p>`;
+// Default lookups = the HEALTHY answers: the page's nonce is main's current one
+// (in baseline history), and the working nonce was freshly minted (so it is NOT
+// in baseline history). All three must be stated. Before `workingInBaseline`
+// was added here, five tests reached the branch that reads it with the key
+// absent — and two of those asserted GREEN, through the very fail-open this
+// suite now pins. A test that omits a lookup is not testing the healthy path;
+// it is testing whatever the missing key happens to coerce to.
+// TWO KNOWN-EQUIVALENT MUTANTS. Both were survivors in the pass-5 fix round,
+// and both are unkillable because a stronger check now runs AHEAD of them —
+// defence in depth, where the outer guard subsumes the inner. Do not "fix" the
+// suite to kill these; the reachability argument is the artifact:
+//
+//   A6  `!inBaseline && !inMine`  ->  `!inMine`
+//       Distinguishable only at inBaseline=true, inMine=false. Reaching that
+//       line requires baselineInMine=true (else the C1 STOP returned), and the
+//       consistency guard rejects `inBaseline && baselineInMine && !inMine`.
+//       So inBaseline implies inMine there, and the two forms agree.
+//
+//   B1  function replacement  ->  string replacement (re-opens $& expansion)
+//       Distinguishable only for a nonce containing a `$` pattern, which the
+//       minted-nonce charset check ([A-Za-z0-9_-]) refuses first. Killing B1
+//       would mean weakening B2.
+const HEALTHY = {
+  inBaseline: true,
+  inMine: true,
+  baselineInMine: true, // my branch DOES contain main's live view
+  workingInBaseline: false, // my working nonce was freshly minted
+};
+const cmp = (o) => comparePublishTokens({ lookups: HEALTHY, ...o });
+// Spread over HEALTHY, for cases that vary one or two answers and mean the
+// rest to stay healthy. A bare `lookups: {...}` REPLACES the defaults, which is
+// how five tests came to exercise a branch with a key missing.
+const L = (over) => ({ lookups: { ...HEALTHY, ...over } });
+
+test('1 ordinary first publish is green', () => {
+  assert.deepEqual(cmp({ working: T(48, 'aaa'), published: T(47, 'zzz'), baseline: T(47, 'zzz') }), []);
+});
+
+test('2 same-branch re-publish is green', () => {
+  // baseline 47, this branch published 48 (committed, so inMine), now 49.
+  assert.deepEqual(
+    cmp({
+      working: T(49, 'bbb'),
+      published: T(48, 'aaa'),
+      baseline: T(47, 'zzz'),
+      ...L({ inBaseline: false, inMine: true, workingInBaseline: false }),
+    }),
+    [],
+  );
+});
+
+test('3 competing publish with identical counters is reported', () => {
+  const e = cmp({
+    working: T(49, 'bbb'),
+    published: T(48, 'ccc'),
+    baseline: T(47, 'zzz'),
+    ...L({ inBaseline: false, inMine: false }),
+  });
+  assert.ok(e.some((x) => x.includes('another lane published')), e.join('|'));
+});
+
+test('4 STALE nonce one commit deep is reported (pass-4 Critical 1)', () => {
+  // main: (46,n46) then (47,n47). Z branched at n46, bumped to 48 without
+  // minting, published (48,'n46'). n46 IS in baseline history.
+  const e = cmp({
+    working: T(48, 'mine'),
+    published: T(48, 'n46'),
+    baseline: T(47, 'n47'),
+    ...L({ inBaseline: true, inMine: true }),
+  });
+  assert.ok(e.some((x) => x.includes('without minting')), e.join('|'));
+  assert.ok(!e.some((x) => x.includes('your own last publish')), 'must not misattribute');
+});
+
+test('5 STALE nonce at arbitrary depth is reported', () => {
+  const e = cmp({
+    working: T(60, 'mine'),
+    published: T(59, 'n12'),
+    baseline: T(50, 'n50'),
+    ...L({ inBaseline: true, inMine: true }),
+  });
+  assert.ok(e.some((x) => x.includes('without minting')), e.join('|'));
+});
+
+test('6 un-minted WORKING file is reported', () => {
+  const e = cmp({
+    working: T(49, 'zzz'),
+    published: T(48, 'zzz'),
+    baseline: T(48, 'zzz'),
+    ...L({ inBaseline: true, inMine: true, workingInBaseline: true }),
+  });
+  assert.ok(e.some((x) => x.includes('not freshly minted')), e.join('|'));
+});
+
+test('7 un-rebased branch is told to REBASE, not to bump', () => {
+  const e = cmp({ working: T(48, 'bbb'), published: T(49, 'zzz'), baseline: T(49, 'zzz') });
+  assert.ok(e.some((x) => x.toUpperCase().includes('REBASE')), e.join('|'));
+  assert.ok(!e.some((x) => x.includes('bump the counter')), e.join('|'));
+});
+
+test('8 rebase outranks behind when BOTH apply', () => {
+  const e = cmp({ working: T(47, 'bbb'), published: T(46, 'yyy'), baseline: T(50, 'zzz') });
+  assert.ok(e.some((x) => x.toUpperCase().includes('REBASE')), e.join('|'));
+  assert.ok(!e.some((x) => x.includes('--live-page-behind-main')), e.join('|'));
+});
+
+test('9 unbumped working file is told to bump', () => {
+  const e = cmp({ working: T(47, 'zzz'), published: T(47, 'zzz'), baseline: T(47, 'zzz') });
+  assert.ok(e.some((x) => x.includes('bump the counter')), e.join('|'));
+});
+
+test('10 forgetting to bump for round two of your OWN cycle is reported', () => {
+  const e = cmp({
+    working: T(48, 'aaa'),
+    published: T(48, 'aaa'),
+    baseline: T(47, 'zzz'),
+    // 'aaa' was minted on this branch: in HEAD's history, not in the baseline's.
+    ...L({ inBaseline: false, inMine: true, workingInBaseline: false }),
+  });
+  assert.ok(e.some((x) => x.includes('your own last publish')), e.join('|'));
+});
+
+test('11 live page BEHIND main is reported', () => {
+  const e = cmp({ working: T(49, 'bbb'), published: T(46, 'yyy'), baseline: T(47, 'zzz') });
+  assert.ok(e.some((x) => x.includes('BEHIND')), e.join('|'));
+});
+
+test('12 --live-page-behind-main CLEARS the behind state (pass-4 Critical 2)', () => {
+  assert.deepEqual(
+    cmp({
+      working: T(49, 'bbb'),
+      published: T(46, 'yyy'),
+      baseline: T(47, 'zzz'),
+      allowBehind: true,
+    }),
+    [],
+  );
+});
+
+test('13 --live-page-behind-main is an ERROR when the page is not behind', () => {
+  const e = cmp({
+    working: T(49, 'bbb'),
+    published: T(48, 'zzz'),
+    baseline: T(48, 'zzz'),
+    allowBehind: true,
+  });
+  assert.ok(e.some((x) => x.includes('--live-page-behind-main')), e.join('|'));
+});
+
+test('14 your OWN uncommitted publish is diagnosed as such', () => {
+  const e = cmp({
+    working: T(49, 'bbb'),
+    published: T(49, 'bbb'),
+    baseline: T(48, 'zzz'),
+    ...L({ inBaseline: false, inMine: false }),
+  });
+  assert.ok(e.some((x) => x.includes('commit')), e.join('|'));
+  assert.ok(!e.some((x) => x.includes('another lane published')), e.join('|'));
+});
+
+test('15 tokenless published page names the transition case', () => {
+  const e = cmp({ working: T(48, 'bbb'), published: '<p>no token</p>', baseline: T(47, 'zzz') });
+  assert.ok(e.some((x) => x.includes('no publish token')), e.join('|'));
+  assert.ok(e.some((x) => x.includes('predates')), e.join('|'));
+});
+
+test('16 tokenless BASELINE is an explicit error, never a pass', () => {
+  assert.ok(cmp({ working: T(48, 'b'), published: T(47, 'z'), baseline: '<p>x</p>' }).length > 0);
+});
+
+test('17 baseline/published/working unresolvable get DIFFERENT constants', () => {
+  assert.deepEqual(cmp({ working: T(48, 'b'), published: T(47, 'z'), baseline: null }), [
+    PUBLISH_TOKEN_BASELINE_ERROR,
+  ]);
+  assert.deepEqual(cmp({ working: T(48, 'b'), published: null, baseline: T(47, 'z') }), [
+    PUBLISH_TOKEN_PUBLISHED_ERROR,
+  ]);
+  assert.deepEqual(cmp({ working: null, published: T(47, 'z'), baseline: T(47, 'z') }), [
+    PUBLISH_TOKEN_WORKING_ERROR,
+  ]);
+  assert.notEqual(PUBLISH_TOKEN_BASELINE_ERROR, PUBLISH_TOKEN_PUBLISHED_ERROR);
+  assert.notEqual(PUBLISH_TOKEN_BASELINE_ERROR, PUBLISH_TOKEN_WORKING_ERROR);
+});
+
+test('18 an unresolvable ancestry lookup fails closed', () => {
+  const e = cmp({
+    working: T(49, 'b'),
+    published: T(48, 'a'),
+    baseline: T(47, 'z'),
+    ...L({ inBaseline: null, inMine: null }),
+  });
+  // NOT `length > 0`: null is falsy, so dropping the guard falls through to
+  // "another lane published" -- still non-empty, still "passing". Assert the
+  // SPECIFIC failure, or the test cannot tell failing closed from failing wrong.
+  assert.ok(e.some((x) => x.includes('could not search history')), e.join('|'));
+});
+
+test('18b a lookup that is null for ONE ref only still fails closed', () => {
+  // Spread over HEALTHY so exactly ONE answer is null. A bare `lookups: {...}`
+  // here also dropped `workingInBaseline`/`baselineInMine`, and their guards
+  // then satisfied the assertion — the test passed while the guard it NAMES
+  // could be deleted. Asserting the specific message closes the rest of that
+  // gap: "could not search history" alone is emitted by three different guards.
+  for (const over of [
+    { inBaseline: null, inMine: true },
+    { inBaseline: true, inMine: null },
+    { inBaseline: false, inMine: null },
+  ]) {
+    const e = cmp({ working: T(49, 'b'), published: T(48, 'a'), baseline: T(47, 'z'), ...L(over) });
+    assert.ok(
+      e.some((x) => x.includes("could not search history for the published page's nonce")),
+      `${JSON.stringify(over)} -> ${e.join('|')}`,
+    );
+  }
+});
+
+// --- The THIRD lookup. Regression cover for the pass-5 Critical: it was read
+// as a bare `&& lookups.workingInBaseline`, so a FAILED lookup (null) and an
+// ABSENT one both coerced to false and the STOP became a silent pass. Five
+// existing tests reached this branch with the key missing; two asserted [].
+test('18c a null workingInBaseline fails CLOSED, never green', () => {
+  const e = cmp({
+    working: T(49, 'ccc'),
+    published: T(48, 'bbb'),
+    baseline: T(47, 'aaa'),
+    ...L({ inBaseline: false, inMine: true, workingInBaseline: null }),
+  });
+  assert.notDeepEqual(e, [], 'a failed working-nonce lookup must not pass');
+  assert.ok(e.some((x) => x.includes('could not search history')), e.join('|'));
+});
+
+test('18d an ABSENT workingInBaseline fails closed too', () => {
+  // Distinct from 18c: `undefined` is what a caller wired for the two-lookup
+  // signature supplies, and it must not read as "freshly minted".
+  const e = comparePublishTokens({
+    working: T(49, 'ccc'),
+    published: T(48, 'bbb'),
+    baseline: T(47, 'aaa'),
+    lookups: { inBaseline: false, inMine: true },
+  });
+  assert.notDeepEqual(e, []);
+  assert.ok(e.some((x) => x.includes('could not search history')), e.join('|'));
+});
+
+test('18e workingInBaseline false is genuinely green (the guard is not always-on)', () => {
+  assert.deepEqual(
+    comparePublishTokens({
+      working: T(49, 'ccc'),
+      published: T(48, 'bbb'),
+      baseline: T(47, 'aaa'),
+      ...L({ inBaseline: false, inMine: true, workingInBaseline: false }),
+    }),
+    [],
+  );
+});
+
+test('18f the working-nonce lookup is only consulted when w.n > b.n', () => {
+  // At w.n === b.n the un-bumped verdict must win, WITHOUT demanding the third
+  // lookup — otherwise every caller pays a git call on a state that cannot use it.
+  const e = comparePublishTokens({
+    working: T(47, 'zzz'),
+    published: T(47, 'zzz'),
+    baseline: T(47, 'zzz'),
+    ...L({ inBaseline: true, inMine: true }),
+  });
+  assert.ok(e.some((x) => x.includes('same as origin/main')), e.join('|'));
+  assert.ok(!e.some((x) => x.includes('could not search history')), e.join('|'));
+});
+
+// --- C1: the working-side invariant. Pass 5's Critical, and the shape four
+// earlier passes never reached because EVERY green-asserting test used
+// inMine: true — so "the live page is in main's history but not in mine" was
+// never once evaluated.
+test('18g STALE LANE: told to bump, obeys, and must NOT go green', () => {
+  // Two lanes branch from main at 47; each stamps once (47 -> 48). B merges and
+  // publishes. A has never rebased and has never seen B's page.
+  const asA = { published: T(48, 'nonceB'), baseline: T(48, 'nonceB') };
+  const lanes = L({ inBaseline: true, inMine: false, baselineInMine: false });
+
+  const step1 = cmp({ working: T(48, 'nonceA'), ...asA, ...lanes });
+  assert.ok(step1.length > 0, 'a stale lane must not be waved through');
+  assert.ok(step1.some((x) => x.toUpperCase().includes('REBASE')), step1.join('|'));
+  // The pass-5 Critical was that the advice here was "bump", and obeying it
+  // produced green. Both halves are now pinned.
+  assert.ok(!step1.some((x) => x.includes('bump the counter')), step1.join('|'));
+
+  const step2 = cmp({ working: T(49, 'nonceA2'), ...asA, ...lanes });
+  assert.notDeepEqual(step2, [], 'bumping must not clear a staleness STOP');
+});
+
+test('18h green REQUIRES the baseline nonce to be in my history', () => {
+  const base = { working: T(49, 'ccc'), published: T(48, 'bbb'), baseline: T(47, 'aaa') };
+  assert.deepEqual(cmp({ ...base, ...L({ inBaseline: false, inMine: true }) }), []);
+  // flipping ONLY baselineInMine must break it
+  assert.notDeepEqual(
+    cmp({ ...base, ...L({ inBaseline: false, inMine: true, baselineInMine: false }) }),
+    [],
+  );
+});
+
+test('18i a null baselineInMine fails CLOSED', () => {
+  const e = cmp({
+    working: T(49, 'ccc'),
+    published: T(48, 'bbb'),
+    baseline: T(47, 'aaa'),
+    ...L({ inBaseline: false, inMine: true, baselineInMine: null }),
+  });
+  assert.notDeepEqual(e, []);
+  assert.ok(e.some((x) => x.includes('could not search history')), e.join('|'));
+});
+
+test('18j the ENTIRE green region requires baselineInMine (enumeration)', () => {
+  // The reviewer found C1 by enumerating the green region and reading it: one
+  // shape announced inMine=false on the green path. Making the enumeration a
+  // test means the next such gap surfaces mechanically instead of depending on
+  // whether a reviewer imagined the right input.
+  const vals = [true, false];
+  let green = 0;
+  for (const n of [[47, 47, 47], [48, 47, 47], [49, 48, 47], [48, 48, 47], [49, 46, 47]]) {
+    for (const inBaseline of vals)
+      for (const inMine of vals)
+        for (const baselineInMine of vals)
+          for (const workingInBaseline of vals)
+            for (const allowBehind of vals) {
+              const out = comparePublishTokens({
+                working: T(n[0], 'wwwwww'),
+                published: T(n[1], 'pppppp'),
+                baseline: T(n[2], 'bbbbbb'),
+                lookups: { inBaseline, inMine, baselineInMine, workingInBaseline },
+                allowBehind,
+              });
+              if (out.length === 0) {
+                green++;
+                assert.equal(baselineInMine, true, `GREEN without baselineInMine: ${JSON.stringify(n)}`);
+                assert.ok(n[0] > n[2], `GREEN without w.n > b.n: ${JSON.stringify(n)}`);
+                assert.ok(n[0] > n[1], `GREEN without w.n > p.n: ${JSON.stringify(n)}`);
+                assert.equal(workingInBaseline, false, 'GREEN with an un-minted working nonce');
+              }
+            }
+  }
+  assert.ok(green > 0, 'the enumeration must actually reach green, or it proves nothing');
+});
+
+test('18m a counter bumped WITHOUT minting is caught with no history lookup', () => {
+  const e = cmp({ working: T(49, 'same'), published: T(48, 'same'), baseline: T(47, 'aaa') });
+  assert.ok(e.some((x) => x.includes('without minting')), e.join('|'));
+});
+
+test('18n lookups: null fails closed instead of throwing', () => {
+  // `= {}` defaults only undefined; a caller batching failed lookups hands null.
+  const e = comparePublishTokens({
+    working: T(49, 'ccc'),
+    published: T(48, 'bbb'),
+    baseline: T(47, 'aaa'),
+    lookups: null,
+  });
+  assert.notDeepEqual(e, []);
+  assert.ok(e.some((x) => x.includes('could not search history')), e.join('|'));
+});
+
+test('18k contradictory lookups (a mis-wired caller) fail closed', () => {
+  // inBaseline && baselineInMine IMPLIES inMine. The delivery plan wires one
+  // lookup where four are consumed, so this is the live mis-wiring hazard.
+  const e = cmp({
+    working: T(49, 'ccc'),
+    published: T(48, 'bbb'),
+    baseline: T(47, 'aaa'),
+    ...L({ inBaseline: true, inMine: false, baselineInMine: true }),
+  });
+  assert.notDeepEqual(e, []);
+  assert.ok(e.some((x) => x.includes('contradict each other')), e.join('|'));
+});
+
+test('18l bumpToken REFUSES a nonce its own parser would reject', () => {
+  const src = TRAW(47, 'zzzxxx');
+  for (const bad of ['ab', '', 'a b', '-Sx', 'has"q', '$&$`', null, 42]) {
+    assert.throws(
+      () => bumpToken(src, () => bad),
+      /minted nonce/,
+      `mintNonce -> ${JSON.stringify(bad)} must be refused`,
+    );
+  }
+  // A stamper that writes a token its own reader rejects would wedge the check
+  // permanently, so the round trip is the real assertion.
+  const { html } = bumpToken(src, () => 'abc123');
+  assert.deepEqual(parsePublishToken(html), { n: 48, nonce: 'abc123' });
+});
+
+test('19 malformed tokens are errors, not skips', () => {
+  const bad = (w) => cmp({ working: w, published: T(1, 'z'), baseline: T(1, 'z') });
+  assert.ok(
+    bad(`<p data-published-as="abc" data-publish-id="a">x</p>`).some((x) =>
+      x.includes('not a bare integer'),
+    ),
+  );
+  assert.ok(bad(TRAW(2, '')).some((x) => x.includes('nonce')));
+  assert.ok(bad(T(2, 'a') + T(3, 'b')).some((x) => x.includes('more than once')));
+
+  // The nonce is spliced into a `git log -S data-publish-id="<nonce>"` anchor,
+  // so each of these is an injection or a match-everything hazard, not a nit.
+  // Each of these is 6+ chars, so it must be rejected by its OWN rule rather
+  // than by the length floor. '-Sfoo' was 5 chars, which made the leading-dash
+  // clause dead code that no test could distinguish from the floor.
+  for (const evil of ['a bcde', '-Sfooo', 'has"quo', "has'quo", '$&$`xy', 'aaa.bbb', 'aaa/bbb']) {
+    assert.ok(
+      bad(TRAW(2, evil)).some((x) => x.includes('nonce')),
+      `nonce ${JSON.stringify(evil)} must be rejected`,
+    );
+  }
+  // 2^53 collapses neighbouring counters onto one Number, losing a STOP.
+  assert.ok(
+    bad(TRAW(2, 'aaaaaa').replace('"2"', '"9007199254740993"')).some((x) =>
+      x.includes('1-15 digits'),
+    ),
+  );
+});
+
+test('20 nonceInHistory pins the ref and never uses --all', () => {
+  const calls = [];
+  const runner = (args) => {
+    calls.push(args.join(' '));
+    return { status: 0, stdout: 'commit abc\n' };
+  };
+  assert.equal(nonceInHistory('/repo', 'live.html', 'k7f2a9', 'deadbeef', runner), true);
+  assert.ok(!calls[0].includes('--all'), '--all would find a fetched rival commit');
+
+  // ORDER and the `--` separator, not just "these substrings appear". A ref
+  // placed after `--` is a pathspec, and silently matches nothing.
+  const argv = argvOf();
+  const sep = argv.indexOf('--');
+  assert.ok(sep > 0, 'the pathspec separator must be present');
+  assert.ok(argv.indexOf('deadbeef') < sep, 'the ref must precede --');
+  assert.ok(argv.indexOf('live.html') > sep, 'the path must follow --');
+
+  // C2: without --full-history a pathspec'd log prunes merge parents, so
+  // "absent" and "pruned" collapse into one answer — permissive for every STOP.
+  assert.ok(argv.includes('--full-history'), '--full-history is load-bearing');
+
+  // Pass 6 / F1: git computes NO diff for a merge commit unless asked, so a
+  // nonce born in a conflict resolution reads as ABSENT from the history that
+  // contains it — and absent is the permissive answer for the STOPs this
+  // gates. This repo mandates merge commits, so it is a routine state.
+  assert.ok(
+    argv.some((a) => a.startsWith('--diff-merges=')),
+    'merge commits must be diffed or a re-stamped conflict resolution is invisible',
+  );
+  // -s suppresses the patch body; without it every lookup streams a full diff
+  // of a 250 KB file. It must NOT be one of the flags that also drops the
+  // pickaxe selection.
+  assert.ok(argv.includes('-s'), 'the patch body must be suppressed');
+
+  // C3: -S is a SUBSTRING search, so the query must carry the attribute anchor
+  // rather than the bare nonce — six hex chars otherwise match a quoted SHA.
+  assert.ok(
+    argv.includes('data-publish-id="k7f2a9"'),
+    `the search must be anchored to the attribute, got: ${argv.join(' ')}`,
+  );
+  assert.ok(!argv.includes('k7f2a9'), 'the bare nonce must not be the query');
+});
+
+// Captures argv as an ARRAY — joining to a string hides adjacency and order.
+function argvOf() {
+  let seen = null;
+  nonceInHistory('/repo', 'live.html', 'k7f2a9', 'deadbeef', (args) => {
+    seen = args;
+    return { status: 0, stdout: 'x\n' };
+  });
+  return seen;
+}
+
+test('21 nonceInHistory returns null on git failure — each channel ALONE', () => {
+  // Previously ONE stub set status:128 AND error, so either clause could be
+  // deleted with the test still green. Three channels, three cases.
+  const call = (r) => nonceInHistory('/repo', 'live.html', 'kkkkkk', 'HEAD', () => r);
+  assert.equal(call({ status: 0, stdout: '', error: new Error('spawn') }), null, 'error alone');
+  assert.equal(call({ status: 128, stdout: '' }), null, 'nonzero status alone');
+  assert.equal(call({ status: 0 }), null, 'missing stdout must not throw, and must not pass');
+  // ...and the true/false contract still holds on success.
+  assert.equal(call({ status: 0, stdout: '' }), false);
+  assert.equal(call({ status: 0, stdout: 'commit abc\n' }), true);
+});
+
+test('22 bumpToken increments and mints, touching nothing else', () => {
+  const before =
+    '<h1>Register</h1>\n<p data-published-as="47" data-publish-id="zzzxxx">x</p>\n<p>47</p>';
+  const { html, n, nonce } = bumpToken(before, () => 'newid1');
+  assert.equal(n, 48);
+  assert.equal(nonce, 'newid1');
+  assert.match(html, /data-published-as="48"/);
+  assert.ok(html.includes('<p>47</p>'), 'a bare 47 elsewhere must survive');
+  assert.ok(html.includes('<h1>Register</h1>'));
+});
+
+test('23 bumpToken refuses no-token and two-token files', () => {
+  assert.throws(() => bumpToken('<p>nothing</p>', () => 'x'), /no publish token/);
+  assert.throws(() => bumpToken(T(1, 'a') + T(2, 'b'), () => 'x'), /more than once/);
+});
+
+test('24 the regex factory has no lastIndex leak', () => {
+  const html = T(5, 'abc');
+  // A stray .test() on a SHARED /g object would poison the next matchAll. The
+  // factory makes that impossible; prove the factory is actually a factory.
+  const r = publishTokenRegex();
+  r.test(html);
+  assert.notEqual(r.lastIndex, 0, 'sanity: a /g regex does carry lastIndex');
+  assert.equal(parsePublishToken(html).n, 5, 'parse must be unaffected');
+});

--- a/scripts/tests/stamp-publish-token.test.mjs
+++ b/scripts/tests/stamp-publish-token.test.mjs
@@ -1,0 +1,91 @@
+// Tests for the stamper — the half of the publish-token design that makes
+// "nothing hand-maintained is trusted" true. Two of the eight designs that
+// preceded the token failed because a human maintained part of it by hand and
+// the value went stale, which fails in the GREEN direction. If this script is
+// wrong, the comparator's guarantees rest on nothing.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { seedToken, mintNonce } from '../stamp-publish-token.mjs';
+import { parsePublishToken, bumpToken } from '../publish-token.mjs';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const LIVE_VIEW = resolve(REPO_ROOT, 'docs/testing/onbox-acceptance-register-live-view.html');
+
+test('the tracked live view carries exactly one well-formed publish token', () => {
+  // The bootstrap invariant. `comparePublishTokens` returns a hard error when
+  // origin/main carries no token, so if this ever regresses, every
+  // --against-published run fails with a message blaming a revert.
+  const parsed = parsePublishToken(readFileSync(LIVE_VIEW, 'utf8'));
+  assert.notEqual(parsed, null, 'the live view must carry a publish token');
+  assert.equal(parsed.malformed, undefined, `token is malformed: ${parsed.malformed}`);
+  assert.ok(Number.isInteger(parsed.n) && parsed.n >= 1);
+});
+
+test('the token sits on a real element, NOT inside an HTML comment', () => {
+  // checkLiveView's first action is stripHtmlComments, so a comment-carried
+  // token is invisible to the one function that must read it.
+  const html = readFileSync(LIVE_VIEW, 'utf8');
+  const stripped = html.replace(/<!--[\s\S]*?-->/g, '');
+  assert.notEqual(
+    parsePublishToken(stripped),
+    null,
+    'the token must survive comment stripping, or checkLiveView cannot see it',
+  );
+});
+
+test('mintNonce produces a value the parser accepts, every time', () => {
+  // A stamper that writes a token its own reader rejects wedges the check
+  // permanently — the file cannot be fixed by stamping it again.
+  const seen = new Set();
+  for (let i = 0; i < 500; i++) {
+    const n = mintNonce();
+    assert.match(n, /^[A-Za-z0-9_-]{6,64}$/, `minted ${JSON.stringify(n)} is not parseable`);
+    seen.add(n);
+  }
+  assert.ok(seen.size > 490, `nonces must not repeat: only ${seen.size}/500 distinct`);
+});
+
+test('mintNonce is distinguishable from an abbreviated commit SHA', () => {
+  // The live view quotes short SHAs in its own changelog prose. The history
+  // lookup is anchored, so a collision is not a correctness bug — but keeping
+  // the shapes distinct keeps the logs readable, and the length is the tell.
+  assert.notEqual(mintNonce().length, 7, 'must not look like a short SHA');
+  assert.notEqual(mintNonce().length, 8);
+});
+
+test('seedToken creates a token where there is none', () => {
+  const { html, n, nonce } = seedToken('<h1>Title</h1>\n<p>body</p>', () => 'seed01');
+  assert.equal(n, 1, 'a seeded counter starts at 1');
+  assert.equal(nonce, 'seed01');
+  assert.deepEqual(parsePublishToken(html), { n: 1, nonce: 'seed01' });
+  assert.ok(html.includes('<p>body</p>'), 'the rest of the document must survive');
+});
+
+test('seedToken REFUSES a file that already has a token', () => {
+  // Seeding over an existing token would reset the counter to 1 and orphan the
+  // nonce chain — every later comparison is anchored to that history.
+  const once = seedToken('<h1>T</h1>', () => 'seed01').html;
+  assert.throws(() => seedToken(once, () => 'seed02'), /already has a token/);
+});
+
+test('seedToken refuses a file with no anchor rather than guessing', () => {
+  assert.throws(() => seedToken('<p>no heading</p>', () => 'seed01'), /no <h1>/);
+});
+
+test('seed then bump produces a strictly increasing counter and a fresh id', () => {
+  let html = seedToken('<h1>T</h1>', () => 'aaaaaa').html;
+  const ids = new Set(['aaaaaa']);
+  let prev = 1;
+  for (const id of ['bbbbbb', 'cccccc', 'dddddd']) {
+    const out = bumpToken(html, () => id);
+    assert.equal(out.n, prev + 1, 'the counter must advance by exactly one');
+    assert.ok(!ids.has(out.nonce), 'each stamp must mint an unused id');
+    ids.add(out.nonce);
+    prev = out.n;
+    html = out.html;
+  }
+  assert.deepEqual(parsePublishToken(html), { n: 4, nonce: 'dddddd' });
+});

--- a/scripts/tests/stamp-publish-token.test.mjs
+++ b/scripts/tests/stamp-publish-token.test.mjs
@@ -5,14 +5,19 @@
 // wrong, the comparator's guarantees rest on nothing.
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { seedToken, mintNonce } from '../stamp-publish-token.mjs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { seedToken, mintNonce, parseArgs, DEFAULT_FILE } from '../stamp-publish-token.mjs';
 import { parsePublishToken, bumpToken } from '../publish-token.mjs';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
-const LIVE_VIEW = resolve(REPO_ROOT, 'docs/testing/onbox-acceptance-register-live-view.html');
+// Imported rather than re-typed: a copy here would let the test keep passing
+// while the script targeted a different file.
+const LIVE_VIEW_REL = DEFAULT_FILE;
+const LIVE_VIEW = resolve(REPO_ROOT, LIVE_VIEW_REL);
 
 test('the tracked live view carries exactly one well-formed publish token', () => {
   // The bootstrap invariant. `comparePublishTokens` returns a hard error when
@@ -88,4 +93,93 @@ test('seed then bump produces a strictly increasing counter and a fresh id', () 
     html = out.html;
   }
   assert.deepEqual(parsePublishToken(html), { n: 4, nonce: 'dddddd' });
+});
+
+// --- The CLI. Previously untested end-to-end, which is exactly why a typo'd
+// flag silently performed the WRITE: `--chek` stamped the live view and exited
+// 0, and `--file=x` stamped the DEFAULT file. This script's default action is a
+// write to a tracked file, so its argument parser is a safety boundary.
+const SCRIPT = resolve(REPO_ROOT, 'scripts/stamp-publish-token.mjs');
+
+function runCli(args, cwd) {
+  try {
+    const stdout = execFileSync(process.execPath, [SCRIPT, ...args], {
+      cwd,
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+    return { code: 0, stdout, stderr: '' };
+  } catch (err) {
+    return { code: err.status ?? 1, stdout: err.stdout ?? '', stderr: err.stderr ?? '' };
+  }
+}
+
+test('parseArgs REFUSES anything it does not recognise', () => {
+  for (const argv of [['--chek'], ['--Check'], ['-c'], ['stamp'], ['--file'], ['--file=']]) {
+    const out = parseArgs(argv);
+    assert.ok(out.error, `${JSON.stringify(argv)} must be refused, got ${JSON.stringify(out)}`);
+  }
+});
+
+test('parseArgs accepts the documented forms, including --file=', () => {
+  assert.deepEqual(parseArgs([]), { check: false, file: LIVE_VIEW_REL });
+  assert.deepEqual(parseArgs(['--check']), { check: true, file: LIVE_VIEW_REL });
+  assert.deepEqual(parseArgs(['--file', 'a.html']), { check: false, file: 'a.html' });
+  // `--file=x` used to be swallowed as unknown, leaving the DEFAULT file targeted.
+  assert.deepEqual(parseArgs(['--file=a.html']), { check: false, file: 'a.html' });
+  assert.deepEqual(parseArgs(['--check', '--file=a.html']), { check: true, file: 'a.html' });
+});
+
+test('CLI: a typo\'d flag exits non-zero and writes NOTHING', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'stamp-cli-'));
+  try {
+    const target = join(dir, 'page.html');
+    const before = '<h1>T</h1>\n<div hidden data-published-as="7" data-publish-id="abc123"></div>';
+    writeFileSync(target, before);
+    const r = runCli(['--chek', '--file', target], dir);
+    assert.notEqual(r.code, 0, 'a typo must not exit 0');
+    assert.match(r.stderr, /unknown argument/);
+    assert.equal(readFileSync(target, 'utf8'), before, 'a refused invocation must not write');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('CLI: --check reports without writing; a bare run stamps', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'stamp-cli-'));
+  try {
+    const target = join(dir, 'page.html');
+    const before = '<h1>T</h1>\n<div hidden data-published-as="7" data-publish-id="abc123"></div>';
+    writeFileSync(target, before);
+
+    const checked = runCli(['--check', '--file', target], dir);
+    assert.equal(checked.code, 0);
+    assert.match(checked.stdout, /is at 7/);
+    assert.equal(readFileSync(target, 'utf8'), before, '--check must never write');
+
+    const stamped = runCli(['--file', target], dir);
+    assert.equal(stamped.code, 0, stamped.stderr);
+    const after = parsePublishToken(readFileSync(target, 'utf8'));
+    assert.equal(after.n, 8);
+    assert.notEqual(after.nonce, 'abc123', 'a stamp must mint a new id, not only bump');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('CLI: an unreadable file is an error, not a silent seed', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'stamp-cli-'));
+  try {
+    const r = runCli(['--file', join(dir, 'does-not-exist.html')], dir);
+    assert.notEqual(r.code, 0);
+    assert.match(r.stderr, /cannot read/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('bumpToken refuses to exceed the parser\'s 15-digit counter cap', () => {
+  const atCap = `<div data-published-as="999999999999999" data-publish-id="abc123"></div>`;
+  assert.equal(parsePublishToken(atCap).n, 999999999999999, 'precondition: the cap parses');
+  assert.throws(() => bumpToken(atCap, () => 'abc124'), /15-digit counter cap/);
 });


### PR DESCRIPTION
## Summary

Seeds a publish token into the on-box register's live view and adds the command that maintains it. This is the **data half** of #2599; the check that reads the token lands separately.

**Why the split — a bootstrap break that was live and unnoticed.** `check-onbox-register.mjs` validates `origin/main`'s *fetched* copy, so a guard cannot ship in the same change as the data it requires. The Track A/B split moved the seeding task out of the first PR, Track A shipped anyway, and both the spec and the plan still assert *"PR 1 seeds the token as data … so `origin/main` carries one by the time this code runs"*. It does not — `grep -c published-as` returned **0**. Shipping the comparator in that state would have made its first ever run return *"origin/main carries none — this is a revert or a deletion; do not publish; investigate"*: an unclearable STOP misdiagnosing its own cause, on a design whose stated principle is that an unclearable STOP is a guard that gets bypassed. Same data-then-guard shape the stable row IDs needed (#2629).

**Why a command instead of "bump the number".** A hand-maintained token goes stale, and a stale one fails in the **green** direction — a competing lane whose value happens to match yours reads as your own earlier publish, so the check waves through exactly the overwrite it exists to stop. Bumping the counter without minting a fresh id is that failure with an extra step. Two of the eight designs considered for this token died on precisely that, so `npm run stamp:publish-token` does both halves or neither — and it writes the genesis token too, so even the seed is machine-written.

The token is attributes on a hidden `<div>`, not an HTML comment: `checkLiveView`'s first action is `stripHtmlComments`, so a comment-carried token would be invisible to the one function that must read it.

## Test plan

**53 new tests**, all green; `check:onbox-register` and `check:register-citations` both green.

- **Unit (37)** — the comparator PR 2 will wire.
- **Stamper (8)** — pins the bootstrap invariant (the live view carries exactly one well-formed token), that the token survives comment stripping, and that every minted nonce is one the parser accepts. A stamper writing a token its own reader rejects would wedge the check permanently.
- **Real-git (8)** — new in kind. Builds throwaway repositories and asks the real binary, because **four of the five green-direction defects found in review lived in `nonceInHistory`'s nine lines**, where a stubbed runner pins the argv and nothing about what git does with it. Every one of those defects passed a green unit suite. Covers merge-conflict-born nonces, history-simplification pruning, and the `-S` substring anchor.

### Also fixed, found in passing

The git suite scrubs `GIT_*` from the environment of every spawn, and its first test asserts the scrub works. Both are load-bearing: git exports `GIT_DIR`/`GIT_INDEX_FILE` to hook children, `git -C` does **not** override them, so an inheriting `git init` in a temp repo writes to the *real* one. That happened twice while writing this file — 3,979 tracked files down to 1, and the branch moved onto a fixture commit — and it is silent. The scrub is computed **per spawn** rather than once at import: as a module constant it was snapshotted before any test could inject `GIT_DIR`, and the self-check passed with the scrub deleted.

## Notes

- **Release notes deliberately skipped** — maintainer tooling with no user- or operator-visible effect, matching #2717, the same class of change.
- **The token is inert in this PR.** Nothing reads it yet; that is the point of shipping it first.
- The register documents the stamp → commit → publish order in a new "The publish token" section.

Refs #2599

🤖 Generated with [Claude Code](https://claude.com/claude-code)
