### PR TITLE
docs(docs): discharge A1's C-02/C-03/E-03, root-cause a recycle-storm false alarm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1029,6 +1029,15 @@ invalid commit messages sail through, pre-push verify never fires. In that case:
    checkout — the cheap alternative to installing. Frontend tooling resolves via
    root alone, so `server/` is easy to forget and fails the server test legs
    with "vitest not found".
+   **For real sidecar/TTS work, also junction `server/tts-sidecar/voices/`**
+   (found 2026-08-31, register row A1) — it holds the actual model weights
+   (Qwen HF cache, Kokoro ONNX, Coqui/XTTS, cloned-voice artifacts) and is
+   git-ignored like `.venv`, but junctioning only `.venv` leaves it absent. A
+   missing `voices/` doesn't 404 cleanly — Kokoro throws `Kokoro model not
+   found` repeatedly at sidecar boot, which can trigger enough restarts to trip
+   the `recycle-storm` circuit breaker mid-chapter, misreporting as a side-11
+   host-memory-leak regression (#399) when the real cause is the missing
+   junction. See [#2811](https://github.com/dudarenok-maker/Castwright/issues/2811).
 3. **Verify both.** `ls -d .husky/_ && git config core.hooksPath`, and for each
    junction `(Get-Item $p -Force).Target` — a relative `..` target resolves
    against the shell's CWD at creation time, not the link's own directory, so an

--- a/docs/testing/fs38-wave3-onbox-acceptance.md
+++ b/docs/testing/fs38-wave3-onbox-acceptance.md
@@ -1398,9 +1398,17 @@ wastes zero GPU. Discharges 268's owed item (a).
     `Cloned voice(s) unavailable — a cloned voice must never be substituted with another: "<Character>" (revoked). Restore the missing voice(s); reassign the character(s).` (pre-#1967 this read "Re-enable Qwen or restore the missing voice(s)" — a plain `revoked` entry never implies an engine is unavailable, so #1967 dropped the invented "Re-enable Qwen" clause; see clone-voice-resolver.ts.)
   - `generationRemediation` is non-empty.
 
-**Record:** elapsed to failure = ______ s · `tts.log` grew by ______ bytes
+**Record:** elapsed to failure = **0.75 s** · `tts.log` grew by **474 bytes**
+(all `/health` and `/capacity` probes — zero `/synthesize`)
 
-**Result:** ☐ P ☐ F ☐ B ☐ N/A  **Notes:**
+**Result:** ☒ P ☐ F ☐ B ☐ N/A  **Notes:** Run 2026-08-31 (Claude Code, isolated
+worktree `wt-onbox-a1-wave10`, throwaway fixture book, real Qwen 0.6B sidecar,
+no mocks). Revoked a fresh clone assigned to "Wren", generated chapter 2:
+`chapter_failed` in 748 ms with `errorCode: "cloned-voice-broken"`,
+`errorReason` exactly matching the post-#1967 wording
+(`Cloned voice(s) unavailable — a cloned voice must never be substituted with
+another: "Wren" (revoked)...`). `tts.log` delta was pure health-check noise, no
+synth/derive calls. `audio/` dir confirmed empty. All criteria met.
 
 ---
 
@@ -1426,7 +1434,24 @@ Confirm the speaking set from the chapter's sentence attribution before starting
   with `cloned-voice-broken` naming character B. (Same-run confirmation that the
   gate is scoping, not just globally passing.)
 
-**Result:** ☐ P ☐ F ☐ B ☐ N/A  **Notes:**
+**Result:** ☒ P ☐ F ☐ B ☐ N/A  **Notes:** Run 2026-08-31 (Claude Code, same
+worktree/setup as C-02). Clone A (healthy) assigned to Pell Hollis (speaks in
+ch.2 only); Clone B (revoked) assigned to Sela (speaks in ch.3 only, not
+ch.2) — this fixture's chapter-2/chapter-3 character split made a clean B-not-
+speaking chapter available without needing two separate books. Chapter 2:
+completed in ~71s real Qwen 0.6B render (`chapter_complete`,
+`audioQa.status: "ok"`, `measuredLufs: -16.1`) — confirms the first pass also
+retroactively confirmed the recycle-storm finding below wasn't a genuine
+regression. Chapter 3: `chapter_failed` in 681ms naming Sela, reason
+`(revoked)`. Both halves pass.
+**Incidental finding (filed, not a defect in this row's own mechanism):**
+first two chapter-2 attempts hit a real `errorCode: "recycle-storm"` — root
+cause was this worktree's missing `server/tts-sidecar/voices/` junction
+(Kokoro model-not-found crash loop tripping the recycle circuit breaker), NOT
+a side-11 regression. Junctioning `voices/` from the primary checkout fixed it
+immediately and reproducibly. Filed as
+[#2811](https://github.com/dudarenok-maker/Castwright/issues/2811); CLAUDE.md's
+worktree setup checklist updated in this same PR.
 
 ---
 
@@ -2079,7 +2104,13 @@ cannot self-heal (that is expected, not a defect).
 
 **Record:** `instruct` identical after self-heal? ☐ yes ☐ no (fail)
 
-**Result:** ☐ P ☐ F ☐ B ☐ N/A  **Notes:**
+**Result:** ☐ P ☐ F ☒ B ☐ N/A  **Notes:** Attempted 2026-08-31 (Claude Code,
+isolated worktree). `POST .../cast/design` requires `GEMINI_API_KEY` to
+generate the persona text — an isolated worktree deliberately carries no
+secrets (CLAUDE.md: "no GEMINI_API_KEY, no secrets, nothing"), so this row
+cannot be exercised from a worktree at all. Needs a session with real Gemini
+credentials (or a local-Ollama persona path if one exists) — not attempted
+further this run, still owed.
 
 ---
 
@@ -2467,7 +2498,22 @@ generating and before any audio appears.
 **If you miss the window entirely** (revoke lands well before or well after
 the derive), retry — budget 3–5 attempts, same as 268's C-01.
 
-**Result:** ☐ P ☐ F ☐ B ☐ N/A  **Attempts:** ____  **Notes:**
+**Result:** ☒ P ☐ F ☐ B ☐ N/A  **Attempts:** 1  **Notes:** Run 2026-08-31
+(Claude Code, same worktree). No prior `voices\xtts\` artifact existed for
+Pell's clone, so a derive was guaranteed on first Coqui-engine render — no
+need to force-delete a `.pt`. Fired the chapter generation
+(`modelKey: coqui-xtts-v2`, chapter 2) and the revoke ~0.6s later, landing
+during `chapter_preparing_voice` for Pell. Result: `revokedAt` **survived**
+(not clobbered); chapter **failed**, reason named "Pell Hollis"; **no**
+artifact under `voices\xtts\` (directory doesn't even exist) — all three core
+guarantees held on first attempt. One wording deviation from the sheet's
+expected text: the reason read `(derive-failed)`, not `(revoked)` — the revoke
+landed early enough that the derive attempt itself observed the revoked state
+and failed rather than the pre-check short-circuiting first. Substance
+(fail-loud, no resurrection, no orphaned artifact) matches the invariant; the
+exact reason-code branch taken is a minor, not-clearly-wrong classification
+nuance, not filed as a defect — flagging here in case a future reader expects
+byte-identical wording.
 
 ---
 

--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -757,8 +757,8 @@ the **2-card boot** (8 GB RTX 4070 + 16 GB RTX 5070 Ti over OcuLink) — and the
 eGPU is **not hot-pluggable**, so do all 2-card work in one sitting and all
 single-card work in another rather than interleaving.
 
-### A1 · fs-38 Wave 3 — voice cloning (now incl. 3c) · **20 of 60 run (2026-07-29, 2026-07-31) · ~40 still owed · 3 run-2 results retracted**
-<!-- stat:a1-still-owed 40 -->
+### A1 · fs-38 Wave 3 — voice cloning (now incl. 3c) · **23 of 60 run (2026-07-29, 2026-07-31, 2026-08-31) · ~37 still owed · 3 run-2 results retracted**
+<!-- stat:a1-still-owed 37 -->
 <!-- stat:a1-subtotal 60 -->
 
 **Partially discharged.** First execution 2026-07-29 by Claude Code on the
@@ -796,7 +796,12 @@ artifacts across 3 locations all gone including both cached mp3s and the
 original recording; wildcard sweep 0 files; entry + `voice.json` survive with
 `revokedAt`), **C-11** (409-with-usage then `{deleted:true}`, entry dir removed,
 both cast slots cascade-cleared), C-19 first half (1.7B tier renders a cloned
-voice; its erasure is covered by C-10).
+voice; its erasure is covered by C-10), **C-02** (revoked voice fails the
+chapter loud in 748ms, zero audio, zero GPU work), **C-03** (a Broken voice
+not speaking in the chapter under render doesn't fail it; the same voice does
+fail the chapter it actually speaks in), **E-03** (revoke racing an in-flight
+Coqui derive: `revokedAt` survives, no orphaned artifact, chapter fails
+naming the character — Run 4, see below).
 
 **Also proven — the wave's central claim, measured not asserted.** A cloned
 voice renders inside a real book: `wren`'s segments re-recorded into Coalfall
@@ -871,7 +876,38 @@ re-segmentation. **The precondition is only "analysis has run since the last
 render."** Full chapter generation is unaffected. No test caught it because none
 asserts which voice reached the provider.
 
-**Still owed (~40), and why:**
+**Run 4 — 2026-08-31, Claude Code, isolated worktree `wt-onbox-a1-wave10`,
+throwaway fixture book (the canonical `the-coalfall-commission.md`, imported
+fresh, not the operator's real book), real Qwen 0.6B + Coqui/XTTS sidecar, no
+mocks.** Three more discharged: **C-02** (revoked voice fails the chapter
+loud with zero audio and zero GPU work — 748ms to failure, `tts.log` delta was
+pure health-check noise), **C-03** (a Broken voice not used in the current
+chapter doesn't fail it, and the *same* voice does fail the chapter where its
+character actually speaks — both halves run on one real render each), and
+**E-03** (revoke landing during an in-flight Coqui derive: `revokedAt`
+survives, no orphaned `voices\xtts\` artifact, chapter fails naming the
+character — one attempt, first try, though the reported reason read
+`(derive-failed)` rather than the sheet's expected `(revoked)` wording; the
+underlying data-integrity guarantees the row cares about held regardless).
+**C-17** was attempted and is **blocked, not failed**: designing a voice
+requires `GEMINI_API_KEY`, which an isolated worktree deliberately never
+carries (CLAUDE.md's "no secrets" worktree rule) — this row needs a session
+with real Gemini credentials, not a fresh worktree.
+**Incidental finding, filed as [#2811](https://github.com/dudarenok-maker/Castwright/issues/2811):**
+the first two C-03 attempts hit a real `errorCode: "recycle-storm"`, initially
+indistinguishable from a side-11 regression — root-caused to this worktree's
+setup being incomplete (`server/tts-sidecar/voices/` was never junctioned
+alongside `.venv`, so Kokoro's missing weights crash-looped the sidecar into
+tripping the recycle-storm breaker mid-chapter). Junctioning `voices/` fixed
+it immediately and reproducibly; CLAUDE.md's worktree checklist updated in the
+same PR. **This means the row's "BLOCKED by the side-11 host-memory leak"
+framing above is likely stale for a *properly-set-up* box** — not
+re-verified at full-book scale this run (only single-chapter renders), so C-02
+above is left as its own row rather than assumed to also clear full-book
+work, but the specific failure mode this run hit was environmental, not
+side-11 recurring.
+
+**Still owed (~37), and why:**
 - **Browser/mic (4):** A-07 (recorder webm/opus), A-08 (mic-denial fallback),
   A-09 (consent gates Continue), B-02 (record-path clone). Need a real browser
   with a real microphone.
@@ -939,23 +975,29 @@ asserts which voice reached the provider.
   sticky `coqui_import_ok` reflecting a real import attempt, which is the one
   to read. Note #1963: `models-status`'s `importable` is still the old
   find_spec value.
-- **C-02, D-02 and any full-book work — BLOCKED by the side-11 host-memory
-  leak.** Two full-chapter render attempts died: one at the QA gate (ASR could
+- **C-02 — DISCHARGED, Run 4 (above).** D-02 and full-book work at scale
+  remain unconfirmed (only single-chapter renders proven in Run 4). #1972
+  (the splice attribution defect) is CLOSED (2026-07-31) and #399/side-11
+  itself is CLOSED — Run 4's own `recycle-storm` hit was root-caused to a
+  worktree-setup gap ([#2811](https://github.com/dudarenok-maker/Castwright/issues/2811)),
+  not a live leak. Treat the paragraph below as historical context for how
+  this row was scoped, not a current blocker.
+  <details><summary>Original 2026-07 finding (kept for history)</summary>
+
+  Two full-chapter render attempts died: one at the QA gate (ASR could
   not get VRAM alongside Kokoro), one with `recycle-storm` after the sidecar
   recycled 3× (committed memory peaked at 29,395 MB). The sidecar's own log
   names it: *"expected for the variable-shape leak; the restart ceiling is the
-  real guard"*. **Workaround, qualified since [#1972](https://github.com/dudarenok-maker/Castwright/issues/1972):**
-  the per-character re-record (splice) path renders one character's lines
-  without the full-chapter memory churn — that is how the central claim above
-  was proven — but it now REFUSES on a chapter whose `segments.json` and the
-  current analysis disagree (exactly the shape both fixture books in this run
-  hit). It only stays usable as a workaround when the two agree; when they
-  don't, re-run analysis first (so the splice becomes usable again), or fall
-  back to a full chapter generation — which the side-11 leak still blocks, but
-  which is at least immune to the splice's own attribution defect.
-- **The rest of Section C (18) and Section D (3):** not reached. C-08/C-12
-  (deliberate mid-write sidecar kills) and C-01/E-03 (revoke racing an in-flight
-  derive) are untouched and remain the highest-risk unproven behaviour here.
+  real guard"*. The per-character re-record (splice) path rendered one
+  character's lines without the full-chapter memory churn — that is how the
+  central claim above was proven — but at the time it refused on a chapter
+  whose `segments.json` and the current analysis disagreed (exactly the shape
+  both fixture books in that run hit); #1972 has since closed that refusal.
+  </details>
+- **The rest of Section C (15) and Section D (2):** not reached. C-08/C-12
+  (deliberate mid-write sidecar kills) and C-01 (revoke racing an in-flight
+  Qwen derive) are untouched and remain the highest-risk unproven behaviour
+  here. E-03 (the Coqui equivalent of C-01) is now discharged (Run 4, above).
 - **C-05 (one of the 18 above) now has two recorded sub-observations owed, not
   a new row:** [#2023](https://github.com/dudarenok-maker/Castwright/issues/2023)
   / PR #2041 split it into C-05a (a healthy cloned narrator refuses an


### PR DESCRIPTION
## Summary

- Real on-box run against register row A1 (fs-38 Wave 3, voice cloning) in an isolated worktree, real Qwen 0.6B + Coqui/XTTS sidecar, no mocks, against a fresh throwaway import of the canonical fixture book — not the operator's real workspace.
- Discharges three previously-owed sub-tests: **C-02** (revoked voice fails the chapter loud, zero audio, zero GPU work), **C-03** (a Broken voice not speaking in the rendered chapter doesn't fail it, and does fail the chapter it actually speaks in), **E-03** (revoke racing an in-flight Coqui derive — `revokedAt` survives, no orphaned artifact, chapter fails naming the character).
- Root-caused and filed a reproducible `recycle-storm` false alarm hit along the way: a fresh worktree junctions `server/tts-sidecar/.venv` but not `.../voices/`, so Kokoro's missing weights crash-loop the sidecar into tripping the recycle-storm breaker — easily misread as a side-11 regression. Filed #2811; updated CLAUDE.md's worktree setup checklist in this same PR.
- **C-17** (designed-voice self-heal) attempted and recorded as blocked, not failed: needs `GEMINI_API_KEY`, which an isolated worktree deliberately never carries.
- A1's owed count moves from ~40 to ~37.

## Test plan

- [x] `npm run check:onbox-register` passes (glance-table arithmetic verified).
- [x] Real on-box evidence recorded in `docs/testing/fs38-wave3-onbox-acceptance.md` for C-02/C-03/E-03/C-17.
- [x] Docs-only change (CLAUDE.md + two `docs/testing/*.md` files) — no runtime code, no tests to add.
- [ ] Live-view HTML republish — not done this round (left for a follow-up; the register's own history flags this step as easy to botch under time pressure, and I'd rather leave it accurate-but-stale than risk corrupting the canonical artifact).

Refs #2811

🤖 Generated with [Claude Code](https://claude.com/claude-code)
