### PR TITLE
docs(docs): spec + plan for test-suite hardening (timing margins, e2e sharding, dev scripts)

### DIFF
--- a/docs/superpowers/plans/2026-09-02-test-suite-hardening.md
+++ b/docs/superpowers/plans/2026-09-02-test-suite-hardening.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** TypeScript/Vitest (frontend + server), GitHub Actions YAML, npm scripts, Playwright.
 
-**Spec:** `docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md` (HEAD `72e25bd3` at plan-writing time) — read Decisions A, B, D, E and the "Shipping notes" section before starting; this plan pulls exact values from it but the spec has the full rationale and review history behind each one.
+**Spec:** `docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md` — the spec and this plan were shipped to `main` together via PR #2849 (docs-only, exempt from the review gate) before implementation starts, specifically so `scripts/wt-new.mjs`'s default `--from main` in Task 1 actually has both documents to check out. If for any reason PR #2849 has NOT merged yet when you start Task 1, stop and merge it first (or pass `--from docs/docs-verify-scope-branch-timing-design` to `wt-new.mjs`) — do not proceed against a worktree missing the spec. Read Decisions A, B, D, E and the "Shipping notes" section before starting; this plan pulls exact values from it but the spec has the full rationale and review history behind each one.
 
 ## Global Constraints
 
@@ -16,10 +16,11 @@
 - Every widened/changed value must come from the spec verbatim — do not re-derive or "improve" a number while implementing (e.g. don't retune Decision B's margins beyond what's specified; don't pick a different shard count for Decision D).
 - `cast-lock.test.ts` and `design-lock.test.ts` are explicitly NOT touched (spec, Decision B) — do not "helpfully" apply the same widening pattern there.
 - `test:e2e:visual` is explicitly NOT sharded further and its `--workers=1` constraint is NOT touched (spec, Decision D / Out of scope).
-- Decision A (CI's zero-test-selection hazard) is NOT implemented by this plan — filed as its own issue only (Task 1, sub-step 4). Do not attempt to fix it here; it needs a design pass the spec explicitly deferred.
+- Decision A (CI's zero-test-selection hazard) is NOT implemented by this plan — filed as its own issue only (Task 1, **Step 5**). Do not attempt to fix it here; it needs a design pass the spec explicitly deferred.
 - Decision C (sidecar pytest scoping) requires no action at all — nothing to file, nothing to implement.
-- Every commit message follows CONTRIBUTING.md's `<type>(<scope>): <subject>` convention. These are `test`/`ci`/`chore` scoped changes — no `feat`/`fix`, since nothing here is new user-visible behavior or a bug fix.
-- CLAUDE.md's Before-shipping checklist steps 5 (release notes, both files) and 6 (issue linkage, `Closes #NN` in the PR body) apply — both are explicit tasks below, not left implicit.
+- **Tasks run strictly in the order below (1→2→3→4→5).** Each task's own scope-verification step (e.g. "confirm only these files changed") assumes every prior task is already committed — that's what keeps `git status`/`git diff` checks meaningful, not an independent guarantee restated per task.
+- Every commit message follows CONTRIBUTING.md's `<type>(<scope>): <subject>` convention, and **scope is mandatory for every type except `chore`** (verified against `scripts/validate-commit-msg.mjs`) — a bare `ci:`/`test:`/`docs:` with no `(scope)` is rejected by the commit-msg hook. Allowed scopes: `frontend|server|sidecar|app|scripts|e2e|mocks|openapi|docs|deps|ci|ops`. Each task below already specifies the exact valid `type(scope):` to use — don't substitute a different one (in particular, `release-notes` is NOT an allowed scope; Task 5 uses `docs(docs):`).
+- CLAUDE.md's Before-shipping checklist steps 5 (release notes, both files) and 6 (issue linkage, `Closes #NN` in the PR body) apply and are explicit tasks below. Steps 1 (new `docs/features/` regression plan), 3 (on-box acceptance), 4 (`docs/features/INDEX.md`), and 8 (plan status → `stable` + archive) are explicitly **waived, not silently skipped**: nothing here is cross-cutting or hardware-dependent enough to need a `docs/features/` plan (this repo's own rule: "Small/localized items skip the plan doc"), and the `docs/superpowers/plans/` convention this plan itself uses has no archive step — that's a `docs/features/*` convention, not applicable here.
 
 ---
 
@@ -30,6 +31,8 @@
 
 **Interfaces:**
 - Produces: a working, hook-gated worktree at a path this plan calls `$WORKTREE` for the rest of its tasks, on branch `$BRANCH`; four GitHub issue numbers (`$ISSUE_B`, `$ISSUE_D`, `$ISSUE_E`, `$ISSUE_A`) referenced by later tasks and by the final PR body.
+
+Issue titles below use plain descriptive text, not CONTRIBUTING.md's `<prefix>-<n> — <what>` backlog-item shape — that shape is for `docs/BACKLOG.md`-rendered items, and CLAUDE.md is explicit that `type:chore` issues (all four of these) never render there and don't need it.
 
 - [ ] **Step 1: Cut the worktree and branch**
 
@@ -287,7 +290,7 @@ git -C $WORKTREE diff main -- server/src/workspace/file-lock.test.ts
 cd $WORKTREE/server && npx vitest run src/workspace/file-lock.test.ts
 ```
 
-Expected: all tests in the file pass, same pass count as before the edit (no test added or removed, only constants changed).
+Expected: all tests in the file pass, 0 failures (no test was added or removed, only constants changed, so there's nothing to compare a "before" count against — just confirm the file is fully green).
 
 - [ ] **Step 7: Commit**
 
@@ -430,13 +433,13 @@ Change the trailing `/4` to `/8`:
 
 - [ ] **Step 5: Confirm `test:e2e:visual`'s job is untouched**
 
-Grep the file to confirm no other `/4` or `[1, 2, 3, 4]` reference was accidentally changed:
+Grep narrowly — the `e2e-visual` job's own comment block legitimately says "shard" several times in prose (describing how it now runs concurrently with the sharded `e2e` job), so a bare `shard` grep will false-positive there. Check only the mechanical sites:
 
 ```bash
-grep -n "shard\|/4\b" $WORKTREE/.github/workflows/verify.yml
+grep -n "matrix:\|shard: \[\|--shard=" $WORKTREE/.github/workflows/verify.yml
 ```
 
-Only the `e2e` job's three sites (now `/8`) should reference sharding. The `test:e2e:visual` job must still show no `matrix:`/`shard` at all — confirm it wasn't touched.
+Expected: exactly the three sites this task just changed (the matrix array, the `--shard=` argument) plus the job `name:` label (not matched by this grep, already confirmed visually in Step 3) — all now `/8`. No `matrix:`/`shard: [...]`/`--shard=` should appear anywhere near `test:e2e:visual`'s job definition; if one does, something was touched that shouldn't have been.
 
 - [ ] **Step 6: Validate the YAML is well-formed**
 
@@ -451,24 +454,26 @@ cd $WORKTREE && node -e "require('js-yaml').load(require('fs').readFileSync('.gi
 ```bash
 git -C $WORKTREE add .github/workflows/verify.yml
 git -C $WORKTREE commit -m "$(cat <<'EOF'
-ci: increase e2e Playwright sharding from 4-way to 8-way
+ci(e2e): increase e2e Playwright sharding from 4-way to 8-way
 
 Also fixes two stale prose comments (verify.yml's header block and the e2e
 job's own rationale comment) that still cited the old 4-way figure and a
 ~110-spec-files estimate -- actual is 137. Per docs/superpowers/specs/
 2026-09-01-verify-scope-branch-timing-design.md Decision D; see that
 section for the cost caveats (unconditional per-shard checkout/setup
-overhead, unverified concurrent-job-slot ceiling) worth watching after
-this ships.
+overhead, unverified concurrent-job-slot ceiling) that the Ship section's
+timing dispatch is meant to actually check, not just watch after the fact.
 
 Refs #ISSUE_D_NUMBER
 EOF
 )"
 ```
 
+(Note the `ci(e2e):` type/scope — a bare `ci:` with no scope is rejected by this repo's commit-msg hook, since scope is mandatory for every type except `chore`.)
+
 Replace `#ISSUE_D_NUMBER` with the actual `$ISSUE_D` issue number from Task 1.
 
-**Note:** this task cannot be locally test-run end-to-end (it's cloud CI config) — the actual verification (8 shard jobs appear and complete) happens via a manual `gh workflow run` dispatch after the PR is pushed, covered in the final "Ship" section below, not as a task step here.
+**Note:** this task cannot be locally test-run end-to-end (it's cloud CI config). The spec conditions the 8-way number itself on "a real timing comparison during implementation, the same method the original 4-way split's comment cites" — that comparison is NOT optional post-ship monitoring, it's part of discharging this task, and it happens in the "Ship" section below (the manual `gh workflow run` dispatch step) since it requires the branch to actually be pushed to run cloud CI.
 
 ---
 
@@ -490,33 +495,38 @@ Find the `"scripts"` block's `test:server-slow` line (currently):
     "test:server-slow": "npm --prefix server run test:slow",
 ```
 
-Add the 8 new scripts immediately after it (before `"test:scripts"`):
+Add the 8 new scripts immediately after it (before `"test:scripts"`). Note: NOT column-aligned (unlike this plan's own prose elsewhere) — `package.json` is not in `.prettierignore`, and `npm run lint` doesn't catch JSON formatting, so a column-aligned block would ship a latent Prettier diff nothing in this repo's CI flags. Use plain single-space-after-colon formatting matching the rest of the file:
 
 ```json
     "test:server-slow": "npm --prefix server run test:slow",
-    "test:server:routes":    "npm --prefix server run test -- src/routes",
-    "test:server:tts":       "npm --prefix server run test -- src/tts",
-    "test:server:analyzer":  "npm --prefix server run test -- src/analyzer",
+    "test:server:routes": "npm --prefix server run test -- src/routes",
+    "test:server:tts": "npm --prefix server run test -- src/tts",
+    "test:server:analyzer": "npm --prefix server run test -- src/analyzer",
     "test:server:workspace": "npm --prefix server run test -- src/workspace",
     "test:components": "vitest run src/components",
-    "test:store":       "vitest run src/store",
-    "test:lib":         "vitest run src/lib",
-    "test:views":       "vitest run src/views",
+    "test:store": "vitest run src/store",
+    "test:lib": "vitest run src/lib",
+    "test:views": "vitest run src/views",
 ```
 
-(Match the existing file's actual indentation/quoting style exactly — `npm run format:check` will catch a mismatch if Prettier disagrees with manual spacing; run `npm run format` on just this file if needed before committing, or just match the two-space JSON indent already used throughout the file.)
+- [ ] **Step 2: Confirm each of the 8 scripts selects the right files — with `npx vitest list`, not a full run**
 
-- [ ] **Step 2: Run each of the 8 scripts and confirm it selects real tests**
-
-This is the step that matters most — round 4 of the spec's own review found a real path bug here (`server/src/routes` instead of the correct `src/routes`, since `npm --prefix server` already sets `cwd=server/`) that inspection alone missed and only running the command caught. Do not skip this by "it looks right."
+This is the step that matters most — round 4 of the spec's own review found a real path bug here (`server/src/routes` instead of the correct `src/routes`, since `npm --prefix server` already sets `cwd=server/`) that inspection alone missed and only running the command caught. Do not skip this by "it looks right." But also don't fully execute all 8 — between them they select roughly 10,500 tests (the spec's own measured totals), which on this repo's documented contention-prone box could take as long as the entire rest of this plan. Use the same lightweight instrument the spec itself used to derive its numbers — `vitest list`, which resolves the file selection without running anything:
 
 ```bash
-cd $WORKTREE && npm run test:server:routes -- --reporter=verbose 2>&1 | tail -20
+cd $WORKTREE/server && npx vitest list src/routes --filesOnly | wc -l   # expect 138
+npx vitest list src/tts --filesOnly | wc -l                             # expect 123
+npx vitest list src/analyzer --filesOnly | wc -l                        # expect 73
+npx vitest list src/workspace --filesOnly | wc -l                       # expect 57
+cd $WORKTREE && npx vitest list src/components --filesOnly | wc -l      # expect 112
+npx vitest list src/store --filesOnly | wc -l                           # expect 52
+npx vitest list src/lib --filesOnly | wc -l                             # expect 102
+npx vitest list src/views --filesOnly | wc -l                           # expect 29
 ```
 
-Expected: a real test run, NOT "No test files found, exiting with code 1". Repeat for `test:server:tts`, `test:server:analyzer`, `test:server:workspace`, `test:components`, `test:store`, `test:lib`, `test:views` — each must select a nonzero number of real test files matching its subdirectory. For the server-side four, additionally confirm the selected file count is in the right ballpark (spec's measured figures: routes 138 files, tts 123, analyzer 73, workspace 57) — a wildly different count (e.g. 0, or the whole suite) means the path is still wrong.
+Each must match its expected count exactly (these are the spec's own measured, verified-correct numbers) — 0, or the full suite's file count, means the path is still wrong. This doesn't run the scripts themselves (their exact `npm run test:server:routes` invocation isn't exercised by `npx vitest list`), so pick ONE of the 8 (`test:server:routes` is a reasonable choice — it exercises the nested `npm --prefix server run test -- <path>` shape the round-4 bug lived in) and actually run it once, letting it complete, purely to confirm the full `npm run` invocation chain (including `pretest`'s ffmpeg preflight) works end to end — the other 7 are covered by the `vitest list` check plus the shared mechanism this one run proves.
 
-If any of the 8 fails this check, the fix is almost certainly the same class of bug the spec's round 4 already found once — double-check the path is relative to the correct `cwd` for that invocation (server-relative for the four `npm --prefix server` ones, repo-root-relative for the four bare `vitest run` ones) rather than assuming the string in this plan is already correct without running it.
+If any of the 8 fails the `vitest list` check, the fix is almost certainly the same class of bug the spec's round 4 already found once — double-check the path is relative to the correct `cwd` for that invocation (server-relative for the four `npm --prefix server` ones, repo-root-relative for the four bare `vitest run` ones) rather than assuming the string in this plan is already correct without checking it.
 
 - [ ] **Step 3: Add the CLAUDE.md Commands-section bullet**
 
@@ -529,7 +539,7 @@ Find (`CLAUDE.md`, in the Commands section, immediately after the `test:server-s
 Add a new bullet immediately after it:
 
 ```markdown
-- `npm run test:server:routes` / `:tts` / `:analyzer` / `:workspace` and `npm run test:components` / `:store` / `:lib` / `:views` — opt-in, manual, subsystem-scoped test runs (`vitest run <subdir>` under the hood) for a fast local loop when you know you're only touching one area. Not part of the automated verify pipeline — not in `STEPS[]`, not cached, not gated by any hook, and carry no coverage guarantee (a `routes/` change that breaks something in `workspace/` isn't caught by `test:server:routes` alone). The four server-side ones cover 76.9% of `test:server` by test count; the four frontend ones cover most of `test`'s largest directories. See `docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md` Decision E.
+- `npm run test:server:routes` / `:tts` / `:analyzer` / `:workspace` and `npm run test:components` / `:store` / `:lib` / `:views` — opt-in, manual, subsystem-scoped test runs (`vitest run <subdir>` under the hood) for a fast local loop when you know you're only touching one area. Not part of the automated verify pipeline — not in `STEPS[]`, not cached, not gated by any hook, and carry no coverage guarantee (a `routes/` change that breaks something in `workspace/` isn't caught by `test:server:routes` alone). The four server-side scripts cover 76.9% of `test:server` by test count (`test:server:routes` selects 138 files, not the 146 a raw file search under `server/src/routes/` would find — 8 are in `vitest.config.slow.ts`'s `SLOW_FILES` and excluded from `test:server` itself, so this matches, not a gap); the four frontend scripts cover 86.3% of `test` by test count. See `docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md` Decision E.
 ```
 
 - [ ] **Step 4: Confirm the diff is scoped to exactly these two files**
@@ -573,7 +583,9 @@ Replace `#ISSUE_E_NUMBER` with the actual `$ISSUE_E` issue number from Task 1.
 
 - [ ] **Step 1: Append the technical entry to `docs/release-notes-next.md`**
 
-Find the end of the "### Test harness & suite hygiene" section (the last bullet currently ends with `.gitignore` did not cover `.env.bak`...` — find that section's last line and append after it, still inside the same `###` section, before the next `##`/`###` heading).
+Find the "### Test harness & suite hygiene" heading (`grep -n '^### Test harness' docs/release-notes-next.md`) — this is the LAST heading in the file, and its section runs from there to end-of-file (confirm with `grep -n '^## \|^### '` and checking nothing follows it), so "append after the section's last bullet" means append at the very end of the file, not immediately after any one named bullet — the section has many bullets in it, don't search for a specific one that may not be the true last line. Add a blank line, then the new bullet, at the end of the file.
+
+**Encoding note:** this repo's own history records Windows PowerShell 5.1 writing cp1252 instead of UTF-8 when text containing non-ASCII characters (the bullet below has `≥`, `→`, and em-dashes) is appended via shell redirection — corrupting exactly this kind of file. Use an editor/file-write tool that writes UTF-8 directly (the Edit/Write tool, not `Add-Content`/`>>` from PowerShell) for both this file and `RELEASE_NOTES.md` below.
 
 Append:
 
@@ -602,7 +614,7 @@ Confirm each diff is a single new bullet appended in the right section — nothi
 ```bash
 git -C $WORKTREE add docs/release-notes-next.md RELEASE_NOTES.md
 git -C $WORKTREE commit -m "$(cat <<'EOF'
-docs(release-notes): add v1.15.0 entries for test-suite hardening
+docs(docs): add v1.15.0 entries for test-suite hardening
 
 Technical register entry under Test harness & suite hygiene, plus a
 matching brand-voice line in RELEASE_NOTES.md, for the file-lock.test.ts
@@ -614,13 +626,15 @@ EOF
 
 ---
 
-## Ship (not a task — controlling-thread work per CLAUDE.md's Execution model phase 3)
+## Ship (not a task — deliberately controlling-thread work, per CLAUDE.md's Execution model phase 3, "the mandatory gate is phase 3's, not this one")
+
+This section is intentionally NOT dispatched as a subagent task — CLAUDE.md's own Execution model reserves shipping (PR, review gate, merge) for the controlling thread, distinct from the per-task implementer/reviewer subagents Tasks 1-5 use.
 
 Once Tasks 1-5 are all committed:
 
 1. **Run `npm run verify:fast:branch`** locally in `$WORKTREE` and confirm it's green (Decision B's file is under `test:server`'s scope, so this exercises the widened tests for real).
 2. **Push the branch** and open the PR. PR title must match the commit-convention subject format (this is a multi-scope change — `test`/`ci`/`chore` — so title it something like `chore(ops): widen timing margins, shard e2e, add dev-loop scripts`). PR body: `Closes #<ISSUE_B>`, `Closes #<ISSUE_D>`, `Closes #<ISSUE_E>` (three separate `Closes` lines so all three auto-close on merge) — do NOT close `$ISSUE_A`, it stays open. Link the spec doc in the body.
 3. **Cloud `verify.yml`** runs automatically and is the required check — confirm green, including watching the e2e job specifically since this PR changes its shard count.
-4. **Mandatory `pr-review-gate` pass** — per CLAUDE.md's Before-shipping checklist step 10 and the `pr-review-gate` skill. This PR is multi-scope (`test`+`ci`+`chore` in one PR), which the review-depth ladder maps to `high` depth regardless of any individual commit's size — dispatch accordingly, not at `low`/`medium`.
-5. **Manually dispatch `gh workflow run verify.yml --ref <branch>`** once on the pushed branch specifically to observe the e2e job's 8 shards appear and complete (Task 3's own verification step, which can't run locally) — this is in addition to, not instead of, the PR's automatic CI run.
+4. **Discharge Decision D's own stated condition — a real timing comparison, not just "it completed."** Manually dispatch `gh workflow run verify.yml --ref <branch>` once on the pushed branch. Once it completes, pull each of the 8 `e2e` shard jobs' durations (`gh run view <run-id> --json jobs` or the Actions UI) and compare against the known 4-way baseline (~4 min/shard, per the pre-existing workflow comment this task updated). This is the comparison the spec's Decision D explicitly conditions the "8" number on — record the actual per-shard durations in the PR description or a PR comment so the number is traceable, not just asserted. If shards are queuing rather than running in parallel (visible as jobs sitting `queued` well past when 8 concurrent runners should have picked them up), that's the concurrent-job-slot ceiling the spec flagged as a risk — surface it before merging, don't silently accept degraded wall-clock.
+5. **Mandatory `pr-review-gate` pass** — per CLAUDE.md's Before-shipping checklist step 10 and the `pr-review-gate` skill. This PR is multi-scope (`test`+`ci`+`chore` in one PR), which the review-depth ladder maps to `high` depth regardless of any individual commit's size — dispatch accordingly, not at `low`/`medium`.
 6. Once findings are triaged and CI + review are both green: merge via "Create a merge commit" per CLAUDE.md's Branching workflow. Tear down the worktree (junctions first, if any — `wt-new.mjs` real-installs `node_modules` rather than junctioning, so this worktree's `node_modules`/`server/node_modules` are real directories, not junctions; a plain `git worktree remove` after deleting the directory is sufficient, no junction-deletion-first step needed. Verify with `Test-Path` before assuming.)

--- a/docs/superpowers/plans/2026-09-02-test-suite-hardening.md
+++ b/docs/superpowers/plans/2026-09-02-test-suite-hardening.md
@@ -1,0 +1,626 @@
+# Test Suite Hardening (timing margins, e2e sharding, dev scripts) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the three independent, already-decided changes from the spec — widen three thin timing-margin pairs in `server/src/workspace/file-lock.test.ts`, raise cloud e2e Playwright sharding from 4-way to 8-way, and add eight opt-in subsystem-scoped npm scripts for local dev loops — plus file the one design-pass issue the spec explicitly declined to implement.
+
+**Architecture:** No new subsystems. Three small, independent edits (a test file's constants, a GitHub Actions workflow's matrix/shard config, a `package.json` scripts block + a CLAUDE.md doc bullet) bundled into one branch/PR since each is individually trivial-to-small and the spec explicitly declared them shippable together. One GitHub issue per decision (B, D, E) plus a fourth, separate issue for Decision A (filed, not implemented).
+
+**Tech Stack:** TypeScript/Vitest (frontend + server), GitHub Actions YAML, npm scripts, Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md` (HEAD `72e25bd3` at plan-writing time) — read Decisions A, B, D, E and the "Shipping notes" section before starting; this plan pulls exact values from it but the spec has the full rationale and review history behind each one.
+
+## Global Constraints
+
+- No behavior change to production code anywhere in this plan — Decision B widens test constants only (`server/src/workspace/file-lock.ts` itself is untouched), Decision D changes CI config only, Decision E adds new opt-in npm scripts that touch nothing else.
+- Every widened/changed value must come from the spec verbatim — do not re-derive or "improve" a number while implementing (e.g. don't retune Decision B's margins beyond what's specified; don't pick a different shard count for Decision D).
+- `cast-lock.test.ts` and `design-lock.test.ts` are explicitly NOT touched (spec, Decision B) — do not "helpfully" apply the same widening pattern there.
+- `test:e2e:visual` is explicitly NOT sharded further and its `--workers=1` constraint is NOT touched (spec, Decision D / Out of scope).
+- Decision A (CI's zero-test-selection hazard) is NOT implemented by this plan — filed as its own issue only (Task 1, sub-step 4). Do not attempt to fix it here; it needs a design pass the spec explicitly deferred.
+- Decision C (sidecar pytest scoping) requires no action at all — nothing to file, nothing to implement.
+- Every commit message follows CONTRIBUTING.md's `<type>(<scope>): <subject>` convention. These are `test`/`ci`/`chore` scoped changes — no `feat`/`fix`, since nothing here is new user-visible behavior or a bug fix.
+- CLAUDE.md's Before-shipping checklist steps 5 (release notes, both files) and 6 (issue linkage, `Closes #NN` in the PR body) apply — both are explicit tasks below, not left implicit.
+
+---
+
+## Task 1: Worktree, branch, and issue filing
+
+**Files:**
+- None modified — this task only sets up the worktree and files GitHub issues.
+
+**Interfaces:**
+- Produces: a working, hook-gated worktree at a path this plan calls `$WORKTREE` for the rest of its tasks, on branch `$BRANCH`; four GitHub issue numbers (`$ISSUE_B`, `$ISSUE_D`, `$ISSUE_E`, `$ISSUE_A`) referenced by later tasks and by the final PR body.
+
+- [ ] **Step 1: Cut the worktree and branch**
+
+From the primary checkout (`C:\Claude\Projects\Audiobook-Generator`):
+
+```bash
+node scripts/wt-new.mjs chore/ops-test-suite-hardening
+```
+
+This creates a worktree (path printed by the command — call it `$WORKTREE` below) on branch `chore/ops-test-suite-hardening`, runs both `npm install`s, activates husky, and writes `.env.local`/`server/.env` with a non-clashing port slot. Verify hooks are active:
+
+```bash
+ls -d $WORKTREE/.husky/_ && git -C $WORKTREE config core.hooksPath
+```
+
+Both must print non-empty output. If `wt-new.mjs` fails or isn't available for some reason, follow CLAUDE.md's "Worktree setup" section manually (branch, `npx husky`, both `node_modules` junctions, `server/.env` + `.env.local`) before proceeding — do not skip hook activation.
+
+- [ ] **Step 2: File the issue for Decision B**
+
+```bash
+gh issue create --repo dudarenok-maker/Castwright \
+  --title "chore(ops): widen file-lock.test.ts's thin timing-margin pairs" \
+  --label "type:chore" --label "area:ops" \
+  --body "Three tests in \`server/src/workspace/file-lock.test.ts\`'s \`withKeyLock acquisition timeout (#2260)\` \`describe\` block race a 20ms lock-acquisition-timeout budget against a 150-200ms holder to assert ordering. Widen to an absolute-gap floor of \u2265500ms per pair, per \`docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md\` Decision B. Shipped as cheap, no-regret insurance, not a diagnosed fix \u2014 the spec's own review found a real technical argument that these margins may never have been able to flip under contention (Node dispatches timers by expiry, not arrival, and the waiter's timer is armed before the holder's). No production code change; three tests' constants widen, with comments recording the new absolute gap.
+
+Closes nothing on its own; part of the shipping PR for docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md."
+```
+
+Record the returned issue number as `$ISSUE_B`.
+
+- [ ] **Step 3: File the issue for Decision D**
+
+```bash
+gh issue create --repo dudarenok-maker/Castwright \
+  --title "chore(ops): increase cloud e2e Playwright sharding from 4-way to 8-way" \
+  --label "type:chore" --label "area:ops" \
+  --body ".github/workflows/verify.yml's e2e job shards test:e2e 4-way today. Per docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md Decision D, raise to 8-way (matrix array, the single --shard=N/4 site, job name label) and fix two stale prose comments in the same file that still cite the 4-way figure and a ~110-spec-files estimate (actual: 137). Cost caveats (unconditional per-shard checkout/setup overhead, an unverified concurrent-job-slot ceiling) are documented in the spec and should be watched after shipping, not resolved here."
+```
+
+Record the returned issue number as `$ISSUE_D`.
+
+- [ ] **Step 4: File the issue for Decision E**
+
+```bash
+gh issue create --repo dudarenok-maker/Castwright \
+  --title "chore(ops): add subsystem-scoped npm scripts for local test-loop convenience" \
+  --label "type:chore" --label "area:ops" \
+  --body "Add 8 opt-in, manual npm scripts (test:server:routes/tts/analyzer/workspace, test:components/store/lib/views) that narrow vitest to one subsystem, per docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md Decision E. Not added to the automated verify pipeline (STEPS[]), not cached, not gated by any hook \u2014 pure developer convenience for a fast local loop when working in one area. Document in CLAUDE.md's Commands section."
+```
+
+Record the returned issue number as `$ISSUE_E`.
+
+- [ ] **Step 5: File the separate, NOT-implemented issue for Decision A**
+
+This one is filed but nothing in this plan fixes it — it needs the design pass the spec names.
+
+```bash
+gh issue create --repo dudarenok-maker/Castwright \
+  --title "chore(ops): CI's --changed narrowing can select zero tests on a server-lockfile-only diff" \
+  --label "type:chore" --label "area:ops" \
+  --body "\`.github/workflows/verify.yml\`'s \`test:server\`/\`test:server-slow\` step body decides narrowed-vs-full only on whether \`\$BASE\` is set, never on the \`shared\` scope boolean \`computeShared\` already computes. Confirmed live hazard: a \`server/package-lock.json\`-only PR is not \`shared\` scope (only the ROOT lockfile/manifest and \`.github/actions/**\` are), so it reaches \`step_test_server\` through \`stepTouchedByDiff\`'s \`includeLockfiles\` branch and stays narrowed \u2014 and neither \`package-lock.json\` nor \`server/package-lock.json\` appears in \`server/vitest.config.ts\`'s \`forceRerunTriggers\`, so \`--changed \"\$BASE\"\` can select zero tests and report green.
+
+Root \`package.json\` is NOT part of this hazard \u2014 already protected by both vitest configs' \`forceRerunTriggers\` (measured proof already in \`server/vitest.config.ts\`'s own comment: stripped selects 0, restored selects 5389). The frontend leg is NOT part of this hazard either \u2014 it runs \`npm run test:a11y\` unconditionally regardless of what \`--changed\` selects, so it always does real work. \`test:server-slow\` shares \`test:server\`'s step body, so whatever fix lands applies to both, not as a separate instance.
+
+**Needs a design pass, not a mechanical fix** \u2014 a naive \`shared\`-only check (tried and rejected during this spec's review) doesn't cover the server-lockfile case. The decision this issue is waiting on: what property of a diff actually guarantees \`--changed <base>\` selects a correct, non-empty test set for a given vitest config, given that config's own \`forceRerunTriggers\` list? A real answer likely needs to reconcile per-config \`forceRerunTriggers\` coverage with the CI-side scope decision in \`scripts/ci-scope.mjs\`, not just patch \`verify.yml\`'s step-body conditional.
+
+Full history and review trail: docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md, Decision A."
+```
+
+Record the returned issue number as `$ISSUE_A`. This issue stays open at the end of this plan — do not close it.
+
+- [ ] **Step 6: Confirm all four issue numbers are recorded**
+
+Before moving to Task 2, write down `$ISSUE_B`, `$ISSUE_D`, `$ISSUE_E`, `$ISSUE_A` somewhere durable (the PR body in the final task needs all three of B/D/E as `Closes #NN`, and `$ISSUE_A` gets referenced but never closed). No commit for this task — it's pure GitHub-side setup.
+
+---
+
+## Task 2: Decision B — widen `file-lock.test.ts`'s timing margins
+
+**Files:**
+- Modify: `server/src/workspace/file-lock.test.ts:113-216` (three tests inside the `withKeyLock acquisition timeout (#2260)` describe block)
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: nothing other tasks depend on — this task is self-contained.
+
+- [ ] **Step 1: Read the current three tests to confirm line numbers match**
+
+```bash
+sed -n '113,216p' $WORKTREE/server/src/workspace/file-lock.test.ts
+```
+
+(Or use the Read tool.) Confirm the three tests below are exactly as described — `wt-new.mjs` clones from `main`, and if `main` has moved since this plan was written the surrounding code may have shifted slightly; match by test name / describe text, not blindly by line number, if they've drifted.
+
+- [ ] **Step 2: Widen `'does not poison the key after a timeout...'`**
+
+Current (lines ~113-148):
+
+```typescript
+  it('does not poison the key after a timeout -- a later call still works once the holder finishes', async () => {
+    const key = 'unpoisoned-key';
+    const order: string[] = [];
+    /* The real holder -- NOT permanently stuck, unlike the deadlock test
+       above. It finishes on its own, comfortably after the waiter below has
+       already timed out. This is the case review Finding 2 called out: a
+       first holder that never releases makes "a later call still works"
+       provable only by barging past a still-running holder, which proves
+       the opposite of what this test claims -- a neutralisation proof, not
+       coverage. */
+    const holder = withKeyLock(key, async () => {
+      order.push('first-start');
+      await new Promise((r) => setTimeout(r, 150));
+      order.push('first-end');
+      return 'first-done';
+    });
+
+    /* Comfortably shorter than the holder's 150ms hold, so this one times out
+       while the holder is still running. */
+    await expect(
+      withKeyLock(key, async () => 'never', 20),
+    ).rejects.toThrow(/unpoisoned-key/);
+```
+
+Change to:
+
+```typescript
+  it('does not poison the key after a timeout -- a later call still works once the holder finishes', async () => {
+    const key = 'unpoisoned-key';
+    const order: string[] = [];
+    /* The real holder -- NOT permanently stuck, unlike the deadlock test
+       above. It finishes on its own, comfortably after the waiter below has
+       already timed out. This is the case review Finding 2 called out: a
+       first holder that never releases makes "a later call still works"
+       provable only by barging past a still-running holder, which proves
+       the opposite of what this test claims -- a neutralisation proof, not
+       coverage. */
+    const holder = withKeyLock(key, async () => {
+      order.push('first-start');
+      await new Promise((r) => setTimeout(r, 700));
+      order.push('first-end');
+      return 'first-done';
+    });
+
+    /* Comfortably shorter than the holder's 700ms hold, so this one times out
+       while the holder is still running. 700ms/50ms is a ~650ms absolute
+       gap -- widened from 150ms/20ms (an ~130ms gap) as cheap, no-regret
+       insurance per docs/superpowers/specs/2026-09-01-verify-scope-branch-
+       timing-design.md Decision B; not a claim these margins were ever
+       provably flippable. */
+    await expect(
+      withKeyLock(key, async () => 'never', 50),
+    ).rejects.toThrow(/unpoisoned-key/);
+```
+
+Leave the rest of the test (the `2000`ms second timing pair at what's currently line ~143, and everything after) untouched — the spec explicitly does not ask for that pair to change, only notes its headroom shrinks (from ~1870ms to ~1350ms against the widened 700ms holder), which is still comfortable.
+
+- [ ] **Step 3: Widen `'does not let a later caller barge past a still-running holder...'`**
+
+Current (lines ~150-181):
+
+```typescript
+  it('does not let a later caller barge past a still-running holder after an earlier waiter times out', async () => {
+    /* Case review Finding 3 -- the regression test for Finding 1. Nothing in
+       the tests above pins ordering strictly enough to catch a `chains`
+       cleanup on the timeout path that deletes the wrong thing: a subsequent
+       caller must queue behind the ACTUAL holder, not merely "eventually
+       succeed" (which a barge-past-and-race outcome can also produce by
+       accident once the holder happens to finish first). */
+    const key = 'mutex-key';
+    const order: string[] = [];
+    const holder = withKeyLock(key, async () => {
+      order.push('a-start');
+      await new Promise((r) => setTimeout(r, 200));
+      order.push('a-end');
+    });
+
+    /* Times out well before the holder's 200ms hold ends. */
+    await expect(
+      withKeyLock(key, async () => { order.push('b-ran'); }, 20),
+    ).rejects.toThrow(/mutex-key/);
+```
+
+Change to:
+
+```typescript
+  it('does not let a later caller barge past a still-running holder after an earlier waiter times out', async () => {
+    /* Case review Finding 3 -- the regression test for Finding 1. Nothing in
+       the tests above pins ordering strictly enough to catch a `chains`
+       cleanup on the timeout path that deletes the wrong thing: a subsequent
+       caller must queue behind the ACTUAL holder, not merely "eventually
+       succeed" (which a barge-past-and-race outcome can also produce by
+       accident once the holder happens to finish first). */
+    const key = 'mutex-key';
+    const order: string[] = [];
+    const holder = withKeyLock(key, async () => {
+      order.push('a-start');
+      await new Promise((r) => setTimeout(r, 750));
+      order.push('a-end');
+    });
+
+    /* Times out well before the holder's 750ms hold ends -- a ~700ms
+       absolute gap, widened from 200ms/20ms (an ~180ms gap) per Decision B,
+       same no-regret-insurance rationale as the test above. */
+    await expect(
+      withKeyLock(key, async () => { order.push('b-ran'); }, 50),
+    ).rejects.toThrow(/mutex-key/);
+```
+
+Leave the rest of the test (the `later` acquisition and its assertions) untouched.
+
+- [ ] **Step 4: Widen `'leaves exactly one chains entry after a timeout...'`**
+
+Current (lines ~183-216):
+
+```typescript
+    const key = 'chains-accounting-key';
+    const before = __chainsSizeForTest();
+
+    const holder = withKeyLock(key, async () => {
+      await new Promise((r) => setTimeout(r, 150));
+    });
+    await expect(withKeyLock(key, async () => 'never', 20)).rejects.toThrow(/chains-accounting-key/);
+    await holder;
+```
+
+Change to:
+
+```typescript
+    const key = 'chains-accounting-key';
+    const before = __chainsSizeForTest();
+
+    const holder = withKeyLock(key, async () => {
+      /* 700ms/50ms is a ~650ms absolute gap, widened from 150ms/20ms per
+         Decision B -- same no-regret-insurance rationale as the two tests
+         above in this file. */
+      await new Promise((r) => setTimeout(r, 700));
+    });
+    await expect(withKeyLock(key, async () => 'never', 50)).rejects.toThrow(/chains-accounting-key/);
+    await holder;
+```
+
+Leave the rest of the test (the `__chainsSizeForTest()` assertions) untouched.
+
+- [ ] **Step 5: Confirm nothing else in the file changed**
+
+Diff against `main` and confirm the only changes are the six literal values above (three `150`→`700` or `200`→`750`, three `20`→`50`) plus the three comment updates:
+
+```bash
+git -C $WORKTREE diff main -- server/src/workspace/file-lock.test.ts
+```
+
+- [ ] **Step 6: Run the file's own tests to confirm they still pass**
+
+```bash
+cd $WORKTREE/server && npx vitest run src/workspace/file-lock.test.ts
+```
+
+Expected: all tests in the file pass, same pass count as before the edit (no test added or removed, only constants changed).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C $WORKTREE add server/src/workspace/file-lock.test.ts
+git -C $WORKTREE commit -m "$(cat <<'EOF'
+test(server): widen file-lock.test.ts's thin timing-margin pairs
+
+Three tests in withKeyLock acquisition timeout (#2260) race a 20ms
+lock-acquisition-timeout budget against a 150-200ms holder to assert
+ordering -- widened to an absolute-gap floor of >=500ms per pair, as cheap,
+no-regret insurance rather than a diagnosed fix. No production code change.
+
+Refs #ISSUE_B_NUMBER
+EOF
+)"
+```
+
+Replace `#ISSUE_B_NUMBER` with the actual `$ISSUE_B` issue number from Task 1.
+
+---
+
+## Task 3: Decision D — increase cloud e2e sharding to 8-way
+
+**Files:**
+- Modify: `.github/workflows/verify.yml` (header comment block near the top, the `e2e` job's own rationale comment, and the `e2e` job definition itself)
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: nothing other tasks depend on.
+
+- [ ] **Step 1: Fix the file's header comment (near the top, the "E2E ITSELF IS SHARDED" block)**
+
+Find the comment block (originally around line 34-43) that reads approximately:
+
+```yaml
+# E2E ITSELF IS SHARDED (2026-07-10): a live timing comparison showed the
+# functional e2e battery (~110 spec files, CI-pinned to workers=1 to avoid
+# in-job Vite dev-server contention) was the dominant leg at ~16 min, dwarfing
+# every other job. `--shard=N/4` splits it across 4 matrix jobs, each its own
+# runner/dev-server — the workers=1 anti-flake guarantee still holds PER
+# SHARD, just with 4x less work per shard. Visual baselines were pulled into
+```
+
+Change the four stale figures (`~110`, `N/4`, `4 matrix jobs`, `4x less work`) to match the 8-way split:
+
+```yaml
+# E2E ITSELF IS SHARDED (2026-07-10, raised to 8-way 2026-09): a live timing
+# comparison showed the functional e2e battery (137 spec files, CI-pinned to
+# workers=1 to avoid in-job Vite dev-server contention) was the dominant leg
+# at ~16 min, dwarfing every other job. `--shard=N/8` splits it across 8
+# matrix jobs, each its own runner/dev-server — the workers=1 anti-flake
+# guarantee still holds PER SHARD, just with less work per shard (per-shard
+# fixed cost — checkout, setup, the warmup project, a fresh Vite dev server —
+# doesn't shrink with more shards, so the wall-clock win is sub-linear; see
+# docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md
+# Decision D). Visual baselines were pulled into
+```
+
+Keep the rest of that comment block (everything after "Visual baselines were pulled into...") unchanged.
+
+- [ ] **Step 2: Fix the `e2e` job's own rationale comment**
+
+Find the comment immediately above the `e2e:` job definition (originally around line 392-399), reading approximately:
+
+```yaml
+  # E2E functional battery (~110 spec files) is the long pole of the whole
+  # workflow — CI intentionally pins Playwright to `workers: 1` (playwright.
+  # config.ts) so parallel Chromium instances can't thundering-herd the
+  # single Vite dev server WITHIN one job. That constraint is per-job, not
+  # global: `--shard=N/4` below splits the spec list across 4 independent
+  # matrix jobs, each on its own runner with its own dev server (no shared
+  # process to contend over), while every shard still runs serially inside
+  # itself — same anti-flake guarantee, ~4x less wall-clock.
+```
+
+Change to:
+
+```yaml
+  # E2E functional battery (137 spec files) is the long pole of the whole
+  # workflow — CI intentionally pins Playwright to `workers: 1` (playwright.
+  # config.ts) so parallel Chromium instances can't thundering-herd the
+  # single Vite dev server WITHIN one job. That constraint is per-job, not
+  # global: `--shard=N/8` below splits the spec list across 8 independent
+  # matrix jobs, each on its own runner with its own dev server (no shared
+  # process to contend over), while every shard still runs serially inside
+  # itself — same anti-flake guarantee, less wall-clock (sub-linear: fixed
+  # per-shard cost — checkout, setup, the warmup project, a fresh Vite dev
+  # server — doesn't shrink with more shards; watch actual PR wall-clock
+  # after this ships, not just this job's own duration).
+```
+
+- [ ] **Step 3: Raise the matrix shard count**
+
+Find (originally around line 400-408):
+
+```yaml
+  e2e:
+    name: E2E (chromium) — shard ${{ matrix.shard }}/4
+    needs: detect
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+```
+
+Change to:
+
+```yaml
+  e2e:
+    name: E2E (chromium) — shard ${{ matrix.shard }}/8
+    needs: detect
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+```
+
+- [ ] **Step 4: Fix the `--shard=` argument itself**
+
+Find (originally around line 442-444):
+
+```yaml
+      - name: E2E (chromium)
+        if: fromJSON(needs.detect.outputs.scopes).step_test_e2e || fromJSON(needs.detect.outputs.scopes).shared
+        run: npm run test:e2e -- --shard=${{ matrix.shard }}/4
+```
+
+Change the trailing `/4` to `/8`:
+
+```yaml
+      - name: E2E (chromium)
+        if: fromJSON(needs.detect.outputs.scopes).step_test_e2e || fromJSON(needs.detect.outputs.scopes).shared
+        run: npm run test:e2e -- --shard=${{ matrix.shard }}/8
+```
+
+- [ ] **Step 5: Confirm `test:e2e:visual`'s job is untouched**
+
+Grep the file to confirm no other `/4` or `[1, 2, 3, 4]` reference was accidentally changed:
+
+```bash
+grep -n "shard\|/4\b" $WORKTREE/.github/workflows/verify.yml
+```
+
+Only the `e2e` job's three sites (now `/8`) should reference sharding. The `test:e2e:visual` job must still show no `matrix:`/`shard` at all — confirm it wasn't touched.
+
+- [ ] **Step 6: Validate the YAML is well-formed**
+
+```bash
+cd $WORKTREE && node -e "require('js-yaml').load(require('fs').readFileSync('.github/workflows/verify.yml', 'utf8')); console.log('OK')"
+```
+
+(If `js-yaml` isn't directly requirable from the repo root in this context, use `npx -y js-yaml .github/workflows/verify.yml > /dev/null && echo OK` instead — either way, confirm the file still parses as valid YAML before committing.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C $WORKTREE add .github/workflows/verify.yml
+git -C $WORKTREE commit -m "$(cat <<'EOF'
+ci: increase e2e Playwright sharding from 4-way to 8-way
+
+Also fixes two stale prose comments (verify.yml's header block and the e2e
+job's own rationale comment) that still cited the old 4-way figure and a
+~110-spec-files estimate -- actual is 137. Per docs/superpowers/specs/
+2026-09-01-verify-scope-branch-timing-design.md Decision D; see that
+section for the cost caveats (unconditional per-shard checkout/setup
+overhead, unverified concurrent-job-slot ceiling) worth watching after
+this ships.
+
+Refs #ISSUE_D_NUMBER
+EOF
+)"
+```
+
+Replace `#ISSUE_D_NUMBER` with the actual `$ISSUE_D` issue number from Task 1.
+
+**Note:** this task cannot be locally test-run end-to-end (it's cloud CI config) — the actual verification (8 shard jobs appear and complete) happens via a manual `gh workflow run` dispatch after the PR is pushed, covered in the final "Ship" section below, not as a task step here.
+
+---
+
+## Task 4: Decision E — subsystem-scoped npm scripts + CLAUDE.md doc
+
+**Files:**
+- Modify: `package.json` (root — add 8 new scripts)
+- Modify: `CLAUDE.md:340` (Commands section — add one bullet documenting the new scripts)
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: nothing other tasks depend on.
+
+- [ ] **Step 1: Add the 8 new scripts to root `package.json`**
+
+Find the `"scripts"` block's `test:server-slow` line (currently):
+
+```json
+    "test:server-slow": "npm --prefix server run test:slow",
+```
+
+Add the 8 new scripts immediately after it (before `"test:scripts"`):
+
+```json
+    "test:server-slow": "npm --prefix server run test:slow",
+    "test:server:routes":    "npm --prefix server run test -- src/routes",
+    "test:server:tts":       "npm --prefix server run test -- src/tts",
+    "test:server:analyzer":  "npm --prefix server run test -- src/analyzer",
+    "test:server:workspace": "npm --prefix server run test -- src/workspace",
+    "test:components": "vitest run src/components",
+    "test:store":       "vitest run src/store",
+    "test:lib":         "vitest run src/lib",
+    "test:views":       "vitest run src/views",
+```
+
+(Match the existing file's actual indentation/quoting style exactly — `npm run format:check` will catch a mismatch if Prettier disagrees with manual spacing; run `npm run format` on just this file if needed before committing, or just match the two-space JSON indent already used throughout the file.)
+
+- [ ] **Step 2: Run each of the 8 scripts and confirm it selects real tests**
+
+This is the step that matters most — round 4 of the spec's own review found a real path bug here (`server/src/routes` instead of the correct `src/routes`, since `npm --prefix server` already sets `cwd=server/`) that inspection alone missed and only running the command caught. Do not skip this by "it looks right."
+
+```bash
+cd $WORKTREE && npm run test:server:routes -- --reporter=verbose 2>&1 | tail -20
+```
+
+Expected: a real test run, NOT "No test files found, exiting with code 1". Repeat for `test:server:tts`, `test:server:analyzer`, `test:server:workspace`, `test:components`, `test:store`, `test:lib`, `test:views` — each must select a nonzero number of real test files matching its subdirectory. For the server-side four, additionally confirm the selected file count is in the right ballpark (spec's measured figures: routes 138 files, tts 123, analyzer 73, workspace 57) — a wildly different count (e.g. 0, or the whole suite) means the path is still wrong.
+
+If any of the 8 fails this check, the fix is almost certainly the same class of bug the spec's round 4 already found once — double-check the path is relative to the correct `cwd` for that invocation (server-relative for the four `npm --prefix server` ones, repo-root-relative for the four bare `vitest run` ones) rather than assuming the string in this plan is already correct without running it.
+
+- [ ] **Step 3: Add the CLAUDE.md Commands-section bullet**
+
+Find (`CLAUDE.md`, in the Commands section, immediately after the `test:server-slow` bullet):
+
+```markdown
+- `npm run test:server-slow` — Vitest single-run for 10 timeout-prone server test files (analyzer/gemini, a parsers PDF test, and routes tests), pinned to one fork via `server/vitest.config.slow.ts`. Runs in the cloud `verify.yml` battery and the full local `npm run verify`, not in pre-push `verify:fast:branch` or `verify:fast` pre-commit. See `docs/features/archive/45-vitest-pool-tuning.md` for the rationale.
+```
+
+Add a new bullet immediately after it:
+
+```markdown
+- `npm run test:server:routes` / `:tts` / `:analyzer` / `:workspace` and `npm run test:components` / `:store` / `:lib` / `:views` — opt-in, manual, subsystem-scoped test runs (`vitest run <subdir>` under the hood) for a fast local loop when you know you're only touching one area. Not part of the automated verify pipeline — not in `STEPS[]`, not cached, not gated by any hook, and carry no coverage guarantee (a `routes/` change that breaks something in `workspace/` isn't caught by `test:server:routes` alone). The four server-side ones cover 76.9% of `test:server` by test count; the four frontend ones cover most of `test`'s largest directories. See `docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md` Decision E.
+```
+
+- [ ] **Step 4: Confirm the diff is scoped to exactly these two files**
+
+```bash
+git -C $WORKTREE status --porcelain
+```
+
+Expected: only `package.json` and `CLAUDE.md` modified.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C $WORKTREE add package.json CLAUDE.md
+git -C $WORKTREE commit -m "$(cat <<'EOF'
+chore(ops): add subsystem-scoped npm scripts for local test-loop convenience
+
+8 opt-in, manual scripts (test:server:routes/tts/analyzer/workspace,
+test:components/store/lib/views) narrowing vitest to one subsystem. Not
+added to the automated verify pipeline -- pure developer convenience.
+Documented in CLAUDE.md's Commands section.
+
+Refs #ISSUE_E_NUMBER
+EOF
+)"
+```
+
+Replace `#ISSUE_E_NUMBER` with the actual `$ISSUE_E` issue number from Task 1.
+
+---
+
+## Task 5: Release notes
+
+**Files:**
+- Modify: `docs/release-notes-next.md` (append to the "🧪 Test gates → Test harness & suite hygiene" section)
+- Modify: `RELEASE_NOTES.md` (append one brand-voice bullet to the in-progress version section at the top)
+
+**Interfaces:**
+- Consumes: nothing from other tasks (this task runs last, after B/D/E are all committed, so it can describe what actually shipped).
+- Produces: nothing — this is the final content task before the PR/ship section.
+
+- [ ] **Step 1: Append the technical entry to `docs/release-notes-next.md`**
+
+Find the end of the "### Test harness & suite hygiene" section (the last bullet currently ends with `.gitignore` did not cover `.env.bak`...` — find that section's last line and append after it, still inside the same `###` section, before the next `##`/`###` heading).
+
+Append:
+
+```markdown
+- **Three thin timing-margin pairs in `file-lock.test.ts` widened to an absolute-gap floor, cloud e2e sharding raised 4-way to 8-way, and eight opt-in subsystem-scoped npm scripts added for local dev loops** (see `docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md`). A pre-push run on a box with several concurrent worktree test batteries took 70-80 minutes and failed three times in a row on different lock tests, unrelated to the diff being pushed — no failure log was captured, and the repo separately documents fork-pool crashes (which retry the entire step up to 3x under contention) as an independently-sufficient explanation, so this doesn't claim to have diagnosed the incident. The three widened tests race a 20ms lock-acquisition-timeout budget against a 150-200ms holder; margins now target ≥500ms of absolute gap, shipped as cheap insurance rather than a proven fix — later review found a real argument that Node's timer-dispatch-by-expiry-time behavior may mean these margins were never actually flippable by contention. Separately, `--shard=N/4` → `N/8` on the e2e job (137 spec files, not the stale ~110 the workflow's own comments cited) for cloud wall-clock, and eight new manual `npm run test:server:<routes|tts|analyzer|workspace>` / `test:<components|store|lib|views>` scripts (not part of the automated gate) for a fast local check of one subsystem. A fourth, larger idea from the same investigation — extending pre-push's `--changed`-based test narrowing from pre-commit to pre-push — was explored across four rounds of review and declined: its real-world hit rate measured at 0 of the last 60 merged branches, too small to justify the machinery it would have required.
+```
+
+- [ ] **Step 2: Append the brand-voice entry to `RELEASE_NOTES.md`**
+
+Find the top-of-file version section (`# Castwright 1.15.0` or whatever the current in-progress version marker is — check `docs/release-notes-next.md`'s `release-notes-next-version:` line for the current number) and append one bullet after the existing last bullet in that section.
+
+```markdown
+- **A stuck test run on a busy machine can no longer eat an hour of your time for reasons that have nothing to do with what you changed.** A few timing-sensitive checks in Castwright's own test suite have been given more breathing room, and the checks that run before your code ships now split across more machines in parallel — both aimed at keeping a red result meaningful instead of a symptom of a busy computer.
+```
+
+- [ ] **Step 3: Confirm both files' diffs are scoped correctly**
+
+```bash
+git -C $WORKTREE diff docs/release-notes-next.md RELEASE_NOTES.md
+```
+
+Confirm each diff is a single new bullet appended in the right section — nothing else in either file changed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C $WORKTREE add docs/release-notes-next.md RELEASE_NOTES.md
+git -C $WORKTREE commit -m "$(cat <<'EOF'
+docs(release-notes): add v1.15.0 entries for test-suite hardening
+
+Technical register entry under Test harness & suite hygiene, plus a
+matching brand-voice line in RELEASE_NOTES.md, for the file-lock.test.ts
+margin widening, the e2e shard bump, and the new subsystem-scoped dev
+scripts.
+EOF
+)"
+```
+
+---
+
+## Ship (not a task — controlling-thread work per CLAUDE.md's Execution model phase 3)
+
+Once Tasks 1-5 are all committed:
+
+1. **Run `npm run verify:fast:branch`** locally in `$WORKTREE` and confirm it's green (Decision B's file is under `test:server`'s scope, so this exercises the widened tests for real).
+2. **Push the branch** and open the PR. PR title must match the commit-convention subject format (this is a multi-scope change — `test`/`ci`/`chore` — so title it something like `chore(ops): widen timing margins, shard e2e, add dev-loop scripts`). PR body: `Closes #<ISSUE_B>`, `Closes #<ISSUE_D>`, `Closes #<ISSUE_E>` (three separate `Closes` lines so all three auto-close on merge) — do NOT close `$ISSUE_A`, it stays open. Link the spec doc in the body.
+3. **Cloud `verify.yml`** runs automatically and is the required check — confirm green, including watching the e2e job specifically since this PR changes its shard count.
+4. **Mandatory `pr-review-gate` pass** — per CLAUDE.md's Before-shipping checklist step 10 and the `pr-review-gate` skill. This PR is multi-scope (`test`+`ci`+`chore` in one PR), which the review-depth ladder maps to `high` depth regardless of any individual commit's size — dispatch accordingly, not at `low`/`medium`.
+5. **Manually dispatch `gh workflow run verify.yml --ref <branch>`** once on the pushed branch specifically to observe the e2e job's 8 shards appear and complete (Task 3's own verification step, which can't run locally) — this is in addition to, not instead of, the PR's automatic CI run.
+6. Once findings are triaged and CI + review are both green: merge via "Create a merge commit" per CLAUDE.md's Branching workflow. Tear down the worktree (junctions first, if any — `wt-new.mjs` real-installs `node_modules` rather than junctioning, so this worktree's `node_modules`/`server/node_modules` are real directories, not junctions; a plain `git worktree remove` after deleting the directory is sufficient, no junction-deletion-first step needed. Verify with `Test-Path` before assuming.)

--- a/docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md
+++ b/docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md
@@ -23,7 +23,7 @@ contention, `scripts/verify-cache.mjs`'s `MAX_POOL_ATTEMPTS`) as a plausible
 independent or compounding cause of "70-80 minutes." This spec does not
 resolve which explanation is right — see Decision B for how that's handled.
 
-Four problems, addressed together because they're all "tests take too long
+Five problems, addressed together because they're all "tests take too long
 or fail for reasons unrelated to the change":
 
 1. **Local volume** — pre-push runs far more tests locally than the diff
@@ -36,6 +36,10 @@ or fail for reasons unrelated to the change":
 4. **GPU/hardware coverage must not quietly ride along** — none of the above
    may be read as "CI now covers everything"; CI never has and still won't
    run anything GPU/hardware-dependent.
+5. **No fast manual loop for "I'm only working in one subsystem"** — even
+   with A1's automated narrowing, a developer who wants a quick local check
+   of just the area they're touching has no way to do that short of the full
+   leg or hand-typing a `vitest run <path>` invocation.
 
 ## Prior art, and two rounds of adversarial review
 
@@ -294,6 +298,55 @@ reasonable stopping point before fixed per-shard cost dominates; exact number
 confirmed with a real timing comparison during implementation, the same
 method the original 4-way split's comment cites.
 
+### E — manual subsystem-scoped npm scripts (developer convenience, not part of the gate)
+
+Separate from, and doesn't touch, A1/A2's automated `--changed` gate.
+Measured `test:server`'s 7730 tests by top-level subdirectory: `routes`
+2527/146 files, `tts` 1688/122, `analyzer` 1299/73, `workspace` 758/57 — those
+four alone are 81% of the leg, with everything else under 450 each. Frontend
+`test`'s 4769 by top-level subdirectory: `components` 1192/112, `store`
+1130/52, `lib` 1046/102, `views` 828/29.
+
+Add named npm scripts that just narrow `vitest run` to one subdirectory, for
+a developer who knows they're only touching one subsystem and wants a fast
+local sanity check without waiting on the full leg or reasoning about
+whether `--changed` will narrow for their diff:
+
+```
+"test:server:routes":    "npm --prefix server run test -- server/src/routes",
+"test:server:tts":       "npm --prefix server run test -- server/src/tts",
+"test:server:analyzer":  "npm --prefix server run test -- server/src/analyzer",
+"test:server:workspace": "npm --prefix server run test -- server/src/workspace",
+"test:components": "vitest run src/components",
+"test:store":       "vitest run src/store",
+"test:lib":         "vitest run src/lib",
+"test:views":       "vitest run src/views",
+```
+
+The server-side scripts are safe against A1's nested-npm forwarding hazard
+(Decision A1's "Invocation — corrected" note) because the path is baked into
+the script definition itself, not appended by a caller at invocation time —
+there's no outer `--` trying to reach through two levels of npm, just one
+literal command line, the same shape the existing (working) `test:server`
+definition already uses. Because these invoke the server's real `test`
+script by name, `pretest`'s ffmpeg preflight still runs automatically via
+npm's normal lifecycle-script convention — nothing to wire separately.
+
+**Deliberately not added to `STEPS[]`, not scope-gated, not cached, not part
+of any hook.** These are opt-in, manual, developer-run commands — exactly
+the same status `npm run verify:fast` or `npm run test:all` already have.
+No safety guarantee is being made about what they cover (a routes/ change
+that breaks something in workspace/ or store/ isn't caught by
+`test:server:routes` alone — that's what the full leg, `--changed`, and CI
+are for); they exist purely to make the common "I'm working in one area,
+give me a fast local loop" case fast, which the incident report's overall
+"tests take too long" complaint was also partly about.
+
+Only the four biggest subdirectories per leg are wired — the rest are
+already small enough (under ~450 tests, most under 200) that running the
+full leg or a plain `vitest run server/src/<dir>` by hand is fine without a
+named script. Not wired preemptively for the smaller ones.
+
 ## Testing
 
 - `scripts/tests/verify-cache.test.mjs`: source-regex cases (mirroring
@@ -319,6 +372,10 @@ method the original 4-way split's comment cites.
   proper subset and exits nonzero on a genuine failure.
 - `.github/workflows/verify.yml`'s e2e shard change: verified by a manual
   `gh workflow run` dispatch, confirming 8 shard jobs appear and complete.
+- Decision E's scripts: no automated test (they carry no correctness
+  guarantee to pin — see Decision E's own note). Verified by running each
+  once locally and confirming it selects only its subdirectory's tests.
+  CLAUDE.md's Commands section gets a bullet listing them.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md
+++ b/docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md
@@ -2,238 +2,164 @@
 status: draft
 ---
 
-# Local test scope, timing-margin fragility, and cloud e2e sharding
+# Test timing-margin hardening, cloud e2e sharding, and subsystem-scoped dev scripts
 
 ## Problem
 
-Pre-push (`npm run verify:fast:branch`, `.husky/pre-push`) runs `test:server`
-(and, on a frontend-touching diff, the frontend `test` leg) unscoped whenever
-the branch diff touches any file in that leg's tree — the full battery,
-currently 8000+ tests for `test:server` alone, no `--changed` narrowing. On a
-box running several concurrent worktree test batteries this took 70-80
-minutes and failed three times in a row, each time on a different
-timing-sensitive lock test unrelated to the diff being pushed.
-`server/src/workspace/file-lock.test.ts` has confirmed-fragile pairs — a
-20ms lock-acquisition-timeout budget racing a 150-200ms holder to assert
-ordering — that are unambiguously too thin to survive real scheduler jitter,
-regardless of whether they were this specific incident's proximate cause; no
-failure log from the three runs was captured, and the repo separately
-documents fork-pool crashes (which retry the *entire* step up to 3x under
-contention, `scripts/verify-cache.mjs`'s `MAX_POOL_ATTEMPTS`) as a plausible
-independent or compounding cause of "70-80 minutes." This spec does not
-resolve which explanation is right — see Decision B for how that's handled.
+On a box running several concurrent worktree test batteries, a pre-push run
+took 70-80 minutes and failed three times in a row, each time on a different
+lock test in `server/src/workspace/file-lock.test.ts` unrelated to the diff
+being pushed. No failure log from the three runs was captured. Two plausible,
+non-exclusive explanations: (a) that file's `withKeyLock acquisition timeout`
+tests race a 20ms timeout budget against a 150-200ms holder to assert
+ordering, margins thin enough to look contention-sensitive on their face
+(though see Decision B for a real counter-argument that they may not actually
+be); (b) the repo separately documents fork-pool crashes, which retry the
+*entire* step up to 3x under contention (`scripts/verify-cache.mjs`'s
+`MAX_POOL_ATTEMPTS`), as independently capable of producing "70-80 minutes."
+This spec does not resolve which explanation is right.
 
-Five problems, addressed together because they're all "tests take too long
-or fail for reasons unrelated to the change":
+Four problems this round addresses, plus one it investigated and explicitly
+does not fix:
 
-1. **Local volume** — pre-push runs far more tests locally than the diff
-   could possibly affect, for every leg that can be diff-scoped.
-2. **Fragility** — `file-lock.test.ts` has real-wall-clock-ordering pairs
-   with margins too thin to survive contention, independent of whether
-   they're proven to have caused this specific incident.
-3. **Cloud e2e wall-clock** — separately raised: the e2e leg (the dominant
-   single cost in cloud CI) is sharded 4-way today and can be sharded further.
-4. **GPU/hardware coverage must not quietly ride along** — none of the above
-   may be read as "CI now covers everything"; CI never has and still won't
-   run anything GPU/hardware-dependent.
-5. **No fast manual loop for "I'm only working in one subsystem"** — even
-   with A1's automated narrowing, a developer who wants a quick local check
-   of just the area they're touching has no way to do that short of the full
-   leg or hand-typing a `vitest run <path>` invocation.
+1. **Fragility** — `file-lock.test.ts` has real-wall-clock-ordering pairs
+   with margins thin enough to be worth widening as cheap insurance,
+   independent of whether they're proven to have caused this incident (see
+   Decision B — the fragility claim itself turned out to be contested, not
+   confirmed).
+2. **Cloud e2e wall-clock** — the e2e leg (the dominant single cost in cloud
+   CI) is sharded 4-way today and can be sharded further.
+3. **GPU/hardware coverage must not quietly ride along** — nothing here may
+   be read as "CI now covers everything"; CI never has and still won't run
+   anything GPU/hardware-dependent.
+4. **No fast manual loop for "I'm only working in one subsystem"** — a
+   developer who wants a quick local check of just the area they're touching
+   has no way to do that short of the full leg or hand-typing a
+   `vitest run <path>` invocation.
+5. **Local pre-push volume — investigated, explicitly NOT fixed this round.**
+   Pre-push runs `test`/`test:server` unscoped whenever the branch diff
+   touches either leg's tree (8201 tests for `test:server` alone), no
+   `--changed` narrowing. See "Considered and declined" below for why: the
+   safe version of that narrowing measures at a real-world hit rate of
+   effectively zero, so building it wasn't worth the machinery. The
+   already-shipped sibling-contention throttle (PR #2839,
+   `detectSiblingContention`) remains the actual mitigation for the
+   concurrent-worktree-contention shape of this incident.
 
-## Prior art, and two rounds of adversarial review
+## Considered and declined: branch-scope `--changed` narrowing
 
 PR #2839 (merged, `main@75a86ed8`) added `--changed HEAD`-based narrowing to
 **pre-commit** (`--scope-staged`) for the `test`/`test:server` legs, gated by
 a positive allowlist (`diffSafeForChangedOnly`, `scripts/verify-cache.mjs`)
 requiring every file in the diff sit under the step's own primary source root
-(`src/**`, `server/src/**`) with a safe TS/JS extension. It did not extend
-the substitution to `--scope-branch` (pre-push).
-
-This spec went through two independent Opus review rounds before this
-version. Both found real defects; the second round additionally **measured**
-the design's core premise against this repo's actual git history rather than
-asserting it, and that measurement changed the design materially. Summary,
-because the reasoning matters for what shipped:
+(`src/**`, `server/src/**`) with a safe TS/JS extension. Extending the same
+substitution to `--scope-branch` (pre-push) was explored at length across
+four rounds of adversarial review before being **declined**:
 
 - **Round 1** found the originally-proposed invocation
   (`npm run test:server -- --changed <sha>`) doesn't work — `test:server` is
   `npm --prefix server run test`, a *nested* npm call, so the outer `--`
   never reaches the inner vitest; the SHA lands as a positional filename
-  filter and the run fails with "No test files found." Fixed below by
-  bypassing npm-script indirection and spawning the underlying command
-  directly, the same shape CI's own step already uses.
+  filter and the run fails with "No test files found."
 - **Round 2 measured** `diffSafeForChangedOnly`'s real-world hit rate: **0 of
   the last 60 merged branches, 1 of 1360 real push-states**, because
   CLAUDE.md's own Before-shipping checklist mandates a
   `docs/release-notes-next.md`/plan-doc touch on nearly every non-trivial PR,
-  which disqualifies the whole branch under the original allowlist. Owner
-  decision: widen the allowlist to also tolerate `docs/**` and
-  `RELEASE_NOTES.md` alongside real source changes — verified safe (grepped
-  the whole repo for any `test`/`test:server`-scoped file reading a `docs/`
-  path at runtime; the one hit, `scripts/tests/release-notes-gate.test.mjs`,
-  lives under a different step entirely and is unaffected) — then
-  **re-measured**: 0/60 → 3/60 (5%) for `test:server`. Real, but modest — the
-  remaining disqualifying files in the same 60 branches (`server/tts-sidecar/
-  main.py`, `openapi.yaml`+`api-types.ts` co-changes, cross-cutting
-  `scripts/**`) are files that *should* disqualify narrowing, not artifacts
-  of an overly strict allowlist, so this isn't pushed further.
-- That measurement changes the shape of the whole spec: since local narrowing
-  fires on only ~5% of real branches, pre-push keeps running the **full**
-  suite on the other ~95%, same as today. The coverage exposure from giving
-  up pre-push's blanket full-run guarantee is therefore small and bounded,
-  not the wholesale policy reversal an earlier draft treated it as — which
-  in turn means the earlier plan to force CI's own narrowing onto the same
-  *strict* allowlist (so CI could serve as full replacement backstop) is the
-  wrong fix: CI's current narrowing is looser (governed only by `shared`
-  scope) and already works in production on far more PRs than 5%; forcing it
-  onto the strict allowlist would regress CI's own performance to chase a
-  now-small residual risk. **Dropped.** In its place: round 2 also surfaced a
-  real, small, pre-existing CI bug independent of this whole allowlist
-  question — see Decision A2.
-- **Round 3 found the round-2 `docs/**` widening itself unsafe**: a live
-  counterexample (`src/lib/wiki-links.test.ts`, which reads `docs/wiki/*.md`
-  at runtime with no `forceRerunTriggers` protection) means the widened
-  allowlist could silently skip that guard test on an ordinary
-  `src/`+`docs/wiki/` diff — and, measured per leg rather than combined, the
-  widening's benefit was 3/60 for `test:server` and **zero** for `test`, the
-  leg with the hole. **Reverted** — see Decision A1's current text, which is
-  back to PR #2839's original strict allowlist. Round 3 also found the
-  round-2 A2 fix didn't cover its own worked example and was actually a
-  class of at least three related gaps; A2 below reflects that — filed as a
-  named design decision rather than fixed this round.
+  which disqualifies the whole branch under the strict allowlist. An
+  attempt to widen the allowlist to also tolerate `docs/**` alongside real
+  source changes raised `test:server`'s hit rate to 3/60.
+- **Round 3 found that widening unsafe**: a live counterexample
+  (`src/lib/wiki-links.test.ts`, which reads `docs/wiki/*.md` at runtime with
+  no `forceRerunTriggers` protection) meant the widened allowlist could
+  silently skip that guard test on an ordinary `src/`+`docs/wiki/` diff — and
+  measured per leg rather than combined, the widening's benefit was 3/60 for
+  `test:server` and **zero** for `test`, the leg with the hole. Reverted back
+  to PR #2839's original strict allowlist.
+- **Round 4 confirmed the strict allowlist's real hit rate is effectively
+  zero for the leg that matters**: 0/60 merged branches, 1/1360 push-states,
+  for both `test` and `test:server`, under the restored strict allowlist.
+  Building this out — a new direct-invocation spawn mode bypassing
+  npm-script nesting, a `branchDiffFiles` contract change to carry a
+  merge-base SHA, a repo-wide dirty-working-tree probe, hand-rolling npm's
+  `pretest` lifecycle for the bypassed path, a spawning integration test —
+  is real, non-trivial machinery to guard a path that fired on essentially
+  none of this repo's actual branch history.
 
-## Decision
+**Owner decision (this round): drop it.** The mismatch between the
+machinery's cost and its measured benefit doesn't clear this repo's
+"simplicity first" bar. Pre-push keeps running the full `test`/`test:server`
+suite exactly as it does today — no regression, no change — and this
+section exists so the idea isn't silently re-proposed without the
+measurement that killed it. Revisiting it later would need either a
+materially different allowlist design (see Decision A2's design-pass note
+for the adjacent, still-open question of what property actually guarantees
+`--changed` selects correctly) or evidence that this repo's branch shapes
+have changed enough to move the hit rate.
 
-### A1 — extend `--changed` narrowing to `--scope-branch`, with a widened allowlist
+## Decision A2 — CI's zero-test-selection hazard: real, found in passing, filed as a design-pass item
 
-Widen the substitution gate in `runPipeline` (`scripts/verify-cache.mjs`,
-currently `flags.scopeStaged && !scopeShared && scopeDiff !== null &&
-diffSafeForChangedOnly(step, scopeDiff)`) to also fire under
-`flags.scopeBranch`, for both `CHANGED_ONLY_NPM_SCRIPT` entries — `test`
-(frontend) and `test:server`.
+Independent of the narrowing question above — found while reading
+`.github/workflows/verify.yml` during this investigation, not caused or
+motivated by anything else in this spec. `verify.yml`'s `test`/`test:server`
+step bodies decide narrowed-vs-full only on whether `$BASE` is set (`if [ -n
+"$BASE" ]; then --changed; else full; fi` — `$BASE` is only empty on
+`workflow_dispatch`), never on the `shared` scope boolean
+(`needs.detect.outputs.scopes.shared`, from `computeShared` — true for a
+root-manifest/lockfile/`.github/actions/**` change) that's already computed
+and available. Two confirmed live instances where this lets a step run
+`--changed "$BASE"` over a diff that selects zero tests and reports green:
 
-**`diffSafeForChangedOnly` allowlist widening — dropped.** An earlier
-version of this spec widened the allowlist to also tolerate `docs/**` and
-`RELEASE_NOTES.md`, on the strength of a grep claiming no `src/**`/
-`server/src/**` test reads a `docs/` path at runtime. **Round 3 review found
-that claim false, with a live counterexample**: `src/lib/wiki-links.test.ts`
-`readFileSync`/`existsSync`-es every page under `docs/wiki/*.md` at runtime,
-and the root `vitest.config.ts`'s `forceRerunTriggers` has no `docs/` entry
-protecting it — so a normal diff touching both `src/**` and `docs/wiki/**`
-would narrow via `--changed`, skip `wiki-links.test.ts` (the guard whose
-entire job is catching a deleted/renamed wiki page), and report green. The
-earlier grep that claimed safety didn't actually check `forceRerunTriggers`
-coverage, only "does anything read `docs/`" — the real invariant is "is this
-`docs/` path covered by the relevant vitest config's `forceRerunTriggers`,"
-which is unstated, unenforced, and false here. Compounding this: re-measured
-per leg rather than combined, the widening's benefit is **3/60 for
-`test:server`, 0/60 for `test`** — the frontend leg that has the hole gets
-zero benefit from the widening that opens it. **Reverted.** The allowlist
-stays exactly PR #2839's original: every file in the diff under the step's
-own source root (`src/**`/`server/src/**`) with a safe extension, no second
-category. This gives up the small `test:server` gain (3/60 → back to 0/60)
-in exchange for not shipping a known, demonstrated silent-coverage-loss
-regression. Revisiting a docs exemption later would need to key off actual
-`forceRerunTriggers` coverage per config, not a point-in-time grep — a
-real design question, not reopened here.
+1. A `shared`-scope PR (root `package.json`/`package-lock.json`,
+   `.github/actions/**`) — `shared` is `true` but the step body never checks
+   it.
+2. A `server/package-lock.json`-only PR — `computeShared` only matches the
+   *root* lockfile/manifest, so this diff is **not** `shared`; it reaches
+   `step_test_server` through a separate `includeLockfiles` branch and stays
+   narrowed regardless. Neither `package-lock.json` nor
+   `server/package-lock.json` appears in `server/vitest.config.ts`'s
+   `forceRerunTriggers`.
 
-**Base SHA, not `HEAD`.** The staged-scope substitution reuses the static
-npm scripts `test:changed`/`test:server:changed` (`vitest run --changed
-HEAD`), correct there because pre-commit's diff is uncommitted changes vs.
-`HEAD`. At push time everything is committed, so `--changed HEAD` would
-select nothing. Branch scope instead needs `--changed
-<merge-base-with-main>`, the same shape CI's own `$BASE` uses (not the exact
-same SHA — CI diffs against the fetched PR base, `branchDiffFiles` diffs
-against local `main`; direction is fail-safe, a stale local `main` only
-widens the diff and makes narrowing less likely, never silently more).
-`branchDiffFiles` (`scripts/verify-cache.mjs`) already computes this
-merge-base internally (one `git merge-base` spawn, then one `git diff` spawn)
-to produce its file list; it's refactored to also return that SHA so
-`runPipeline` reuses the one already used to decide scope. Its existing
-callers/contract (it's independently exported and unit-tested) are preserved
-— the return shape gains the SHA, doesn't lose the file list.
+(An earlier draft of this spec also listed an `e2e/**`-only diff scheduling
+the frontend step as a third instance — **that turned out not to be a real
+hazard**: the frontend step also runs `npm run test:a11y` unconditionally,
+so the step still does real work even when `--changed` selects nothing from
+vitest. Dropped from the count.)
 
-**Working-tree vs. committed diff.** `vitest --changed <sha>` diffs against
-the *working tree*, not just `HEAD`. `branchDiffFiles`'s scope decision is
-based on committed changes only. Pre-push does not require a clean tree, so
-an uncommitted edit outside the allowlist (e.g. to `server/vitest.config.ts`)
-would be invisible to the allowlist check but present in vitest's actual
-selection — reopening the exact "diff touches this step but isn't
-`--changed`-reachable" hazard the allowlist exists to close. Fixed by
-checking `git status --porcelain` **repo-wide, not scoped to the step's
-source tree** — round 3 review caught that the obvious narrower reading
-("just check `server/src/`") misses the actual worked example, an
-uncommitted edit to `server/vitest.config.ts`, which sits outside
-`server/src/` entirely. Any uncommitted change anywhere forces the full run;
-simplest correct rule, same conservative default as everywhere else in this
-design.
+`test:server-slow` shares `test:server`'s step body (same `if:`, same
+narrowing logic), so whatever the eventual fix is, it applies there too —
+not a third independent instance, just a consequence of the shared body.
 
-**Invocation — bypasses npm-script nesting.** `runStepProcess` gains a
-direct-invocation mode: spawn `npx vitest run --changed <sha>` with `cwd` set
-to the step's own directory (`server/` for `test:server`, repo root for
-`test`), pinned to the local binary (`<cwd>/node_modules/.bin/vitest`,
-falling back to `npx` only if that path doesn't exist) rather than bare
-`npx vitest`, so a missing/un-junctioned `node_modules` fails loudly with
-"vitest not found" as documented, instead of `npx` silently resolving a
-different version from the registry. `retryKey` stays `step.name`, so the
-existing fork-pool-crash retry logic (keyed on `step.name`, not on which
-invocation shape ran) is untouched.
-
-**The server suite's `pretest` preflight must not be silently dropped.**
-`server/package.json` runs `node ../scripts/preflight-ffmpeg.cjs` as
-`pretest`/`pretest:changed` before every existing `test:server` invocation
-path. Bypassing the npm-script wrapper for direct invocation would silently
-skip it. The direct-invocation path runs the same preflight script itself,
-first, before spawning vitest — same check, same failure shape, just called
-directly instead of via npm's lifecycle-script convention.
-
-**Cache-write gate.** Unchanged in shape: a `--changed`-only pass (staged or
-branch) is never written to the verify-cache; only a full run is.
-
-### A2 — CI's zero-test-selection hazard: real, but a class, not a single bug — filed, not fixed this round
-
-An earlier version of this spec proposed a one-line fix: thread `shared`
-into `verify.yml`'s `test`/`test:server` step bodies so a `shared`-scope
-diff forces a full run instead of still trying `--changed "$BASE"`. Real bug
-(`verify.yml`'s step bodies decide narrowed-vs-full only on whether `$BASE`
-is set, never on `shared`), but **round 3 review found the proposed fix
-doesn't cover its own worked example**: `server/package-lock.json` is not
-`shared` scope (`computeShared` only matches the root lockfile/manifest and
-`.github/actions/**`) — it reaches `step_test_server` through a separate
-`includeLockfiles` branch, so a `server/package-lock.json`-only diff stays
-narrowed under the proposed fix and can still select zero tests. Review
-found a third instance too: an `e2e/**`-only diff schedules the frontend
-step (via `step_test_e2e`) which then runs `--changed "$BASE"` over a diff
-with no frontend module-graph edge at all. Three known instances of "this
-diff is in scope for a CI step, but nothing guarantees `--changed` selects
-anything real" — `shared`, `server/package-lock.json`, and cross-leg
-triggers — and the correct unifying rule (something like "narrow only when
-every touched file is covered by that config's own `forceRerunTriggers`")
-is a real design decision spanning both vitest configs, not a mechanical
-one-liner. Per CLAUDE.md's incidental-findings rule, this is the one class
-of finding that's filed rather than fixed in the same round — it needs a
-design pass, and the decision it's waiting on is named here: *what property
-of a diff actually guarantees `--changed <base>` selects a correct,
+The correct unifying rule — something like "narrow only when every touched
+file is covered by that config's own `forceRerunTriggers`" — is a real
+design decision spanning both vitest configs, not a mechanical one-liner: a
+naive `shared`-only fix (tried and rejected in an earlier draft) doesn't
+cover instance 2. Per CLAUDE.md's incidental-findings rule, this is the one
+class of finding that's filed rather than fixed in the same round — it needs
+a design pass, and the decision it's waiting on is named here: *what
+property of a diff actually guarantees `--changed <base>` selects a correct,
 non-empty test set for a given vitest config, given that config's own
 `forceRerunTriggers` list.* File as its own issue at implementation time;
-until it ships, this pre-existing hazard is unchanged by anything else in
-this spec — no worse than before, just not closed by A1 either.
+this is a pre-existing hazard, unaffected by anything else in this spec —
+no worse than before.
 
-### B — widen `file-lock.test.ts`'s confirmed-thin margins, as a no-regret hardening
+## Decision B — widen `file-lock.test.ts`'s thin-looking margins, as harmless hardening
 
-Not claimed to be proven-confirmed as this specific incident's root cause —
-no failure log from the three runs was captured, and the repo separately
-documents fork-pool crashes retrying the whole step up to 3x under
-contention (`MAX_POOL_ATTEMPTS`) as a plausible independent or compounding
-cause that this fix does not touch. Round 3 review additionally couldn't
-confirm actual fragility under measurement (no repro attempted, no jitter
-figure captured) and notes the acquisition timer is armed synchronously
-while the holder's timer is armed a microtask later, so the vulnerable
-window is narrower than "20ms is thin" suggests. Shipped anyway as a cheap
-(~+1.5s total), directionally-correct hardening — not because it's been
-proven to be this incident's cause, and that distinction is kept explicit
-rather than claimed as a confirmed fix.
+Not claimed to be proven-confirmed as this specific incident's root cause,
+and — after two more rounds of scrutiny — **not claimed to be confirmed
+fragile at all**. Round 3 couldn't confirm actual fragility under
+measurement (no repro attempted, no jitter figure captured). Round 4 raised
+a more direct challenge: `file-lock.ts`'s acquisition timer is armed
+synchronously at `withKeyLock` entry, the holder's `setTimeout` is armed one
+microtask later, and Node fires expired timers in arrival order — meaning a
+uniform event-loop stall delays both timers roughly together and *preserves*
+the ordering these assertions depend on, rather than threatening to flip it.
+Under that reading, these margins may not be a real defect at all. **Owner
+decision: ship the widening anyway, as cheap (~+1.5s total), no-regret
+insurance** — it costs almost nothing, and the theoretical case against
+fragility isn't airtight either. This is explicitly not a claim that a
+mechanism has been identified or a bug fixed; it's cheap insurance against
+an unconfirmed but plausible-looking risk, stated as such rather than
+oversold.
 
 **Scope, corrected to the three tests that actually race.**
 `server/src/workspace/file-lock.test.ts`'s `withKeyLock acquisition timeout
@@ -255,10 +181,10 @@ The other two tests in the same `describe` block (`'throws instead of
 hanging when acquisition deadlocks...'`, at line 82) plus the separate
 `withKeyLock typed timeout error` block's test (a different `describe`, line
 224) are **not** touched — both race a 20/50ms timeout against a holder that
-**never releases** — there's no finishing-holder deadline to jitter past, so no
-amount of contention flips their outcome, and the typed-error test asserts
-the literal constant (`timeoutMs).toBe(20)`, message `'timed out after
-20ms'`) that a mechanical margin-widening pass would otherwise break.
+**never releases** — there's no finishing-holder deadline to jitter past, so
+no amount of contention flips their outcome, and the typed-error test
+asserts the literal constant (`timeoutMs).toBe(20)`, message `'timed out
+after 20ms'`) that a mechanical margin-widening pass would otherwise break.
 `'does not fire for legitimate contention comfortably under budget'` (20ms
 hold vs. 500ms budget) already has enough headroom and isn't touched either.
 
@@ -275,178 +201,189 @@ few `setTimeout` uses are 5ms macrotask-flush ticks, not races. Neither is
 touched.
 
 **Fix is an absolute-gap floor, not a ratio.** A 20ms-vs-200ms pair is
-already a 10x ratio and it's one of the three that's fragile — ratio isn't
-the load-bearing quantity, the *absolute* gap between "when the short timer
-could plausibly fire under jitter" and "when the long one finishes" is.
-Target ≥500ms of absolute gap for each of the three pairs (a deliberately
-generous floor — this box's actual jitter under the reported 39+-process
-contention was never measured, so it's chosen with margin rather than
-tightly calibrated), e.g. 20ms→50ms budget racing 150ms→700ms holder. Total
-added wall-clock to the file: roughly +1.5s across the three widened
-`await`s, serial, negligible.
+already a 10x ratio and it's one of the three being widened — ratio isn't
+the load-bearing quantity (if fragility applies at all — see above), the
+*absolute* gap between "when the short timer could plausibly fire under
+delay" and "when the long one finishes" is. Target ≥500ms of absolute gap
+for each of the three pairs (a deliberately generous, unmeasured floor), e.g.
+20ms→50ms budget racing 150ms→700ms holder. Total added wall-clock to the
+file: roughly +1.5s across the three widened `await`s, serial, negligible.
 
-**Search for other instances — corrected to the predicate that actually
-explains why this file's failures were visible.** Not "any competing real
-`setTimeout`" (141 occurrences across 52 files repo-wide, almost all plain
-"wait long enough" delays with no race). The reason these three tests'
-failures would surface as loud, specific red rather than being silently
-absorbed is that their `describe` block opts out of the suite-wide `retry: 1`
-(`{ retry: 0 }`, `#2028`'s documented reason: this file's module-level
-`chains` state must never be silently rescued by a retry). The repo already
-has the right instrument for finding this class rather than a fresh manual
-grep: `server/vitest.config.ts`'s `retryHazardReporter` flags exactly the
-"passed only because the suite-wide retry rescued it" case, and the file
-records a prior `--retry=0` survey having been run across the suite. Rerun
-that survey (or read its most recent output if still current) as part of
-implementation to enumerate any other genuinely-masked-by-retry timing races,
-rather than trusting a narrower manual grep to be exhaustive. Anything it
-turns up in this same fragile-race shape is fixed in the same round per
-CLAUDE.md's incidental-findings rule.
+**No further search for other instances.** The repo has exactly **four**
+`{ retry: 0 }` blocks total — three in `file-lock.test.ts` (all covered
+above), one in `design-lock.test.ts` (confirmed above not to race). That is
+the complete population of "a timing test whose failure wouldn't be silently
+absorbed by the suite-wide `retry: 1`," and all four have already been read
+in full for this spec. `server/vitest.config.ts`'s `retryHazardReporter` is
+**not** a usable instrument for finding more instances — it only reports
+tests *rescued* by `retry: 1`, which by construction excludes every
+`{ retry: 0 }` block; running it would survey the wrong population (and
+would itself require the very 70-80-minute battery this spec is trying to
+shrink). A blanket audit of the repo's 141 other `setTimeout`-in-server-test
+occurrences is correspondingly out of scope — see Out of scope.
 
 **What this does not do.** No switch to `vi.useFakeTimers()` — higher blast
 radius than this fix calls for.
 
-### C — `test:sidecar` (pytest): investigated, deliberately out of scope
+## Decision C — `test:sidecar` (pytest): investigated, deliberately out of scope
 
 `server/tts-sidecar/tests/` has **1136** `test_`-prefixed functions (`def
-test_`/`async def test_`) across **83** files — an order of magnitude
-smaller than `test:server`'s 8000+, and the CI-gating tier is
-CPU-only/mocked, so it isn't the leg producing 70-80 minute runs. Unlike
-vitest, pytest has no built-in `--changed`-equivalent; the closest analogues
-(`pytest-testmon`, `pytest-picked`) are new dependencies meriting their own
-evaluation. Left for a future round if `test:sidecar` itself ever becomes the
-bottleneck. Unrelated to, and doesn't affect, the GPU/hardware carve-out
-below — sidecar's weights-gated tests were already opt-in before this spec.
+test_`/`async def test_`) across **83** files — roughly 7x smaller than
+`test:server`'s 8201, and the CI-gating tier is CPU-only/mocked, so it isn't
+the leg producing 70-80 minute runs. Unlike vitest, pytest has no built-in
+`--changed`-equivalent; the closest analogues (`pytest-testmon`,
+`pytest-picked`) are new dependencies meriting their own evaluation. Left for
+a future round if `test:sidecar` itself ever becomes the bottleneck.
+Unrelated to, and doesn't affect, the GPU/hardware carve-out below —
+sidecar's weights-gated tests were already opt-in before this spec.
 
-### D — increase cloud e2e sharding
+## Decision D — increase cloud e2e sharding
 
 `.github/workflows/verify.yml`'s `e2e` job shards `test:e2e` 4-way today
 (`matrix.shard: [1, 2, 3, 4]`, `--shard=${{ matrix.shard }}/4`), cutting a
 ~16 min unsharded run to ~4 min/shard. Raise it to **8-way**: three live
-sites, corrected from an earlier draft that miscounted them as four — the
-matrix array → `[1, 2, 3, 4, 5, 6, 7, 8]`, the single `--shard=N/4` reference
-in the `test:e2e` step → `/8` (`test:e2e:visual` isn't sharded today and
-stays that way), and the job `name:` label → `/8`. Standard GitHub-hosted
-runners are free/uncapped for
-this public repo, so the real constraint is fixed per-shard cost that
-doesn't shrink with more shards: `playwright.config.ts`'s `chromium` project
-depends on the `warmup` project (Vite transform-cache warm-up), and
-`webServer.reuseExistingServer: !CI` means every shard boots its own Vite dev
-server — both run once per shard and double when shards double. `e2e/**/
-*.spec.ts` is **137** files (not the ~110 the job's own 2026-07-10 comment
-cites), so 8-way lands at ~17/shard. **Also fixed in the same diff**: two
-further prose comments in `verify.yml` (the job's rationale block, and its
-own header comment) that repeat both the stale `4`-way figure and the stale
-`~110 spec files` count — a comment the change makes false is a chore this
-repo's own rules already say is owed, not a separate follow-up. 8-way is a
-reasonable stopping point before fixed per-shard cost dominates; exact number
-confirmed with a real timing comparison during implementation, the same
-method the original 4-way split's comment cites.
+sites — the matrix array → `[1, 2, 3, 4, 5, 6, 7, 8]`, the single
+`--shard=N/4` reference in the `test:e2e` step → `/8` (`test:e2e:visual`
+isn't sharded today and stays that way), and the job `name:` label → `/8`.
 
-### E — manual subsystem-scoped npm scripts (developer convenience, not part of the gate)
+**Cost caveat, more complete than an earlier draft's.** Standard
+GitHub-hosted Actions *minutes* are free/uncapped for this public repo, but
+that's not the only constraint: (a) accounts have a **concurrent job slot**
+ceiling separate from the minutes budget — 8 shards means 8 concurrent `e2e`
+jobs (16 once `test:e2e:visual`'s job and others are counted alongside), and
+if that ceiling is hit, shards queue rather than run in parallel, which
+would blunt exactly the wall-clock win this decision is for; worth watching
+after shipping, not assumed away. (b) The `e2e` job's `Checkout` and
+`Setup Node + deps` steps carry **no `if:` scope condition** — they run on
+every shard unconditionally, including on a docs-only PR where every other
+leg in the job is scoped-off. Doubling the shard count doubles that fixed
+overhead on **every PR in the repo**, not just e2e-touching ones. Combined
+with `playwright.config.ts`'s `chromium` project depending on the `warmup`
+project (Vite transform-cache warm-up) and `webServer.reuseExistingServer:
+!CI` booting a fresh Vite dev server per shard — both run once per shard and
+double when shards double — the real per-shard fixed cost is higher than
+"just checkout and Playwright browser install."
 
-Separate from, and doesn't touch, A1/A2's automated `--changed` gate.
-Measured `test:server`'s 7730 tests by top-level subdirectory: `routes`
-2527/146 files, `tts` 1688/122, `analyzer` 1299/73, `workspace` 758/57 — those
-four alone are 81% of the leg, with everything else under 450 each. Frontend
-`test`'s 4769 by top-level subdirectory: `components` 1192/112, `store`
-1130/52, `lib` 1046/102, `views` 828/29.
+`e2e/**/*.spec.ts` is **137** files (not the ~110 the job's own 2026-07-10
+comment cites), so 8-way lands at ~17/shard. **Also fixed in the same
+diff**: two further prose comments in `verify.yml` (the job's rationale
+block, and its own header comment) that repeat both the stale `4`-way figure
+and the stale `~110 spec files` count. 8-way is still a reasonable stopping
+point given the fixed-cost caveats above; exact number confirmed with a real
+timing comparison during implementation, the same method the original
+4-way split's comment cites — and worth a follow-up look at actual PR
+wall-clock (not just the e2e job's own duration) after it ships, given (a)
+and (b) above.
 
-Add named npm scripts that just narrow `vitest run` to one subdirectory, for
-a developer who knows they're only touching one subsystem and wants a fast
-local sanity check without waiting on the full leg or reasoning about
-whether `--changed` will narrow for their diff:
+## Decision E — manual subsystem-scoped npm scripts (developer convenience, not part of any gate)
+
+Doesn't touch, and isn't gated by, anything else in this spec — the branch-
+scope narrowing this was originally meant to complement was declined above,
+so this stands on its own as the answer to Problem #4. Measured by actually
+running `npx vitest list` (not a raw file-count grep, which earlier drafts
+used and which overcounts by including files `test:server` itself excludes)
+by top-level subdirectory:
+
+- `test:server` (8201 tests total): `routes` 2314 tests/138 files, `tts`
+  1908/123, `analyzer` 1321/73, `workspace` 766/57 — those four are 76.9% of
+  the leg (6309/8201), everything else smaller.
+- `test` (frontend, 4769 tests total): `components` 1192/112, `store`
+  1130/52, `lib` 1046/102, `views` 828/29.
+
+(`routes`'s file count is 138, not the 146 a raw `find` would report — 8 of
+`server/src/routes/`'s test files are in `server/vitest.config.slow.ts`'s
+`SLOW_FILES` list and excluded from `test:server` itself; a
+`test:server:routes` script built the same way `test:server` runs naturally
+excludes the same 8, which is the correct, matching behavior, not a gap —
+worth a one-line comment so a developer isn't confused when the count looks
+short of a raw file search.)
+
+Add named npm scripts that just narrow `vitest run` to one subdirectory:
 
 ```
-"test:server:routes":    "npm --prefix server run test -- server/src/routes",
-"test:server:tts":       "npm --prefix server run test -- server/src/tts",
-"test:server:analyzer":  "npm --prefix server run test -- server/src/analyzer",
-"test:server:workspace": "npm --prefix server run test -- server/src/workspace",
+"test:server:routes":    "npm --prefix server run test -- src/routes",
+"test:server:tts":       "npm --prefix server run test -- src/tts",
+"test:server:analyzer":  "npm --prefix server run test -- src/analyzer",
+"test:server:workspace": "npm --prefix server run test -- src/workspace",
 "test:components": "vitest run src/components",
 "test:store":       "vitest run src/store",
 "test:lib":         "vitest run src/lib",
 "test:views":       "vitest run src/views",
 ```
 
-The server-side scripts are safe against A1's nested-npm forwarding hazard
-(Decision A1's "Invocation — corrected" note) because the path is baked into
-the script definition itself, not appended by a caller at invocation time —
-there's no outer `--` trying to reach through two levels of npm, just one
-literal command line, the same shape the existing (working) `test:server`
-definition already uses. Because these invoke the server's real `test`
-script by name, `pretest`'s ffmpeg preflight still runs automatically via
-npm's normal lifecycle-script convention — nothing to wire separately.
+**Path note, corrected.** An earlier draft of these scripts prefixed the
+server-side filter with `server/` (`-- server/src/routes`), copying the
+path shape used from the *repo root*. `npm --prefix server run test` runs
+with `cwd=server/`, so vitest's project root is already `server/` and the
+filter must be **server-relative** (`src/routes`, not `server/src/routes`)
+— verified by running it: the `server/`-prefixed form matches zero files and
+exits 1 with "No test files found," the corrected form matches exactly the
+138 files above. This was caught by round 4 review, not assumed from the
+`test:server` name's surface resemblance to the path.
+
+These are safe against the nested-npm argument-forwarding hazard round 1
+found for a *different* invocation shape (`npm run <script> -- <args>`,
+where a caller's `--` tries to reach through two levels of npm and fails)
+because the filter path is baked into the script definition itself, not
+appended by a caller at invocation time — one literal command line, same
+shape the existing (working) `test:server` script already uses. Because
+these invoke the server's real `test` script by name, `pretest`'s ffmpeg
+preflight still runs automatically via npm's normal lifecycle-script
+convention — nothing to wire separately.
 
 **Deliberately not added to `STEPS[]`, not scope-gated, not cached, not part
 of any hook.** These are opt-in, manual, developer-run commands — exactly
 the same status `npm run verify:fast` or `npm run test:all` already have.
-No safety guarantee is being made about what they cover (a routes/ change
-that breaks something in workspace/ or store/ isn't caught by
-`test:server:routes` alone — that's what the full leg, `--changed`, and CI
-are for); they exist purely to make the common "I'm working in one area,
-give me a fast local loop" case fast, which the incident report's overall
-"tests take too long" complaint was also partly about.
+No safety guarantee is being made about what they cover (a `routes/` change
+that breaks something in `workspace/` or `store/` isn't caught by
+`test:server:routes` alone — that's what the full leg and CI are for); they
+exist purely to make the common "I'm working in one area, give me a fast
+local loop" case fast.
 
 Only the four biggest subdirectories per leg are wired — the rest are
-already small enough (under ~450 tests, most under 200) that running the
-full leg or a plain `vitest run server/src/<dir>` by hand is fine without a
-named script. Not wired preemptively for the smaller ones.
+already small enough that running the full leg or a plain
+`vitest run <dir>` by hand is fine without a named script.
 
 ## Testing
 
-- `scripts/tests/verify-cache.test.mjs`: source-regex cases (mirroring
-  PR #2839's staged-scope tests) for the widened-to-branch-scope gate
-  condition (the allowlist itself is unchanged from PR #2839 — no new case
-  needed there), the repo-wide dirty-working-tree check, and the cache-write
-  exclusion for branch-scope changed-only passes.
-  **Additionally** — a source-regex test can't catch a broken invocation,
-  only a missing one (round 1's finding) — add a test that actually spawns
-  the new direct-invocation path against a small disposable fixture repo (not
-  this repo's own tree, to avoid the spawned vitest itself tripping
-  `detectSiblingContention`'s process-count probe if this test ever ran
-  inside a `test:hooks`-style pre-commit leg) confirming it forwards
-  `--changed` correctly and actually narrows the selection.
 - `server/src/workspace/file-lock.test.ts`: no new test cases for the three
   widened pairs — existing assertions unchanged, only the millisecond
   constants widen, each with a short comment recording the new absolute gap.
-- Manual: run the new direct-invocation command for both `test` and
-  `test:server` against a real narrow branch locally, confirm it selects a
-  proper subset and exits nonzero on a genuine failure.
 - `.github/workflows/verify.yml`'s e2e shard change: verified by a manual
-  `gh workflow run` dispatch, confirming 8 shard jobs appear and complete.
+  `gh workflow run` dispatch, confirming 8 shard jobs appear and complete;
+  also spot-check actual PR wall-clock once live, given Decision D's cost
+  caveats.
 - Decision E's scripts: no automated test (they carry no correctness
   guarantee to pin — see Decision E's own note). Verified by running each
-  once locally and confirming it selects only its subdirectory's tests.
-  CLAUDE.md's Commands section gets a bullet listing them.
+  once locally and confirming it selects only its subdirectory's tests (and
+  specifically that the corrected server-relative paths actually match —
+  the path bug round 4 found is exactly the kind of thing that must be
+  checked by running the command, not inferred). CLAUDE.md's Commands
+  section gets a bullet listing them.
+- Decision A2: no test this round — filed as an issue, not implemented.
 
 ## Out of scope
 
+- Extending `--changed` narrowing to `--scope-branch` (pre-push) at all —
+  see "Considered and declined" above.
 - Auditing all 141 `setTimeout`-in-server-test occurrences for margin safety
-  — round 3 found `retryHazardReporter` structurally can't see the `{ retry:
-  0 }` population Decision B targets (it only reports tests *rescued* by
-  `retry: 1`), so it's not offered as a substitute survey. The repo has
-  exactly four `{ retry: 0 }` blocks total (three in `file-lock.test.ts`, one
-  in `design-lock.test.ts`), already read in full for this spec — that is
-  the actual scope, not a sampled subset of 141.
+  — the complete relevant population is the four `{ retry: 0 }` blocks
+  already covered by Decision B; see that section's "No further search"
+  note.
 - Any change to the production `withKeyLock`/`file-lock.ts` timeout values —
   test-fragility fix, not a behavior change.
 - `cast-lock.test.ts`, `design-lock.test.ts` — confirmed not to share the
   fragile shape; not touched.
-- Forcing CI's own `--changed` narrowing onto the strict
-  `diffSafeForChangedOnly` allowlist — dropped after measurement showed it
-  would regress CI's current, looser, working narrowing far more than the
-  local change's residual risk justifies (see Prior art's round-2 note).
-  Fixing CI's actual zero-test-selection hazard (of which `test:server-slow`
-  sharing `test:server`'s step body is one instance) is Decision A2, filed
-  as a design-pass item this round rather than fixed.
-- Extending the `--changed`-substitution mechanism to any step besides
-  `test`/`test:server` — `test:sidecar` evaluated and deliberately deferred,
-  see Decision C.
+- Fixing CI's zero-test-selection hazard — Decision A2, filed as a
+  design-pass item this round rather than fixed.
+- Extending any `--changed`-substitution mechanism to `test:sidecar` —
+  evaluated and deliberately deferred, see Decision C.
 - Sharding `test:e2e:visual`, or changing its `--workers=1` anti-flake
   constraint.
 - Any change to GPU/hardware-dependent test tooling (`test:golden-audio`,
-  weights-gated sidecar tests, the on-box acceptance register) — never ran in
-  CI, unaffected by anything in this spec, stays local-only.
-- Determining, retroactively, which mechanism (timing fragility vs. fork-pool
-  crash retries) actually caused the reported three-failure incident — no
-  log was captured; Decision B ships as a no-regret hardening regardless.
+  weights-gated sidecar tests, the on-box acceptance register) — never ran
+  in CI, unaffected by anything in this spec, stays local-only.
+- Determining, retroactively, which mechanism (timing fragility vs.
+  fork-pool crash retries, or something else entirely) actually caused the
+  reported three-failure incident — no log was captured; Decision B ships as
+  harmless insurance regardless, not as a diagnosed fix.

--- a/docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md
+++ b/docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md
@@ -20,20 +20,20 @@ budget racing a 150-200ms holder) to assert ordering, and 39+ concurrent
 node/python processes on the box introduced enough scheduler jitter to
 occasionally flip that ordering.
 
-Three problems, addressed together because they're all "tests take too long
+Four problems, addressed together because they're all "tests take too long
 or fail for reasons unrelated to the change":
 
 1. **Local volume** — pre-push runs far more tests locally than the diff
-   could possibly affect, for every leg that can be diff-scoped, not only
-   `test:server`.
+   could possibly affect, for every leg that can be diff-scoped.
 2. **Fragility** — a handful of tests assert real-wall-clock ordering with
    margins too thin to survive this box's actual contention.
 3. **Cloud e2e wall-clock** — separately raised: the e2e leg (the dominant
-   single cost in cloud CI) is sharded 4-way today and can be sharded further
-   for a straightforward wall-clock win, independent of the local-scoping
-   fix.
+   single cost in cloud CI) is sharded 4-way today and can be sharded further.
+4. **GPU/hardware coverage must not quietly ride along** — none of the above
+   may be read as "CI now covers everything," because CI never has and still
+   won't run anything GPU/hardware-dependent.
 
-## Prior art this builds on
+## Prior art this builds on, and what pass-1 review found wrong about it
 
 PR #2839 (merged, `main@75a86ed8`) added `--changed HEAD`-based narrowing to
 **pre-commit** (`--scope-staged`) for the `test`/`test:server` legs, gated by
@@ -43,181 +43,278 @@ requiring every file in the diff sit under the step's own primary source root
 that (config, CSS, docs, mixed scope) falls back to a full run. It did **not**
 extend the same substitution to `--scope-branch` (pre-push).
 
-Cloud CI (`.github/workflows/verify.yml`) already does the equivalent
-narrowing on every PR push: `npx vitest run --changed "$BASE"` for
-`test:server`/`test:server-slow`, falling back to an unscoped `vitest run`
-only when the diff hits `shared` scope (root manifest/lockfile). This spec
-does not invent a new guarantee for pre-push — it makes pre-push mirror what
-CI already does for the same diff.
+Cloud CI (`.github/workflows/verify.yml`) already narrows on every PR push:
+`npx vitest run --changed "$BASE"` for `test`/`test:server`/
+`test:server-slow`, falling back to an unscoped `vitest run` only when the
+diff hits `shared` scope (root manifest/lockfile). **A draft of this spec
+claimed CI's narrowing meant CI could serve as "the authoritative full-suite
+gate" once pre-push stopped being one — an adversarial review pass (Opus)
+caught that this contradicts itself and, more importantly, contradicts
+CLAUDE.md's actual documented invariant**: pre-push's unscoped run is
+currently the *only* full-suite gate before merge, precisely because CI
+already narrows. Retiring it without anything replacing its guarantee is a
+real coverage regression, not a wash — and the review found a second,
+independent problem: CI's own narrowing has no `diffSafeForChangedOnly`-style
+allowlist, so it carries the identical "diff touches this step but
+`--changed`'s dependency graph can't reach it" hazard PR #2839 hardened
+against locally. That gap was tolerable while pre-push's full run backstopped
+it; it stops being tolerable the moment CI becomes the only full-suite gate
+left.
+
+**Resolution (owner decision, this round):** accept that no unscoped
+`test`/`test:server` run gates merge day-to-day once this ships — the
+twice-weekly `cross-os.yml` cron and `release.yml`'s full `npm run verify`
+remain the periodic backstops for the residual "reached by a non-import edge"
+class — **on the condition that CI's own `--changed` narrowing gets the same
+`diffSafeForChangedOnly` allowlist protection local narrowing has**, so the
+gate CI is now solely responsible for is exactly as safe as the one it
+replaces, just relocated. This is Decision A's second half, not a separate
+follow-up.
+
+The review pass also caught that the originally-proposed invocation mechanism
+for branch-scope narrowing doesn't work at all (see Decision A below), that
+two of the three "same-shape" test files named for Decision B don't actually
+share the fragile pattern, that the proposed 10x-margin-ratio heuristic
+optimizes the wrong quantity, and several stale counts. All incorporated
+below; none of the numbers or file lists in this version are carried over
+unverified from the draft.
 
 ## Decision
 
-### A — extend `--changed` narrowing to `--scope-branch`, for every leg it already covers
+### A — extend `--changed` narrowing to `--scope-branch`, and give CI's own narrowing the same safety allowlist
 
-Widen the existing substitution gate in `runPipeline` (`scripts/
-verify-cache.mjs`, currently `flags.scopeStaged && !scopeShared && scopeDiff
-!== null && diffSafeForChangedOnly(step, scopeDiff)`) to also fire under
-`flags.scopeBranch`. This is generic over `CHANGED_ONLY_NPM_SCRIPT`'s two
-existing entries — **`test` (frontend) and `test:server` both** — so the
-frontend leg gets the identical fix, not just the server one; the incident's
-symptom happened to be `test:server` because that's the 8000+-test leg, but
-the mechanism and this fix apply to both equally. The allowlist
-(`diffSafeForChangedOnly`) is generic over `diffFiles` and needs no change —
-the same conservative default holds: any diff outside `src/**`/`server/src/**`
-with a safe extension still runs the full suite locally, on both scoping
-paths, for either leg.
+**A1 — pre-push.** Widen the existing substitution gate in `runPipeline`
+(`scripts/verify-cache.mjs`, currently `flags.scopeStaged && !scopeShared &&
+scopeDiff !== null && diffSafeForChangedOnly(step, scopeDiff)`) to also fire
+under `flags.scopeBranch`, for both `CHANGED_ONLY_NPM_SCRIPT` entries — `test`
+(frontend) and `test:server`. The allowlist itself needs no change: any diff
+outside `src/**`/`server/src/**` with a safe extension still runs the full
+suite locally on either scoping path. Reviewer's question worth stating
+plainly: this narrowing only fires when the *entire* branch diff since
+merge-base sits under one safe root — a branch that also touches a config
+file, doc, or crosses both `src/` and `server/src/` still gets the full local
+run, same as today. That's expected, not a bug; the volume win applies to the
+(common, not universal) case of a branch confined to one tree.
 
 **Base SHA, not `HEAD`.** The staged-scope substitution reuses the static
 npm scripts `test:changed`/`test:server:changed` (`vitest run --changed
-HEAD`), which is correct there because pre-commit's diff is uncommitted
-changes vs. `HEAD`. At push time everything is committed, so `--changed
-HEAD` would select nothing and vitest would silently exit 0 via
-`passWithNoTests` — the exact silent-false-pass hazard PR #2839's pass-1
-review caught in a different shape. Branch scope instead needs `--changed
+HEAD`), correct there because pre-commit's diff is uncommitted changes vs.
+`HEAD`. At push time everything is committed, so `--changed HEAD` would
+select nothing. Branch scope instead needs `--changed
 <merge-base-with-main>`, mirroring CI's own `$BASE`. `branchDiffFiles`
-(`scripts/verify-cache.mjs`) already computes this merge-base internally via
-`git merge-base HEAD main` to produce its file list; it's refactored to also
-return that SHA (or a sibling `branchMergeBase(cwd)` helper it and
-`branchDiffFiles` both call, memoized so scope computation still costs one
-git spawn) so `runPipeline` reuses the exact SHA already used to decide scope,
-rather than a second, independently-timed `git merge-base` call.
+(`scripts/verify-cache.mjs`) already computes this merge-base internally
+(one `git merge-base` spawn, then one `git diff` spawn) to produce its file
+list; it's refactored to also return that SHA so `runPipeline` reuses the
+exact one already used to decide scope, rather than a second,
+independently-timed `git merge-base` call — this doesn't reduce today's git
+spawn count (still two), it just avoids adding a third.
 
-**Invocation, not a new static script.** Because the base is dynamic, branch
-scope can't reuse a fixed `test:server:changed` script string. `runStepProcess`
-gains an optional `extraArgs` passthrough (`npm run <script> -- <extraArgs>`);
-branch-scope substitution calls `runStepProcess(step.name, { extraArgs:
-['--changed', baseSha], ... })` — i.e. `npm run test:server -- --changed
-<sha>`, which becomes `vitest run --changed <sha>` after npm's arg
-passthrough, the same shape CI already runs. `retryKey` stays `step.name`
-either way, so the existing fork-pool-crash retry logic is untouched.
+**Invocation — corrected.** The draft proposed `npm run test:server --
+--changed <sha>`, assuming npm forwards `--changed` into the underlying
+vitest call. **It doesn't, on this leg**: `test:server` is `npm --prefix
+server run test` — a *nested* npm invocation — so the outer `--` is consumed
+by the *outer* npm and never reaches the inner one; the SHA lands as a bare
+positional argument to `vitest run`, which then tries to match it as a
+filename filter and exits 1 with "No test files found." (Verified against
+this repo's actual `package.json`/`server/package.json` scripts, not assumed.)
+The frontend `test` script has no such nesting and the naive form would have
+worked for it alone — which is exactly the kind of asymmetry that's easy to
+miss if only one leg gets manually tried. Fix: bypass the npm-script
+indirection for the branch-scope path entirely and spawn the underlying
+command directly, the same shape CI's own step already runs successfully —
+`npx vitest run --changed <sha>` with `cwd` set to the step's own directory
+(`server/` for `test:server`, repo root for `test`). `runStepProcess` gains a
+`directInvocation` mode alongside the existing npm-script mode so
+`retryKey`/pool-crash-retry logic (keyed on `step.name`, unaffected by which
+invocation shape ran) stays untouched.
 
-**Cache-write gate.** The existing rule — a `--changed`-only pass is never
-written to the verify-cache (only a full run is, so a later cache hit can't
-mean "a full run happened" when it didn't) — already keys off a single
-`changedOnlyScript`-shaped truthy value in the per-step loop; it extends to
-cover the branch-scope substitution with no change in shape, just a wider set
-of inputs that can produce a truthy value.
+**Cache-write gate.** Unchanged in shape: a `--changed`-only pass (staged or
+branch) is never written to the verify-cache; only a full run is.
+
+**A2 — CI's own `--changed` gets the allowlist too.** `scripts/ci-scope.mjs`
+today emits one boolean per step (`step_test_server`, etc. — "does this leg's
+scope intersect the diff at all") via `stepTouchedByDiff`, consumed by
+`verify.yml`'s `if:` conditions to decide whether a job step *runs*; the
+`--changed "$BASE"` vs. full-`vitest run` choice *inside* an in-scope step is
+then hardcoded inline in the workflow YAML, keyed only on `shared`. Add a
+second boolean per changed-only-eligible step —
+`step_test_server_changed_safe: diffSafeForChangedOnly(testServerStep,
+files)`, `step_test_changed_safe` likewise — computed in `ci-scope.mjs` from
+the same `files` list already diffed against the PR base, using the same
+exported `diffSafeForChangedOnly` function Decision A1 uses locally (single
+source of truth, no duplicated logic). `verify.yml`'s `test`/`test:server`
+step bodies gain a third branch: `shared` → full run (unchanged); else
+`changed_safe` → `--changed "$BASE"` (unchanged shape, now gated); else → full
+run (new — today this case silently narrows). `workflow_dispatch` and the
+`ci-scope.mjs` crash fail-safe already default every scope boolean to `true`,
+which correctly forces the full-run branch here too (a `true` scope with an
+unset/`undefined` `changed_safe` boolean must read as "not safe" — verified
+by how the new field composes with the existing `allTrue()`/fail-safe paths,
+pinned by a test rather than inspection alone).
 
 **Docs.** CLAUDE.md's Commit gate section and `docs/features/
-156-precommit-scope-contention.md` currently frame pre-push's unscoped
-`test:server` run as the deliberate "full local safety net" that exists
-*because* CI narrows its own runs. That framing is retired. Replacement:
-local runs (pre-commit and pre-push both) narrow via `--changed` whenever the
-diff is confined to source; cloud `verify.yml` — required, opt-out, runs
-automatically on every PR push — is the authoritative full-suite gate; a
-diff outside the allowlist (config/docs/CSS/mixed-scope) still gets a full
-run locally too, so the common case of a source-only PR is the only one that
-actually loses local full-suite coverage, and that PR gets full coverage
-from CI before merge regardless.
+156-precommit-scope-contention.md` currently state, as a decision, that
+pre-push's unscoped run is deliberately the full local safety net *because*
+CI narrows its own runs (plan 156's own acceptance item: "Pre-push runs the
+full battery; only pre-commit is scope-filtered"). That decision is reversed,
+not reframed — plan 156 gets a dated addendum recording the reversal and its
+reasoning (the same treatment its 2026-09-01 addendum from PR #2839 already
+used), and its acceptance criteria are updated to match, not left stale next
+to contradicting prose. Replacement invariant, stated plainly: local runs
+(pre-commit and pre-push) narrow via `--changed` whenever the diff is
+confined to source; CI's own narrowing now carries the identical allowlist
+protection (A2); the twice-weekly cross-OS cron and release-time full
+`verify` are the periodic backstops for the narrow residual class no
+`--changed`-based mechanism can close by construction (a source-only diff
+that reaches a test through a non-import runtime edge). **None of this
+extends to GPU/hardware-dependent testing** — `test:golden-audio` and any
+weights-gated `test:sidecar` case were never run in CI (GitHub-hosted runners
+have no GPU) and are unaffected by any of A1/A2; they remain opt-in, run
+locally on demand via their existing flags, exactly as documented today. This
+line is added explicitly to CLAUDE.md's Commit gate section so "CI is now the
+full-suite gate" can't be misread as "CI covers hardware-dependent behavior
+too" — it never did.
 
 ### B — widen the real-timer margins that made this fail
 
 `quarantinedIt` (`server/src/test-utils/quarantine.ts`) skips in **both**
-gating lanes — local and CI. Wrong tool here: these tests are correct and
-pass reliably in isolation (confirmed), so quarantining them would silently
-drop real coverage from CI forever to solve a problem that's purely about
-this box's local contention. Fix the actual fragility instead.
+gating lanes — local and CI. Wrong tool: these tests are correct and pass
+reliably in isolation, so quarantining would silently drop real coverage from
+CI forever to solve a problem that's purely about this box's local
+contention. Fix the fragility instead.
 
-**Scope.** `server/src/workspace/file-lock.test.ts` is the confirmed
-instance: several tests race a short lock-acquisition-timeout budget (20ms)
-against a longer holder (30-200ms) to assert relative ordering. Widen every
-such pair's margins — aim for roughly 10x headroom between the short
-(timeout) value and the long (hold) value it's racing, e.g. a 20ms timeout
-budget racing a 150ms holder becomes something like a 100ms budget racing an
-800ms holder — tuned per test during implementation, verified by running the
-file under `LOW_CONCURRENCY=1` plus an artificially loaded box if one is
-available, or just by inspection of the margin ratio if not.
+**Scope — corrected.** `server/src/workspace/file-lock.test.ts` is the only
+confirmed instance: several tests in its two `{ retry: 0 }` `describe` blocks
+race a short lock-acquisition-timeout budget (20ms) against a longer holder
+(30-200ms) to assert relative ordering. **The draft also named
+`cast-lock.test.ts` and `server/src/tts/design-lock.test.ts` as same-shape
+siblings; review read both in full and found neither shares the pattern** —
+`cast-lock.test.ts`'s timers are failure sentinels (a 2000ms/1000ms ceiling
+racing critical sections that finish in ~0ms, three orders of magnitude of
+headroom, the opposite of thin) and its 2000ms sentinel is *deliberately*
+calibrated to fire well before the production `withKeyLock` 10s budget — its
+own comment says so; `design-lock.test.ts` orders exclusively via explicit
+promise gates, not competing timers, and doesn't call `withKeyLock` at all
+(`design-lock.ts` has its own separate lock map). **Both are dropped from
+this fix's scope entirely** — touching either would violate "Surgical
+changes," and mechanically widening `cast-lock.test.ts`'s sentinel past the
+production 10s budget it's deliberately calibrated under would change what
+failure mode the test actually observes.
 
-Apply the same fix to same-shape siblings in the lock-test family —
-`server/src/workspace/cast-lock.test.ts` and `server/src/tts/
-design-lock.test.ts` — since they share the same "two real timers racing for
-an ordering assertion" pattern over the same underlying lock primitive. This
-is **not** a blanket pass over every `setTimeout` in the server test suite
-(a repo-wide grep found 76 occurrences across 33 files); most of those are
-plain "wait long enough for an async op" delays with no competing timer, and
-are insensitive to jitter for correctness purposes — only widening them would
-just make the suite slower for no gain. If implementation turns up another
-file doing the same competing-timer-ordering shape, it's fixed in the same
-round per CLAUDE.md's incidental-findings rule, not filed and deferred.
+**The fix is an absolute-margin floor, not a ratio.** The draft's "~10x
+headroom" framing is wrong on its own evidence: the existing 20ms-vs-200ms
+pair is already a 10x ratio and it's one of the ones that flaked, while a
+20ms-vs-30ms pair (a 1.5x ratio, comfortably passing in the same file today
+because nothing times out on that path) shows ratio isn't the load-bearing
+quantity — the *absolute* gap between "when the short timer fires" and "when
+the long one finishes" is what has to survive scheduler jitter. Target: widen
+each racing pair so the absolute gap is at least ~500ms (this box's observed
+contention window under 39+ concurrent processes gave no precise jitter
+figure, so 500ms is a deliberately generous floor, not a measured one) —
+e.g. a 20ms timeout racing a 150ms holder becomes something like a 50ms
+timeout racing a 600ms+ holder. Tuned per test during implementation; each
+widened pair gets a short comment recording the new absolute gap and that
+it's deliberate, matching this file's existing comment-heavy convention.
 
-**What this does not do.** No switch to `vi.useFakeTimers()` / fake-timer
-rewrite. The lock primitives under test (`withKeyLock`'s promise-chained
-queue) have real async/microtask interleaving that a fake-timer rewrite would
-need to get right across every existing case, including the deliberately
-`retry: 0` deadlock/timeout-typing suites — higher blast radius than this
-incident calls for. Worth revisiting only if margin-widening turns out not to
-hold up.
+**Search predicate for "did we miss another instance," corrected.** Not "any
+competing real `setTimeout`" (a repo-wide grep on that shape returns 141
+occurrences across 52 files, mostly plain "wait long enough" delays with no
+race and no jitter sensitivity). The predicate that actually explains why
+this file's failures were *visible* rather than silently rescued is
+**"competing real timers asserting ordering, inside a `{ retry: 0 }` block"**
+— vitest's suite-wide `retry: 1` (`#2028`'s documented reason `file-lock.
+test.ts` itself opts out of it) would otherwise absorb a one-off jitter flake
+silently. If implementation finds another file matching that narrower
+predicate, it's fixed in the same round per CLAUDE.md's incidental-findings
+rule; a file with the broader "has a setTimeout" shape but ordinary retry
+semantics is not in scope.
+
+**What this does not do.** No switch to `vi.useFakeTimers()`. Higher blast
+radius than this incident calls for; worth revisiting only if margin-widening
+turns out not to hold up.
 
 ### C — `test:sidecar` (pytest): investigated, deliberately out of scope
 
-Considered for the same `--changed`-style narrowing since it's the third
-locally-gating test leg (`verify:fast:branch` runs it alongside `test`/
-`test:server`). Sized it first rather than assuming: `server/tts-sidecar/
-tests/` has ~900 `test_*` functions across ~75 files — roughly a ninth of
-`test:server`'s volume — and the CI-gating tier is CPU-only/mocked (no real
-model load; per CLAUDE.md's own description it SKIPs+exits 0 on an
-unbootstrapped venv), so it isn't the leg producing 70-80 minute runs or the
-lock-timing failures this incident is about. Unlike vitest, pytest has no
-built-in `--changed`-equivalent flag; the closest analogues
+Considered for the same narrowing since it's the third locally-gating test
+leg. Sized it first: `server/tts-sidecar/tests/` has **1120** `test_*`
+functions across **83** files — an order of magnitude smaller than
+`test:server`'s 8000+, and the CI-gating tier is CPU-only/mocked (SKIPs+exits
+0 on an unbootstrapped venv per CLAUDE.md), so it isn't the leg producing
+70-80 minute runs or the lock-timing failures this incident is about. Unlike
+vitest, pytest has no built-in `--changed`-equivalent; the closest analogues
 (`pytest-testmon`, `pytest-picked`) are new dependencies with their own
-correctness model (coverage-based or git-diff-based test selection) that
-would need their own evaluation, not a small extension of the mechanism this
-spec already built for vitest. Given the volume here doesn't justify it,
-that evaluation is left for a future round if `test:sidecar` itself ever
-becomes the bottleneck — named explicitly here so its absence is a decision,
-not an oversight.
+correctness model, meriting their own evaluation rather than a small
+extension of this spec's vitest-specific mechanism. Left for a future round
+if `test:sidecar` itself ever becomes the bottleneck. This decision is
+unrelated to, and doesn't affect, the GPU/hardware carve-out in Decision A's
+Docs subsection — sidecar's weights-gated tests were already opt-in before
+this spec and stay that way regardless of C's outcome.
 
 ### D — increase cloud e2e sharding
 
 `.github/workflows/verify.yml`'s `e2e` job shards `test:e2e` 4-way today
-(`matrix.shard: [1, 2, 3, 4]`, `--shard=${{ matrix.shard }}/4`) — per the
-job's own comment, this was the dominant single leg in the whole workflow at
-~16 min unsharded, cut to ~4 min/shard by the existing 4-way split. Raise it
-to **8-way**: change the matrix array to `[1, 2, 3, 4, 5, 6, 7, 8]` and both
-`--shard=N/4` references (the `test:e2e` step; `test:e2e:visual` in the
-neighboring job is unaffected — it already runs `--workers=1` for a different
-reason and is not sharded today, out of scope here) to `/8`, and the job
-name label (`E2E (chromium) — shard ${{ matrix.shard }}/4` → `/8`). Standard
-GitHub-hosted runners are free/uncapped for this public repo (per the
-2026-07-06 CI-rebalance design CLAUDE.md already documents), so the only real
-cost is fixed per-job overhead (checkout, Node setup, Playwright browser
-cache/install) that doesn't shrink with more shards — 8-way is a reasonable
-stopping point for ~110 spec files (roughly 14/shard) before that overhead
-starts to dominate the per-shard wall-clock; the exact number is a tuning
-call to confirm with a real timing comparison during implementation (same
-method the existing comment cites for the original 4-way split), not
-something this spec can pin exactly without running it.
+(`matrix.shard: [1, 2, 3, 4]`, `--shard=${{ matrix.shard }}/4`), cutting a
+~16 min unsharded run to ~4 min/shard. Raise it to **8-way**: matrix array →
+`[1, 2, 3, 4, 5, 6, 7, 8]`, both `--shard=N/4` references (the `test:e2e`
+step only — `test:e2e:visual` in the neighboring job isn't sharded today and
+stays that way, out of scope) → `/8`, job name label → `/8`. Standard
+GitHub-hosted runners are free/uncapped for this public repo, so the real
+constraint is fixed per-shard cost that doesn't shrink with more shards —
+**corrected from the draft**, that cost isn't just checkout/setup/Playwright
+cache: `playwright.config.ts`'s `chromium` project depends on a `warmup`
+project (the Vite transform-cache warm-up in `e2e/warmup.setup.ts`), and
+`webServer.reuseExistingServer: !CI` means every shard boots its own Vite dev
+server — both run once per shard and double when shards double. Spec count
+corrected too: `e2e/**/*.spec.ts` is **137** files, not ~110, so 8-way is
+~17/shard, not ~14. 8-way is still a reasonable stopping point before
+per-shard fixed cost dominates, but the exact number is a tuning call to
+confirm with a real timing comparison during implementation, the same method
+the existing 4-way split's own comment cites — not something pinned exactly
+here.
 
 ## Testing
 
-- `scripts/tests/verify-cache.test.mjs`: new cases pinning the branch-scope
-  substitution (source-regex, mirroring the existing staged-scope tests from
-  PR #2839) — the widened gate condition, the `extraArgs`/base-SHA wiring,
-  and that the cache-write gate still excludes a branch-scope changed-only
-  pass.
-- `server/src/workspace/file-lock.test.ts` (and the two siblings, if their
-  margins also move): no new test cases — the existing assertions are
-  unchanged, only the millisecond constants widen. The margin choice is
-  self-documenting via a short comment at each widened pair, matching this
-  file's existing comment-heavy convention, so a future reader knows the
-  headroom is deliberate and not an arbitrary number.
-- Manual: run `npm run test:server -- --changed <some-older-sha>` and the
-  frontend equivalent locally once implemented, confirm each selects a proper
-  subset and exits nonzero on a genuine failure (not just
-  `passWithNoTests`-style silent 0).
-- `.github/workflows/verify.yml`'s e2e shard change: no unit test (it's CI
-  config) — verified by a manual `gh workflow run verify.yml --ref <branch>`
-  dispatch and reading the run's job list, confirming 8 shard jobs appear and
-  each completes, before merge.
+- `scripts/tests/verify-cache.test.mjs`: source-regex cases (mirroring
+  PR #2839's staged-scope tests) pinning the widened gate condition and the
+  cache-write exclusion for branch-scope changed-only passes. **Additionally
+  — the review's strongest finding was that source-regex tests can't catch a
+  broken invocation, only a missing one**: add at least one test that
+  actually spawns the new direct-invocation path (`npx vitest run --changed
+  <sha>` with `cwd` set appropriately) against a disposable fixture — enough
+  to prove the command as constructed actually forwards `--changed` and
+  actually selects a subset, not just that the source text mentions the right
+  strings. This is new territory for this file's existing "no process
+  execution" convention and is called out explicitly rather than silently
+  matching the old style.
+- `scripts/ci-scope.mjs`'s existing test file: cases for the new
+  `*_changed_safe` fields — safe diff, diff outside the allowlist, empty
+  diff, and `workflow_dispatch`/fail-safe paths (must read as "not safe",
+  pinned directly rather than inferred).
+- `server/src/workspace/file-lock.test.ts`: no new test cases — existing
+  assertions unchanged, only the millisecond constants widen, each with a
+  comment recording the new absolute gap.
+- Manual: run the new direct-invocation command for both `test` and
+  `test:server` against a real narrow branch locally, confirm each selects a
+  proper subset and exits nonzero on a genuine failure.
+- `.github/workflows/verify.yml`'s e2e shard change and the A2 `changed_safe`
+  branching: no unit test for the workflow YAML itself — verified by a
+  manual `gh workflow run verify.yml --ref <branch>` dispatch, reading the
+  job list (8 shard jobs, each completing) and confirming a
+  known-`changed_safe`-diff PR actually took the narrowed path in the logs.
 
 ## Out of scope
 
-- Auditing all 76 `setTimeout`-in-server-test occurrences for margin safety —
-  only the confirmed lock-ordering-race shape is in scope this round.
+- Auditing all 141 `setTimeout`-in-server-test occurrences for margin safety
+  — only the confirmed lock-ordering-race-under-`retry:0` shape is in scope.
 - Any change to the production `withKeyLock`/`file-lock.ts` timeout values —
-  this is a test-fragility fix, not a behavior change.
+  test-fragility fix, not a behavior change.
+- `cast-lock.test.ts`, `design-lock.test.ts` — confirmed not to share the
+  fragile shape; not touched.
 - Extending the `--changed`-substitution *mechanism* to any step besides
-  `test`/`test:server` (unchanged from PR #2839's scope) — `test:sidecar` was
-  evaluated and deliberately deferred, see Decision C.
+  `test`/`test:server` (local or CI) — `test:sidecar` evaluated and
+  deliberately deferred, see Decision C.
 - Sharding `test:e2e:visual`, or changing its `--workers=1` anti-flake
   constraint.
+- Any change to GPU/hardware-dependent test tooling (`test:golden-audio`,
+  weights-gated sidecar tests, the on-box acceptance register) — explicitly
+  unaffected, see Decision A's Docs subsection.

--- a/docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md
+++ b/docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md
@@ -12,243 +12,264 @@ the branch diff touches any file in that leg's tree — the full battery,
 currently 8000+ tests for `test:server` alone, no `--changed` narrowing. On a
 box running several concurrent worktree test batteries this took 70-80
 minutes and failed three times in a row, each time on a different
-timing-sensitive lock test unrelated to the diff being pushed. Root cause of
-the failures, confirmed by rerunning the flagged tests in isolation (they
-passed clean): `server/src/workspace/file-lock.test.ts` races real
-`setTimeout` calls with thin margins (e.g. a 20ms lock-acquisition-timeout
-budget racing a 150-200ms holder) to assert ordering, and 39+ concurrent
-node/python processes on the box introduced enough scheduler jitter to
-occasionally flip that ordering.
+timing-sensitive lock test unrelated to the diff being pushed.
+`server/src/workspace/file-lock.test.ts` has confirmed-fragile pairs — a
+20ms lock-acquisition-timeout budget racing a 150-200ms holder to assert
+ordering — that are unambiguously too thin to survive real scheduler jitter,
+regardless of whether they were this specific incident's proximate cause; no
+failure log from the three runs was captured, and the repo separately
+documents fork-pool crashes (which retry the *entire* step up to 3x under
+contention, `scripts/verify-cache.mjs`'s `MAX_POOL_ATTEMPTS`) as a plausible
+independent or compounding cause of "70-80 minutes." This spec does not
+resolve which explanation is right — see Decision B for how that's handled.
 
 Four problems, addressed together because they're all "tests take too long
 or fail for reasons unrelated to the change":
 
 1. **Local volume** — pre-push runs far more tests locally than the diff
    could possibly affect, for every leg that can be diff-scoped.
-2. **Fragility** — a handful of tests assert real-wall-clock ordering with
-   margins too thin to survive this box's actual contention.
+2. **Fragility** — `file-lock.test.ts` has real-wall-clock-ordering pairs
+   with margins too thin to survive contention, independent of whether
+   they're proven to have caused this specific incident.
 3. **Cloud e2e wall-clock** — separately raised: the e2e leg (the dominant
    single cost in cloud CI) is sharded 4-way today and can be sharded further.
 4. **GPU/hardware coverage must not quietly ride along** — none of the above
-   may be read as "CI now covers everything," because CI never has and still
-   won't run anything GPU/hardware-dependent.
+   may be read as "CI now covers everything"; CI never has and still won't
+   run anything GPU/hardware-dependent.
 
-## Prior art this builds on, and what pass-1 review found wrong about it
+## Prior art, and two rounds of adversarial review
 
 PR #2839 (merged, `main@75a86ed8`) added `--changed HEAD`-based narrowing to
 **pre-commit** (`--scope-staged`) for the `test`/`test:server` legs, gated by
 a positive allowlist (`diffSafeForChangedOnly`, `scripts/verify-cache.mjs`)
 requiring every file in the diff sit under the step's own primary source root
-(`src/**`, `server/src/**`) with a safe TS/JS extension — any diff outside
-that (config, CSS, docs, mixed scope) falls back to a full run. It did **not**
-extend the same substitution to `--scope-branch` (pre-push).
+(`src/**`, `server/src/**`) with a safe TS/JS extension. It did not extend
+the substitution to `--scope-branch` (pre-push).
 
-Cloud CI (`.github/workflows/verify.yml`) already narrows on every PR push:
-`npx vitest run --changed "$BASE"` for `test`/`test:server`/
-`test:server-slow`, falling back to an unscoped `vitest run` only when the
-diff hits `shared` scope (root manifest/lockfile). **A draft of this spec
-claimed CI's narrowing meant CI could serve as "the authoritative full-suite
-gate" once pre-push stopped being one — an adversarial review pass (Opus)
-caught that this contradicts itself and, more importantly, contradicts
-CLAUDE.md's actual documented invariant**: pre-push's unscoped run is
-currently the *only* full-suite gate before merge, precisely because CI
-already narrows. Retiring it without anything replacing its guarantee is a
-real coverage regression, not a wash — and the review found a second,
-independent problem: CI's own narrowing has no `diffSafeForChangedOnly`-style
-allowlist, so it carries the identical "diff touches this step but
-`--changed`'s dependency graph can't reach it" hazard PR #2839 hardened
-against locally. That gap was tolerable while pre-push's full run backstopped
-it; it stops being tolerable the moment CI becomes the only full-suite gate
-left.
+This spec went through two independent Opus review rounds before this
+version. Both found real defects; the second round additionally **measured**
+the design's core premise against this repo's actual git history rather than
+asserting it, and that measurement changed the design materially. Summary,
+because the reasoning matters for what shipped:
 
-**Resolution (owner decision, this round):** accept that no unscoped
-`test`/`test:server` run gates merge day-to-day once this ships — the
-twice-weekly `cross-os.yml` cron and `release.yml`'s full `npm run verify`
-remain the periodic backstops for the residual "reached by a non-import edge"
-class — **on the condition that CI's own `--changed` narrowing gets the same
-`diffSafeForChangedOnly` allowlist protection local narrowing has**, so the
-gate CI is now solely responsible for is exactly as safe as the one it
-replaces, just relocated. This is Decision A's second half, not a separate
-follow-up.
-
-The review pass also caught that the originally-proposed invocation mechanism
-for branch-scope narrowing doesn't work at all (see Decision A below), that
-two of the three "same-shape" test files named for Decision B don't actually
-share the fragile pattern, that the proposed 10x-margin-ratio heuristic
-optimizes the wrong quantity, and several stale counts. All incorporated
-below; none of the numbers or file lists in this version are carried over
-unverified from the draft.
+- **Round 1** found the originally-proposed invocation
+  (`npm run test:server -- --changed <sha>`) doesn't work — `test:server` is
+  `npm --prefix server run test`, a *nested* npm call, so the outer `--`
+  never reaches the inner vitest; the SHA lands as a positional filename
+  filter and the run fails with "No test files found." Fixed below by
+  bypassing npm-script indirection and spawning the underlying command
+  directly, the same shape CI's own step already uses.
+- **Round 2 measured** `diffSafeForChangedOnly`'s real-world hit rate: **0 of
+  the last 60 merged branches, 1 of 1360 real push-states**, because
+  CLAUDE.md's own Before-shipping checklist mandates a
+  `docs/release-notes-next.md`/plan-doc touch on nearly every non-trivial PR,
+  which disqualifies the whole branch under the original allowlist. Owner
+  decision: widen the allowlist to also tolerate `docs/**` and
+  `RELEASE_NOTES.md` alongside real source changes — verified safe (grepped
+  the whole repo for any `test`/`test:server`-scoped file reading a `docs/`
+  path at runtime; the one hit, `scripts/tests/release-notes-gate.test.mjs`,
+  lives under a different step entirely and is unaffected) — then
+  **re-measured**: 0/60 → 3/60 (5%) for `test:server`. Real, but modest — the
+  remaining disqualifying files in the same 60 branches (`server/tts-sidecar/
+  main.py`, `openapi.yaml`+`api-types.ts` co-changes, cross-cutting
+  `scripts/**`) are files that *should* disqualify narrowing, not artifacts
+  of an overly strict allowlist, so this isn't pushed further.
+- That measurement changes the shape of the whole spec: since local narrowing
+  fires on only ~5% of real branches, pre-push keeps running the **full**
+  suite on the other ~95%, same as today. The coverage exposure from giving
+  up pre-push's blanket full-run guarantee is therefore small and bounded,
+  not the wholesale policy reversal an earlier draft treated it as — which
+  in turn means the earlier plan to force CI's own narrowing onto the same
+  *strict* allowlist (so CI could serve as full replacement backstop) is the
+  wrong fix: CI's current narrowing is looser (governed only by `shared`
+  scope) and already works in production on far more PRs than 5%; forcing it
+  onto the strict allowlist would regress CI's own performance to chase a
+  now-small residual risk. **Dropped.** In its place: round 2 also surfaced a
+  real, small, pre-existing CI bug independent of this whole allowlist
+  question — see Decision A2.
 
 ## Decision
 
-### A — extend `--changed` narrowing to `--scope-branch`, and give CI's own narrowing the same safety allowlist
+### A1 — extend `--changed` narrowing to `--scope-branch`, with a widened allowlist
 
-**A1 — pre-push.** Widen the existing substitution gate in `runPipeline`
-(`scripts/verify-cache.mjs`, currently `flags.scopeStaged && !scopeShared &&
-scopeDiff !== null && diffSafeForChangedOnly(step, scopeDiff)`) to also fire
-under `flags.scopeBranch`, for both `CHANGED_ONLY_NPM_SCRIPT` entries — `test`
-(frontend) and `test:server`. The allowlist itself needs no change: any diff
-outside `src/**`/`server/src/**` with a safe extension still runs the full
-suite locally on either scoping path. Reviewer's question worth stating
-plainly: this narrowing only fires when the *entire* branch diff since
-merge-base sits under one safe root — a branch that also touches a config
-file, doc, or crosses both `src/` and `server/src/` still gets the full local
-run, same as today. That's expected, not a bug; the volume win applies to the
-(common, not universal) case of a branch confined to one tree.
+Widen the substitution gate in `runPipeline` (`scripts/verify-cache.mjs`,
+currently `flags.scopeStaged && !scopeShared && scopeDiff !== null &&
+diffSafeForChangedOnly(step, scopeDiff)`) to also fire under
+`flags.scopeBranch`, for both `CHANGED_ONLY_NPM_SCRIPT` entries — `test`
+(frontend) and `test:server`.
+
+**`diffSafeForChangedOnly` gets a second allowed category.** Alongside the
+existing "every file under the step's own source root with a safe
+extension" rule, a file matching `docs/**` or the root `RELEASE_NOTES.md` is
+also allowed, unconditionally, on either scoping path (staged or branch) —
+confirmed by measurement to raise the real-world hit rate (0/60 → 3/60 for
+`test:server` over the last 60 merged branches) and confirmed safe by a
+repo-wide grep: no file under `src/**` or `server/src/**`'s own test suites
+reads anything under `docs/` at runtime. (The one file in the repo that does,
+`scripts/tests/release-notes-gate.test.mjs`, belongs to `test:hooks`, a
+different step this substitution never touches.) At least one file in the
+diff must still be a real, safe-extension source file under the step's own
+root — an all-docs diff never reaches this function, because
+`stepTouchedByDiff` already filters the step out of scope entirely upstream.
 
 **Base SHA, not `HEAD`.** The staged-scope substitution reuses the static
 npm scripts `test:changed`/`test:server:changed` (`vitest run --changed
 HEAD`), correct there because pre-commit's diff is uncommitted changes vs.
 `HEAD`. At push time everything is committed, so `--changed HEAD` would
 select nothing. Branch scope instead needs `--changed
-<merge-base-with-main>`, mirroring CI's own `$BASE`. `branchDiffFiles`
-(`scripts/verify-cache.mjs`) already computes this merge-base internally
-(one `git merge-base` spawn, then one `git diff` spawn) to produce its file
-list; it's refactored to also return that SHA so `runPipeline` reuses the
-exact one already used to decide scope, rather than a second,
-independently-timed `git merge-base` call — this doesn't reduce today's git
-spawn count (still two), it just avoids adding a third.
+<merge-base-with-main>`, the same shape CI's own `$BASE` uses (not the exact
+same SHA — CI diffs against the fetched PR base, `branchDiffFiles` diffs
+against local `main`; direction is fail-safe, a stale local `main` only
+widens the diff and makes narrowing less likely, never silently more).
+`branchDiffFiles` (`scripts/verify-cache.mjs`) already computes this
+merge-base internally (one `git merge-base` spawn, then one `git diff` spawn)
+to produce its file list; it's refactored to also return that SHA so
+`runPipeline` reuses the one already used to decide scope. Its existing
+callers/contract (it's independently exported and unit-tested) are preserved
+— the return shape gains the SHA, doesn't lose the file list.
 
-**Invocation — corrected.** The draft proposed `npm run test:server --
---changed <sha>`, assuming npm forwards `--changed` into the underlying
-vitest call. **It doesn't, on this leg**: `test:server` is `npm --prefix
-server run test` — a *nested* npm invocation — so the outer `--` is consumed
-by the *outer* npm and never reaches the inner one; the SHA lands as a bare
-positional argument to `vitest run`, which then tries to match it as a
-filename filter and exits 1 with "No test files found." (Verified against
-this repo's actual `package.json`/`server/package.json` scripts, not assumed.)
-The frontend `test` script has no such nesting and the naive form would have
-worked for it alone — which is exactly the kind of asymmetry that's easy to
-miss if only one leg gets manually tried. Fix: bypass the npm-script
-indirection for the branch-scope path entirely and spawn the underlying
-command directly, the same shape CI's own step already runs successfully —
-`npx vitest run --changed <sha>` with `cwd` set to the step's own directory
-(`server/` for `test:server`, repo root for `test`). `runStepProcess` gains a
-`directInvocation` mode alongside the existing npm-script mode so
-`retryKey`/pool-crash-retry logic (keyed on `step.name`, unaffected by which
-invocation shape ran) stays untouched.
+**Working-tree vs. committed diff.** `vitest --changed <sha>` diffs against
+the *working tree*, not just `HEAD`. `branchDiffFiles`'s scope decision is
+based on committed changes only. Pre-push does not require a clean tree, so
+an uncommitted edit outside the allowlist (e.g. to `server/vitest.config.ts`)
+would be invisible to the allowlist check but present in vitest's actual
+selection — reopening the exact "diff touches this step but isn't
+`--changed`-reachable" hazard the allowlist exists to close. Fixed by
+checking `git status --porcelain` for the step's own tree alongside the
+committed diff before allowing substitution; a dirty tree in scope forces the
+full run, same conservative default as everywhere else in this design.
+
+**Invocation — bypasses npm-script nesting.** `runStepProcess` gains a
+direct-invocation mode: spawn `npx vitest run --changed <sha>` with `cwd` set
+to the step's own directory (`server/` for `test:server`, repo root for
+`test`), pinned to the local binary (`<cwd>/node_modules/.bin/vitest`,
+falling back to `npx` only if that path doesn't exist) rather than bare
+`npx vitest`, so a missing/un-junctioned `node_modules` fails loudly with
+"vitest not found" as documented, instead of `npx` silently resolving a
+different version from the registry. `retryKey` stays `step.name`, so the
+existing fork-pool-crash retry logic (keyed on `step.name`, not on which
+invocation shape ran) is untouched.
+
+**The server suite's `pretest` preflight must not be silently dropped.**
+`server/package.json` runs `node ../scripts/preflight-ffmpeg.cjs` as
+`pretest`/`pretest:changed` before every existing `test:server` invocation
+path. Bypassing the npm-script wrapper for direct invocation would silently
+skip it. The direct-invocation path runs the same preflight script itself,
+first, before spawning vitest — same check, same failure shape, just called
+directly instead of via npm's lifecycle-script convention.
 
 **Cache-write gate.** Unchanged in shape: a `--changed`-only pass (staged or
 branch) is never written to the verify-cache; only a full run is.
 
-**A2 — CI's own `--changed` gets the allowlist too.** `scripts/ci-scope.mjs`
-today emits one boolean per step (`step_test_server`, etc. — "does this leg's
-scope intersect the diff at all") via `stepTouchedByDiff`, consumed by
-`verify.yml`'s `if:` conditions to decide whether a job step *runs*; the
-`--changed "$BASE"` vs. full-`vitest run` choice *inside* an in-scope step is
-then hardcoded inline in the workflow YAML, keyed only on `shared`. Add a
-second boolean per changed-only-eligible step —
-`step_test_server_changed_safe: diffSafeForChangedOnly(testServerStep,
-files)`, `step_test_changed_safe` likewise — computed in `ci-scope.mjs` from
-the same `files` list already diffed against the PR base, using the same
-exported `diffSafeForChangedOnly` function Decision A1 uses locally (single
-source of truth, no duplicated logic). `verify.yml`'s `test`/`test:server`
-step bodies gain a third branch: `shared` → full run (unchanged); else
-`changed_safe` → `--changed "$BASE"` (unchanged shape, now gated); else → full
-run (new — today this case silently narrows). `workflow_dispatch` and the
-`ci-scope.mjs` crash fail-safe already default every scope boolean to `true`,
-which correctly forces the full-run branch here too (a `true` scope with an
-unset/`undefined` `changed_safe` boolean must read as "not safe" — verified
-by how the new field composes with the existing `allTrue()`/fail-safe paths,
-pinned by a test rather than inspection alone).
+### A2 — fix CI's `shared`-scope diffs actually forcing a full run (found in passing)
 
-**Docs.** CLAUDE.md's Commit gate section and `docs/features/
-156-precommit-scope-contention.md` currently state, as a decision, that
-pre-push's unscoped run is deliberately the full local safety net *because*
-CI narrows its own runs (plan 156's own acceptance item: "Pre-push runs the
-full battery; only pre-commit is scope-filtered"). That decision is reversed,
-not reframed — plan 156 gets a dated addendum recording the reversal and its
-reasoning (the same treatment its 2026-09-01 addendum from PR #2839 already
-used), and its acceptance criteria are updated to match, not left stale next
-to contradicting prose. Replacement invariant, stated plainly: local runs
-(pre-commit and pre-push) narrow via `--changed` whenever the diff is
-confined to source; CI's own narrowing now carries the identical allowlist
-protection (A2); the twice-weekly cross-OS cron and release-time full
-`verify` are the periodic backstops for the narrow residual class no
-`--changed`-based mechanism can close by construction (a source-only diff
-that reaches a test through a non-import runtime edge). **None of this
-extends to GPU/hardware-dependent testing** — `test:golden-audio` and any
-weights-gated `test:sidecar` case were never run in CI (GitHub-hosted runners
-have no GPU) and are unaffected by any of A1/A2; they remain opt-in, run
-locally on demand via their existing flags, exactly as documented today. This
-line is added explicitly to CLAUDE.md's Commit gate section so "CI is now the
-full-suite gate" can't be misread as "CI covers hardware-dependent behavior
-too" — it never did.
+Not a new mechanism — a pre-existing bug, unrelated to A1's allowlist,
+surfaced while reading `verify.yml` for this spec. `verify.yml`'s `test`/
+`test:server` step bodies decide narrowed-vs-full only on whether `$BASE` is
+set (`if [ -n "$BASE" ]; then --changed; else full; fi` — `$BASE` is only
+empty on `workflow_dispatch`). The `shared` scope boolean
+(`needs.detect.outputs.scopes.shared`, from `computeShared` — true for a
+root-manifest/lockfile/`.github/actions/**` change) controls whether the
+**job step runs at all**, but never reaches this narrowed-vs-full choice
+**inside** the step body — so a `shared`-scope PR (e.g. touching only
+`server/package-lock.json`) still runs `--changed "$BASE"`, and neither
+`package-lock.json` nor `.github/actions/**` appears in
+`server/vitest.config.ts`'s `forceRerunTriggers`, so that `--changed` call
+can select zero tests and report green. Fix: thread the same `shared`
+boolean already available in `needs.detect.outputs.scopes` into the step
+body's condition — `shared` (or an empty `$BASE`) → full run; otherwise
+`--changed "$BASE"`, unchanged from today. One conditional per affected step
+(`test`, `test:server`/`test:server-slow`'s shared body). This is a defect
+fix with one correct outcome, not a design decision, so it's fixed here
+rather than filed.
 
-### B — widen the real-timer margins that made this fail
+### B — widen `file-lock.test.ts`'s confirmed-thin margins, as a no-regret hardening
 
-`quarantinedIt` (`server/src/test-utils/quarantine.ts`) skips in **both**
-gating lanes — local and CI. Wrong tool: these tests are correct and pass
-reliably in isolation, so quarantining would silently drop real coverage from
-CI forever to solve a problem that's purely about this box's local
-contention. Fix the fragility instead.
+Not claimed to be proven-confirmed as this specific incident's root cause —
+no failure log from the three runs was captured, and the repo separately
+documents fork-pool crashes retrying the whole step up to 3x under
+contention (`MAX_POOL_ATTEMPTS`) as a plausible independent or compounding
+cause that this fix does not touch. Shipped anyway because the fragility is
+real and unambiguous on its own terms, independent of whether it explains
+this incident.
 
-**Scope — corrected.** `server/src/workspace/file-lock.test.ts` is the only
-confirmed instance: several tests in its two `{ retry: 0 }` `describe` blocks
-race a short lock-acquisition-timeout budget (20ms) against a longer holder
-(30-200ms) to assert relative ordering. **The draft also named
-`cast-lock.test.ts` and `server/src/tts/design-lock.test.ts` as same-shape
-siblings; review read both in full and found neither shares the pattern** —
-`cast-lock.test.ts`'s timers are failure sentinels (a 2000ms/1000ms ceiling
-racing critical sections that finish in ~0ms, three orders of magnitude of
-headroom, the opposite of thin) and its 2000ms sentinel is *deliberately*
-calibrated to fire well before the production `withKeyLock` 10s budget — its
-own comment says so; `design-lock.test.ts` orders exclusively via explicit
-promise gates, not competing timers, and doesn't call `withKeyLock` at all
-(`design-lock.ts` has its own separate lock map). **Both are dropped from
-this fix's scope entirely** — touching either would violate "Surgical
-changes," and mechanically widening `cast-lock.test.ts`'s sentinel past the
-production 10s budget it's deliberately calibrated under would change what
-failure mode the test actually observes.
+**Scope, corrected to the three tests that actually race.**
+`server/src/workspace/file-lock.test.ts`'s `withKeyLock acquisition timeout
+(#2260)` `describe` block (`{ retry: 0 }`) has five tests; only three
+actually race a short timeout against a real, finishing holder:
 
-**The fix is an absolute-margin floor, not a ratio.** The draft's "~10x
-headroom" framing is wrong on its own evidence: the existing 20ms-vs-200ms
-pair is already a 10x ratio and it's one of the ones that flaked, while a
-20ms-vs-30ms pair (a 1.5x ratio, comfortably passing in the same file today
-because nothing times out on that path) shows ratio isn't the load-bearing
-quantity — the *absolute* gap between "when the short timer fires" and "when
-the long one finishes" is what has to survive scheduler jitter. Target: widen
-each racing pair so the absolute gap is at least ~500ms (this box's observed
-contention window under 39+ concurrent processes gave no precise jitter
-figure, so 500ms is a deliberately generous floor, not a measured one) —
-e.g. a 20ms timeout racing a 150ms holder becomes something like a 50ms
-timeout racing a 600ms+ holder. Tuned per test during implementation; each
-widened pair gets a short comment recording the new absolute gap and that
-it's deliberate, matching this file's existing comment-heavy convention.
+- `'does not poison the key after a timeout...'` — 20ms waiter budget vs.
+  150ms holder.
+- `'does not let a later caller barge past a still-running holder...'` —
+  20ms vs. 200ms holder.
+- `'leaves exactly one chains entry after a timeout...'` — 20ms vs. 150ms
+  holder.
 
-**Search predicate for "did we miss another instance," corrected.** Not "any
-competing real `setTimeout`" (a repo-wide grep on that shape returns 141
-occurrences across 52 files, mostly plain "wait long enough" delays with no
-race and no jitter sensitivity). The predicate that actually explains why
-this file's failures were *visible* rather than silently rescued is
-**"competing real timers asserting ordering, inside a `{ retry: 0 }` block"**
-— vitest's suite-wide `retry: 1` (`#2028`'s documented reason `file-lock.
-test.ts` itself opts out of it) would otherwise absorb a one-off jitter flake
-silently. If implementation finds another file matching that narrower
-predicate, it's fixed in the same round per CLAUDE.md's incidental-findings
-rule; a file with the broader "has a setTimeout" shape but ordinary retry
-semantics is not in scope.
+The other two in the same block are **not** touched: `'throws instead of
+hanging when acquisition deadlocks...'` and the `withKeyLock typed timeout
+error` block's test race a 20/50ms timeout against a holder that **never
+releases** — there's no finishing-holder deadline to jitter past, so no
+amount of contention flips their outcome, and the typed-error test asserts
+the literal constant (`timeoutMs).toBe(20)`, message `'timed out after
+20ms'`) that a mechanical margin-widening pass would otherwise break.
+`'does not fire for legitimate contention comfortably under budget'` (20ms
+hold vs. 500ms budget) already has enough headroom and isn't touched either.
 
-**What this does not do.** No switch to `vi.useFakeTimers()`. Higher blast
-radius than this incident calls for; worth revisiting only if margin-widening
-turns out not to hold up.
+`cast-lock.test.ts` and `design-lock.test.ts` were considered in an earlier
+draft and dropped after being read in full: neither races two competing real
+timers for an ordering assertion. `cast-lock.test.ts`'s timers are failure
+sentinels (a 2000ms/1000ms ceiling racing critical sections that finish in
+~0ms — three orders of magnitude of headroom, the opposite of thin) and its
+2000ms sentinel is deliberately calibrated, by its own comment, to fire
+before the production `withKeyLock` 10s budget; widening it would falsify
+that relationship. `design-lock.test.ts` orders via explicit promise gates
+against its own separate lock map (`design-lock.ts`, not `withKeyLock`) — its
+few `setTimeout` uses are 5ms macrotask-flush ticks, not races. Neither is
+touched.
+
+**Fix is an absolute-gap floor, not a ratio.** A 20ms-vs-200ms pair is
+already a 10x ratio and it's one of the three that's fragile — ratio isn't
+the load-bearing quantity, the *absolute* gap between "when the short timer
+could plausibly fire under jitter" and "when the long one finishes" is.
+Target ≥500ms of absolute gap for each of the three pairs (a deliberately
+generous floor — this box's actual jitter under the reported 39+-process
+contention was never measured, so it's chosen with margin rather than
+tightly calibrated), e.g. 20ms→50ms budget racing 150ms→700ms holder. Total
+added wall-clock to the file: roughly +1.5s across the three widened
+`await`s, serial, negligible.
+
+**Search for other instances — corrected to the predicate that actually
+explains why this file's failures were visible.** Not "any competing real
+`setTimeout`" (141 occurrences across 52 files repo-wide, almost all plain
+"wait long enough" delays with no race). The reason these three tests'
+failures would surface as loud, specific red rather than being silently
+absorbed is that their `describe` block opts out of the suite-wide `retry: 1`
+(`{ retry: 0 }`, `#2028`'s documented reason: this file's module-level
+`chains` state must never be silently rescued by a retry). The repo already
+has the right instrument for finding this class rather than a fresh manual
+grep: `server/vitest.config.ts`'s `retryHazardReporter` flags exactly the
+"passed only because the suite-wide retry rescued it" case, and the file
+records a prior `--retry=0` survey having been run across the suite. Rerun
+that survey (or read its most recent output if still current) as part of
+implementation to enumerate any other genuinely-masked-by-retry timing races,
+rather than trusting a narrower manual grep to be exhaustive. Anything it
+turns up in this same fragile-race shape is fixed in the same round per
+CLAUDE.md's incidental-findings rule.
+
+**What this does not do.** No switch to `vi.useFakeTimers()` — higher blast
+radius than this fix calls for.
 
 ### C — `test:sidecar` (pytest): investigated, deliberately out of scope
 
-Considered for the same narrowing since it's the third locally-gating test
-leg. Sized it first: `server/tts-sidecar/tests/` has **1120** `test_*`
-functions across **83** files — an order of magnitude smaller than
-`test:server`'s 8000+, and the CI-gating tier is CPU-only/mocked (SKIPs+exits
-0 on an unbootstrapped venv per CLAUDE.md), so it isn't the leg producing
-70-80 minute runs or the lock-timing failures this incident is about. Unlike
+`server/tts-sidecar/tests/` has **1136** `test_`-prefixed functions (`def
+test_`/`async def test_`) across **83** files — an order of magnitude
+smaller than `test:server`'s 8000+, and the CI-gating tier is
+CPU-only/mocked, so it isn't the leg producing 70-80 minute runs. Unlike
 vitest, pytest has no built-in `--changed`-equivalent; the closest analogues
-(`pytest-testmon`, `pytest-picked`) are new dependencies with their own
-correctness model, meriting their own evaluation rather than a small
-extension of this spec's vitest-specific mechanism. Left for a future round
-if `test:sidecar` itself ever becomes the bottleneck. This decision is
-unrelated to, and doesn't affect, the GPU/hardware carve-out in Decision A's
-Docs subsection — sidecar's weights-gated tests were already opt-in before
-this spec and stay that way regardless of C's outcome.
+(`pytest-testmon`, `pytest-picked`) are new dependencies meriting their own
+evaluation. Left for a future round if `test:sidecar` itself ever becomes the
+bottleneck. Unrelated to, and doesn't affect, the GPU/hardware carve-out
+below — sidecar's weights-gated tests were already opt-in before this spec.
 
 ### D — increase cloud e2e sharding
 
@@ -256,65 +277,72 @@ this spec and stay that way regardless of C's outcome.
 (`matrix.shard: [1, 2, 3, 4]`, `--shard=${{ matrix.shard }}/4`), cutting a
 ~16 min unsharded run to ~4 min/shard. Raise it to **8-way**: matrix array →
 `[1, 2, 3, 4, 5, 6, 7, 8]`, both `--shard=N/4` references (the `test:e2e`
-step only — `test:e2e:visual` in the neighboring job isn't sharded today and
-stays that way, out of scope) → `/8`, job name label → `/8`. Standard
-GitHub-hosted runners are free/uncapped for this public repo, so the real
-constraint is fixed per-shard cost that doesn't shrink with more shards —
-**corrected from the draft**, that cost isn't just checkout/setup/Playwright
-cache: `playwright.config.ts`'s `chromium` project depends on a `warmup`
-project (the Vite transform-cache warm-up in `e2e/warmup.setup.ts`), and
+step only — `test:e2e:visual` isn't sharded today and stays that way) → `/8`,
+job name label → `/8`. Standard GitHub-hosted runners are free/uncapped for
+this public repo, so the real constraint is fixed per-shard cost that
+doesn't shrink with more shards: `playwright.config.ts`'s `chromium` project
+depends on the `warmup` project (Vite transform-cache warm-up), and
 `webServer.reuseExistingServer: !CI` means every shard boots its own Vite dev
-server — both run once per shard and double when shards double. Spec count
-corrected too: `e2e/**/*.spec.ts` is **137** files, not ~110, so 8-way is
-~17/shard, not ~14. 8-way is still a reasonable stopping point before
-per-shard fixed cost dominates, but the exact number is a tuning call to
-confirm with a real timing comparison during implementation, the same method
-the existing 4-way split's own comment cites — not something pinned exactly
-here.
+server — both run once per shard and double when shards double. `e2e/**/
+*.spec.ts` is **137** files (not the ~110 the job's own 2026-07-10 comment
+cites), so 8-way lands at ~17/shard. **Also fixed in the same diff**: two
+further prose comments in `verify.yml` (the job's rationale block, and its
+own header comment) that repeat both the stale `4`-way figure and the stale
+`~110 spec files` count — a comment the change makes false is a chore this
+repo's own rules already say is owed, not a separate follow-up. 8-way is a
+reasonable stopping point before fixed per-shard cost dominates; exact number
+confirmed with a real timing comparison during implementation, the same
+method the original 4-way split's comment cites.
 
 ## Testing
 
 - `scripts/tests/verify-cache.test.mjs`: source-regex cases (mirroring
-  PR #2839's staged-scope tests) pinning the widened gate condition and the
-  cache-write exclusion for branch-scope changed-only passes. **Additionally
-  — the review's strongest finding was that source-regex tests can't catch a
-  broken invocation, only a missing one**: add at least one test that
-  actually spawns the new direct-invocation path (`npx vitest run --changed
-  <sha>` with `cwd` set appropriately) against a disposable fixture — enough
-  to prove the command as constructed actually forwards `--changed` and
-  actually selects a subset, not just that the source text mentions the right
-  strings. This is new territory for this file's existing "no process
-  execution" convention and is called out explicitly rather than silently
-  matching the old style.
-- `scripts/ci-scope.mjs`'s existing test file: cases for the new
-  `*_changed_safe` fields — safe diff, diff outside the allowlist, empty
-  diff, and `workflow_dispatch`/fail-safe paths (must read as "not safe",
-  pinned directly rather than inferred).
-- `server/src/workspace/file-lock.test.ts`: no new test cases — existing
-  assertions unchanged, only the millisecond constants widen, each with a
-  comment recording the new absolute gap.
+  PR #2839's staged-scope tests) for the widened gate condition, the
+  `docs/**`/`RELEASE_NOTES.md` allowlist addition, the dirty-working-tree
+  check, and the cache-write exclusion for branch-scope changed-only passes.
+  **Additionally** — a source-regex test can't catch a broken invocation,
+  only a missing one (round 1's finding) — add a test that actually spawns
+  the new direct-invocation path against a small disposable fixture repo (not
+  this repo's own tree, to avoid the spawned vitest itself tripping
+  `detectSiblingContention`'s process-count probe if this test ever ran
+  inside a `test:hooks`-style pre-commit leg) confirming it forwards
+  `--changed` correctly and actually narrows the selection.
+- `.github/workflows/verify.yml`'s A2 fix: no unit test (workflow YAML) —
+  verified by a manual `gh workflow run verify.yml --ref <branch>` dispatch
+  against a deliberately root-lockfile-only diff, confirming the full suite
+  runs rather than a narrowed `--changed` pass.
+- `server/src/workspace/file-lock.test.ts`: no new test cases for the three
+  widened pairs — existing assertions unchanged, only the millisecond
+  constants widen, each with a short comment recording the new absolute gap.
 - Manual: run the new direct-invocation command for both `test` and
-  `test:server` against a real narrow branch locally, confirm each selects a
+  `test:server` against a real narrow branch locally, confirm it selects a
   proper subset and exits nonzero on a genuine failure.
-- `.github/workflows/verify.yml`'s e2e shard change and the A2 `changed_safe`
-  branching: no unit test for the workflow YAML itself — verified by a
-  manual `gh workflow run verify.yml --ref <branch>` dispatch, reading the
-  job list (8 shard jobs, each completing) and confirming a
-  known-`changed_safe`-diff PR actually took the narrowed path in the logs.
+- `.github/workflows/verify.yml`'s e2e shard change: verified by a manual
+  `gh workflow run` dispatch, confirming 8 shard jobs appear and complete.
 
 ## Out of scope
 
 - Auditing all 141 `setTimeout`-in-server-test occurrences for margin safety
-  — only the confirmed lock-ordering-race-under-`retry:0` shape is in scope.
+  — only the three confirmed fragile-race-under-`retry:0` pairs are in
+  scope; the rest is covered by rerunning the repo's own `retryHazardReporter`
+  survey instead of a fresh manual sweep.
 - Any change to the production `withKeyLock`/`file-lock.ts` timeout values —
   test-fragility fix, not a behavior change.
 - `cast-lock.test.ts`, `design-lock.test.ts` — confirmed not to share the
   fragile shape; not touched.
-- Extending the `--changed`-substitution *mechanism* to any step besides
-  `test`/`test:server` (local or CI) — `test:sidecar` evaluated and
-  deliberately deferred, see Decision C.
+- Forcing CI's own `--changed` narrowing onto the strict
+  `diffSafeForChangedOnly` allowlist (the original Decision A2) — dropped
+  after measurement showed it would regress CI's current, looser, working
+  narrowing far more than the ~5%-hit-rate local change's residual risk
+  justifies. `test:server-slow`'s CI narrowing is likewise unchanged.
+- Extending the `--changed`-substitution mechanism to any step besides
+  `test`/`test:server` — `test:sidecar` evaluated and deliberately deferred,
+  see Decision C.
 - Sharding `test:e2e:visual`, or changing its `--workers=1` anti-flake
   constraint.
 - Any change to GPU/hardware-dependent test tooling (`test:golden-audio`,
-  weights-gated sidecar tests, the on-box acceptance register) — explicitly
-  unaffected, see Decision A's Docs subsection.
+  weights-gated sidecar tests, the on-box acceptance register) — never ran in
+  CI, unaffected by anything in this spec, stays local-only.
+- Determining, retroactively, which mechanism (timing fragility vs. fork-pool
+  crash retries) actually caused the reported three-failure incident — no
+  log was captured; Decision B ships as a no-regret hardening regardless.

--- a/docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md
+++ b/docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md
@@ -36,7 +36,7 @@ does not fix:
    developer who wants a quick local check of just the area they're touching
    has no way to do that short of the full leg or hand-typing a
    `vitest run <path>` invocation.
-5. **Local pre-push volume — investigated, explicitly NOT fixed this round.**
+5. **Local pre-push volume — investigated and declined, not deferred.**
    Pre-push runs `test`/`test:server` unscoped whenever the branch diff
    touches either leg's tree (8201 tests for `test:server` alone), no
    `--changed` narrowing. See "Considered and declined" below for why: the
@@ -91,12 +91,16 @@ machinery's cost and its measured benefit doesn't clear this repo's
 suite exactly as it does today — no regression, no change — and this
 section exists so the idea isn't silently re-proposed without the
 measurement that killed it. Revisiting it later would need either a
-materially different allowlist design (see Decision A2's design-pass note
+materially different allowlist design (see Decision A's design-pass note
 for the adjacent, still-open question of what property actually guarantees
 `--changed` selects correctly) or evidence that this repo's branch shapes
 have changed enough to move the hit rate.
 
-## Decision A2 — CI's zero-test-selection hazard: real, found in passing, filed as a design-pass item
+## Decision A — CI's zero-test-selection hazard: real, found in passing, filed as a design-pass item
+
+(Labeled "A" rather than "A2" — there is no "A1" in this document; the
+branch-scope narrowing project that number originally paired with was
+declined above, not shipped.)
 
 Independent of the narrowing question above — found while reading
 `.github/workflows/verify.yml` during this investigation, not caused or
@@ -106,41 +110,61 @@ step bodies decide narrowed-vs-full only on whether `$BASE` is set (`if [ -n
 `workflow_dispatch`), never on the `shared` scope boolean
 (`needs.detect.outputs.scopes.shared`, from `computeShared` — true for a
 root-manifest/lockfile/`.github/actions/**` change) that's already computed
-and available. Two confirmed live instances where this lets a step run
-`--changed "$BASE"` over a diff that selects zero tests and reports green:
+and available. One confirmed live instance where this lets a step run
+`--changed "$BASE"` over a diff that selects zero tests and reports green,
+and one already-covered case that round 5 review found was never actually a
+hazard:
 
-1. A `shared`-scope PR (root `package.json`/`package-lock.json`,
-   `.github/actions/**`) — `shared` is `true` but the step body never checks
-   it.
-2. A `server/package-lock.json`-only PR — `computeShared` only matches the
-   *root* lockfile/manifest, so this diff is **not** `shared`; it reaches
-   `step_test_server` through a separate `includeLockfiles` branch and stays
-   narrowed regardless. Neither `package-lock.json` nor
-   `server/package-lock.json` appears in `server/vitest.config.ts`'s
-   `forceRerunTriggers`.
+1. **Confirmed hazard — `test:server`/`test:server-slow` only.** A
+   `server/package-lock.json`-only PR: `computeShared` matches only the
+   *root* lockfile/manifest and `.github/actions/**`, so this diff is
+   **not** `shared` — it reaches `step_test_server` through a separate
+   `includeLockfiles` branch and stays narrowed regardless, and neither
+   `package-lock.json` nor `server/package-lock.json` appears in
+   `server/vitest.config.ts`'s `forceRerunTriggers`. The frontend step is
+   not exposed to this one at all (it has no server-lockfile trigger to
+   miss).
+2. **Root `package.json` — not actually a hazard, corrected.** An earlier
+   draft of this spec listed a root-`package.json`/`.github/actions/**`
+   `shared`-scope diff as a second instance, on the theory that `shared`
+   being `true` doesn't stop the step body still trying `--changed`. Round 5
+   review found this doesn't hold for `package.json` specifically: both
+   `vitest.config.ts` and `server/vitest.config.ts` already carry
+   `'{**/package.json,**/.*/**/package.json}'` in their `forceRerunTriggers`
+   — `server/vitest.config.ts`'s own comment records the measured proof
+   (stripped, a root-manifest diff selects 0 tests; restored, 5389). A bare
+   root `package-lock.json`-only or `.github/actions/**`-only diff is
+   **still** an unprotected `shared`-scope gap (neither is a trigger,
+   either), but it's a narrower case than "any shared-scope diff," and per
+   the same `test:a11y`-runs-unconditionally reasoning that ruled out the
+   `e2e/**`-only case below, it isn't a frontend hazard either — `test:a11y`
+   still does real work regardless of what `--changed` selects. So this
+   collapses into instance 1's shape: server-side lockfile/composite-action
+   diffs, `test:server`/`test:server-slow` only.
 
-(An earlier draft of this spec also listed an `e2e/**`-only diff scheduling
-the frontend step as a third instance — **that turned out not to be a real
-hazard**: the frontend step also runs `npm run test:a11y` unconditionally,
-so the step still does real work even when `--changed` selects nothing from
-vitest. Dropped from the count.)
+(An earlier draft also listed an `e2e/**`-only diff scheduling the frontend
+step as a third instance — **not a real hazard**: the frontend step runs
+`npm run test:a11y` unconditionally, so it still does real work regardless
+of what `--changed` selects. Dropped from the count.)
 
 `test:server-slow` shares `test:server`'s step body (same `if:`, same
 narrowing logic), so whatever the eventual fix is, it applies there too —
-not a third independent instance, just a consequence of the shared body.
+not a separate instance, just a consequence of the shared body.
 
 The correct unifying rule — something like "narrow only when every touched
 file is covered by that config's own `forceRerunTriggers`" — is a real
 design decision spanning both vitest configs, not a mechanical one-liner: a
 naive `shared`-only fix (tried and rejected in an earlier draft) doesn't
-cover instance 2. Per CLAUDE.md's incidental-findings rule, this is the one
-class of finding that's filed rather than fixed in the same round — it needs
-a design pass, and the decision it's waiting on is named here: *what
-property of a diff actually guarantees `--changed <base>` selects a correct,
-non-empty test set for a given vitest config, given that config's own
-`forceRerunTriggers` list.* File as its own issue at implementation time;
-this is a pre-existing hazard, unaffected by anything else in this spec —
-no worse than before.
+cover the server-lockfile case. Per CLAUDE.md's incidental-findings rule,
+this is the one class of finding that's filed rather than fixed in the same
+round — it needs a design pass, and the decision it's waiting on is named
+here: *what property of a diff actually guarantees `--changed <base>`
+selects a correct, non-empty test set for a given vitest config, given that
+config's own `forceRerunTriggers` list.* File as its own issue at
+implementation time, scoped to the server-side lockfile/composite-action gap
+— not to root `package.json` (already protected) or the frontend leg
+(already protected by `test:a11y`); this is a pre-existing hazard,
+unaffected by anything else in this spec — no worse than before.
 
 ## Decision B — widen `file-lock.test.ts`'s thin-looking margins, as harmless hardening
 
@@ -148,18 +172,28 @@ Not claimed to be proven-confirmed as this specific incident's root cause,
 and — after two more rounds of scrutiny — **not claimed to be confirmed
 fragile at all**. Round 3 couldn't confirm actual fragility under
 measurement (no repro attempted, no jitter figure captured). Round 4 raised
-a more direct challenge: `file-lock.ts`'s acquisition timer is armed
-synchronously at `withKeyLock` entry, the holder's `setTimeout` is armed one
-microtask later, and Node fires expired timers in arrival order — meaning a
-uniform event-loop stall delays both timers roughly together and *preserves*
-the ordering these assertions depend on, rather than threatening to flip it.
-Under that reading, these margins may not be a real defect at all. **Owner
-decision: ship the widening anyway, as cheap (~+1.5s total), no-regret
-insurance** — it costs almost nothing, and the theoretical case against
-fragility isn't airtight either. This is explicitly not a claim that a
-mechanism has been identified or a bug fixed; it's cheap insurance against
-an unconfirmed but plausible-looking risk, stated as such rather than
-oversold.
+a more direct challenge, and round 5 corrected the mechanism it names:
+`file-lock.ts`'s acquisition timer is armed synchronously at `withKeyLock`
+entry, the holder's `setTimeout` is armed one microtask later — and Node
+does not dispatch timers by arrival order, it dispatches by **expiry time**.
+For a 20ms timer armed fractionally before a 150/200ms one, expiry order and
+arrival order agree here, and a uniform event-loop stall delays both
+roughly together, which *preserves* the ordering these assertions depend on
+rather than threatening to flip it — if anything a stronger guarantee than
+"arrival order" would have implied. Under that reading, these margins may
+not be a real defect at all, and the case against fragility is more solid
+than an earlier draft of this section stated. **Owner decision: ship the
+widening anyway, as cheap (~+1.5s total) insurance** — three integer
+literals is a low enough cost that shipping it doesn't need the mechanism
+to be airtight, even though — unlike Decision "considered and declined"
+above, which was killed on a materially larger cost for a similarly small
+measured benefit — this section can't point to a concrete failure mode the
+change closes. That asymmetry (declined there, shipped here) is a real,
+deliberate call on cost alone, not a claim that a mechanism has been
+identified or a bug fixed here. One real cost, not free: widening test 1's
+holder to ~700ms cuts that same test's *second* timing pair (below) from
+~1870ms of headroom to ~1350ms — still comfortable, but a genuine trade, not
+a pure add.
 
 **Scope, corrected to the three tests that actually race.**
 `server/src/workspace/file-lock.test.ts`'s `withKeyLock acquisition timeout
@@ -168,9 +202,8 @@ actually race a short timeout against a real, finishing holder:
 
 - `'does not poison the key after a timeout...'` — 20ms waiter budget vs.
   150ms holder. **This test has a second timing pair** (a later `2000`ms
-  budget racing the same holder, lines ~140-143) — widening the holder to
-  ~700ms shrinks that second pair's own headroom from ~1850ms to ~1300ms;
-  still comfortable, but not "only the first pair changes," and an
+  budget racing the same holder, lines ~140-143, the ~1870ms→~1350ms
+  headroom trade noted above) — not "only the first pair changes," and an
   implementer widening mechanically must account for both.
 - `'does not let a later caller barge past a still-running holder...'` —
   20ms vs. 200ms holder.
@@ -210,17 +243,30 @@ for each of the three pairs (a deliberately generous, unmeasured floor), e.g.
 file: roughly +1.5s across the three widened `await`s, serial, negligible.
 
 **No further search for other instances.** The repo has exactly **four**
-`{ retry: 0 }` blocks total — three in `file-lock.test.ts` (all covered
-above), one in `design-lock.test.ts` (confirmed above not to race). That is
-the complete population of "a timing test whose failure wouldn't be silently
-absorbed by the suite-wide `retry: 1`," and all four have already been read
-in full for this spec. `server/vitest.config.ts`'s `retryHazardReporter` is
-**not** a usable instrument for finding more instances — it only reports
-tests *rescued* by `retry: 1`, which by construction excludes every
-`{ retry: 0 }` block; running it would survey the wrong population (and
-would itself require the very 70-80-minute battery this spec is trying to
-shrink). A blanket audit of the repo's 141 other `setTimeout`-in-server-test
-occurrences is correspondingly out of scope — see Out of scope.
+`{ retry: 0 }` blocks total, all already read in full for this spec:
+
+- `file-lock.test.ts:37` — `describe('withKeyLock', { retry: 0 })`, three
+  tests. Not discussed above because none of the three race two competing
+  timers: the ordering assertions in this block (e.g.
+  `expect(order.indexOf('b-end')).toBeLessThan(order.indexOf('a-end'))`)
+  race a real `setTimeout` against a fully **synchronous** competing branch
+  — nothing to widen, no margin exists to be thin.
+- `file-lock.test.ts:81` — `describe('withKeyLock acquisition timeout
+  (#2260)', { retry: 0 })`, five tests, three of which are the widened pairs
+  above.
+- `file-lock.test.ts:224` — the separate `withKeyLock typed timeout error`
+  block, one test, not touched (races an infinite holder — see above).
+- `design-lock.test.ts:29`, one test, confirmed above not to race.
+
+That is the complete population of "a timing test whose failure wouldn't be
+silently absorbed by the suite-wide `retry: 1`." `server/vitest.config.ts`'s
+`retryHazardReporter` is **not** a usable instrument for finding more
+instances — it only reports tests *rescued* by `retry: 1`, which by
+construction excludes every `{ retry: 0 }` block; running it would survey
+the wrong population (and would itself require the very 70-80-minute
+battery this spec is trying to shrink). A blanket audit of the repo's 141
+total `setTimeout`-in-server-test occurrences (6 of which are in
+`file-lock.test.ts`) is correspondingly out of scope — see Out of scope.
 
 **What this does not do.** No switch to `vi.useFakeTimers()` — higher blast
 radius than this fix calls for.
@@ -249,11 +295,15 @@ isn't sharded today and stays that way), and the job `name:` label → `/8`.
 **Cost caveat, more complete than an earlier draft's.** Standard
 GitHub-hosted Actions *minutes* are free/uncapped for this public repo, but
 that's not the only constraint: (a) accounts have a **concurrent job slot**
-ceiling separate from the minutes budget — 8 shards means 8 concurrent `e2e`
-jobs (16 once `test:e2e:visual`'s job and others are counted alongside), and
-if that ceiling is hit, shards queue rather than run in parallel, which
-would blunt exactly the wall-clock win this decision is for; worth watching
-after shipping, not assumed away. (b) The `e2e` job's `Checkout` and
+ceiling separate from the minutes budget, exact number not established here
+— 8 shards means 8 concurrent `e2e` jobs, plus whatever else the workflow's
+other jobs (build, server-tests, frontend-tests, etc.) add concurrently
+(`detect` finishes first and the `verify` aggregator runs last, so this
+isn't simply "every job at once"); if the account's ceiling is hit, shards
+queue rather than run in parallel, which would blunt exactly the wall-clock
+win this decision is for — worth checking against the account's actual
+limit and watching real PR timing after shipping, not assumed away. (b) The
+`e2e` job's `Checkout` and
 `Setup Node + deps` steps carry **no `if:` scope condition** — they run on
 every shard unconditionally, including on a docs-only PR where every other
 leg in the job is scoped-off. Doubling the shard count doubles that fixed
@@ -265,10 +315,14 @@ double when shards double — the real per-shard fixed cost is higher than
 "just checkout and Playwright browser install."
 
 `e2e/**/*.spec.ts` is **137** files (not the ~110 the job's own 2026-07-10
-comment cites), so 8-way lands at ~17/shard. **Also fixed in the same
-diff**: two further prose comments in `verify.yml` (the job's rationale
-block, and its own header comment) that repeat both the stale `4`-way figure
-and the stale `~110 spec files` count. 8-way is still a reasonable stopping
+comment cites — note `--shard` splits by *test*, not file, since
+`playwright.config.ts` sets `fullyParallel: true`, so this file count is an
+approximation of shard balance, not the number Playwright actually uses to
+split), so 8-way lands at ~17 files/shard. **Also fixed in the same diff**:
+that job comment itself, plus **one further** site — the file's own header
+comment near the top of `verify.yml` — both currently repeating the stale
+`4`-way figure and the stale `~110 spec files` count. 8-way is still a
+reasonable stopping
 point given the fixed-cost caveats above; exact number confirmed with a real
 timing comparison during implementation, the same method the original
 4-way split's comment cites — and worth a follow-up look at actual PR
@@ -286,9 +340,15 @@ by top-level subdirectory:
 
 - `test:server` (8201 tests total): `routes` 2314 tests/138 files, `tts`
   1908/123, `analyzer` 1321/73, `workspace` 766/57 — those four are 76.9% of
-  the leg (6309/8201), everything else smaller.
-- `test` (frontend, 4769 tests total): `components` 1192/112, `store`
-  1130/52, `lib` 1046/102, `views` 828/29.
+  the leg (6309/8201), everything else smaller (largest unwired,
+  `src/store`, is 459).
+- `test` (frontend, **4923** tests total — corrected from an earlier
+  draft's 4769, which was a raw `it(`/`test(` grep undercounting `it.each`
+  expansions rather than an actual `npx vitest list` run despite this
+  section's own opening sentence): `components` **1208**/112, `store`
+  **1135**/52, `lib` **1074**/102, `views` **832**/29. File counts (112/52/
+  102/29) were already correct in the earlier draft; only the test counts
+  were stale.
 
 (`routes`'s file count is 138, not the 146 a raw `find` would report — 8 of
 `server/src/routes/`'s test files are in `server/vitest.config.slow.ts`'s
@@ -360,7 +420,7 @@ already small enough that running the full leg or a plain
   the path bug round 4 found is exactly the kind of thing that must be
   checked by running the command, not inferred). CLAUDE.md's Commands
   section gets a bullet listing them.
-- Decision A2: no test this round — filed as an issue, not implemented.
+- Decision A: no test this round — filed as an issue, not implemented.
 
 ## Out of scope
 
@@ -374,10 +434,13 @@ already small enough that running the full leg or a plain
   test-fragility fix, not a behavior change.
 - `cast-lock.test.ts`, `design-lock.test.ts` — confirmed not to share the
   fragile shape; not touched.
-- Fixing CI's zero-test-selection hazard — Decision A2, filed as a
+- Fixing CI's zero-test-selection hazard — Decision A, filed as a
   design-pass item this round rather than fixed.
-- Extending any `--changed`-substitution mechanism to `test:sidecar` —
-  evaluated and deliberately deferred, see Decision C.
+- A pytest-side `--changed`-equivalent for `test:sidecar` (there is no
+  vitest-based mechanism left in this spec to "extend" to it, since A was
+  declined — but a dedicated pytest test-selection tool like
+  `pytest-testmon`/`pytest-picked` was independently considered and
+  declined; see Decision C).
 - Sharding `test:e2e:visual`, or changing its `--workers=1` anti-flake
   constraint.
 - Any change to GPU/hardware-dependent test tooling (`test:golden-audio`,
@@ -387,3 +450,15 @@ already small enough that running the full leg or a plain
   fork-pool crash retries, or something else entirely) actually caused the
   reported three-failure incident — no log was captured; Decision B ships as
   harmless insurance regardless, not as a diagnosed fix.
+
+## Shipping notes (owed at plan/implementation time, not resolved here)
+
+This spec names no GitHub issue and no release-notes entry — round 5 review
+flagged both as required by CLAUDE.md's Before-shipping checklist (steps 5
+and 6) and the Execution model's "trivial, or ticketed" rule, neither of
+which this design-phase document itself satisfies. Left for the
+implementation plan: file an issue (or issues — B/D/E are independent
+enough to ship separately if that's simpler) before cutting the branch, and
+land both `docs/release-notes-next.md` and `RELEASE_NOTES.md` entries in the
+shipping PR(s). Decision A's own issue is filed separately, scoped as
+described in that section.

--- a/docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md
+++ b/docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md
@@ -2,28 +2,36 @@
 status: draft
 ---
 
-# Pre-push `--changed` scoping and lock-test timing margins
+# Local test scope, timing-margin fragility, and cloud e2e sharding
 
 ## Problem
 
 Pre-push (`npm run verify:fast:branch`, `.husky/pre-push`) runs `test:server`
-unscoped whenever the branch diff touches any server file — the full battery,
-currently 8000+ tests, no `--changed` narrowing. On a box running several
-concurrent worktree test batteries this took 70-80 minutes and failed three
-times in a row, each time on a different timing-sensitive lock test unrelated
-to the diff being pushed. Root cause of the failures, confirmed by rerunning
-the flagged tests in isolation (they passed clean): `server/src/workspace/
-file-lock.test.ts` races real `setTimeout` calls with thin margins (e.g. a
-20ms lock-acquisition-timeout budget racing a 150-200ms holder) to assert
-ordering, and 39+ concurrent node/python processes on the box introduced
-enough scheduler jitter to occasionally flip that ordering.
+(and, on a frontend-touching diff, the frontend `test` leg) unscoped whenever
+the branch diff touches any file in that leg's tree — the full battery,
+currently 8000+ tests for `test:server` alone, no `--changed` narrowing. On a
+box running several concurrent worktree test batteries this took 70-80
+minutes and failed three times in a row, each time on a different
+timing-sensitive lock test unrelated to the diff being pushed. Root cause of
+the failures, confirmed by rerunning the flagged tests in isolation (they
+passed clean): `server/src/workspace/file-lock.test.ts` races real
+`setTimeout` calls with thin margins (e.g. a 20ms lock-acquisition-timeout
+budget racing a 150-200ms holder) to assert ordering, and 39+ concurrent
+node/python processes on the box introduced enough scheduler jitter to
+occasionally flip that ordering.
 
-Two independent problems, one incident:
+Three problems, addressed together because they're all "tests take too long
+or fail for reasons unrelated to the change":
 
-1. **Volume** — pre-push runs far more tests locally than the diff could
-   possibly affect.
+1. **Local volume** — pre-push runs far more tests locally than the diff
+   could possibly affect, for every leg that can be diff-scoped, not only
+   `test:server`.
 2. **Fragility** — a handful of tests assert real-wall-clock ordering with
    margins too thin to survive this box's actual contention.
+3. **Cloud e2e wall-clock** — separately raised: the e2e leg (the dominant
+   single cost in cloud CI) is sharded 4-way today and can be sharded further
+   for a straightforward wall-clock win, independent of the local-scoping
+   fix.
 
 ## Prior art this builds on
 
@@ -44,15 +52,20 @@ CI already does for the same diff.
 
 ## Decision
 
-### A — extend `--changed` narrowing to `--scope-branch`
+### A — extend `--changed` narrowing to `--scope-branch`, for every leg it already covers
 
 Widen the existing substitution gate in `runPipeline` (`scripts/
 verify-cache.mjs`, currently `flags.scopeStaged && !scopeShared && scopeDiff
 !== null && diffSafeForChangedOnly(step, scopeDiff)`) to also fire under
-`flags.scopeBranch`. The allowlist (`diffSafeForChangedOnly`) is generic over
-`diffFiles` and needs no change — the same conservative default holds: any
-diff outside `src/**`/`server/src/**` with a safe extension still runs the
-full suite locally, on both scoping paths.
+`flags.scopeBranch`. This is generic over `CHANGED_ONLY_NPM_SCRIPT`'s two
+existing entries — **`test` (frontend) and `test:server` both** — so the
+frontend leg gets the identical fix, not just the server one; the incident's
+symptom happened to be `test:server` because that's the 8000+-test leg, but
+the mechanism and this fix apply to both equally. The allowlist
+(`diffSafeForChangedOnly`) is generic over `diffFiles` and needs no change —
+the same conservative default holds: any diff outside `src/**`/`server/src/**`
+with a safe extension still runs the full suite locally, on both scoping
+paths, for either leg.
 
 **Base SHA, not `HEAD`.** The staged-scope substitution reuses the static
 npm scripts `test:changed`/`test:server:changed` (`vitest run --changed
@@ -135,6 +148,46 @@ need to get right across every existing case, including the deliberately
 incident calls for. Worth revisiting only if margin-widening turns out not to
 hold up.
 
+### C — `test:sidecar` (pytest): investigated, deliberately out of scope
+
+Considered for the same `--changed`-style narrowing since it's the third
+locally-gating test leg (`verify:fast:branch` runs it alongside `test`/
+`test:server`). Sized it first rather than assuming: `server/tts-sidecar/
+tests/` has ~900 `test_*` functions across ~75 files — roughly a ninth of
+`test:server`'s volume — and the CI-gating tier is CPU-only/mocked (no real
+model load; per CLAUDE.md's own description it SKIPs+exits 0 on an
+unbootstrapped venv), so it isn't the leg producing 70-80 minute runs or the
+lock-timing failures this incident is about. Unlike vitest, pytest has no
+built-in `--changed`-equivalent flag; the closest analogues
+(`pytest-testmon`, `pytest-picked`) are new dependencies with their own
+correctness model (coverage-based or git-diff-based test selection) that
+would need their own evaluation, not a small extension of the mechanism this
+spec already built for vitest. Given the volume here doesn't justify it,
+that evaluation is left for a future round if `test:sidecar` itself ever
+becomes the bottleneck — named explicitly here so its absence is a decision,
+not an oversight.
+
+### D — increase cloud e2e sharding
+
+`.github/workflows/verify.yml`'s `e2e` job shards `test:e2e` 4-way today
+(`matrix.shard: [1, 2, 3, 4]`, `--shard=${{ matrix.shard }}/4`) — per the
+job's own comment, this was the dominant single leg in the whole workflow at
+~16 min unsharded, cut to ~4 min/shard by the existing 4-way split. Raise it
+to **8-way**: change the matrix array to `[1, 2, 3, 4, 5, 6, 7, 8]` and both
+`--shard=N/4` references (the `test:e2e` step; `test:e2e:visual` in the
+neighboring job is unaffected — it already runs `--workers=1` for a different
+reason and is not sharded today, out of scope here) to `/8`, and the job
+name label (`E2E (chromium) — shard ${{ matrix.shard }}/4` → `/8`). Standard
+GitHub-hosted runners are free/uncapped for this public repo (per the
+2026-07-06 CI-rebalance design CLAUDE.md already documents), so the only real
+cost is fixed per-job overhead (checkout, Node setup, Playwright browser
+cache/install) that doesn't shrink with more shards — 8-way is a reasonable
+stopping point for ~110 spec files (roughly 14/shard) before that overhead
+starts to dominate the per-shard wall-clock; the exact number is a tuning
+call to confirm with a real timing comparison during implementation (same
+method the existing comment cites for the original 4-way split), not
+something this spec can pin exactly without running it.
+
 ## Testing
 
 - `scripts/tests/verify-cache.test.mjs`: new cases pinning the branch-scope
@@ -148,9 +201,14 @@ hold up.
   self-documenting via a short comment at each widened pair, matching this
   file's existing comment-heavy convention, so a future reader knows the
   headroom is deliberate and not an arbitrary number.
-- Manual: run `npm run test:server -- --changed <some-older-sha>` locally
-  once implemented, confirm it selects a proper subset and exits nonzero on a
-  genuine failure (not just `passWithNoTests`-style silent 0).
+- Manual: run `npm run test:server -- --changed <some-older-sha>` and the
+  frontend equivalent locally once implemented, confirm each selects a proper
+  subset and exits nonzero on a genuine failure (not just
+  `passWithNoTests`-style silent 0).
+- `.github/workflows/verify.yml`'s e2e shard change: no unit test (it's CI
+  config) — verified by a manual `gh workflow run verify.yml --ref <branch>`
+  dispatch and reading the run's job list, confirming 8 shard jobs appear and
+  each completes, before merge.
 
 ## Out of scope
 
@@ -158,5 +216,8 @@ hold up.
   only the confirmed lock-ordering-race shape is in scope this round.
 - Any change to the production `withKeyLock`/`file-lock.ts` timeout values —
   this is a test-fragility fix, not a behavior change.
-- Extending `--changed` substitution to any step besides `test`/`test:server`
-  (unchanged from PR #2839's scope).
+- Extending the `--changed`-substitution *mechanism* to any step besides
+  `test`/`test:server` (unchanged from PR #2839's scope) — `test:sidecar` was
+  evaluated and deliberately deferred, see Decision C.
+- Sharding `test:e2e:visual`, or changing its `--workers=1` anti-flake
+  constraint.

--- a/docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md
+++ b/docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md
@@ -1,0 +1,162 @@
+---
+status: draft
+---
+
+# Pre-push `--changed` scoping and lock-test timing margins
+
+## Problem
+
+Pre-push (`npm run verify:fast:branch`, `.husky/pre-push`) runs `test:server`
+unscoped whenever the branch diff touches any server file — the full battery,
+currently 8000+ tests, no `--changed` narrowing. On a box running several
+concurrent worktree test batteries this took 70-80 minutes and failed three
+times in a row, each time on a different timing-sensitive lock test unrelated
+to the diff being pushed. Root cause of the failures, confirmed by rerunning
+the flagged tests in isolation (they passed clean): `server/src/workspace/
+file-lock.test.ts` races real `setTimeout` calls with thin margins (e.g. a
+20ms lock-acquisition-timeout budget racing a 150-200ms holder) to assert
+ordering, and 39+ concurrent node/python processes on the box introduced
+enough scheduler jitter to occasionally flip that ordering.
+
+Two independent problems, one incident:
+
+1. **Volume** — pre-push runs far more tests locally than the diff could
+   possibly affect.
+2. **Fragility** — a handful of tests assert real-wall-clock ordering with
+   margins too thin to survive this box's actual contention.
+
+## Prior art this builds on
+
+PR #2839 (merged, `main@75a86ed8`) added `--changed HEAD`-based narrowing to
+**pre-commit** (`--scope-staged`) for the `test`/`test:server` legs, gated by
+a positive allowlist (`diffSafeForChangedOnly`, `scripts/verify-cache.mjs`)
+requiring every file in the diff sit under the step's own primary source root
+(`src/**`, `server/src/**`) with a safe TS/JS extension — any diff outside
+that (config, CSS, docs, mixed scope) falls back to a full run. It did **not**
+extend the same substitution to `--scope-branch` (pre-push).
+
+Cloud CI (`.github/workflows/verify.yml`) already does the equivalent
+narrowing on every PR push: `npx vitest run --changed "$BASE"` for
+`test:server`/`test:server-slow`, falling back to an unscoped `vitest run`
+only when the diff hits `shared` scope (root manifest/lockfile). This spec
+does not invent a new guarantee for pre-push — it makes pre-push mirror what
+CI already does for the same diff.
+
+## Decision
+
+### A — extend `--changed` narrowing to `--scope-branch`
+
+Widen the existing substitution gate in `runPipeline` (`scripts/
+verify-cache.mjs`, currently `flags.scopeStaged && !scopeShared && scopeDiff
+!== null && diffSafeForChangedOnly(step, scopeDiff)`) to also fire under
+`flags.scopeBranch`. The allowlist (`diffSafeForChangedOnly`) is generic over
+`diffFiles` and needs no change — the same conservative default holds: any
+diff outside `src/**`/`server/src/**` with a safe extension still runs the
+full suite locally, on both scoping paths.
+
+**Base SHA, not `HEAD`.** The staged-scope substitution reuses the static
+npm scripts `test:changed`/`test:server:changed` (`vitest run --changed
+HEAD`), which is correct there because pre-commit's diff is uncommitted
+changes vs. `HEAD`. At push time everything is committed, so `--changed
+HEAD` would select nothing and vitest would silently exit 0 via
+`passWithNoTests` — the exact silent-false-pass hazard PR #2839's pass-1
+review caught in a different shape. Branch scope instead needs `--changed
+<merge-base-with-main>`, mirroring CI's own `$BASE`. `branchDiffFiles`
+(`scripts/verify-cache.mjs`) already computes this merge-base internally via
+`git merge-base HEAD main` to produce its file list; it's refactored to also
+return that SHA (or a sibling `branchMergeBase(cwd)` helper it and
+`branchDiffFiles` both call, memoized so scope computation still costs one
+git spawn) so `runPipeline` reuses the exact SHA already used to decide scope,
+rather than a second, independently-timed `git merge-base` call.
+
+**Invocation, not a new static script.** Because the base is dynamic, branch
+scope can't reuse a fixed `test:server:changed` script string. `runStepProcess`
+gains an optional `extraArgs` passthrough (`npm run <script> -- <extraArgs>`);
+branch-scope substitution calls `runStepProcess(step.name, { extraArgs:
+['--changed', baseSha], ... })` — i.e. `npm run test:server -- --changed
+<sha>`, which becomes `vitest run --changed <sha>` after npm's arg
+passthrough, the same shape CI already runs. `retryKey` stays `step.name`
+either way, so the existing fork-pool-crash retry logic is untouched.
+
+**Cache-write gate.** The existing rule — a `--changed`-only pass is never
+written to the verify-cache (only a full run is, so a later cache hit can't
+mean "a full run happened" when it didn't) — already keys off a single
+`changedOnlyScript`-shaped truthy value in the per-step loop; it extends to
+cover the branch-scope substitution with no change in shape, just a wider set
+of inputs that can produce a truthy value.
+
+**Docs.** CLAUDE.md's Commit gate section and `docs/features/
+156-precommit-scope-contention.md` currently frame pre-push's unscoped
+`test:server` run as the deliberate "full local safety net" that exists
+*because* CI narrows its own runs. That framing is retired. Replacement:
+local runs (pre-commit and pre-push both) narrow via `--changed` whenever the
+diff is confined to source; cloud `verify.yml` — required, opt-out, runs
+automatically on every PR push — is the authoritative full-suite gate; a
+diff outside the allowlist (config/docs/CSS/mixed-scope) still gets a full
+run locally too, so the common case of a source-only PR is the only one that
+actually loses local full-suite coverage, and that PR gets full coverage
+from CI before merge regardless.
+
+### B — widen the real-timer margins that made this fail
+
+`quarantinedIt` (`server/src/test-utils/quarantine.ts`) skips in **both**
+gating lanes — local and CI. Wrong tool here: these tests are correct and
+pass reliably in isolation (confirmed), so quarantining them would silently
+drop real coverage from CI forever to solve a problem that's purely about
+this box's local contention. Fix the actual fragility instead.
+
+**Scope.** `server/src/workspace/file-lock.test.ts` is the confirmed
+instance: several tests race a short lock-acquisition-timeout budget (20ms)
+against a longer holder (30-200ms) to assert relative ordering. Widen every
+such pair's margins — aim for roughly 10x headroom between the short
+(timeout) value and the long (hold) value it's racing, e.g. a 20ms timeout
+budget racing a 150ms holder becomes something like a 100ms budget racing an
+800ms holder — tuned per test during implementation, verified by running the
+file under `LOW_CONCURRENCY=1` plus an artificially loaded box if one is
+available, or just by inspection of the margin ratio if not.
+
+Apply the same fix to same-shape siblings in the lock-test family —
+`server/src/workspace/cast-lock.test.ts` and `server/src/tts/
+design-lock.test.ts` — since they share the same "two real timers racing for
+an ordering assertion" pattern over the same underlying lock primitive. This
+is **not** a blanket pass over every `setTimeout` in the server test suite
+(a repo-wide grep found 76 occurrences across 33 files); most of those are
+plain "wait long enough for an async op" delays with no competing timer, and
+are insensitive to jitter for correctness purposes — only widening them would
+just make the suite slower for no gain. If implementation turns up another
+file doing the same competing-timer-ordering shape, it's fixed in the same
+round per CLAUDE.md's incidental-findings rule, not filed and deferred.
+
+**What this does not do.** No switch to `vi.useFakeTimers()` / fake-timer
+rewrite. The lock primitives under test (`withKeyLock`'s promise-chained
+queue) have real async/microtask interleaving that a fake-timer rewrite would
+need to get right across every existing case, including the deliberately
+`retry: 0` deadlock/timeout-typing suites — higher blast radius than this
+incident calls for. Worth revisiting only if margin-widening turns out not to
+hold up.
+
+## Testing
+
+- `scripts/tests/verify-cache.test.mjs`: new cases pinning the branch-scope
+  substitution (source-regex, mirroring the existing staged-scope tests from
+  PR #2839) — the widened gate condition, the `extraArgs`/base-SHA wiring,
+  and that the cache-write gate still excludes a branch-scope changed-only
+  pass.
+- `server/src/workspace/file-lock.test.ts` (and the two siblings, if their
+  margins also move): no new test cases — the existing assertions are
+  unchanged, only the millisecond constants widen. The margin choice is
+  self-documenting via a short comment at each widened pair, matching this
+  file's existing comment-heavy convention, so a future reader knows the
+  headroom is deliberate and not an arbitrary number.
+- Manual: run `npm run test:server -- --changed <some-older-sha>` locally
+  once implemented, confirm it selects a proper subset and exits nonzero on a
+  genuine failure (not just `passWithNoTests`-style silent 0).
+
+## Out of scope
+
+- Auditing all 76 `setTimeout`-in-server-test occurrences for margin safety —
+  only the confirmed lock-ordering-race shape is in scope this round.
+- Any change to the production `withKeyLock`/`file-lock.ts` timeout values —
+  this is a test-fragility fix, not a behavior change.
+- Extending `--changed` substitution to any step besides `test`/`test:server`
+  (unchanged from PR #2839's scope).

--- a/docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md
+++ b/docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md
@@ -91,6 +91,17 @@ because the reasoning matters for what shipped:
   now-small residual risk. **Dropped.** In its place: round 2 also surfaced a
   real, small, pre-existing CI bug independent of this whole allowlist
   question — see Decision A2.
+- **Round 3 found the round-2 `docs/**` widening itself unsafe**: a live
+  counterexample (`src/lib/wiki-links.test.ts`, which reads `docs/wiki/*.md`
+  at runtime with no `forceRerunTriggers` protection) means the widened
+  allowlist could silently skip that guard test on an ordinary
+  `src/`+`docs/wiki/` diff — and, measured per leg rather than combined, the
+  widening's benefit was 3/60 for `test:server` and **zero** for `test`, the
+  leg with the hole. **Reverted** — see Decision A1's current text, which is
+  back to PR #2839's original strict allowlist. Round 3 also found the
+  round-2 A2 fix didn't cover its own worked example and was actually a
+  class of at least three related gaps; A2 below reflects that — filed as a
+  named design decision rather than fixed this round.
 
 ## Decision
 
@@ -102,19 +113,30 @@ diffSafeForChangedOnly(step, scopeDiff)`) to also fire under
 `flags.scopeBranch`, for both `CHANGED_ONLY_NPM_SCRIPT` entries — `test`
 (frontend) and `test:server`.
 
-**`diffSafeForChangedOnly` gets a second allowed category.** Alongside the
-existing "every file under the step's own source root with a safe
-extension" rule, a file matching `docs/**` or the root `RELEASE_NOTES.md` is
-also allowed, unconditionally, on either scoping path (staged or branch) —
-confirmed by measurement to raise the real-world hit rate (0/60 → 3/60 for
-`test:server` over the last 60 merged branches) and confirmed safe by a
-repo-wide grep: no file under `src/**` or `server/src/**`'s own test suites
-reads anything under `docs/` at runtime. (The one file in the repo that does,
-`scripts/tests/release-notes-gate.test.mjs`, belongs to `test:hooks`, a
-different step this substitution never touches.) At least one file in the
-diff must still be a real, safe-extension source file under the step's own
-root — an all-docs diff never reaches this function, because
-`stepTouchedByDiff` already filters the step out of scope entirely upstream.
+**`diffSafeForChangedOnly` allowlist widening — dropped.** An earlier
+version of this spec widened the allowlist to also tolerate `docs/**` and
+`RELEASE_NOTES.md`, on the strength of a grep claiming no `src/**`/
+`server/src/**` test reads a `docs/` path at runtime. **Round 3 review found
+that claim false, with a live counterexample**: `src/lib/wiki-links.test.ts`
+`readFileSync`/`existsSync`-es every page under `docs/wiki/*.md` at runtime,
+and the root `vitest.config.ts`'s `forceRerunTriggers` has no `docs/` entry
+protecting it — so a normal diff touching both `src/**` and `docs/wiki/**`
+would narrow via `--changed`, skip `wiki-links.test.ts` (the guard whose
+entire job is catching a deleted/renamed wiki page), and report green. The
+earlier grep that claimed safety didn't actually check `forceRerunTriggers`
+coverage, only "does anything read `docs/`" — the real invariant is "is this
+`docs/` path covered by the relevant vitest config's `forceRerunTriggers`,"
+which is unstated, unenforced, and false here. Compounding this: re-measured
+per leg rather than combined, the widening's benefit is **3/60 for
+`test:server`, 0/60 for `test`** — the frontend leg that has the hole gets
+zero benefit from the widening that opens it. **Reverted.** The allowlist
+stays exactly PR #2839's original: every file in the diff under the step's
+own source root (`src/**`/`server/src/**`) with a safe extension, no second
+category. This gives up the small `test:server` gain (3/60 → back to 0/60)
+in exchange for not shipping a known, demonstrated silent-coverage-loss
+regression. Revisiting a docs exemption later would need to key off actual
+`forceRerunTriggers` coverage per config, not a point-in-time grep — a
+real design question, not reopened here.
 
 **Base SHA, not `HEAD`.** The staged-scope substitution reuses the static
 npm scripts `test:changed`/`test:server:changed` (`vitest run --changed
@@ -139,9 +161,13 @@ an uncommitted edit outside the allowlist (e.g. to `server/vitest.config.ts`)
 would be invisible to the allowlist check but present in vitest's actual
 selection — reopening the exact "diff touches this step but isn't
 `--changed`-reachable" hazard the allowlist exists to close. Fixed by
-checking `git status --porcelain` for the step's own tree alongside the
-committed diff before allowing substitution; a dirty tree in scope forces the
-full run, same conservative default as everywhere else in this design.
+checking `git status --porcelain` **repo-wide, not scoped to the step's
+source tree** — round 3 review caught that the obvious narrower reading
+("just check `server/src/`") misses the actual worked example, an
+uncommitted edit to `server/vitest.config.ts`, which sits outside
+`server/src/` entirely. Any uncommitted change anywhere forces the full run;
+simplest correct rule, same conservative default as everywhere else in this
+design.
 
 **Invocation — bypasses npm-script nesting.** `runStepProcess` gains a
 direct-invocation mode: spawn `npx vitest run --changed <sha>` with `cwd` set
@@ -165,27 +191,34 @@ directly instead of via npm's lifecycle-script convention.
 **Cache-write gate.** Unchanged in shape: a `--changed`-only pass (staged or
 branch) is never written to the verify-cache; only a full run is.
 
-### A2 — fix CI's `shared`-scope diffs actually forcing a full run (found in passing)
+### A2 — CI's zero-test-selection hazard: real, but a class, not a single bug — filed, not fixed this round
 
-Not a new mechanism — a pre-existing bug, unrelated to A1's allowlist,
-surfaced while reading `verify.yml` for this spec. `verify.yml`'s `test`/
-`test:server` step bodies decide narrowed-vs-full only on whether `$BASE` is
-set (`if [ -n "$BASE" ]; then --changed; else full; fi` — `$BASE` is only
-empty on `workflow_dispatch`). The `shared` scope boolean
-(`needs.detect.outputs.scopes.shared`, from `computeShared` — true for a
-root-manifest/lockfile/`.github/actions/**` change) controls whether the
-**job step runs at all**, but never reaches this narrowed-vs-full choice
-**inside** the step body — so a `shared`-scope PR (e.g. touching only
-`server/package-lock.json`) still runs `--changed "$BASE"`, and neither
-`package-lock.json` nor `.github/actions/**` appears in
-`server/vitest.config.ts`'s `forceRerunTriggers`, so that `--changed` call
-can select zero tests and report green. Fix: thread the same `shared`
-boolean already available in `needs.detect.outputs.scopes` into the step
-body's condition — `shared` (or an empty `$BASE`) → full run; otherwise
-`--changed "$BASE"`, unchanged from today. One conditional per affected step
-(`test`, `test:server`/`test:server-slow`'s shared body). This is a defect
-fix with one correct outcome, not a design decision, so it's fixed here
-rather than filed.
+An earlier version of this spec proposed a one-line fix: thread `shared`
+into `verify.yml`'s `test`/`test:server` step bodies so a `shared`-scope
+diff forces a full run instead of still trying `--changed "$BASE"`. Real bug
+(`verify.yml`'s step bodies decide narrowed-vs-full only on whether `$BASE`
+is set, never on `shared`), but **round 3 review found the proposed fix
+doesn't cover its own worked example**: `server/package-lock.json` is not
+`shared` scope (`computeShared` only matches the root lockfile/manifest and
+`.github/actions/**`) — it reaches `step_test_server` through a separate
+`includeLockfiles` branch, so a `server/package-lock.json`-only diff stays
+narrowed under the proposed fix and can still select zero tests. Review
+found a third instance too: an `e2e/**`-only diff schedules the frontend
+step (via `step_test_e2e`) which then runs `--changed "$BASE"` over a diff
+with no frontend module-graph edge at all. Three known instances of "this
+diff is in scope for a CI step, but nothing guarantees `--changed` selects
+anything real" — `shared`, `server/package-lock.json`, and cross-leg
+triggers — and the correct unifying rule (something like "narrow only when
+every touched file is covered by that config's own `forceRerunTriggers`")
+is a real design decision spanning both vitest configs, not a mechanical
+one-liner. Per CLAUDE.md's incidental-findings rule, this is the one class
+of finding that's filed rather than fixed in the same round — it needs a
+design pass, and the decision it's waiting on is named here: *what property
+of a diff actually guarantees `--changed <base>` selects a correct,
+non-empty test set for a given vitest config, given that config's own
+`forceRerunTriggers` list.* File as its own issue at implementation time;
+until it ships, this pre-existing hazard is unchanged by anything else in
+this spec — no worse than before, just not closed by A1 either.
 
 ### B — widen `file-lock.test.ts`'s confirmed-thin margins, as a no-regret hardening
 
@@ -193,9 +226,14 @@ Not claimed to be proven-confirmed as this specific incident's root cause —
 no failure log from the three runs was captured, and the repo separately
 documents fork-pool crashes retrying the whole step up to 3x under
 contention (`MAX_POOL_ATTEMPTS`) as a plausible independent or compounding
-cause that this fix does not touch. Shipped anyway because the fragility is
-real and unambiguous on its own terms, independent of whether it explains
-this incident.
+cause that this fix does not touch. Round 3 review additionally couldn't
+confirm actual fragility under measurement (no repro attempted, no jitter
+figure captured) and notes the acquisition timer is armed synchronously
+while the holder's timer is armed a microtask later, so the vulnerable
+window is narrower than "20ms is thin" suggests. Shipped anyway as a cheap
+(~+1.5s total), directionally-correct hardening — not because it's been
+proven to be this incident's cause, and that distinction is kept explicit
+rather than claimed as a confirmed fix.
 
 **Scope, corrected to the three tests that actually race.**
 `server/src/workspace/file-lock.test.ts`'s `withKeyLock acquisition timeout
@@ -203,16 +241,21 @@ this incident.
 actually race a short timeout against a real, finishing holder:
 
 - `'does not poison the key after a timeout...'` — 20ms waiter budget vs.
-  150ms holder.
+  150ms holder. **This test has a second timing pair** (a later `2000`ms
+  budget racing the same holder, lines ~140-143) — widening the holder to
+  ~700ms shrinks that second pair's own headroom from ~1850ms to ~1300ms;
+  still comfortable, but not "only the first pair changes," and an
+  implementer widening mechanically must account for both.
 - `'does not let a later caller barge past a still-running holder...'` —
   20ms vs. 200ms holder.
 - `'leaves exactly one chains entry after a timeout...'` — 20ms vs. 150ms
   holder.
 
-The other two in the same block are **not** touched: `'throws instead of
-hanging when acquisition deadlocks...'` and the `withKeyLock typed timeout
-error` block's test race a 20/50ms timeout against a holder that **never
-releases** — there's no finishing-holder deadline to jitter past, so no
+The other two tests in the same `describe` block (`'throws instead of
+hanging when acquisition deadlocks...'`, at line 82) plus the separate
+`withKeyLock typed timeout error` block's test (a different `describe`, line
+224) are **not** touched — both race a 20/50ms timeout against a holder that
+**never releases** — there's no finishing-holder deadline to jitter past, so no
 amount of contention flips their outcome, and the typed-error test asserts
 the literal constant (`timeoutMs).toBe(20)`, message `'timed out after
 20ms'`) that a mechanical margin-widening pass would otherwise break.
@@ -279,10 +322,12 @@ below — sidecar's weights-gated tests were already opt-in before this spec.
 
 `.github/workflows/verify.yml`'s `e2e` job shards `test:e2e` 4-way today
 (`matrix.shard: [1, 2, 3, 4]`, `--shard=${{ matrix.shard }}/4`), cutting a
-~16 min unsharded run to ~4 min/shard. Raise it to **8-way**: matrix array →
-`[1, 2, 3, 4, 5, 6, 7, 8]`, both `--shard=N/4` references (the `test:e2e`
-step only — `test:e2e:visual` isn't sharded today and stays that way) → `/8`,
-job name label → `/8`. Standard GitHub-hosted runners are free/uncapped for
+~16 min unsharded run to ~4 min/shard. Raise it to **8-way**: three live
+sites, corrected from an earlier draft that miscounted them as four — the
+matrix array → `[1, 2, 3, 4, 5, 6, 7, 8]`, the single `--shard=N/4` reference
+in the `test:e2e` step → `/8` (`test:e2e:visual` isn't sharded today and
+stays that way), and the job `name:` label → `/8`. Standard GitHub-hosted
+runners are free/uncapped for
 this public repo, so the real constraint is fixed per-shard cost that
 doesn't shrink with more shards: `playwright.config.ts`'s `chromium` project
 depends on the `warmup` project (Vite transform-cache warm-up), and
@@ -350,9 +395,10 @@ named script. Not wired preemptively for the smaller ones.
 ## Testing
 
 - `scripts/tests/verify-cache.test.mjs`: source-regex cases (mirroring
-  PR #2839's staged-scope tests) for the widened gate condition, the
-  `docs/**`/`RELEASE_NOTES.md` allowlist addition, the dirty-working-tree
-  check, and the cache-write exclusion for branch-scope changed-only passes.
+  PR #2839's staged-scope tests) for the widened-to-branch-scope gate
+  condition (the allowlist itself is unchanged from PR #2839 — no new case
+  needed there), the repo-wide dirty-working-tree check, and the cache-write
+  exclusion for branch-scope changed-only passes.
   **Additionally** — a source-regex test can't catch a broken invocation,
   only a missing one (round 1's finding) — add a test that actually spawns
   the new direct-invocation path against a small disposable fixture repo (not
@@ -360,10 +406,6 @@ named script. Not wired preemptively for the smaller ones.
   `detectSiblingContention`'s process-count probe if this test ever ran
   inside a `test:hooks`-style pre-commit leg) confirming it forwards
   `--changed` correctly and actually narrows the selection.
-- `.github/workflows/verify.yml`'s A2 fix: no unit test (workflow YAML) —
-  verified by a manual `gh workflow run verify.yml --ref <branch>` dispatch
-  against a deliberately root-lockfile-only diff, confirming the full suite
-  runs rather than a narrowed `--changed` pass.
 - `server/src/workspace/file-lock.test.ts`: no new test cases for the three
   widened pairs — existing assertions unchanged, only the millisecond
   constants widen, each with a short comment recording the new absolute gap.
@@ -380,18 +422,23 @@ named script. Not wired preemptively for the smaller ones.
 ## Out of scope
 
 - Auditing all 141 `setTimeout`-in-server-test occurrences for margin safety
-  — only the three confirmed fragile-race-under-`retry:0` pairs are in
-  scope; the rest is covered by rerunning the repo's own `retryHazardReporter`
-  survey instead of a fresh manual sweep.
+  — round 3 found `retryHazardReporter` structurally can't see the `{ retry:
+  0 }` population Decision B targets (it only reports tests *rescued* by
+  `retry: 1`), so it's not offered as a substitute survey. The repo has
+  exactly four `{ retry: 0 }` blocks total (three in `file-lock.test.ts`, one
+  in `design-lock.test.ts`), already read in full for this spec — that is
+  the actual scope, not a sampled subset of 141.
 - Any change to the production `withKeyLock`/`file-lock.ts` timeout values —
   test-fragility fix, not a behavior change.
 - `cast-lock.test.ts`, `design-lock.test.ts` — confirmed not to share the
   fragile shape; not touched.
 - Forcing CI's own `--changed` narrowing onto the strict
-  `diffSafeForChangedOnly` allowlist (the original Decision A2) — dropped
-  after measurement showed it would regress CI's current, looser, working
-  narrowing far more than the ~5%-hit-rate local change's residual risk
-  justifies. `test:server-slow`'s CI narrowing is likewise unchanged.
+  `diffSafeForChangedOnly` allowlist — dropped after measurement showed it
+  would regress CI's current, looser, working narrowing far more than the
+  local change's residual risk justifies (see Prior art's round-2 note).
+  Fixing CI's actual zero-test-selection hazard (of which `test:server-slow`
+  sharing `test:server`'s step body is one instance) is Decision A2, filed
+  as a design-pass item this round rather than fixed.
 - Extending the `--changed`-substitution mechanism to any step besides
   `test`/`test:server` — `test:sidecar` evaluated and deliberately deferred,
   see Decision C.


### PR DESCRIPTION
## Summary

Design-phase docs only, no code — the spec and implementation plan for shrinking a 70-80 minute, 3x-failing pre-push run.

- `docs/superpowers/specs/2026-09-01-verify-scope-branch-timing-design.md`: went through 5 rounds of adversarial Opus review. Decides to widen 3 thin timing-margin pairs in `file-lock.test.ts` (cheap insurance, not a diagnosed fix), raise cloud e2e sharding 4-way to 8-way, add 8 opt-in subsystem-scoped npm scripts, file (not fix) a real CI zero-test-selection hazard as a design-pass issue, and declines extending pre-push `--changed` narrowing after measuring its real-world hit rate at ~0%.
- `docs/superpowers/plans/2026-09-02-test-suite-hardening.md`: the implementation plan for the above, reviewed once by the mandatory assumption-checker pass (a second round is in progress to fold in its findings before implementation starts).

## Test plan

Docs-only — no runtime surface. `verify.yml`'s docs-only fast path applies.

Closes #2848