### PR TITLE
fix(server): restore correct cookie-parse import in lan-auth.ts (again)

### DIFF
--- a/server/src/lan-auth.ts
+++ b/server/src/lan-auth.ts
@@ -12,7 +12,7 @@
 import { timingSafeEqual, randomBytes } from 'node:crypto';
 import { readFileSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
-import { parseCookie } from 'cookie';
+import { parse as parseCookie } from 'cookie';
 import type { Request, Response, NextFunction } from './http.js';
 import { isLanHttpsEnabled } from './routes/export-lan.js';
 import { isValidDeviceToken } from './workspace/device-tokens.js';


### PR DESCRIPTION
## Summary

Security regression fix: restores the correct cookie import that was broken by commit 67e1d7a1 and incorrectly reverted by commit 6e8044cc.

The broken import  (claiming cookie v2.0.1 renamed the export) prevents readCwLanCookie() from working. The correct import is .

This breaks two security checks in opposite directions:
- Cookie-bearing cross-origin CSRF requests are no longer rejected (hasCwLanCookie() returns false, causing requireSameOrigin() to skip validation)
- Legitimate __Host-cw_lan device-token cookies cannot authenticate

## Test plan

The three test files that catch this regression all pass after the fix:
- src/csrf-origin.test.ts — CSRF origin checks
- src/lan-auth.test.ts — LAN cookie authentication
- src/routes/lan-cookie-integration.test.ts — integration tests

Closes #2819