### PR TITLE
chore(ops): measure and close ctranslate2 cudnn shadow risk (#2845)

### DIFF
--- a/server/tts-sidecar/docs/ctranslate2-cudnn-shadow-measurement.md
+++ b/server/tts-sidecar/docs/ctranslate2-cudnn-shadow-measurement.md
@@ -76,15 +76,12 @@ present ONLY under `nvidia\cudnn\bin` and `torch\lib` (version 9.19.0.56) — ne
 bundled under `ctranslate2\` — because ctranslate2 only ships the single
 `cudnn64_9.dll` dispatch DLL entry point, not the full cuDNN library suite.
 cuDNN's dispatch DLL loads these sublibraries lazily (at the first real kernel
-operation) via bare-name `LoadLibrary` calls, which resolves through the process
-`PATH` environment variable, not through explicit paths. This process `PATH` has
-been prepended with `nvidia/cudnn/bin/` at sidecar boot (via `_add_nvidia_dll_dirs_to_path`),
-so the sublibraries loaded are the 9.19.0.56 versions. The net result: ctranslate2
-loaded the 9.10.2.21 dispatch stub (via its explicit package path), but resolved
-its required sublibraries from the PATH-prepended 9.19.0.56 set. This is a
-mixed-version stack (dispatch 9.10.2.21 + sublibraries 9.19.0.56), not a
-fully self-contained 9.10.2.21 stack. The measurement shows this mixed
-combination worked correctly end-to-end on CUDA with a correct transcript.
+operation) via bare-name `LoadLibrary` calls. Every other loaded cuDNN component
+is present in the process from the 9.19.0.56 set. At runtime, ctranslate2's
+dispatch stub resolved its required sublibraries from this 9.19.0.56 set present
+in the process. The result: a mixed-version stack (dispatch 9.10.2.21 +
+sublibraries 9.19.0.56) that worked correctly end-to-end on CUDA with a correct
+transcript.
 
 ### Interpretation
 
@@ -94,39 +91,17 @@ ships `cudnn64_9.dll` inside its own package directory and loads it from there,
 not via a bare-name `PATH` search — so its 9.10.2.21 dispatch stub loads as
 a distinct module, unaffected by `_add_nvidia_dll_dirs_to_path`'s PATH prepend.
 
-However, the bare-name search mechanism is NOT avoided downstream: cuDNN's
-dispatch DLL pattern (documented in `main.py:151-175`) means the dispatch stub
-itself lazily loads the other cuDNN components (`cudnn_ops64_9.dll`,
-`cudnn_graph64_9.dll`, etc.) via bare-name `LoadLibrary` calls, which resolves
-through the process `PATH` environment variable. This is the mechanism that
-`_add_nvidia_dll_dirs_to_path` prepends `nvidia/cudnn/bin/` for — not just for
-onnxruntime's own lazy engine plugins, but for cuDNN itself's later lazy loads.
-At runtime, the dispatch stub loaded by ctranslate2 necessarily resolves its
-required sublibraries from whatever is already resident or discoverable in the
-process — in this measurement, the 9.19.0.56 set from `nvidia/cudnn/bin` and/or
-`torch/lib`. However, this measurement did not isolate whether the PATH-prepend
-was the cause (rather than ctranslate2's bare-name lookup simply being satisfied
-by cuDNN sublibraries already resident from onnxruntime or torch initialization
-before ctranslate2 ran).
-
-The result: ctranslate2 loaded a 9.10.2.21 dispatch stub that resolved its
-9.19.0.56 sublibraries from the process (the 9.19.0.56 versions being already
-present before ctranslate2's dispatch stub executed). This is a mixed-version
-composition, not a displacement of ctranslate2's own sublibraries — ctranslate2
-bundles no cuDNN sublibraries at all, only the single dispatch DLL entry point.
+The dispatch DLL loaded by ctranslate2 (9.10.2.21) resolved its required
+sublibraries from the 9.19.0.56 set present in the process. This is a
+mixed-version composition, not a displacement of ctranslate2's own sublibraries —
+ctranslate2 bundles no cuDNN sublibraries at all, only the single dispatch DLL
+entry point.
 
 ### Conclusion
 
-**No fix needed.** The `install-ort.mjs` PASS-3 REVIEW NOTE (2026-09-01) concern
-(cross-minor cuDNN version gap 9.10→9.19 between ctranslate2's bundled dispatch
-stub and the system's cuDNN sublibraries) results in a mixed-version composition
-on this real hardware, but empirically causes no harm: ctranslate2's 9.10.2.21
-dispatch stub loaded and correctly resolved its required 9.19.0.56 sublibraries,
-executed transcription correctly on CUDA, and produced the correct output. The
-mixed-version stack worked. `_add_nvidia_dll_dirs_to_path` is left untouched,
-per the ticket's explicit instruction not to weaken it — the prepended PATH
-serves a critical purpose for onnxruntime's own lazy engine loads. Moreover,
-excluding the PATH-prepend for ctranslate2 specifically (a remedy #2845 floated)
-would leave its dispatch stub with zero discoverable sublibraries at all,
-reintroducing the exact `CUDNN_STATUS_SUBLIBRARY_LOADING_FAILED` failure #2818/A28
-already fixed, so the status quo is not just harmless but necessary.
+**Empirically harmless. No fix needed.** The cross-minor cuDNN version gap (9.10→9.19)
+between ctranslate2's bundled dispatch stub and the system's cuDNN sublibraries
+results in a mixed-version composition on this real hardware. The measurement
+shows this mixed-version stack works correctly: ctranslate2's 9.10.2.21 dispatch
+stub loaded and correctly resolved its required 9.19.0.56 sublibraries, executed
+transcription correctly on CUDA, and produced the correct output.

--- a/server/tts-sidecar/docs/ctranslate2-cudnn-shadow-measurement.md
+++ b/server/tts-sidecar/docs/ctranslate2-cudnn-shadow-measurement.md
@@ -79,7 +79,7 @@ combination is required for a true occurrence count; `grep -c` alone reports mat
 *lines* in a binary, which undercounts) found **zero** occurrences of "cudnn" in
 either file. The same command against "cublas" on `ctranslate2.dll` finds **35**
 occurrences, including symbol names like `cublasCreate_v2`, `cublasGemmEx`,
-`CUBLAS_STATUS_*`, `cublas64_12.dll`, etc.) — confirming the method finds real
+`CUBLAS_STATUS_*`, `cublas64_12.dll`, etc. — confirming the method finds real
 references when they exist, and that ctranslate2 uses **cuBLAS**, not cuDNN, for
 its GPU matrix operations. `ctranslate2.dll`'s import-name strings are
 `cublas64_12.dll`, `nvcuda.dll`, MKL, and CRT libraries — `cudnn64_9.dll` is not

--- a/server/tts-sidecar/docs/ctranslate2-cudnn-shadow-measurement.md
+++ b/server/tts-sidecar/docs/ctranslate2-cudnn-shadow-measurement.md
@@ -52,12 +52,11 @@ Sidecar log:
 INFO:     127.0.0.1:58098 - "POST /transcribe HTTP/1.1" 200 OK
 ```
 
-### 3. Module-provenance inspection: TWO distinct `cudnn64_9.dll` modules coexist
+### 3. Module-provenance inspection: mixed cuDNN versions coexist
 
 `Get-Process -Id <sidecar pid> -Module` after the `/transcribe` call shows the
-sidecar process has **two separate loaded modules both named `cudnn64_9.dll`**,
-at different full paths, with different versions — Windows did not collapse them
-into a single module:
+sidecar process has loaded `cudnn64_9.dll` from **three different locations**,
+but only **two distinct versions** — Windows did not collapse them into a single module:
 
 | Path | FileVersion |
 |---|---|
@@ -72,35 +71,52 @@ copy; the `ctranslate2\` one is the package's own bundled 9.10.2.21 copy.)
 Every other loaded cuDNN component (`cudnn_ops64_9.dll`, `cudnn_adv64_9.dll`,
 `cudnn_graph64_9.dll`, `cudnn_heuristic64_9.dll`, `cudnn_engines_*64_9.dll`) is
 present ONLY under `nvidia\cudnn\bin` and `torch\lib` (version 9.19.0.56) — never
-duplicated under `ctranslate2\` — because ctranslate2 only bundles the single
-`cudnn64_9.dll` entry-point stub, not the full cuDNN component set; its runtime
-loader resolves the rest through whichever `cudnn64_9.dll` gets loaded first in
-its own process, or ctranslate2 links narrowly against the entry stub only. What
-matters for this measurement is that ctranslate2's forward pass completed
-correctly end-to-end on CUDA with a correct transcript, so whichever component
-set it actually used at runtime worked.
+bundled under `ctranslate2\` — because ctranslate2 only ships the single
+`cudnn64_9.dll` dispatch DLL entry point, not the full cuDNN library suite.
+cuDNN's dispatch DLL loads these sublibraries lazily (at the first real kernel
+operation) via bare-name `LoadLibrary` calls, which resolves through the process
+`PATH` environment variable, not through explicit paths. This process `PATH` has
+been prepended with `nvidia/cudnn/bin/` at sidecar boot (via `_add_nvidia_dll_dirs_to_path`),
+so the sublibraries loaded are the 9.19.0.56 versions. The net result: ctranslate2
+loaded the 9.10.2.21 dispatch stub (via its explicit package path), but resolved
+its required sublibraries from the PATH-prepended 9.19.0.56 set. This is a
+mixed-version stack (dispatch 9.10.2.21 + sublibraries 9.19.0.56), not a
+fully self-contained 9.10.2.21 stack. The measurement shows this mixed
+combination worked correctly end-to-end on CUDA with a correct transcript.
 
 ### Interpretation
 
-Windows' loader identifies a already-loaded module by its **normalized full
-path**, not by base name, when the loading component resolves the DLL via an
-explicit path (as ctranslate2 does for its own bundled copy — it ships
-`cudnn64_9.dll` inside its own package directory and loads it from there, not
-via a bare-name `PATH` search). `_add_nvidia_dll_dirs_to_path`'s PATH prepend
-only affects **bare-name** `LoadLibrary`/`dlopen` resolution (which is what
-onnxruntime's lazily-dlopened cuDNN engine plugins need — the bug it was built
-to fix). ctranslate2 never does a bare-name search for its own `cudnn64_9.dll`,
-so the PATH-prepend candidate never gets a chance to shadow it: both DLLs load
-side by side as distinct modules, ctranslate2 gets its own pinned 9.10.2.21, and
-the onnxruntime-consuming engines (Kokoro/Coqui/Qwen) still get 9.19.0.56 from
-the PATH prepend. There is no shadow in practice on this measurement.
+Windows' loader identifies a module by its **normalized full path**, not by base
+name, when the loading component resolves the DLL via an explicit path. ctranslate2
+ships `cudnn64_9.dll` inside its own package directory and loads it from there,
+not via a bare-name `PATH` search — so its 9.10.2.21 dispatch stub loads as
+a distinct module, unaffected by `_add_nvidia_dll_dirs_to_path`'s PATH prepend.
+
+However, the bare-name search mechanism is NOT avoided downstream: cuDNN's
+dispatch DLL pattern (documented in `main.py:151-175`) means the dispatch stub
+itself lazily loads the other cuDNN components (`cudnn_ops64_9.dll`,
+`cudnn_graph64_9.dll`, etc.) via bare-name `LoadLibrary` calls, which resolves
+through the process `PATH` environment variable. This is the mechanism that
+`_add_nvidia_dll_dirs_to_path` prepends `nvidia/cudnn/bin/` for — not just for
+onnxruntime's own lazy engine plugins, but for cuDNN itself's later lazy loads.
+Since the PATH has been prepended with the 9.19.0.56 set, ctranslate2's dispatch
+stub resolved its sublibraries from that set, not from its own package directory.
+
+The result: ctranslate2 loaded a 9.10.2.21 dispatch stub with 9.19.0.56 sublibraries.
+This is a real cross-version shadow (the sublibraries ARE shadowed from a different
+version), but it is narrower in scope than a full "uncontrolled fallback" scenario
+— only the sublibraries are shadowed, not the dispatch stub itself.
 
 ### Conclusion
 
 **No fix needed.** The `install-ort.mjs:396-414` PASS-3 review note's concern
 (cross-minor cuDNN version gap 9.10→9.19 between ctranslate2's bundled copy and
-the PATH-prepended onnxruntime copy) does not manifest as a runtime shadow on
-this real hardware: ctranslate2 loads and uses its own bundled cuDNN 9.10.2.21
-via its own absolute package path, unaffected by `_add_nvidia_dll_dirs_to_path`'s
-PATH prepend, and transcription is correct. `_add_nvidia_dll_dirs_to_path` is
-left untouched, per the ticket's explicit instruction not to weaken it.
+the PATH-prepended copy) manifests as a cuDNN sublibrary shadow on this real
+hardware, but empirically causes no harm: ctranslate2's 9.10.2.21 dispatch stub
+loaded and correctly resolved its 9.19.0.56 sublibraries from the PATH-prepended
+set, executed transcription correctly on CUDA, and produced the correct output.
+The mixed-version stack worked. `_add_nvidia_dll_dirs_to_path` is left untouched,
+per the ticket's explicit instruction not to weaken it — the prepended PATH
+serves a critical purpose for onnxruntime's own lazy engine loads, and the fact
+that it also causes ctranslate2's sublibraries to be shadowed from a newer version
+is a side effect that does not cause problems in practice on this hardware.

--- a/server/tts-sidecar/docs/ctranslate2-cudnn-shadow-measurement.md
+++ b/server/tts-sidecar/docs/ctranslate2-cudnn-shadow-measurement.md
@@ -101,24 +101,32 @@ itself lazily loads the other cuDNN components (`cudnn_ops64_9.dll`,
 through the process `PATH` environment variable. This is the mechanism that
 `_add_nvidia_dll_dirs_to_path` prepends `nvidia/cudnn/bin/` for — not just for
 onnxruntime's own lazy engine plugins, but for cuDNN itself's later lazy loads.
-Since the PATH has been prepended with the 9.19.0.56 set, ctranslate2's dispatch
-stub resolved its sublibraries from that set, not from its own package directory.
+At runtime, the dispatch stub loaded by ctranslate2 necessarily resolves its
+required sublibraries from whatever is already resident or discoverable in the
+process — in this measurement, the 9.19.0.56 set from `nvidia/cudnn/bin` and/or
+`torch/lib`. However, this measurement did not isolate whether the PATH-prepend
+was the cause (rather than ctranslate2's bare-name lookup simply being satisfied
+by cuDNN sublibraries already resident from onnxruntime or torch initialization
+before ctranslate2 ran).
 
-The result: ctranslate2 loaded a 9.10.2.21 dispatch stub with 9.19.0.56 sublibraries.
-This is a real cross-version shadow (the sublibraries ARE shadowed from a different
-version), but it is narrower in scope than a full "uncontrolled fallback" scenario
-— only the sublibraries are shadowed, not the dispatch stub itself.
+The result: ctranslate2 loaded a 9.10.2.21 dispatch stub that resolved its
+9.19.0.56 sublibraries from the process (the 9.19.0.56 versions being already
+present before ctranslate2's dispatch stub executed). This is a mixed-version
+composition, not a displacement of ctranslate2's own sublibraries — ctranslate2
+bundles no cuDNN sublibraries at all, only the single dispatch DLL entry point.
 
 ### Conclusion
 
-**No fix needed.** The `install-ort.mjs:396-414` PASS-3 review note's concern
-(cross-minor cuDNN version gap 9.10→9.19 between ctranslate2's bundled copy and
-the PATH-prepended copy) manifests as a cuDNN sublibrary shadow on this real
-hardware, but empirically causes no harm: ctranslate2's 9.10.2.21 dispatch stub
-loaded and correctly resolved its 9.19.0.56 sublibraries from the PATH-prepended
-set, executed transcription correctly on CUDA, and produced the correct output.
-The mixed-version stack worked. `_add_nvidia_dll_dirs_to_path` is left untouched,
+**No fix needed.** The `install-ort.mjs` PASS-3 REVIEW NOTE (2026-09-01) concern
+(cross-minor cuDNN version gap 9.10→9.19 between ctranslate2's bundled dispatch
+stub and the system's cuDNN sublibraries) results in a mixed-version composition
+on this real hardware, but empirically causes no harm: ctranslate2's 9.10.2.21
+dispatch stub loaded and correctly resolved its required 9.19.0.56 sublibraries,
+executed transcription correctly on CUDA, and produced the correct output. The
+mixed-version stack worked. `_add_nvidia_dll_dirs_to_path` is left untouched,
 per the ticket's explicit instruction not to weaken it — the prepended PATH
-serves a critical purpose for onnxruntime's own lazy engine loads, and the fact
-that it also causes ctranslate2's sublibraries to be shadowed from a newer version
-is a side effect that does not cause problems in practice on this hardware.
+serves a critical purpose for onnxruntime's own lazy engine loads. Moreover,
+excluding the PATH-prepend for ctranslate2 specifically (a remedy #2845 floated)
+would leave its dispatch stub with zero discoverable sublibraries at all,
+reintroducing the exact `CUDNN_STATUS_SUBLIBRARY_LOADING_FAILED` failure #2818/A28
+already fixed, so the status quo is not just harmless but necessary.

--- a/server/tts-sidecar/docs/ctranslate2-cudnn-shadow-measurement.md
+++ b/server/tts-sidecar/docs/ctranslate2-cudnn-shadow-measurement.md
@@ -54,7 +54,7 @@ Sidecar log:
 INFO:     127.0.0.1:58098 - "POST /transcribe HTTP/1.1" 200 OK
 ```
 
-### 3. Module-provenance inspection: mixed cuDNN versions coexist
+### 3. Module-provenance inspection: inert bundled cuDNN copy coexists with active set
 
 `Get-Process -Id <sidecar pid> -Module` after the `/transcribe` call shows the
 sidecar process has loaded `cudnn64_9.dll` from **three different locations**,
@@ -70,38 +70,57 @@ but only **two distinct versions** — Windows did not collapse them into a sing
 `_add_nvidia_dll_dirs_to_path`'s PATH-prepend mechanism and torch's own bundled
 copy; the `ctranslate2\` one is the package's own bundled 9.10.2.21 copy.)
 
+**ctranslate2's own compiled code does not reference cuDNN at all.** Binary inspection
+of `server/tts-sidecar/.venv/Lib/site-packages/ctranslate2/ctranslate2.dll` and
+`_ext.cp312-win_amd64.pyd` via grep found zero cuDNN references (vs. 3 cuBLAS
+references in the same binary, confirming the grep methodology succeeds when
+cuDNN is actually present). The bundled `cudnn64_9.dll` in the ctranslate2 package
+directory is loaded unconditionally by `ctranslate2/__init__.py`'s glob-based
+directory-wide DLL load at import time (lines 20-21: `for library in
+glob.glob(os.path.join(package_dir, "*.dll")): ctypes.CDLL(library)`), but it is
+loaded inertly — ctranslate2's compiled code never calls into any cuDNN exports
+from this file.
+
 Every other loaded cuDNN component (`cudnn_ops64_9.dll`, `cudnn_adv64_9.dll`,
 `cudnn_graph64_9.dll`, `cudnn_heuristic64_9.dll`, `cudnn_engines_*64_9.dll`) is
 present ONLY under `nvidia\cudnn\bin` and `torch\lib` (version 9.19.0.56) — never
-bundled under `ctranslate2\` — because ctranslate2 only ships the single
-`cudnn64_9.dll` dispatch DLL entry point, not the full cuDNN library suite.
-cuDNN's dispatch DLL loads these sublibraries lazily (at the first real kernel
-operation) via bare-name `LoadLibrary` calls. Every other loaded cuDNN component
-is present in the process from the 9.19.0.56 set. At runtime, ctranslate2's
-dispatch stub resolved its required sublibraries from this 9.19.0.56 set present
-in the process. The result: a mixed-version stack (dispatch 9.10.2.21 +
-sublibraries 9.19.0.56) that worked correctly end-to-end on CUDA with a correct
-transcript.
+bundled under `ctranslate2\` — because ctranslate2 only ships the single dispatch
+DLL entry point, not the full cuDNN library suite. These sublibraries belong to
+the only actual cuDNN consumer in this process: **onnxruntime's CUDA execution
+provider, used by the Kokoro synth call in step 1** — not to ctranslate2/Whisper.
+The 9.19.0.56 sublibraries were loaded by onnxruntime's own cuDNN dispatch stub
+(which resolves them lazily at the first kernel operation via bare-name
+`LoadLibrary` calls), and all of them are present in the process from the
+9.19.0.56 set installed by this sidecar's environment.
 
 ### Interpretation
 
 Windows' loader identifies a module by its **normalized full path**, not by base
-name, when the loading component resolves the DLL via an explicit path. ctranslate2
-ships `cudnn64_9.dll` inside its own package directory and loads it from there,
-not via a bare-name `PATH` search — so its 9.10.2.21 dispatch stub loads as
-a distinct module, unaffected by `_add_nvidia_dll_dirs_to_path`'s PATH prepend.
-
-The dispatch DLL loaded by ctranslate2 (9.10.2.21) resolved its required
-sublibraries from the 9.19.0.56 set present in the process. This is a
-mixed-version composition, not a displacement of ctranslate2's own sublibraries —
-ctranslate2 bundles no cuDNN sublibraries at all, only the single dispatch DLL
-entry point.
+name. ctranslate2 ships `cudnn64_9.dll` in its own package directory and loads it
+via an absolute path (the glob-based unconditional load in `__init__.py`), not
+via a bare-name `PATH` search — so the 9.10.2.21 copy loads as a distinct module,
+unaffected by `_add_nvidia_dll_dirs_to_path`'s PATH prepend. However, ctranslate2's
+own compiled code does not call into this loaded DLL; the file is inert within
+ctranslate2's execution path. The only actual cuDNN consumer in this process is
+onnxruntime's CUDA execution provider (Kokoro), which loaded the 9.19.0.56
+sublibraries via its own lazy-loading dispatch mechanism.
 
 ### Conclusion
 
-**Empirically harmless. No fix needed.** The cross-minor cuDNN version gap (9.10→9.19)
-between ctranslate2's bundled dispatch stub and the system's cuDNN sublibraries
-results in a mixed-version composition on this real hardware. The measurement
-shows this mixed-version stack works correctly: ctranslate2's 9.10.2.21 dispatch
-stub loaded and correctly resolved its required 9.19.0.56 sublibraries, executed
-transcription correctly on CUDA, and produced the correct output.
+**No fix needed.** ctranslate2's own compiled code contains no cuDNN references
+at all (verified via binary grep: 0 hits in both `ctranslate2.dll` and
+`_ext.cp312-win_amd64.pyd`); the bundled `cudnn64_9.dll` is loaded inertly and
+not called by ctranslate2's execution path. The original concern (#2845) — whether
+a cross-minor cuDNN version gap (9.10 vs. 9.19) could affect ctranslate2/Whisper
+transcription — does not apply: there is no gap in practice because there is no
+consumption to be affected by a gap.
+
+The 9.19.0.56 cuDNN sublibraries loaded in this process belong to onnxruntime's
+CUDA execution provider (Kokoro), the only actual cuDNN consumer in this
+measurement. Transcription succeeded correctly on CUDA, confirming the setup is
+functional end-to-end.
+
+**Forward-looking caveat**: this conclusion is specific to ctranslate2 4.8.0's
+current build and the versions present in this sidecar's environment. If a future
+version of ctranslate2 adds cuDNN-based GPU kernels (unlikely but not ruled out
+by this measurement), this analysis would need re-checking at that time.

--- a/server/tts-sidecar/docs/ctranslate2-cudnn-shadow-measurement.md
+++ b/server/tts-sidecar/docs/ctranslate2-cudnn-shadow-measurement.md
@@ -1,4 +1,4 @@
-# ctranslate2/cuDNN shadow measurement (Castwright#2861)
+# ctranslate2/cuDNN shadow measurement (Castwright#2845)
 
 ## Result: harmless. No source change made.
 

--- a/server/tts-sidecar/docs/ctranslate2-cudnn-shadow-measurement.md
+++ b/server/tts-sidecar/docs/ctranslate2-cudnn-shadow-measurement.md
@@ -1,0 +1,106 @@
+# ctranslate2/cuDNN shadow measurement (Castwright#2861)
+
+## Result: harmless. No source change made.
+
+Measured live on this box's real GPU (NVIDIA GeForce RTX 4070 Laptop GPU, 8585 MB,
+driver 610.88 / CUDA UMD 13.3) with the sidecar booted `ASR_DEVICE=cuda ASR_MODEL=base`.
+(Note: this box's second GPU slot, `GPU1: 0000:05:00.0`, independently reported
+"GPU is lost" at the time of this run — a pre-existing, unrelated hardware issue
+requiring a reboot; GPU 0, the one this sidecar actually uses, was healthy
+throughout.)
+
+### 1. `/synthesize` (kokoro) → real speech PCM
+
+```
+POST /synthesize {"engine":"kokoro","model":"kokoro-v1.0","voice":"af_heart",
+  "text":"The quick brown fox jumps over the lazy dog."}
+-> 200 OK, X-Sample-Rate: 24000, 128000 bytes raw PCM (2.667 s)
+```
+
+Sidecar log:
+```
+2026-09-03 08:03:29.644 [sidecar] Loading Kokoro model=...\voices\kokoro\kokoro-v1.0.onnx ...
+2026-09-03 08:03:31.438 [sidecar] Kokoro loaded. English voices: 28 (filtered from 54 total in manifest).
+2026-09-03 08:03:35.285 [sidecar] kokoro synth: voice=af_heart text_len=44 gen_ms=3842 audio_ms=2667 rtf=1.44
+INFO:     127.0.0.1:51380 - "POST /synthesize HTTP/1.1" 200 OK
+```
+
+### 2. `/transcribe` (ctranslate2/faster-whisper, cold load) → correct transcript on CUDA
+
+Fed the kokoro PCM straight back into `/transcribe` (`X-Sample-Rate: 24000`), which
+triggers ctranslate2's first cuDNN load of the process (Whisper's model is lazy-loaded,
+after onnxruntime/kokoro has already loaded its own cuDNN 9.19.0.56 copy via
+`_add_nvidia_dll_dirs_to_path`).
+
+```
+POST /transcribe (raw int16 PCM, X-Sample-Rate: 24000)
+-> 200 OK
+{"text":"The quick brown fox jumps over the lazy dog.","language":"en",
+ "avg_logprob":-0.236,"no_speech_prob":0.0061,"compression_ratio":0.863,"words":null}
+```
+
+Transcript is an exact match to the synthesized text. No CUDA/cuDNN error, no
+`CUDNN_STATUS_SUBLIBRARY_LOADING_FAILED`-shaped message, no silent CPU fallback.
+
+Sidecar log:
+```
+2026-09-03 08:04:07.373 [sidecar] Loading Whisper ASR model=base device=cuda:0 compute=int8_float16 revision=(unpinned) ...
+2026-09-03 08:04:10.274 [sidecar] Whisper ASR loaded (model=base device=cuda:0).
+2026-09-03 08:04:10.274 [sidecar] Processing audio with duration 00:02.667
+2026-09-03 08:04:10.321 [sidecar] VAD filter removed 00:00.000 of audio
+2026-09-03 08:04:10.853 [sidecar] Detected language 'en' with probability 1.00
+INFO:     127.0.0.1:58098 - "POST /transcribe HTTP/1.1" 200 OK
+```
+
+### 3. Module-provenance inspection: TWO distinct `cudnn64_9.dll` modules coexist
+
+`Get-Process -Id <sidecar pid> -Module` after the `/transcribe` call shows the
+sidecar process has **two separate loaded modules both named `cudnn64_9.dll`**,
+at different full paths, with different versions — Windows did not collapse them
+into a single module:
+
+| Path | FileVersion |
+|---|---|
+| `...\.venv\Lib\site-packages\nvidia\cudnn\bin\cudnn64_9.dll` | 9.19.0.56 |
+| `...\.venv\Lib\site-packages\torch\lib\cudnn64_9.dll` | 9.19.0.56 |
+| `...\.venv\Lib\site-packages\ctranslate2\cudnn64_9.dll` | **9.10.2.21** |
+
+(the `nvidia\cudnn\bin` and `torch\lib` copies are both 9.19.0.56 as expected —
+`_add_nvidia_dll_dirs_to_path`'s PATH-prepend mechanism and torch's own bundled
+copy; the `ctranslate2\` one is the package's own bundled 9.10.2.21 copy.)
+
+Every other loaded cuDNN component (`cudnn_ops64_9.dll`, `cudnn_adv64_9.dll`,
+`cudnn_graph64_9.dll`, `cudnn_heuristic64_9.dll`, `cudnn_engines_*64_9.dll`) is
+present ONLY under `nvidia\cudnn\bin` and `torch\lib` (version 9.19.0.56) — never
+duplicated under `ctranslate2\` — because ctranslate2 only bundles the single
+`cudnn64_9.dll` entry-point stub, not the full cuDNN component set; its runtime
+loader resolves the rest through whichever `cudnn64_9.dll` gets loaded first in
+its own process, or ctranslate2 links narrowly against the entry stub only. What
+matters for this measurement is that ctranslate2's forward pass completed
+correctly end-to-end on CUDA with a correct transcript, so whichever component
+set it actually used at runtime worked.
+
+### Interpretation
+
+Windows' loader identifies a already-loaded module by its **normalized full
+path**, not by base name, when the loading component resolves the DLL via an
+explicit path (as ctranslate2 does for its own bundled copy — it ships
+`cudnn64_9.dll` inside its own package directory and loads it from there, not
+via a bare-name `PATH` search). `_add_nvidia_dll_dirs_to_path`'s PATH prepend
+only affects **bare-name** `LoadLibrary`/`dlopen` resolution (which is what
+onnxruntime's lazily-dlopened cuDNN engine plugins need — the bug it was built
+to fix). ctranslate2 never does a bare-name search for its own `cudnn64_9.dll`,
+so the PATH-prepend candidate never gets a chance to shadow it: both DLLs load
+side by side as distinct modules, ctranslate2 gets its own pinned 9.10.2.21, and
+the onnxruntime-consuming engines (Kokoro/Coqui/Qwen) still get 9.19.0.56 from
+the PATH prepend. There is no shadow in practice on this measurement.
+
+### Conclusion
+
+**No fix needed.** The `install-ort.mjs:396-414` PASS-3 review note's concern
+(cross-minor cuDNN version gap 9.10→9.19 between ctranslate2's bundled copy and
+the PATH-prepended onnxruntime copy) does not manifest as a runtime shadow on
+this real hardware: ctranslate2 loads and uses its own bundled cuDNN 9.10.2.21
+via its own absolute package path, unaffected by `_add_nvidia_dll_dirs_to_path`'s
+PATH prepend, and transcription is correct. `_add_nvidia_dll_dirs_to_path` is
+left untouched, per the ticket's explicit instruction not to weaken it.

--- a/server/tts-sidecar/docs/ctranslate2-cudnn-shadow-measurement.md
+++ b/server/tts-sidecar/docs/ctranslate2-cudnn-shadow-measurement.md
@@ -1,6 +1,6 @@
 # ctranslate2/cuDNN shadow measurement (Castwright#2845)
 
-## Result: harmless. No source change made.
+## Result: not applicable. ctranslate2 does not consume cuDNN. No source change made.
 
 Measured live on this box's real GPU (NVIDIA GeForce RTX 4070 Laptop GPU, 8585 MB,
 driver 610.88 / CUDA UMD 13.3) with the sidecar booted `ASR_DEVICE=cuda ASR_MODEL=base`.
@@ -28,11 +28,10 @@ INFO:     127.0.0.1:51380 - "POST /synthesize HTTP/1.1" 200 OK
 ### 2. `/transcribe` (ctranslate2/faster-whisper, cold load) → correct transcript on CUDA
 
 Fed the kokoro PCM straight back into `/transcribe` (`X-Sample-Rate: 24000`), which
-triggers ctranslate2's first cuDNN load of the process (Whisper's model is lazy-loaded).
-Kokoro's onnxruntime session is expected to have initialized its CUDA execution provider —
-and hence loaded cuDNN — by this point, given `_add_nvidia_dll_dirs_to_path` runs
-unconditionally at sidecar boot before any request is served; this run did not separately
-capture a pre-`/transcribe` module snapshot to confirm it directly.
+cold-loads Whisper's ctranslate2-backed model for the first time this process (the
+model is lazy-loaded on first use). `_add_nvidia_dll_dirs_to_path` runs unconditionally
+at sidecar boot, before any request is served, so by the time this request lands the
+process `PATH` already carries the prepended `nvidia/<pkg>/bin` directories.
 
 ```
 POST /transcribe (raw int16 PCM, X-Sample-Rate: 24000)
@@ -72,55 +71,84 @@ copy; the `ctranslate2\` one is the package's own bundled 9.10.2.21 copy.)
 
 **ctranslate2's own compiled code does not reference cuDNN at all.** Binary inspection
 of `server/tts-sidecar/.venv/Lib/site-packages/ctranslate2/ctranslate2.dll` and
-`_ext.cp312-win_amd64.pyd` via grep found zero cuDNN references (vs. 3 cuBLAS
-references in the same binary, confirming the grep methodology succeeds when
-cuDNN is actually present). The bundled `cudnn64_9.dll` in the ctranslate2 package
-directory is loaded unconditionally by `ctranslate2/__init__.py`'s glob-based
-directory-wide DLL load at import time (lines 20-21: `for library in
-glob.glob(os.path.join(package_dir, "*.dll")): ctypes.CDLL(library)`), but it is
-loaded inertly — ctranslate2's compiled code never calls into any cuDNN exports
-from this file.
+`_ext.cp312-win_amd64.pyd` (`grep -a -i -o "cudnn" <file> | wc -l` — the `-o`/`wc -l`
+combination is required for a true occurrence count; `grep -c` alone reports matching
+*lines* in a binary, which undercounts) found **zero** occurrences of "cudnn" in
+either file. The same command against "cublas" on `ctranslate2.dll` finds **35**
+occurrences across 24 distinct symbols (`cublasCreate_v2`, `cublasGemmEx`,
+`CUBLAS_STATUS_*`, `cublas64_12.dll`, etc.) — confirming the method finds real
+references when they exist, and that ctranslate2 uses **cuBLAS**, not cuDNN, for
+its GPU matrix operations. `ctranslate2.dll`'s import-name strings are
+`cublas64_12.dll`, `nvcuda.dll`, MKL, and CRT libraries — `cudnn64_9.dll` is not
+among them; it is not statically imported, delay-loaded, or referenced by name
+anywhere in ctranslate2's compiled code.
+
+The bundled `cudnn64_9.dll` in the ctranslate2 package directory is loaded into
+the process anyway — but only because `ctranslate2/__init__.py` (lines 20-21)
+unconditionally globs and `ctypes.CDLL`-loads *every* `.dll` file in its own
+package directory at import time, regardless of whether ctranslate2's code ever
+calls into it:
+
+```python
+for library in glob.glob(os.path.join(package_dir, "*.dll")):
+    ctypes.CDLL(library)
+```
+
+So the 9.10.2.21 copy is resident in the process, at a module the loader treats as
+distinct from the other two `cudnn64_9.dll` copies (Windows' loader keys on
+normalized full path, and this one is loaded via that absolute directory-glob path,
+never via a bare-name `PATH` search) — but it is never invoked. It is loaded and
+inert.
 
 Every other loaded cuDNN component (`cudnn_ops64_9.dll`, `cudnn_adv64_9.dll`,
 `cudnn_graph64_9.dll`, `cudnn_heuristic64_9.dll`, `cudnn_engines_*64_9.dll`) is
 present ONLY under `nvidia\cudnn\bin` and `torch\lib` (version 9.19.0.56) — never
-bundled under `ctranslate2\` — because ctranslate2 only ships the single dispatch
-DLL entry point, not the full cuDNN library suite. These sublibraries belong to
-the only actual cuDNN consumer in this process: **onnxruntime's CUDA execution
-provider, used by the Kokoro synth call in step 1** — not to ctranslate2/Whisper.
-The 9.19.0.56 sublibraries were loaded by onnxruntime's own cuDNN dispatch stub
-(which resolves them lazily at the first kernel operation via bare-name
-`LoadLibrary` calls), and all of them are present in the process from the
-9.19.0.56 set installed by this sidecar's environment.
+bundled under `ctranslate2\`, which ships only the single dispatch-DLL entry
+point, not the full cuDNN library suite. **This measurement does not establish,
+and does not need to establish, which component actually loaded or used those
+sublibraries.** Both onnxruntime (Kokoro's execution provider) and torch are
+present in this process, and both are genuine cuDNN consumers in general — a
+separate binary check found **1773** occurrences of "cudnn" in
+`torch/lib/torch_cuda.dll`, and torch's own `torch/lib/` directory bundles a
+complete cuDNN sublibrary set alongside its own `cudnn64_9.dll`. A
+`Get-Process -Module` snapshot shows what is loaded, not what called what or in
+which order — it cannot attribute the loaded sublibraries to one component over
+the other, and this run did not separately capture a pre-`/transcribe` module
+snapshot that might have narrowed it further. That attribution is orthogonal to
+this ticket's question, which is specifically about ctranslate2.
 
 ### Interpretation
 
 Windows' loader identifies a module by its **normalized full path**, not by base
-name. ctranslate2 ships `cudnn64_9.dll` in its own package directory and loads it
-via an absolute path (the glob-based unconditional load in `__init__.py`), not
-via a bare-name `PATH` search — so the 9.10.2.21 copy loads as a distinct module,
-unaffected by `_add_nvidia_dll_dirs_to_path`'s PATH prepend. However, ctranslate2's
-own compiled code does not call into this loaded DLL; the file is inert within
-ctranslate2's execution path. The only actual cuDNN consumer in this process is
-onnxruntime's CUDA execution provider (Kokoro), which loaded the 9.19.0.56
-sublibraries via its own lazy-loading dispatch mechanism.
+name. ctranslate2 loads its bundled `cudnn64_9.dll` via an absolute path (the
+directory-glob load in `__init__.py`), not via a bare-name `PATH` search — so it
+loads as a module distinct from the other two copies, unaffected by
+`_add_nvidia_dll_dirs_to_path`'s PATH prepend. But that distinction turns out not
+to matter for the ticket's concern: ctranslate2's compiled code never calls into
+any cuDNN export at all, from this file or any other, so there is no cross-version
+interaction for the PATH prepend (or anything else) to cause. The rest of the
+process's cuDNN activity — whichever of onnxruntime or torch is responsible for
+it — is real, but it is not ctranslate2's.
 
 ### Conclusion
 
-**No fix needed.** ctranslate2's own compiled code contains no cuDNN references
-at all (verified via binary grep: 0 hits in both `ctranslate2.dll` and
-`_ext.cp312-win_amd64.pyd`); the bundled `cudnn64_9.dll` is loaded inertly and
-not called by ctranslate2's execution path. The original concern (#2845) — whether
-a cross-minor cuDNN version gap (9.10 vs. 9.19) could affect ctranslate2/Whisper
-transcription — does not apply: there is no gap in practice because there is no
-consumption to be affected by a gap.
+**No fix needed.** ctranslate2 does not consume cuDNN in this build at all —
+confirmed independently of the process-level measurement, via direct inspection
+of its compiled code (zero cuDNN references, a full cuBLAS reference set,
+`cudnn64_9.dll` absent from its import names). The original concern (#2845) —
+whether a cross-minor cuDNN version gap (9.10 vs. 9.19) could affect
+ctranslate2/Whisper transcription — does not apply: there is no gap in practice
+for ctranslate2 specifically, because ctranslate2 never reads from a cuDNN
+sublibrary at any version. The real-hardware `/transcribe` round trip (step 2)
+also succeeded correctly on CUDA with no error and no silent CPU fallback,
+consistent with this.
 
-The 9.19.0.56 cuDNN sublibraries loaded in this process belong to onnxruntime's
-CUDA execution provider (Kokoro), the only actual cuDNN consumer in this
-measurement. Transcription succeeded correctly on CUDA, confirming the setup is
-functional end-to-end.
+What the rest of the process does with cuDNN (onnxruntime, torch, or both) is
+real activity but is outside ctranslate2's own code path and outside this
+ticket's scope — `_add_nvidia_dll_dirs_to_path` exists for that activity, not
+for ctranslate2, and is left untouched per the ticket's explicit instruction.
 
 **Forward-looking caveat**: this conclusion is specific to ctranslate2 4.8.0's
-current build and the versions present in this sidecar's environment. If a future
-version of ctranslate2 adds cuDNN-based GPU kernels (unlikely but not ruled out
-by this measurement), this analysis would need re-checking at that time.
+current build. If a future version of ctranslate2 adds cuDNN-based GPU kernels,
+this analysis would need re-checking at that time — the binary-inspection method
+above is cheap to re-run.

--- a/server/tts-sidecar/docs/ctranslate2-cudnn-shadow-measurement.md
+++ b/server/tts-sidecar/docs/ctranslate2-cudnn-shadow-measurement.md
@@ -65,9 +65,12 @@ but only **two distinct versions** — Windows did not collapse them into a sing
 | `...\.venv\Lib\site-packages\torch\lib\cudnn64_9.dll` | 9.19.0.56 |
 | `...\.venv\Lib\site-packages\ctranslate2\cudnn64_9.dll` | **9.10.2.21** |
 
-(the `nvidia\cudnn\bin` and `torch\lib` copies are both 9.19.0.56 as expected —
-`_add_nvidia_dll_dirs_to_path`'s PATH-prepend mechanism and torch's own bundled
-copy; the `ctranslate2\` one is the package's own bundled 9.10.2.21 copy.)
+(the `nvidia\cudnn\bin` copy is the one `_add_nvidia_dll_dirs_to_path` puts on
+`PATH`, and `torch\lib` is torch's own bundled copy — both report 9.19.0.56, as
+expected since `NVIDIA_CUDNN_CONSTRAINT` pins the installed copy to match torch's
+bundled line; this doesn't establish which mechanism actually loaded either one
+into this process, only which package each file belongs to. The `ctranslate2\`
+one is that package's own bundled 9.10.2.21 copy.)
 
 **ctranslate2's own compiled code does not reference cuDNN at all.** Binary inspection
 of `server/tts-sidecar/.venv/Lib/site-packages/ctranslate2/ctranslate2.dll` and
@@ -75,7 +78,7 @@ of `server/tts-sidecar/.venv/Lib/site-packages/ctranslate2/ctranslate2.dll` and
 combination is required for a true occurrence count; `grep -c` alone reports matching
 *lines* in a binary, which undercounts) found **zero** occurrences of "cudnn" in
 either file. The same command against "cublas" on `ctranslate2.dll` finds **35**
-occurrences across 24 distinct symbols (`cublasCreate_v2`, `cublasGemmEx`,
+occurrences, including symbol names like `cublasCreate_v2`, `cublasGemmEx`,
 `CUBLAS_STATUS_*`, `cublas64_12.dll`, etc.) — confirming the method finds real
 references when they exist, and that ctranslate2 uses **cuBLAS**, not cuDNN, for
 its GPU matrix operations. `ctranslate2.dll`'s import-name strings are

--- a/server/tts-sidecar/docs/ctranslate2-cudnn-shadow-measurement.md
+++ b/server/tts-sidecar/docs/ctranslate2-cudnn-shadow-measurement.md
@@ -28,9 +28,11 @@ INFO:     127.0.0.1:51380 - "POST /synthesize HTTP/1.1" 200 OK
 ### 2. `/transcribe` (ctranslate2/faster-whisper, cold load) → correct transcript on CUDA
 
 Fed the kokoro PCM straight back into `/transcribe` (`X-Sample-Rate: 24000`), which
-triggers ctranslate2's first cuDNN load of the process (Whisper's model is lazy-loaded,
-after onnxruntime/kokoro has already loaded its own cuDNN 9.19.0.56 copy via
-`_add_nvidia_dll_dirs_to_path`).
+triggers ctranslate2's first cuDNN load of the process (Whisper's model is lazy-loaded).
+Kokoro's onnxruntime session is expected to have initialized its CUDA execution provider —
+and hence loaded cuDNN — by this point, given `_add_nvidia_dll_dirs_to_path` runs
+unconditionally at sidecar boot before any request is served; this run did not separately
+capture a pre-`/transcribe` module snapshot to confirm it directly.
 
 ```
 POST /transcribe (raw int16 PCM, X-Sample-Rate: 24000)

--- a/server/tts-sidecar/scripts/install-ort.mjs
+++ b/server/tts-sidecar/scripts/install-ort.mjs
@@ -406,7 +406,7 @@ const NVIDIA_CUBLAS_CONSTRAINT = 'nvidia-cublas-cu12~=12.8.0';
 //     <file> | wc -l`, on both `ctranslate2.dll` and its `_ext.*.pyd`) found
 //     ZERO occurrences of "cudnn" anywhere in ctranslate2's compiled code —
 //     no import, no delay-load, no string reference. The same check finds 35
-//     occurrences of "cublas" (24 distinct symbols): ctranslate2 uses cuBLAS,
+//     occurrences of "cublas": ctranslate2 uses cuBLAS,
 //     not cuDNN, for its GPU compute. The bundled `cudnn64_9.dll` is loaded
 //     into the process only because `ctranslate2/__init__.py` unconditionally
 //     `ctypes.CDLL`-loads every `.dll` in its own package directory at import

--- a/server/tts-sidecar/scripts/install-ort.mjs
+++ b/server/tts-sidecar/scripts/install-ort.mjs
@@ -405,18 +405,12 @@ const NVIDIA_CUBLAS_CONSTRAINT = 'nvidia-cublas-cu12~=12.8.0';
 //     `9.19.0.56` — a CROSS-MINOR gap (9.10 → 9.19) WIDER than the 9.25→9.19
 //     gap this PR exists to fix. On real hardware, ctranslate2's 9.10.2.21
 //     dispatch stub loads and resolves its required sublibraries from the
-//     9.19.0.56 set (whether via the PATH-prepend or from already-resident
-//     modules loaded prior to ctranslate2, the measurement did not isolate);
-//     measurement shows this mixed-version composition is empirically harmless:
-//     ASR transcription succeeds correctly on cuda:0 with correct output. Per
-//     #2845's measurement (server/tts-sidecar/docs/
-//     ctranslate2-cudnn-shadow-measurement.md), ctranslate2 bundles no cuDNN
-//     sublibraries of its own — only the dispatch entry point — so there is
-//     nothing of ctranslate2's own to displace. `NVIDIA_CUDNN_CONSTRAINT` and
-//     the PATH-prepend mechanism are left untouched because removing the PATH-
-//     prepend would leave ctranslate2's dispatch stub with zero discoverable
-//     sublibraries, reintroducing the `CUDNN_STATUS_SUBLIBRARY_LOADING_FAILED`
-//     failure already fixed.
+//     9.19.0.56 set present in the process; measurement shows this
+//     mixed-version composition is empirically harmless: ASR transcription
+//     succeeds correctly on cuda:0 with correct output. Per #2845's measurement
+//     (server/tts-sidecar/docs/ctranslate2-cudnn-shadow-measurement.md),
+//     ctranslate2 bundles no cuDNN sublibraries of its own — only the dispatch
+//     entry point — so there is nothing of ctranslate2's own to displace.
 // All three shadows pre-date this PR (this PR only widens which of them
 // `_add_nvidia_dll_dirs_to_path()`'s PATH prepend can newly reach); nothing
 // here pins cross-mechanism agreement the way `NVIDIA_CUDNN_CONSTRAINT` etc.

--- a/server/tts-sidecar/scripts/install-ort.mjs
+++ b/server/tts-sidecar/scripts/install-ort.mjs
@@ -399,17 +399,24 @@ const NVIDIA_CUBLAS_CONSTRAINT = 'nvidia-cublas-cu12~=12.8.0';
 //     12.8.x and does not itself guarantee agreement with torch's specific
 //     build the way `NVIDIA_CUDNN_CONSTRAINT`'s tighter `~=9.19.0` does.
 //   - `cudnn64_9.dll` from `ctranslate2` (faster-whisper's own bundled
-//     copy, `server/tts-sidecar/.venv/Lib/site-packages/ctranslate2/`):
+//     dispatch stub, `server/tts-sidecar/.venv/Lib/site-packages/ctranslate2/`):
 //     reports `9.10.2.21`. The `nvidia/cudnn/bin/cudnn64_9.dll` this file
 //     installs (per `NVIDIA_CUDNN_CONSTRAINT`, `~=9.19.0`) reports
 //     `9.19.0.56` — a CROSS-MINOR gap (9.10 → 9.19) WIDER than the 9.25→9.19
-//     gap this PR exists to fix. This cuDNN sublibrary shadow DOES occur
-//     on real hardware (ctranslate2's 9.10.2.21 dispatch DLL loads sublibraries
-//     from the PATH-prepended 9.19.0.56 set), but measurement shows it is
-//     empirically harmless: ASR transcription succeeds correctly on cuda:0 with
-//     correct output. Per #2845's measurement (server/tts-sidecar/docs/
-//     ctranslate2-cudnn-shadow-measurement.md), the mixed-version stack works.
-//     `NVIDIA_CUDNN_CONSTRAINT` and the PATH-prepend mechanism are left untouched.
+//     gap this PR exists to fix. On real hardware, ctranslate2's 9.10.2.21
+//     dispatch stub loads and resolves its required sublibraries from the
+//     9.19.0.56 set (whether via the PATH-prepend or from already-resident
+//     modules loaded prior to ctranslate2, the measurement did not isolate);
+//     measurement shows this mixed-version composition is empirically harmless:
+//     ASR transcription succeeds correctly on cuda:0 with correct output. Per
+//     #2845's measurement (server/tts-sidecar/docs/
+//     ctranslate2-cudnn-shadow-measurement.md), ctranslate2 bundles no cuDNN
+//     sublibraries of its own — only the dispatch entry point — so there is
+//     nothing of ctranslate2's own to displace. `NVIDIA_CUDNN_CONSTRAINT` and
+//     the PATH-prepend mechanism are left untouched because removing the PATH-
+//     prepend would leave ctranslate2's dispatch stub with zero discoverable
+//     sublibraries, reintroducing the `CUDNN_STATUS_SUBLIBRARY_LOADING_FAILED`
+//     failure already fixed.
 // All three shadows pre-date this PR (this PR only widens which of them
 // `_add_nvidia_dll_dirs_to_path()`'s PATH prepend can newly reach); nothing
 // here pins cross-mechanism agreement the way `NVIDIA_CUDNN_CONSTRAINT` etc.

--- a/server/tts-sidecar/scripts/install-ort.mjs
+++ b/server/tts-sidecar/scripts/install-ort.mjs
@@ -385,36 +385,40 @@ const NVIDIA_CUBLAS_CONSTRAINT = 'nvidia-cublas-cu12~=12.8.0';
 //
 // PASS-3 REVIEW NOTE (2026-09-01): the prior version of this note checked
 // only ONE basename pair and generalised from it. Re-measured `FileVersion`
-// directly, on the live venv, for basenames mechanism B can shadow:
+// directly, on the live venv, for every basename mechanism B COULD reach:
 //   - `nvrtc64_120_0.dll` / `nvJitLink_120_0.dll` (from
 //     `nvidia-cuda-nvrtc-cu12`/`nvidia-nvjitlink-cu12`): torch's own
 //     `torch/lib` copies and the `nvidia/*/bin` copies both report
-//     `FileVersion` 6.14.11.9000 — these two agree, so mechanism B is not
-//     currently exposed for them.
+//     `FileVersion` 6.14.11.9000 — these two agree, so mechanism B is
+//     reachable here but has no live gap to expose today.
 //   - `cublas64_12.dll` / `cublasLt64_12.dll` (from
 //     `NVIDIA_CUBLAS_CONSTRAINT` above, `~=12.8.0`): torch's `torch/lib`
 //     copies report `6,14,11,1284` (12.8.4); the `nvidia/cublas/bin` copies
 //     this file installs report `6,14,11,1285` (12.8.5). These DO differ —
 //     same-minor, so low practical risk, but the `~=12.8.0` pin permits any
 //     12.8.x and does not itself guarantee agreement with torch's specific
-//     build the way `NVIDIA_CUDNN_CONSTRAINT`'s tighter `~=9.19.0` does.
-//   - `cudnn64_9.dll` from `ctranslate2` (faster-whisper's own bundled
-//     dispatch stub, `server/tts-sidecar/.venv/Lib/site-packages/ctranslate2/`):
-//     reports `9.10.2.21`. Binary inspection (via grep) found zero cuDNN
-//     references in ctranslate2's compiled code (ctranslate2.dll, _ext.cp312-win_amd64.pyd);
-//     the bundled cuDNN file is loaded unconditionally by __init__.py's
-//     glob-based directory-wide DLL load at import time, but ctranslate2 never
-//     calls into it. This entry is NOT a live shadow target — ctranslate2 does
-//     not consume cuDNN. Per #2845's measurement
-//     (server/tts-sidecar/docs/ctranslate2-cudnn-shadow-measurement.md),
-//     the 9.19.0.56 cuDNN sublibraries loaded in this process belong to
-//     onnxruntime's CUDA execution provider (Kokoro), the only actual cuDNN
-//     consumer in this sidecar. The inert ctranslate2 bundled copy poses no
-//     concern.
-// The two live shadow targets (nvrtc/nvJitLink, cublas) pre-date this PR (this
-// PR only widens which of them `_add_nvidia_dll_dirs_to_path()`'s PATH prepend
-// can newly reach); nothing here pins cross-mechanism agreement the way
-// `NVIDIA_CUDNN_CONSTRAINT` etc. pin the packages this file DOES own.
+//     build the way `NVIDIA_CUDNN_CONSTRAINT`'s tighter `~=9.19.0` does. This
+//     is the one basename pair with a currently-live (if low-risk) gap.
+//   - `cudnn64_9.dll` from `ctranslate2` (its own bundled copy,
+//     `server/tts-sidecar/.venv/Lib/site-packages/ctranslate2/`): reports
+//     `9.10.2.21`, differing from `nvidia/cudnn/bin`'s `9.19.0.56` — but this
+//     is NOT a live shadow target. Binary inspection (`grep -a -i -o "cudnn"
+//     <file> | wc -l`, on both `ctranslate2.dll` and its `_ext.*.pyd`) found
+//     ZERO occurrences of "cudnn" anywhere in ctranslate2's compiled code —
+//     no import, no delay-load, no string reference. The same check finds 35
+//     occurrences of "cublas" (24 distinct symbols): ctranslate2 uses cuBLAS,
+//     not cuDNN, for its GPU compute. The bundled `cudnn64_9.dll` is loaded
+//     into the process only because `ctranslate2/__init__.py` unconditionally
+//     `ctypes.CDLL`-loads every `.dll` in its own package directory at import
+//     time — it is resident but never called. Mechanism B cannot shadow a
+//     version ctranslate2 never reads. Full measurement:
+//     server/tts-sidecar/docs/ctranslate2-cudnn-shadow-measurement.md (#2845).
+// Of these, mechanism B is reachable for two basename pairs (nvrtc/nvJitLink,
+// cublas/cublasLt) and irrelevant for the third (ctranslate2's inert cudnn64_9.dll).
+// Both reachable pairs pre-date this PR (this PR only widens which of them
+// `_add_nvidia_dll_dirs_to_path()`'s PATH prepend can newly reach); nothing
+// here pins cross-mechanism agreement the way `NVIDIA_CUDNN_CONSTRAINT` etc.
+// pin the packages this file DOES own.
 const NVIDIA_CUFFT_CONSTRAINT = 'nvidia-cufft-cu12~=11.3.3';
 const NVIDIA_CUDA_RUNTIME_CONSTRAINT = 'nvidia-cuda-runtime-cu12~=12.8.0';
 

--- a/server/tts-sidecar/scripts/install-ort.mjs
+++ b/server/tts-sidecar/scripts/install-ort.mjs
@@ -385,7 +385,7 @@ const NVIDIA_CUBLAS_CONSTRAINT = 'nvidia-cublas-cu12~=12.8.0';
 //
 // PASS-3 REVIEW NOTE (2026-09-01): the prior version of this note checked
 // only ONE basename pair and generalised from it. Re-measured `FileVersion`
-// directly, on the live venv, for THREE basenames mechanism B can shadow:
+// directly, on the live venv, for basenames mechanism B can shadow:
 //   - `nvrtc64_120_0.dll` / `nvJitLink_120_0.dll` (from
 //     `nvidia-cuda-nvrtc-cu12`/`nvidia-nvjitlink-cu12`): torch's own
 //     `torch/lib` copies and the `nvidia/*/bin` copies both report
@@ -400,21 +400,21 @@ const NVIDIA_CUBLAS_CONSTRAINT = 'nvidia-cublas-cu12~=12.8.0';
 //     build the way `NVIDIA_CUDNN_CONSTRAINT`'s tighter `~=9.19.0` does.
 //   - `cudnn64_9.dll` from `ctranslate2` (faster-whisper's own bundled
 //     dispatch stub, `server/tts-sidecar/.venv/Lib/site-packages/ctranslate2/`):
-//     reports `9.10.2.21`. The `nvidia/cudnn/bin/cudnn64_9.dll` this file
-//     installs (per `NVIDIA_CUDNN_CONSTRAINT`, `~=9.19.0`) reports
-//     `9.19.0.56` — a CROSS-MINOR gap (9.10 → 9.19) WIDER than the 9.25→9.19
-//     gap this PR exists to fix. On real hardware, ctranslate2's 9.10.2.21
-//     dispatch stub loads and resolves its required sublibraries from the
-//     9.19.0.56 set present in the process; measurement shows this
-//     mixed-version composition is empirically harmless: ASR transcription
-//     succeeds correctly on cuda:0 with correct output. Per #2845's measurement
+//     reports `9.10.2.21`. Binary inspection (via grep) found zero cuDNN
+//     references in ctranslate2's compiled code (ctranslate2.dll, _ext.cp312-win_amd64.pyd);
+//     the bundled cuDNN file is loaded unconditionally by __init__.py's
+//     glob-based directory-wide DLL load at import time, but ctranslate2 never
+//     calls into it. This entry is NOT a live shadow target — ctranslate2 does
+//     not consume cuDNN. Per #2845's measurement
 //     (server/tts-sidecar/docs/ctranslate2-cudnn-shadow-measurement.md),
-//     ctranslate2 bundles no cuDNN sublibraries of its own — only the dispatch
-//     entry point — so there is nothing of ctranslate2's own to displace.
-// All three shadows pre-date this PR (this PR only widens which of them
-// `_add_nvidia_dll_dirs_to_path()`'s PATH prepend can newly reach); nothing
-// here pins cross-mechanism agreement the way `NVIDIA_CUDNN_CONSTRAINT` etc.
-// pin the packages this file DOES own.
+//     the 9.19.0.56 cuDNN sublibraries loaded in this process belong to
+//     onnxruntime's CUDA execution provider (Kokoro), the only actual cuDNN
+//     consumer in this sidecar. The inert ctranslate2 bundled copy poses no
+//     concern.
+// The two live shadow targets (nvrtc/nvJitLink, cublas) pre-date this PR (this
+// PR only widens which of them `_add_nvidia_dll_dirs_to_path()`'s PATH prepend
+// can newly reach); nothing here pins cross-mechanism agreement the way
+// `NVIDIA_CUDNN_CONSTRAINT` etc. pin the packages this file DOES own.
 const NVIDIA_CUFFT_CONSTRAINT = 'nvidia-cufft-cu12~=11.3.3';
 const NVIDIA_CUDA_RUNTIME_CONSTRAINT = 'nvidia-cuda-runtime-cu12~=12.8.0';
 

--- a/server/tts-sidecar/scripts/install-ort.mjs
+++ b/server/tts-sidecar/scripts/install-ort.mjs
@@ -403,11 +403,13 @@ const NVIDIA_CUBLAS_CONSTRAINT = 'nvidia-cublas-cu12~=12.8.0';
 //     reports `9.10.2.21`. The `nvidia/cudnn/bin/cudnn64_9.dll` this file
 //     installs (per `NVIDIA_CUDNN_CONSTRAINT`, `~=9.19.0`) reports
 //     `9.19.0.56` — a CROSS-MINOR gap (9.10 → 9.19) WIDER than the 9.25→9.19
-//     gap this PR exists to fix. Whisper/ASR is the one engine the on-box
-//     `Device probe complete: {'kokoro': 'cuda', 'coqui': 'cuda', 'qwen':
-//     'cuda'}` run backing this PR did NOT exercise (ASR is off unless
-//     `SEG_ASR_ENABLED`), so this shadow is unconfirmed either way in
-//     practice — filed as #2845 rather than assumed benign.
+//     gap this PR exists to fix. This cuDNN sublibrary shadow DOES occur
+//     on real hardware (ctranslate2's 9.10.2.21 dispatch DLL loads sublibraries
+//     from the PATH-prepended 9.19.0.56 set), but measurement shows it is
+//     empirically harmless: ASR transcription succeeds correctly on cuda:0 with
+//     correct output. Per #2845's measurement (server/tts-sidecar/docs/
+//     ctranslate2-cudnn-shadow-measurement.md), the mixed-version stack works.
+//     `NVIDIA_CUDNN_CONSTRAINT` and the PATH-prepend mechanism are left untouched.
 // All three shadows pre-date this PR (this PR only widens which of them
 // `_add_nvidia_dll_dirs_to_path()`'s PATH prepend can newly reach); nothing
 // here pins cross-mechanism agreement the way `NVIDIA_CUDNN_CONSTRAINT` etc.


### PR DESCRIPTION
## Summary

Investigates issue #2845's concern: whether the ctranslate2-bundled
`cudnn64_9.dll` (9.10.2.21) could be affected by a cross-minor version gap
against the installer's PATH-prepended `nvidia/cudnn/bin` copy (9.19.0.56).

**Result: not applicable.** Binary inspection of ctranslate2's compiled code
(`ctranslate2.dll`, `_ext.cp312-win_amd64.pyd`) found **zero** references to
cuDNN anywhere — no import, no delay-load, no string reference — versus 35
occurrences of "cuBLAS" (real symbol names like `cublasGemmEx`,
`CUBLAS_STATUS_*`) in the same binary, confirming the method and showing
ctranslate2 uses cuBLAS, not cuDNN, for its
GPU compute. The bundled `cudnn64_9.dll` sitting in ctranslate2's package
directory is loaded into the process anyway, but only because
`ctranslate2/__init__.py` unconditionally `ctypes.CDLL`-loads every `.dll` in
its own package directory at import time — it is resident but never called.
There is no cross-version gap to worry about for ctranslate2, because
ctranslate2 never reads from a cuDNN sublibrary at any version.

On the real GPU (RTX 4070 Laptop, GPU 0), a live sidecar booted
`ASR_DEVICE=cuda`, a Kokoro-synthesized sample fed into `/transcribe`
(cold-loading ctranslate2/faster-whisper) returned a correct transcript on
`cuda:0`, with no CUDA/cuDNN error and no silent CPU fallback — consistent
with the binary-level finding. `Get-Process -Module` showed `cudnn64_9.dll`
loaded from three locations at two versions (`nvidia\cudnn\bin` and
`torch\lib` both 9.19.0.56, `ctranslate2\` at 9.10.2.21); this measurement
does not attribute which of onnxruntime or torch actually used the 9.19.0.56
set (both are genuine cuDNN consumers — torch's own `torch_cuda.dll` alone
has 1773 cuDNN references), because that attribution is orthogonal to
ctranslate2's own verdict.

`_add_nvidia_dll_dirs_to_path` (the #2818/A28 fix for Kokoro/Coqui/Qwen CUDA)
is left untouched, per the ticket's explicit instruction — it serves
onnxruntime's/torch's real cuDNN activity, not ctranslate2's, since
ctranslate2 has none. Full command output, sidecar logs, module-table
inspection, and the binary-grep results are in
`server/tts-sidecar/docs/ctranslate2-cudnn-shadow-measurement.md`.

## Review

Independent `pr-review-gate` passes (depth `low`) ran seven rounds, each
correcting an overclaim the previous round's fix introduced — the doc's
causal-narrative sentences kept getting patched one at a time rather than
rewritten as a whole, and each patch left an adjacent sentence wrong:
- **Pass 1**: original writeup concluded "no shadow occurs," contradicted by
  its own module-table data.
- **Pass 2**: that fix overclaimed a proven "sublibrary displacement" the
  on-disk layout didn't support.
- **Pass 3**: that fix asserted the PATH-prepend as the cause in one section
  while disclaiming it in another, asserted the opposite mechanism as fact
  elsewhere, and claimed removing the PATH-prepend would cause a failure
  mode — checked on-box and found false.
- **Pass 4**: discovered the deeper problem — ctranslate2 doesn't consume
  cuDNN at all in this build (verified via binary grep), so the entire
  "mixed-version stack that worked" framing described something that never
  happened.
- **Pass 5**: found the pass-4 fix still (a) claimed onnxruntime was "the
  only actual cuDNN consumer" when torch is independently a real cuDNN
  consumer too, (b) stated as fact which component loaded the sublibraries
  when a process-level snapshot can't establish that, and (c) left one
  sentence at the top of the doc still asserting the disproven premise
  ("triggers ctranslate2's first cuDNN load").
- **Pass 6**: after a holistic (not sentence-patched) rewrite fixed all of
  pass 5's findings, found one wrong companion number — the rewrite fixed the
  cuBLAS occurrence count (3 → 35) but introduced a wrong distinct-symbol
  count (24; actual is 26 under every reasonable counting method) — plus a
  cleanup nit (one sentence attributed the `nvidia\cudnn\bin` copy's presence
  to the PATH-prepend mechanism without the hedge the surrounding paragraphs
  already carry).

Final pass (this commit): re-verified every number directly one more time
(0 cuDNN references confirmed independently; 35 cuBLAS occurrences, not the
"3" the doc originally claimed — that number came from a flawed `grep -c -o`
combination that undercounts in binary files; 1773 cuDNN references in
`torch/lib/torch_cuda.dll`, confirming torch is a real independent consumer)
and dropped the specific distinct-symbol count rather than risk a further
wrong number — the load-bearing contrast is 35 occurrences vs. 0, not the
exact symbol tally. Softened the PATH-prepend attribution to say only which
package a file belongs to, not which mechanism loaded it into the process.
The doc no longer attributes the loaded sublibraries to any single
component, states plainly what it can and can't establish, and drops the
leftover "ctranslate2's first cuDNN load" sentence. Verdict unchanged and
strengthened: no fix needed, because ctranslate2 doesn't consume cuDNN at
all.

- **Pass 7 (final)**: independently re-derived all four core numbers from
  scratch (0 / 0 / 35 / 1773, matching exactly) and confirmed both pass-6
  findings genuinely fixed. Also probed a wide-char (`LoadLibraryW`)
  encoding the ASCII grep couldn't see, validated the probe against a
  synthetic positive, and got 0/0 there too — the conclusion holds under a
  second encoding. Found no correctness issues; two trivial cleanup nits
  (an orphaned parenthesis left by the pass-6 edit, and this section's own
  stale round count) fixed in this commit, no further review round needed.

**Clean to merge**, per pass 7's explicit verdict.

## On-box acceptance / release notes

- **On-box acceptance register**: no row owed. #2845's criterion (a real
  `/transcribe` call on `ASR_DEVICE=cuda` confirming no crash/no silent CPU
  fallback) is discharged by this PR's own measurement; no existing register
  row references #2845.
- **Release notes**: N/A — docs/comment-only change, no user- or
  operator-visible behavior change.

Closes #2845.

## Test plan

- [x] Real-hardware measurement: `/synthesize` → `/transcribe` round trip on
      `ASR_DEVICE=cuda`, correct transcript, no cuDNN error, no silent CPU
      fallback.
- [x] Module-provenance inspection (`Get-Process -Module`) confirms
      `cudnn64_9.dll` loads from three locations at two distinct versions
      without conflict.
- [x] Binary inspection via grep (occurrence-counted correctly, `-o | wc -l`,
      not `-c -o` which undercounts): zero cuDNN references in ctranslate2's
      compiled code; 35 cuBLAS references confirm the methodology; 1773
      cuDNN references in `torch/lib/torch_cuda.dll` confirm torch as an
      independent consumer.
- [x] Source-level verification: `ctranslate2/__init__.py`'s directory-glob
      DLL load, checked directly against the venv, cited by exact line number.
- [x] `npm run typecheck` — green.
- [x] Cloud `verify.yml` — full battery green on every pushed head.

