### PR TITLE
fix(scripts): bump-version.test.mjs cleanGitEnv is case-sensitive

### DIFF
--- a/scripts/tests/bump-version.test.mjs
+++ b/scripts/tests/bump-version.test.mjs
@@ -42,10 +42,15 @@ const MOJIBAKE_EM_DASH = 'â€”'; // should decode to U+2014 —, standalone 
 // which child processes inherit. Without sanitising, the test's `git commit`
 // would write into the PARENT worktree's git instead of the temp fixture —
 // silently creating bogus commits on whatever branch invoked the hook.
+// Case-insensitive match: Windows preserves whatever casing a var was stored
+// under while lookup is case-insensitive, and git honours a lowercase
+// `git_dir` identically to `GIT_DIR` — see git-env.mjs's scrubGitEnv() header
+// for the same trap. A `startsWith('GIT_')` filter alone leaves a `git_dir`
+// (or similar) survivor that still redirects the throwaway repo's commits.
 function cleanGitEnv() {
   const env = { ...process.env };
   for (const key of Object.keys(env)) {
-    if (key.startsWith('GIT_')) delete env[key];
+    if (key.toUpperCase().startsWith('GIT_')) delete env[key];
   }
   return env;
 }
@@ -627,6 +632,33 @@ test('scrubGitEnv strips every git repository-discovery override, preserves GIT_
   assert.equal(scrubbed.GIT_AUTHOR_NAME, 'Someone');
   // Deliberately preserved — see the #2216 correction above.
   assert.equal(scrubbed.GIT_INDEX_FILE, '/decoy/.git/index');
+});
+
+// Case-insensitivity regression for THIS file's own cleanGitEnv(), the same
+// trap scrubGitEnv() was hardened against below (#2175 review, Finding 1).
+// cleanGitEnv() hand-rolls its own filter rather than delegating to
+// scrubGitEnv() (it must also strip GIT_INDEX_FILE, which scrubGitEnv()
+// deliberately preserves — see the #2216 note below), so it needs its own
+// case-insensitive regression. Deliberately mixed-case-only: cannot pass
+// against a `key.startsWith('GIT_')` filter.
+test('cleanGitEnv strips a git env override regardless of stored casing', () => {
+  const saved = { ...process.env };
+  try {
+    for (const key of Object.keys(process.env)) {
+      if (key.toUpperCase().startsWith('GIT_')) delete process.env[key];
+    }
+    process.env.git_dir = '/decoy/.git';
+    process.env.Git_Index_File = '/decoy/.git/index';
+    process.env.PATH = saved.PATH ?? saved.Path;
+
+    const cleaned = cleanGitEnv();
+    assert.equal(cleaned.git_dir, undefined);
+    assert.equal(cleaned.Git_Index_File, undefined);
+    assert.ok(cleaned.PATH ?? cleaned.Path);
+  } finally {
+    for (const key of Object.keys(process.env)) delete process.env[key];
+    Object.assign(process.env, saved);
+  }
 });
 
 // #2175 review, Finding 1 — Windows env lookup is case-insensitive, but

--- a/scripts/tests/bump-version.test.mjs
+++ b/scripts/tests/bump-version.test.mjs
@@ -635,10 +635,10 @@ test('scrubGitEnv strips every git repository-discovery override, preserves GIT_
 });
 
 // Case-insensitivity regression for THIS file's own cleanGitEnv(), the same
-// trap scrubGitEnv() was hardened against below (#2175 review, Finding 1).
+// trap scrubGitEnv() was hardened against above (#2175 review, Finding 1).
 // cleanGitEnv() hand-rolls its own filter rather than delegating to
 // scrubGitEnv() (it must also strip GIT_INDEX_FILE, which scrubGitEnv()
-// deliberately preserves — see the #2216 note below), so it needs its own
+// deliberately preserves — see the #2216 note above), so it needs its own
 // case-insensitive regression. Deliberately mixed-case-only: cannot pass
 // against a `key.startsWith('GIT_')` filter.
 test('cleanGitEnv strips a git env override regardless of stored casing', () => {
@@ -649,12 +649,15 @@ test('cleanGitEnv strips a git env override regardless of stored casing', () => 
     }
     process.env.git_dir = '/decoy/.git';
     process.env.Git_Index_File = '/decoy/.git/index';
-    process.env.PATH = saved.PATH ?? saved.Path;
 
     const cleaned = cleanGitEnv();
     assert.equal(cleaned.git_dir, undefined);
     assert.equal(cleaned.Git_Index_File, undefined);
-    assert.ok(cleaned.PATH ?? cleaned.Path);
+    // Non-GIT_ keys are untouched — spot-check against whichever casing this
+    // OS actually stores the PATH var under (Windows: "Path").
+    const pathKey = Object.keys(cleaned).find((k) => k.toUpperCase() === 'PATH');
+    assert.ok(pathKey, 'PATH must survive the scrub');
+    assert.equal(cleaned[pathKey], saved[pathKey]);
   } finally {
     for (const key of Object.keys(process.env)) delete process.env[key];
     Object.assign(process.env, saved);
@@ -745,7 +748,7 @@ test('createAnnotatedTag resolves repoRoot even with an inherited GIT_DIR pointi
   writeFileSync(notes, '# v9.9.8\n\nFixes:\n- the GIT_DIR leak\n');
   const savedGitEnv = {};
   for (const key of Object.keys(process.env)) {
-    if (key.startsWith('GIT_')) {
+    if (key.toUpperCase().startsWith('GIT_')) {
       savedGitEnv[key] = process.env[key];
       delete process.env[key];
     }
@@ -1198,7 +1201,7 @@ test('createAnnotatedTag strips a BOM even when called directly, bypassing pre-f
     writeBOMFile(notes, '# v9.9.9\n\nFixes:\n- the bug\n');
     const savedGitEnv = {};
     for (const key of Object.keys(process.env)) {
-      if (key.startsWith('GIT_')) {
+      if (key.toUpperCase().startsWith('GIT_')) {
         savedGitEnv[key] = process.env[key];
         delete process.env[key];
       }

--- a/scripts/tests/bump-version.test.mjs
+++ b/scripts/tests/bump-version.test.mjs
@@ -635,7 +635,7 @@ test('scrubGitEnv strips every git repository-discovery override, preserves GIT_
 });
 
 // Case-insensitivity regression for THIS file's own cleanGitEnv(), the same
-// trap scrubGitEnv() was hardened against above (#2175 review, Finding 1).
+// trap scrubGitEnv() was hardened against below (#2175 review, Finding 1).
 // cleanGitEnv() hand-rolls its own filter rather than delegating to
 // scrubGitEnv() (it must also strip GIT_INDEX_FILE, which scrubGitEnv()
 // deliberately preserves — see the #2216 note above), so it needs its own

--- a/scripts/tests/release-body.test.mjs
+++ b/scripts/tests/release-body.test.mjs
@@ -58,10 +58,15 @@ const CONFLICT_FIXTURE =
 // this for real: a stray tag landed in this worktree). Every git
 // invocation below, and every spawned `node release-body.mjs` process,
 // passes this explicit env instead of inheriting process.env.
+// Case-insensitive match: Windows preserves whatever casing a var was stored
+// under while lookup is case-insensitive, and git honours a lowercase
+// `git_dir` identically to `GIT_DIR` — see git-env.mjs's scrubGitEnv() header,
+// and bump-version.test.mjs's identical helper/fix (#2841), for the measured
+// evidence. A `startsWith('GIT_')` filter alone leaves a survivor.
 function cleanGitEnv() {
   const env = { ...process.env };
   for (const key of Object.keys(env)) {
-    if (key.startsWith('GIT_')) delete env[key];
+    if (key.toUpperCase().startsWith('GIT_')) delete env[key];
   }
   return env;
 }
@@ -374,7 +379,7 @@ test('readTagAnnotation resolves repoRoot even with an inherited GIT_DIR pointin
 
   const savedGitEnv = {};
   for (const key of Object.keys(process.env)) {
-    if (key.startsWith('GIT_')) {
+    if (key.toUpperCase().startsWith('GIT_')) {
       savedGitEnv[key] = process.env[key];
       delete process.env[key];
     }
@@ -389,5 +394,28 @@ test('readTagAnnotation resolves repoRoot even with an inherited GIT_DIR pointin
     for (const [k, v] of Object.entries(savedGitEnv)) process.env[k] = v;
     rmSync(dir, { recursive: true, force: true });
     rmSync(decoy, { recursive: true, force: true });
+  }
+});
+
+// #2841 — this file's cleanGitEnv() is a byte-identical copy of
+// bump-version.test.mjs's, which had the same case-sensitivity gap fixed
+// there. Mirrors that file's regression test directly against the local
+// helper. Deliberately mixed-case-only: cannot pass against a
+// `startsWith('GIT_')` filter.
+test('cleanGitEnv strips a git env override regardless of stored casing', () => {
+  const saved = { ...process.env };
+  try {
+    for (const key of Object.keys(process.env)) {
+      if (key.toUpperCase().startsWith('GIT_')) delete process.env[key];
+    }
+    process.env.git_dir = '/decoy/.git';
+    process.env.Git_Index_File = '/decoy/.git/index';
+
+    const cleaned = cleanGitEnv();
+    assert.equal(cleaned.git_dir, undefined);
+    assert.equal(cleaned.Git_Index_File, undefined);
+  } finally {
+    for (const key of Object.keys(process.env)) delete process.env[key];
+    Object.assign(process.env, saved);
   }
 });

--- a/scripts/tests/release-body.test.mjs
+++ b/scripts/tests/release-body.test.mjs
@@ -414,6 +414,11 @@ test('cleanGitEnv strips a git env override regardless of stored casing', () => 
     const cleaned = cleanGitEnv();
     assert.equal(cleaned.git_dir, undefined);
     assert.equal(cleaned.Git_Index_File, undefined);
+    // Non-GIT_ keys are untouched — spot-check against whichever casing this
+    // OS actually stores the PATH var under (Windows: "Path").
+    const pathKey = Object.keys(cleaned).find((k) => k.toUpperCase() === 'PATH');
+    assert.ok(pathKey, 'PATH must survive the scrub');
+    assert.equal(cleaned[pathKey], saved[pathKey]);
   } finally {
     for (const key of Object.keys(process.env)) delete process.env[key];
     Object.assign(process.env, saved);

--- a/scripts/tests/verify-cache.test.mjs
+++ b/scripts/tests/verify-cache.test.mjs
@@ -1461,6 +1461,11 @@ test('cleanGitEnv strips a git env override regardless of stored casing', () => 
     const cleaned = cleanGitEnv();
     assert.equal(cleaned.git_dir, undefined);
     assert.equal(cleaned.Git_Index_File, undefined);
+    // Non-GIT_ keys are untouched — spot-check against whichever casing this
+    // OS actually stores the PATH var under (Windows: "Path").
+    const pathKey = Object.keys(cleaned).find((k) => k.toUpperCase() === 'PATH');
+    assert.ok(pathKey, 'PATH must survive the scrub');
+    assert.equal(cleaned[pathKey], saved[pathKey]);
   } finally {
     for (const key of Object.keys(process.env)) delete process.env[key];
     Object.assign(process.env, saved);

--- a/scripts/tests/verify-cache.test.mjs
+++ b/scripts/tests/verify-cache.test.mjs
@@ -1399,20 +1399,29 @@ test('a --changed-only pass is never written to the verify-cache — only a full
 
 // --- Branch-diff scope filter (verify/CI rebalance, 2026-07-06) --------
 
+// Strip ambient GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE/GIT_PREFIX (and anything
+// else GIT_-prefixed) before spawning: when this suite runs inside a real git
+// hook (pre-commit calls `npm run verify:fast:scoped` -> `npm run
+// test:hooks`), git sets these in the process env for the hook, and without
+// stripping them these fixture commands would operate on the REAL repo
+// instead of the throwaway `cwd`. Case-insensitive match: Windows preserves
+// whatever casing a var was stored under while lookup is case-insensitive,
+// and git honours a lowercase `git_dir` identically to `GIT_DIR` — a
+// destructure keyed on the canonical uppercase names alone (the pre-#2841
+// shape here) leaves a differently-cased survivor that still redirects these
+// fixture commands at the real repo. Demonstrated live: an ambient lowercase
+// `git_dir` flipped a real checkout's `core.bare` from false to true via
+// `makeGitFixture()`'s `git init` below.
+function cleanGitEnv() {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.toUpperCase().startsWith('GIT_')) delete env[key];
+  }
+  return env;
+}
+
 function gitAt(cwd, args) {
-  // Strip ambient GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE/GIT_PREFIX before
-  // spawning: when this suite runs inside a real git hook (pre-commit calls
-  // `npm run verify:fast:scoped` -> `npm run test:hooks`), git sets these in
-  // the process env for the hook, and without stripping them these fixture
-  // commands would operate on the REAL repo instead of the throwaway `cwd`.
-  const {
-    GIT_DIR: _GIT_DIR,
-    GIT_WORK_TREE: _GIT_WORK_TREE,
-    GIT_INDEX_FILE: _GIT_INDEX_FILE,
-    GIT_PREFIX: _GIT_PREFIX,
-    ...cleanEnv
-  } = process.env;
-  const r = spawnSync('git', args, { cwd, encoding: 'utf8', env: cleanEnv });
+  const r = spawnSync('git', args, { cwd, encoding: 'utf8', env: cleanGitEnv() });
   if (r.status !== 0) {
     throw new Error(`git ${args.join(' ')} failed: ${r.stderr}`);
   }
@@ -1432,6 +1441,31 @@ function makeGitFixture() {
   gitAt(dir, ['commit', '-q', '-m', 'base']);
   return dir;
 }
+
+// #2841 review round 2 — this file's own git-env scrub was a hardcoded-
+// uppercase object destructure, the same case-sensitivity gap already fixed
+// in bump-version.test.mjs and release-body.test.mjs, but spelled
+// differently enough to survive a grep for `startsWith('GIT_')`. Mirrors
+// those files' regression test directly against the local helper.
+// Deliberately mixed-case-only: cannot pass against a destructure keyed on
+// canonical uppercase names alone.
+test('cleanGitEnv strips a git env override regardless of stored casing', () => {
+  const saved = { ...process.env };
+  try {
+    for (const key of Object.keys(process.env)) {
+      if (key.toUpperCase().startsWith('GIT_')) delete process.env[key];
+    }
+    process.env.git_dir = '/decoy/.git';
+    process.env.Git_Index_File = '/decoy/.git/index';
+
+    const cleaned = cleanGitEnv();
+    assert.equal(cleaned.git_dir, undefined);
+    assert.equal(cleaned.Git_Index_File, undefined);
+  } finally {
+    for (const key of Object.keys(process.env)) delete process.env[key];
+    Object.assign(process.env, saved);
+  }
+});
 
 test('branchDiffFiles: returns files changed since branching off main', () => {
   const dir = makeGitFixture();
@@ -1581,17 +1615,10 @@ test('stagedDiffFiles: honours an ambient GIT_INDEX_FILE pointing at a temporary
   // a `git commit -a` / `git commit -- <path>` invocation, where the temp
   // index reflects the files that invocation is actually committing.
   writeFileSync(join(repoDir, 'via-temp-index.txt'), 'temp', 'utf8');
-  const {
-    GIT_DIR: _GIT_DIR,
-    GIT_WORK_TREE: _GIT_WORK_TREE,
-    GIT_INDEX_FILE: _GIT_INDEX_FILE,
-    GIT_PREFIX: _GIT_PREFIX,
-    ...cleanEnv
-  } = process.env;
   const populateTempIndex = spawnSync('git', ['add', 'via-temp-index.txt'], {
     cwd: repoDir,
     encoding: 'utf8',
-    env: { ...cleanEnv, GIT_INDEX_FILE: tempIndexPath },
+    env: { ...cleanGitEnv(), GIT_INDEX_FILE: tempIndexPath },
   });
   assert.equal(populateTempIndex.status, 0, populateTempIndex.stderr);
 

--- a/scripts/verify-cache.mjs
+++ b/scripts/verify-cache.mjs
@@ -957,8 +957,11 @@ export function stagedDiffFiles(cwd) {
 // `null`) would NOT trip verify-cache's "diff failed, run everything" safety
 // branch. See scripts/tests/verify-cache.test.mjs for the behavioural proof.
 function gitEnv() {
-  const { GIT_PREFIX: _GIT_PREFIX, ...cleanEnv } = scrubGitEnv();
-  return cleanEnv;
+  const env = scrubGitEnv();
+  for (const key of Object.keys(env)) {
+    if (key.toUpperCase() === 'GIT_PREFIX') delete env[key];
+  }
+  return env;
 }
 
 export function branchDiffFiles(cwd) {


### PR DESCRIPTION
## Summary
- `cleanGitEnv()` in `scripts/tests/bump-version.test.mjs` filtered git env vars with a case-sensitive `startsWith('GIT_')`, missing a lowercase `git_dir`/`git_index_file` survivor Windows can preserve — the same trap `scrubGitEnv()` (`scripts/git-env.mjs`) was already hardened against.
- This made the throwaway-repo test's own `git commit`/`git tag` calls vulnerable to redirection into the real repo's hook context — reproducible only when `test:hooks` runs inside a real `git commit`'s pre-commit hook, never standalone.
- Discovered live: two Open Engine agent runs (#2833, #2827) each burned their full retry budget on this exact failure from a fresh worktree's first commit.

## Fix
`key.toUpperCase().startsWith('GIT_')`, plus a mutation-provable regression test mirroring the existing `scrubGitEnv` casing test in the same file. Confirmed RED against the pre-fix code, GREEN after.

## Also fixed, found in passing (pr-review-gate pass 1, medium depth)

- **`release-body.test.mjs`'s `cleanGitEnv()` was a byte-identical copy** of `bump-version.test.mjs`'s, carrying the same case-sensitive gap. No mechanical guard catches either copy — `git-scrub.test.mjs`'s repo-wide `scrubGitEnv` guard explicitly excludes `scripts/tests/**` from its scan. Fixed identically, with a mirrored, mutation-provable regression test.
- Two adjacent save/restore blocks in `bump-version.test.mjs` (the `#2169` GIT_DIR-decoy test, and the direct-BOM test) and one in `release-body.test.mjs` (its own GIT_DIR-decoy test) had the same latent case-sensitive filter on which ambient `GIT_*` vars to snapshot/restore. Fixed alongside rather than left armed.
- Fixed a stale "see the #2216 note below" comment (both notes are above).
- Replaced this PR's own new test's vacuous `assert.ok(cleaned.PATH ?? cleaned.Path)` (always true; the preceding assignment line was a no-op) with a real spot-check that `PATH` survives the scrub with its value intact.

## Also fixed, found in passing (pr-review-gate pass 2, medium depth)

- **`verify-cache.test.mjs`'s `gitAt()` scrubbed git-hook env vars via a hardcoded-uppercase object destructure** (`{ GIT_DIR: _GIT_DIR, ... } = process.env`) — the same case-sensitivity gap already fixed twice in this PR, spelled differently enough to survive a grep for `startsWith('GIT_')`. **More severe than the earlier two instances**: demonstrated live that an ambient lowercase `git_dir` flips a real checkout's `core.bare` flag from `false` to `true` via `makeGitFixture()`'s `git init`, and its two call sites drive real git writes, not just reads. Replaced with the same `cleanGitEnv()` helper pattern used in the other two files, plus a mirrored mutation-provable regression test.
- Reverted a comment wrongly changed in round 1: `bump-version.test.mjs`'s "`#2175` review, Finding 1" cross-reference genuinely is below that comment, not above — round 1 flipped it without checking; round 2's reviewer caught round 1 breaking what round 1 itself had validated as correct.
- Completed `release-body.test.mjs`'s round-1 regression test to actually mirror its sibling: it was missing the "non-`GIT_` keys survive the scrub" half of the assertion that the sibling test in `bump-version.test.mjs` has.

## Also fixed, found in passing (pr-review-gate pass 3, medium depth — the cap, no round 4)

- `verify-cache.test.mjs`'s new round-2 regression test had the same "partial mirror" defect round 2 fixed in `release-body.test.mjs`: it claimed to mirror its siblings but was missing the "non-`GIT_` keys survive the scrub" half of the assertion. A `cleanGitEnv() { return {}; }` mutant left it green; fixed and re-confirmed mutation-sensitive.
- `scripts/verify-cache.mjs`'s `gitEnv()` stripped `GIT_PREFIX` with a case-sensitive destructure on top of an already case-insensitive `scrubGitEnv()` call. Confirmed inert (no git command here is affected by `GIT_PREFIX`'s casing) — fixed anyway for consistency with the rest of this PR.
- **One item was NOT fixed here and is filed as #2855 instead**: this bug class has now been hand-fixed three separate times in three files, with nothing mechanical stopping a fourth copy (the guard excluding `scripts/tests/**` from its scan is deliberate and pre-existing). Closing that gap needs a design decision — shared helper vs. narrowed guard vs. deliberate duplication — named in #2855 rather than picked blind at the review cap.

**Round 3 verdict: no correctness bug remains. The re-review trigger is not met; this closes the review loop at the cap.**

No shippable/user-visible delta from any of the above — internal test-infra reliability fix. Release-notes update intentionally skipped per CLAUDE.md step 5's no-shippable-delta exemption.

## Test plan
- [x] `node --test scripts/tests/bump-version.test.mjs` — 59/59 passing
- [x] Mutation check: reverted the fix, new test failed with the expected assertion; restored, test passes
- [x] `node --test scripts/tests/bump-version.test.mjs scripts/tests/release-body.test.mjs` — 71/71 passing (both files, after round-1 fixes)
- [x] Mutation check on `release-body.test.mjs`'s new test: reverted its fix, test failed with the expected assertion; restored, test passes
- [x] `node --test scripts/tests/bump-version.test.mjs scripts/tests/release-body.test.mjs scripts/tests/verify-cache.test.mjs` — 198/198 passing (all three files, after round-2 fixes)
- [x] Mutation check on `verify-cache.test.mjs`'s new test: reverted its fix, test failed with the expected assertion; restored, test passes
- [x] 198/198 passing again after round-3 fixes; mutation-checked the completed `verify-cache.test.mjs` mirror (`return {}` mutant now fails on the PATH assertion, as intended)
- [x] `npm run verify:fast:branch` — lint pass, test:hooks/test:server clean, rest correctly out-of-scope. (test:server hit two separate, unrelated, contention-driven flakes across retries — `analysis.fresh-cast-lock.test.ts` and `voice-style.test.ts`, both timing-sensitive concurrency tests, both confirmed passing clean in isolation and both irrelevant to this PR's `scripts/**`-only diff. Multiple other sessions were running concurrent test batteries on the same box throughout this PR.)

Closes #2841
