### PR TITLE
docs(docs): reword self-tripping row-citation example in the register-surfaces plan

### DIFF
--- a/docs/superpowers/plans/2026-08-29-onbox-register-generated-surfaces.md
+++ b/docs/superpowers/plans/2026-08-29-onbox-register-generated-surfaces.md
@@ -54,9 +54,11 @@ replaced. Do not resurrect them.
   source of truth for what "generated" looks like.
 - **A citation or defect description written into any tracked file — including
   this plan — must never place the word "row"/"rows" immediately before a
-  bare register-ID-shaped token** (e.g. ` row A40 `). `check-register-citations.mjs`'s
-  `ROW_CITATION_REGEX` matches that shape anywhere in the tree and will fail
-  `test:hooks` on the prose itself, not just on a real citation. This plan
+  bare register-ID-shaped token**, with nothing but whitespace between them
+  (e.g. the word "row" directly followed by a bare `A40`-style token).
+  `check-register-citations.mjs`'s `ROW_CITATION_REGEX` matches that shape
+  anywhere in the tree and will fail `test:hooks` on the prose itself, not
+  just on a real citation. This plan
   observes that rule throughout (see Task 9).
 
 ---


### PR DESCRIPTION
## Summary

`docs/superpowers/plans/2026-08-29-onbox-register-generated-surfaces.md` (from PR #2785) warns readers, in its own prose, never to write "row"/"rows" immediately before a bare register-ID-shaped token — then demonstrates exactly that shape as its own illustrative example (`row A40`). `check-register-citations.mjs`'s `ROW_CITATION_REGEX` fires on the prose itself, not just on a real citation, making `test:hooks`/`verify.yml`'s "Lint, typecheck & fast checks" leg FATAL on `main` for every PR that merges it — regardless of that PR's own diff. Already flagged as a known, deferred issue in PR #2798's own test plan ("pre-existing and unrelated ... fixed by a later task in the same plan").

Rewords the example so "row" is never immediately followed by whitespace and an ID-shaped token in the same breath, verified against the real checker (`node scripts/check-register-citations.mjs --strict` — exit 0) and its full test suite (100/100 pass).

## Test plan

- [x] `node scripts/check-register-citations.mjs --strict` — exit 0 (was exit 1)
- [x] `node --test scripts/tests/check-register-citations.test.mjs` — 100/100 pass

Closes #2808.