### PR TITLE
fix(scripts,docs): close the three review findings left unfixed by #2740

### DIFF
--- a/docs/superpowers/plans/2026-08-27-onbox-register-stable-row-ids.md
+++ b/docs/superpowers/plans/2026-08-27-onbox-register-stable-row-ids.md
@@ -1057,8 +1057,9 @@ Already shipped, consumed as-is (do not re-declare or re-implement):
     lookups: { inBaseline, inMine, baselineInMine, workingInBaseline }
   PUBLISH_TOKEN_BASELINE_ERROR / _PUBLISHED_ERROR / _WORKING_ERROR   (three, not two)
 
-**Nine facts this task must not get wrong** *(1-7 as originally written, with 2
-corrected; 8 and 9 added after the code was executed and reviewed):*
+**Ten facts this task must not get wrong** *(1-7 as originally written, with 2
+corrected; 8 and 9 added after the code was executed and reviewed; 10 after it
+merged):*
 
 1. **Three designs have died on a hand-maintained identity field** — a bare
    counter, a branch name, and a nonce that the operator had to remember to
@@ -1108,6 +1109,22 @@ corrected; 8 and 9 added after the code was executed and reviewed):*
    writes to the real repository — observed twice, taking 3,979 tracked files
    down to 1. Its first test asserts the scrub works; that assertion is the only
    thing that would catch a regression, because the failure is silent.
+
+   Two corrections to that account, both from the PR #2740 review. The scrub is
+   delegated to `scrubGitEnv` (`scripts/git-env.mjs`) and matches
+   **case-insensitively** — git honours a lowercase `git_dir` identically, and
+   a `startsWith('GIT_')` filter leaves that survivor in place. And an ordinary
+   hook does **not** export `GIT_DIR`; it exports `GIT_INDEX_FILE` (that
+   helper's own measured #2216 note), which is what actually did the damage.
+
+10. **This task carries a review debt it did not incur.** `publish-token.mjs`
+    merged in PR #2740 with **no caller** — only `bumpToken`/`parsePublishToken`
+    are used, by the stamper. Its comparator was reviewed as *code*, hard, but
+    never as *wiring*, and the reviewer named that gap: the module's own riskiest
+    property is the four-lookup contract in fact 8, and no PR has yet exercised
+    it against a real caller. **So this task's review is not "did the wiring
+    land" — it is the first review of the module in use.** Budget for that
+    rather than treating the module as settled because it is on `main`.
 
 - [ ] **Step 1: Write the failing tests**
 

--- a/docs/superpowers/specs/2026-08-27-onbox-register-stable-row-ids-design.md
+++ b/docs/superpowers/specs/2026-08-27-onbox-register-stable-row-ids-design.md
@@ -462,7 +462,7 @@ the query then selects 2 commits rather than 1 — but that second match is
 **redundant**: the commit that ADDED main's nonce is already in your history
 once you have rebased. The stamp answers a different gate, `w.n === b.n`. The
 claim was written from the previous draft rather than from a probe, which is
-the failure mode this document has recorded four times and is the reason the
+the failure mode this document has recorded five times and is the reason the
 correction is left visible here rather than quietly edited out.)*
 
 That residue is adjudicated, not overlooked. Detecting it means comparing

--- a/docs/superpowers/specs/2026-08-27-onbox-register-stable-row-ids-design.md
+++ b/docs/superpowers/specs/2026-08-27-onbox-register-stable-row-ids-design.md
@@ -447,13 +447,23 @@ rather than being implied.
 
 **Second: `baselineInMine` proves your branch HELD main's live view, not that
 your working file still reflects it.** The lookup asks whether main's nonce
-appears anywhere in `HEAD`'s history for that path — and a commit that *removes*
-that nonce satisfies it just as well as one that adds it. Your own stamp is
-exactly such a commit, which is not incidental: it is what lets a correctly
-rebased lane clear the staleness STOP after one stamp, and it is why the STOP is
-self-clearing rather than a dead end. The cost is that a revert, or a wholesale
-"take mine" conflict resolution *after* a clean rebase, also satisfies it and
-goes green.
+appears anywhere in `HEAD`'s history for that path, and it is **the rebase
+alone that satisfies it** — measured in a real repository: before rebasing the
+query selects 0 commits, after rebasing and *before any stamp* it selects 1.
+So the staleness STOP is cleared by rebasing, which is exactly what its message
+instructs. The cost of asking a history question rather than a content one is
+that a revert, or a wholesale "take mine" conflict resolution *after* a clean
+rebase, also satisfies it and goes green.
+
+*(An earlier draft of this paragraph said the removal-match was "what lets a
+correctly rebased lane clear the STOP after one stamp". That inverts the
+causation. `-S` does match a removal — your own stamp removes main's nonce and
+the query then selects 2 commits rather than 1 — but that second match is
+**redundant**: the commit that ADDED main's nonce is already in your history
+once you have rebased. The stamp answers a different gate, `w.n === b.n`. The
+claim was written from the previous draft rather than from a probe, which is
+the failure mode this document has recorded four times and is the reason the
+correction is left visible here rather than quietly edited out.)*
 
 That residue is adjudicated, not overlooked. Detecting it means comparing
 *content* between the working file and the baseline — which is precisely the

--- a/docs/superpowers/specs/2026-08-27-onbox-register-stable-row-ids-design.md
+++ b/docs/superpowers/specs/2026-08-27-onbox-register-stable-row-ids-design.md
@@ -436,12 +436,32 @@ published page, and the tracked working file** — they fail for different reaso
 and the operator does something different about each. Two constants would force
 two of those three onto one message.
 
-**Stated boundary — one, not two.** The token proves the live page came out of
-your history and that nobody else published since your baseline. It does **not**
-prove the bytes you are about to publish are the bytes you intended: a stale local
-build of your own file, correctly bumped and correctly nonced, still publishes.
-That is what git review covers, and it goes in #2599's close comment rather than
-being implied.
+**Stated boundary — two, and both are worth saying out loud.**
+
+**First: the token proves provenance, not intent.** It shows the live page came
+out of your history and that nobody else published since your baseline. It does
+**not** prove the bytes you are about to publish are the bytes you intended: a
+stale local build of your own file, correctly bumped and correctly nonced, still
+publishes. That is what git review covers, and it goes in #2599's close comment
+rather than being implied.
+
+**Second: `baselineInMine` proves your branch HELD main's live view, not that
+your working file still reflects it.** The lookup asks whether main's nonce
+appears anywhere in `HEAD`'s history for that path — and a commit that *removes*
+that nonce satisfies it just as well as one that adds it. Your own stamp is
+exactly such a commit, which is not incidental: it is what lets a correctly
+rebased lane clear the staleness STOP after one stamp, and it is why the STOP is
+self-clearing rather than a dead end. The cost is that a revert, or a wholesale
+"take mine" conflict resolution *after* a clean rebase, also satisfies it and
+goes green.
+
+That residue is adjudicated, not overlooked. Detecting it means comparing
+*content* between the working file and the baseline — which is precisely the
+question the three rejected per-row designs could not answer, for a reason that
+has not changed: content comparison cannot separate "this branch edited the row"
+from "this branch is stale". The token deliberately answers a different, decidable
+question instead. What closes this last gap is git review of the diff, not a
+richer comparator.
 
 *(The previous draft carried a second boundary — that the publisher field was
 "trusted, not proven", justified as detecting accident rather than forgery. That

--- a/scripts/publish-token.mjs
+++ b/scripts/publish-token.mjs
@@ -29,7 +29,20 @@ export const publishTokenRegex = () =>
   /data-published-as="([^"]*)"\s+data-publish-id="([^"]*)"/g;
 
 export function parsePublishToken(rawHtml) {
-  if (typeof rawHtml !== 'string') return null;
+  // `null`/`undefined` mean "no copy" and are the caller's to diagnose — the
+  // comparator answers each with its own named constant before parsing.
+  if (rawHtml === null || rawHtml === undefined) return null;
+  // Anything else non-string is NOT "this file has no token": it is a caller
+  // that handed us the wrong kind of value, and `readFileSync` without an
+  // encoding — which returns a Buffer — is the realistic way to get here.
+  // Returning null routed that into "the tracked live view has none. Restore
+  // it before publishing", sending an operator to repair a file that is
+  // perfectly fine. Report it as malformed so the message names the real fault.
+  if (typeof rawHtml !== 'string') {
+    return {
+      malformed: `expected HTML text but got ${rawHtml instanceof Uint8Array ? 'a Buffer — read the file with an encoding' : typeof rawHtml}`,
+    };
+  }
   const matches = [...rawHtml.matchAll(publishTokenRegex())];
   if (matches.length === 0) return null;
   if (matches.length > 1) {

--- a/scripts/stamp-publish-token.mjs
+++ b/scripts/stamp-publish-token.mjs
@@ -47,7 +47,17 @@ export const mintNonce = () => randomBytes(6).toString('hex');
 const SEED_AFTER = /(<h1[^>]*>[\s\S]*?<\/h1>)/;
 
 export function seedToken(html, mint = mintNonce) {
-  if (parsePublishToken(html) !== null) {
+  // THREE outcomes, not two. `parsePublishToken` returns null (no token),
+  // `{ malformed }` (a token, or a value, this reader will not accept), or a
+  // parsed token — and `{ malformed } !== null`, so a binary `!== null` test
+  // reports "this file already has a token" for a file with NO token in it.
+  // Reading the parser as a binary is precisely the defect this PR fixes in
+  // the comparator; it was mirrored here, at the parser's only other caller.
+  const existing = parsePublishToken(html);
+  if (existing && existing.malformed) {
+    throw new Error(`stamp-publish-token: ${existing.malformed}`);
+  }
+  if (existing !== null) {
     throw new Error('stamp-publish-token: this file already has a token; stamp it, do not seed it.');
   }
   if (!SEED_AFTER.test(html)) {

--- a/scripts/tests/publish-token.test.mjs
+++ b/scripts/tests/publish-token.test.mjs
@@ -307,6 +307,26 @@ test('18g STALE LANE: told to bump, obeys, and must NOT go green', () => {
   assert.notDeepEqual(step2, [], 'bumping must not clear a staleness STOP');
 });
 
+test('18g2 the staleness STOP outranks the both-absent one, not just the counters', () => {
+  // The OTHER half of the ordering claim beside the !baselineInMine guard. 18g
+  // pins that it precedes the COUNTER gates; nothing pinned that it precedes
+  // the both-absent gate, so moving it below that one survived mutation. Both
+  // messages say "rebase", so this is message SELECTION rather than a
+  // correctness hole — but an unpinned ordering claim is one edit from being
+  // false, and the comment asserts it.
+  const e = cmp({
+    working: T(49, 'mine'),
+    published: T(48, 'other'),
+    baseline: T(47, 'mainn'),
+    ...L({ inBaseline: false, inMine: false, baselineInMine: false }),
+  });
+  assert.ok(
+    e.some((x) => x.includes("origin/main's live-view nonce")),
+    `staleness must be diagnosed ahead of "another lane published": ${e.join('|')}`,
+  );
+  assert.ok(!e.some((x) => x.includes('another lane published')), e.join('|'));
+});
+
 test('18h green REQUIRES the baseline nonce to be in my history', () => {
   const base = { working: T(49, 'ccc'), published: T(48, 'bbb'), baseline: T(47, 'aaa') };
   assert.deepEqual(cmp({ ...base, ...L({ inBaseline: false, inMine: true }) }), []);
@@ -403,6 +423,24 @@ test('18l bumpToken REFUSES a nonce its own parser would reject', () => {
   // permanently, so the round trip is the real assertion.
   const { html } = bumpToken(src, () => 'abc123');
   assert.deepEqual(parsePublishToken(html), { n: 48, nonce: 'abc123' });
+});
+
+test('18o a non-string copy names the CALLER\'s fault, not a missing token', () => {
+  // `readFileSync` without an encoding returns a Buffer. That used to parse as
+  // null, i.e. "this file has no token", and the comparator then told the
+  // operator to restore a file that was perfectly fine.
+  const asBuffer = Buffer.from(T(48, 'aaa'), 'utf8');
+  const parsed = parsePublishToken(asBuffer);
+  assert.ok(parsed && parsed.malformed, 'a Buffer must not read as "no token"');
+  assert.match(parsed.malformed, /Buffer/);
+
+  const e = cmp({ working: asBuffer, published: T(47, 'zzz'), baseline: T(47, 'zzz') });
+  assert.ok(e.some((x) => x.includes('encoding')), e.join('|'));
+  assert.ok(!e.some((x) => x.includes('Restore it')), `must not blame the file: ${e.join('|')}`);
+
+  // ...while a genuinely absent copy keeps its own distinct diagnosis.
+  assert.deepEqual(parsePublishToken(null), null);
+  assert.deepEqual(parsePublishToken(undefined), null);
 });
 
 test('19 malformed tokens are errors, not skips', () => {

--- a/scripts/tests/publish-token.test.mjs
+++ b/scripts/tests/publish-token.test.mjs
@@ -381,8 +381,37 @@ test('18j the ENTIRE green region requires baselineInMine (enumeration)', () => 
 });
 
 test('18m a counter bumped WITHOUT minting is caught with no history lookup', () => {
-  const e = cmp({ working: T(49, 'same'), published: T(48, 'same'), baseline: T(47, 'aaa') });
-  assert.ok(e.some((x) => x.includes('without minting')), e.join('|'));
+  // The default lookups put inBaseline=true, which makes the HISTORY-backed
+  // guard fire first — and its message also contains "without minting", so an
+  // earlier version of this test passed while the guard it is named for could
+  // be deleted outright. inBaseline=false is what actually reaches it.
+  const e = cmp({
+    working: T(48, 'same'),
+    published: T(47, 'same'),
+    baseline: T(47, 'aaa'),
+    ...L({ inBaseline: false }),
+  });
+  // Assert on the half of the message that is UNIQUE to this guard, not on the
+  // phrase both guards share.
+  assert.ok(
+    e.some((x) => x.includes("kept the published page's nonce")),
+    e.join('|'),
+  );
+  assert.ok(!e.some((x) => x.includes("already in origin/main's history")), e.join('|'));
+});
+
+test('18m2 the two un-minted guards are distinguishable, not interchangeable', () => {
+  // 170 is history-backed and speaks about the LIVE PAGE vs origin/main; 243
+  // needs no lookup and speaks about the WORKING file vs the live page. Both
+  // say "without minting", which is why one could stand in for the other.
+  const historyBacked = cmp({
+    working: T(49, 'mine'),
+    published: T(48, 'same'),
+    baseline: T(47, 'same'),
+    ...L({ inBaseline: true }),
+  });
+  assert.ok(historyBacked.some((x) => x.includes("already in origin/main's history")));
+  assert.ok(!historyBacked.some((x) => x.includes("kept the published page's nonce")));
 });
 
 test('18n lookups: null fails closed instead of throwing', () => {
@@ -423,6 +452,14 @@ test('18l bumpToken REFUSES a nonce its own parser would reject', () => {
   // permanently, so the round trip is the real assertion.
   const { html } = bumpToken(src, () => 'abc123');
   assert.deepEqual(parsePublishToken(html), { n: 48, nonce: 'abc123' });
+});
+
+test('18p a tokenless WORKING file is reported (the guard-sweep survivor)', () => {
+  // The other guard a deletion sweep found unprotected: nothing asserted the
+  // tokenless-working STOP positively, so it could be removed with the suite
+  // still green. Distinct from 18o, which is about a non-string value.
+  const e = cmp({ working: '<p>no token here</p>', published: T(48, 'bbb'), baseline: T(47, 'aaa') });
+  assert.ok(e.some((x) => x.includes('the tracked live view has none')), e.join('|'));
 });
 
 test('18o a non-string copy names the CALLER\'s fault, not a missing token', () => {

--- a/scripts/tests/publish-token.test.mjs
+++ b/scripts/tests/publish-token.test.mjs
@@ -24,21 +24,28 @@ const TRAW = (n, nonce) => `<p data-published-as="${n}" data-publish-id="${nonce
 // absent — and two of those asserted GREEN, through the very fail-open this
 // suite now pins. A test that omits a lookup is not testing the healthy path;
 // it is testing whatever the missing key happens to coerce to.
-// TWO KNOWN-EQUIVALENT MUTANTS. Both were survivors in the pass-5 fix round,
-// and both are unkillable because a stronger check now runs AHEAD of them —
-// defence in depth, where the outer guard subsumes the inner. Do not "fix" the
-// suite to kill these; the reachability argument is the artifact:
+// THREE KNOWN-EQUIVALENT MUTANTS. Each is unkillable because a stronger check
+// runs AHEAD of it — defence in depth, where the outer guard subsumes the
+// inner. A deletion sweep reports them as survivors on every run, so they are
+// listed here with their reachability arguments to stop the next reviewer
+// re-investigating a settled case. Do NOT "fix" the suite to kill them; that
+// would mean weakening the guard that makes each unreachable.
 //
 //   A6  `!inBaseline && !inMine`  ->  `!inMine`
 //       Distinguishable only at inBaseline=true, inMine=false. Reaching that
-//       line requires baselineInMine=true (else the C1 STOP returned), and the
-//       consistency guard rejects `inBaseline && baselineInMine && !inMine`.
-//       So inBaseline implies inMine there, and the two forms agree.
+//       line requires baselineInMine=true (else the staleness STOP returned),
+//       and the consistency guard rejects
+//       `inBaseline && baselineInMine && !inMine`. So inBaseline implies
+//       inMine there, and the two forms agree.
 //
 //   B1  function replacement  ->  string replacement (re-opens $& expansion)
 //       Distinguishable only for a nonce containing a `$` pattern, which the
 //       minted-nonce charset check ([A-Za-z0-9_-]) refuses first. Killing B1
-//       would mean weakening B2.
+//       would mean weakening that check.
+//
+//   D1  `w.n === b.n`  ->  `w.n <= b.n`   (the un-bumped gate)
+//       Distinguishable only at w.n < b.n, and the REBASE gate immediately
+//       above returns first for exactly that state.
 const HEALTHY = {
   inBaseline: true,
   inMine: true,
@@ -276,11 +283,18 @@ test('18e workingInBaseline false is genuinely green (the guard is not always-on
 test('18f the working-nonce lookup is only consulted when w.n > b.n', () => {
   // At w.n === b.n the un-bumped verdict must win, WITHOUT demanding the third
   // lookup — otherwise every caller pays a git call on a state that cannot use it.
+  //
+  // `workingInBaseline: null` is what gives this test teeth. Inheriting the
+  // healthy `false` made the second assertion unfalsifiable: a `w.n >= b.n`
+  // mutant would consult the lookup, find `false`, decline to STOP, and fall
+  // through to the same verdict — so the test passed while the boundary it is
+  // named for could be moved. `null` is the one value whose consultation is
+  // VISIBLE, because reading it is required to fail closed.
   const e = comparePublishTokens({
     working: T(47, 'zzz'),
     published: T(47, 'zzz'),
     baseline: T(47, 'zzz'),
-    ...L({ inBaseline: true, inMine: true }),
+    ...L({ inBaseline: true, inMine: true, workingInBaseline: null }),
   });
   assert.ok(e.some((x) => x.includes('same as origin/main')), e.join('|'));
   assert.ok(!e.some((x) => x.includes('could not search history')), e.join('|'));

--- a/scripts/tests/stamp-publish-token.test.mjs
+++ b/scripts/tests/stamp-publish-token.test.mjs
@@ -183,3 +183,19 @@ test('bumpToken refuses to exceed the parser\'s 15-digit counter cap', () => {
   assert.equal(parsePublishToken(atCap).n, 999999999999999, 'precondition: the cap parses');
   assert.throws(() => bumpToken(atCap, () => 'abc124'), /15-digit counter cap/);
 });
+
+test('seedToken distinguishes MALFORMED from absent (the F7 mirror)', () => {
+  // `parsePublishToken` has three outcomes and `{ malformed } !== null`, so a
+  // binary `!== null` test reported "this file already has a token" for a file
+  // with none — the same misattribution the comparator fix closes, mirrored at
+  // the parser's only other caller.
+  const noToken = Buffer.from('<h1>Register</h1>\n<p>no token at all</p>\n');
+  assert.throws(() => seedToken(noToken, () => 'abc123'), (err) => {
+    assert.ok(!/already has a token/.test(err.message), `misattributed: ${err.message}`);
+    assert.match(err.message, /Buffer|encoding/);
+    return true;
+  });
+  // A real, already-tokened string still gets the right refusal.
+  const seeded = seedToken('<h1>T</h1>', () => 'seed01').html;
+  assert.throws(() => seedToken(seeded, () => 'seed02'), /already has a token/);
+});

--- a/scripts/tests/stamp-publish-token.test.mjs
+++ b/scripts/tests/stamp-publish-token.test.mjs
@@ -199,3 +199,50 @@ test('seedToken distinguishes MALFORMED from absent (the F7 mirror)', () => {
   const seeded = seedToken('<h1>T</h1>', () => 'seed01').html;
   assert.throws(() => seedToken(seeded, () => 'seed02'), /already has a token/);
 });
+
+test('CLI --check reports a MALFORMED token as an error, not as a value', () => {
+  // Without this the malformed branch could be deleted and --check would exit 0
+  // printing "is at undefined (id undefined)" — reporting a broken token as a
+  // healthy one, in the mode whose entire job is to tell you the token's state.
+  const dir = mkdtempSync(join(tmpdir(), 'stamp-cli-'));
+  try {
+    const target = join(dir, 'page.html');
+    writeFileSync(target, '<h1>T</h1>\n<div data-published-as="abc" data-publish-id="zzzxxx"></div>');
+    const r = runCli(['--check', '--file', target], dir);
+    assert.notEqual(r.code, 0, '--check must not exit 0 on a malformed token');
+    assert.match(r.stderr, /malformed/);
+    assert.ok(!/is at undefined/.test(r.stdout), `must not report a value: ${r.stdout}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('CLI --check reports a TOKENLESS file as needing seeding', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'stamp-cli-'));
+  try {
+    const target = join(dir, 'page.html');
+    writeFileSync(target, '<h1>T</h1>\n<p>no token</p>');
+    const r = runCli(['--check', '--file', target], dir);
+    assert.notEqual(r.code, 0, 'a tokenless file is not a passing --check');
+    assert.match(r.stdout, /NO publish token/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('seedToken REFUSES a mint its own parser would reject (the bumpToken twin)', () => {
+  // bumpToken's identical guard is pinned by 18l; this one was not. Removed, it
+  // writes data-publish-id="ab" — a token the module's own parser rejects, and
+  // one that cannot be repaired by stamping, because stamping needs a parseable
+  // token to bump. That is the unrecoverable state the guard exists to prevent.
+  for (const bad of ['ab', '', 'a b', '-Sx', 'has"q', null, 42]) {
+    assert.throws(
+      () => seedToken('<h1>T</h1>', () => bad),
+      /minted nonce/,
+      `seed mint -> ${JSON.stringify(bad)} must be refused`,
+    );
+  }
+  // and a good mint still round-trips through the parser
+  const { html } = seedToken('<h1>T</h1>', () => 'abc123');
+  assert.deepEqual(parsePublishToken(html), { n: 1, nonce: 'abc123' });
+});


### PR DESCRIPTION
## Summary

#2740's review gate produced ten findings. Nine were folded before merge; **three were not**, on the reasoning that they were Low and red-direction — none could turn a STOP green.

That is a bar this repo does not have. CLAUDE.md requires findings to be fixed in the round that surfaced them, and lists *"it's only a chore"* / *"it's not user-visible"* / *"nothing is broken yet"* among the excuses it explicitly voids — severity is those with a number attached. The three took one round to close, which is the tell: **a finding cheap enough to rank Low is cheap enough to fix now.**

This PR closes those three, then folds everything its own two review passes found.

### F7 — a non-string copy blamed the wrong file

`readFileSync` without an encoding returns a Buffer. `parsePublishToken` returned `null` for it, which means *"this file has no token"*, so the comparator answered *"the tracked live view has none. Restore it before publishing."* It sent an operator to repair a perfectly good file while the real fault — a caller bug one frame up — went unnamed.

Non-string now reports as malformed and names the Buffer case. `null`/`undefined` still return `null`: those genuinely mean *no copy*, and each already has its own constant.

### F5 — half an ordering claim was unpinned

The staleness gate's comment asserts it runs before the counter gates **and** before the both-absent gate. Only the first half was pinned — relocating the gate below both-absent survived mutation.

### F8 — the boundary of `baselineInMine` was undocumented

It asks whether main's nonce appears *anywhere* in `HEAD`'s history for that path, and **the rebase alone satisfies it**. Measured in a real repository:

| state | commits selected |
|---|---|
| before rebase | **0** — STOP fires |
| after rebase, before any stamp | **1** — STOP already cleared |
| after stamping | 2 — redundant second match |

So the staleness STOP is cleared by rebasing, which is exactly what its message instructs. The cost of asking a *history* question rather than a *content* one is that a revert, or a wholesale "take mine" resolution after a clean rebase, also goes green — adjudicated, not overlooked: closing that means comparing content, the undecidable question the three rejected per-row designs died on.

> An earlier revision of this PR claimed the removal-match was "what lets a correctly rebased lane clear the STOP after one stamp". **That inverted the causation and is retracted** — the correction is left visible in the spec rather than edited out, because it is the fifth instance of the failure mode that document records, and it happened in prose describing that very failure.

## Review passes

**Pass 1** — 3 Significant + 1 Minor, all folded in `2b022364`:

- **The F7 fix re-created its own defect at the parser's other caller.** `seedToken` read `parsePublishToken(html) !== null` as a binary, and `{ malformed } !== null` — so seeding a Buffer containing a file with *no token* threw *"this file already has a token"*. Reading the parser as a binary **is** the defect F7 fixes; I fixed one site and mirrored it into the other. All three outcomes now handled; the class audited tree-wide.
- **Test `18m` was satisfied by a different guard than the one it names** — both messages contain `without minting`, so it passed via the history-backed guard while the guard it is named for could be deleted with the suite green.
- **The spec's causal claim was inverted** (above).
- The tokenless-working STOP had no positive test.

**Pass 2** — nothing blocking; all four verified resolved by mutation, and the guard-deletion sweep went from **2 survivors out of 24 to 0 out of 38**. Its five Minors folded in `473456dc`:

- **`18f` could not fail for the boundary it names.** It inherited `workingInBaseline: false`, which neuters its own negative assertion — a `w.n >= b.n` mutant consults the lookup, finds `false`, declines to STOP, and reaches the same verdict. Now passes `null`, the one value whose consultation is *visible*.
- `--check`'s malformed branch, deleted, exited **0** printing `is at undefined (id undefined)` — a broken token reported as healthy, in the mode whose only job is reporting token state. Plus its tokenless branch, and `seedToken`'s mint validation (untested while its `bumpToken` twin was pinned).
- Documented `w.n === b.n → w.n <= b.n` as a third known-equivalent mutant so the next sweep does not re-chase it.

## Recorded, not fixed — not fixable here

`publish-token.mjs` merged in #2740 with **no caller**, so its comparator was reviewed as *code* but never as *wiring*, and its riskiest property — the four-lookup contract — has not been exercised against a real one. Added as **fact 10** on plan Task 10: that task's review is the module's *first review in use*, not a check that wiring landed.

## Test plan

**41 unit + 8 real-git + 18 stamper — all green**; `check:onbox-register` green.

Every fix is mutation-verified, not merely passing. Killed: the non-string branch, the relocated staleness gate, guard 243, guard 123, `seedToken`'s malformed branch, `w.n > b.n → >=`, `--check`'s malformed and tokenless branches, and `seedToken`'s mint validation.

Release notes: skipped, same basis as #2740 — maintainer tooling with no user- or operator-visible effect.

Refs #2599

🤖 Generated with [Claude Code](https://claude.com/claude-code)
