### PR TITLE
chore(scripts): print voices/ junction reminder in wt-new.mjs (#2811)

### DIFF
--- a/scripts/tests/wt-new.test.mjs
+++ b/scripts/tests/wt-new.test.mjs
@@ -371,6 +371,18 @@ test('renderLaunchBlock omits npm install when install=true (auto-installed)', (
   assert.match(block, /npm run dev/);
 });
 
+test('renderLaunchBlock reminds about the .venv AND voices/ junctions for sidecar/TTS work (#2811)', () => {
+  const block = renderLaunchBlock({
+    worktreePath: 'C:/Claude/Projects/wt-foo',
+    branch: 'feat/server-foo',
+    ports: computePorts(1),
+    slot: 1,
+    install: true,
+  });
+  assert.match(block, /\.venv/);
+  assert.match(block, /voices\//);
+});
+
 test('renderLaunchBlock includes both npm install lines when install=false', () => {
   const block = renderLaunchBlock({
     worktreePath: 'C:/Claude/Projects/wt-foo',

--- a/scripts/tests/wt-new.test.mjs
+++ b/scripts/tests/wt-new.test.mjs
@@ -379,8 +379,8 @@ test('renderLaunchBlock reminds about the .venv AND voices/ junctions for sideca
     slot: 1,
     install: true,
   });
-  assert.match(block, /\.venv/);
-  assert.match(block, /voices\//);
+  assert.match(block, /server\/tts-sidecar\/\.venv/);
+  assert.match(block, /server\/tts-sidecar\/voices\//);
 });
 
 test('renderLaunchBlock includes both npm install lines when install=false', () => {

--- a/scripts/wt-new.mjs
+++ b/scripts/wt-new.mjs
@@ -222,9 +222,9 @@ export function renderLaunchBlock({ worktreePath, branch, ports, slot, install }
     `Next steps — paste into a new terminal:`,
     ``,
     `  cd "${winPath}"`,
-    `  # Doing real sidecar/TTS work? Junction .venv AND voices/ from the primary`,
-    `  # checkout first — see CLAUDE.md "Worktree setup" step 2. A missing`,
-    `  # voices/ junction misreports as recycle-storm (#2811), not a missing-weights error.`,
+    `  # Doing real sidecar/TTS work? Junction server/tts-sidecar/.venv AND server/tts-sidecar/voices/ from`,
+    `  # the primary checkout first — see CLAUDE.md "Worktree setup" step 2. Missing voices/ causes`,
+    `  # Kokoro model errors that trigger recycle-storm; check logs/tts.err.log if #399 looks like it.`,
   ];
   if (install === false) {
     lines.push(`  npm install                  # root deps + husky hooks (skipped: --no-install)`);

--- a/scripts/wt-new.mjs
+++ b/scripts/wt-new.mjs
@@ -222,6 +222,9 @@ export function renderLaunchBlock({ worktreePath, branch, ports, slot, install }
     `Next steps — paste into a new terminal:`,
     ``,
     `  cd "${winPath}"`,
+    `  # Doing real sidecar/TTS work? Junction .venv AND voices/ from the primary`,
+    `  # checkout first — see CLAUDE.md "Worktree setup" step 2. A missing`,
+    `  # voices/ junction misreports as recycle-storm (#2811), not a missing-weights error.`,
   ];
   if (install === false) {
     lines.push(`  npm install                  # root deps + husky hooks (skipped: --no-install)`);


### PR DESCRIPTION
## Summary

Adds a printed reminder to `wt-new.mjs`'s "Next steps" output telling anyone
doing sidecar/TTS work to junction both `server/tts-sidecar/.venv` and
`server/tts-sidecar/voices/` from the primary checkout before starting,
referencing CLAUDE.md's "Worktree setup" step 2 and #2811. A missing
`voices/` junction causes Kokoro to throw `Kokoro model not found` errors
that trigger repeated restarts and trip the `recycle-storm` circuit
breaker — which can be misdiagnosed as the unrelated #399 host-memory-leak
regression if `logs/tts.err.log` isn't checked first.

Closes #2811

Also fixed, found in passing during the mandatory PR review gate pass:
- Reminder paths were unqualified (`.venv`, `voices/`) right after a
  root-relative `cd`, which would be misread as worktree-root-relative —
  corrected to the full `server/tts-sidecar/...` paths (commit `d18e8d25`).
- The diagnostic explanation had the #2811/#399 causal chain backwards —
  corrected to match CLAUDE.md's and #2811's actual account (same commit).
- A related doc gap in CLAUDE.md itself (step 2 warned about a missing
  `.venv` junction without ever instructing operators to make one) is
  fixed separately in docs-only PR #2873 (#2869).

Release notes (before-shipping step 5): waived — `wt-new.mjs` is a
dev-tooling script, not in `scripts/build-release-zip.mjs`'s shipped
allowlist, so there's no shippable user-facing delta.

## Test plan

- [x] `npm run test:hooks` — 1777/1777 pass, including new coverage in
      `scripts/tests/wt-new.test.mjs` asserting the printed block mentions
      both `.venv` and `voices/`.
- [x] Mutation kill (re-verified independently during review): temporarily
      reverted the new reminder lines and reran
      `node --test scripts/tests/wt-new.test.mjs` — the new test failed with:
      `AssertionError [ERR_ASSERTION]: The input did not match the regular
      expression /\.venv/` (50/51 pass, 1 fail). Restored the fix and reran —
      51/51 pass again.
- [x] `npm run typecheck` — clean (frontend `tsc --noEmit` + server
      `tsc --noEmit -p .`).
- [x] After the review-gate fix commit: `node --test scripts/tests/wt-new.test.mjs`
      — 51/51 pass again.
- [x] Scope check: only `scripts/wt-new.mjs` and
      `scripts/tests/wt-new.test.mjs` touched — no changes to
      `server/tts-sidecar/`, `buildInstallCommands`, or `runInstalls`.