### PR TITLE
fix(ops): use single backticks instead of double backticks in register-citations documentation

### DIFF
--- a/docs/superpowers/plans/2026-08-29-onbox-register-generated-surfaces.md
+++ b/docs/superpowers/plans/2026-08-29-onbox-register-generated-surfaces.md
@@ -54,7 +54,7 @@ replaced. Do not resurrect them.
   source of truth for what "generated" looks like.
 - **A citation or defect description written into any tracked file — including
   this plan — must never place the word "row"/"rows" immediately before a
-  bare register-ID-shaped token** (e.g. `` row A40 ``). `check-register-citations.mjs`'s
+  bare register-ID-shaped token** (e.g. ` row A40 `). `check-register-citations.mjs`'s
   `ROW_CITATION_REGEX` matches that shape anywhere in the tree and will fail
   `test:hooks` on the prose itself, not just on a real citation. This plan
   observes that rule throughout (see Task 9).


### PR DESCRIPTION
## Summary

Fixed the check-register-citations checker failing on main by correcting a documentation example that was using double backticks instead of single backticks for inline code spans.

The checker's stripInlineCodeSpans function only recognizes single-backtick code spans. When the documentation used double backticks, the example citation pattern 'row A40' was not being treated as a code span, causing it to be detected as a real (but nonexistent) register ID citation. This caused the checker to exit with code 1.

## Test plan

- `node --test scripts/tests/check-register-citations.test.mjs` — all 100 tests pass (was failing: 5 tests related to CLI binary file detection and Check C)
- `node scripts/check-register-citations.mjs` — exits with code 0 and reports binary file count
- `npm run typecheck` — no errors

Closes #2802