### PR TITLE
chore(scripts): extract shared throwaway-repo git-env scrub helper (#2855)

### DIFF
--- a/scripts/git-env.mjs
+++ b/scripts/git-env.mjs
@@ -82,3 +82,23 @@ export function scrubGitEnv(env = process.env) {
   }
   return out;
 }
+
+/** A copy of `env` with EVERY key whose name starts with `GIT_` (matched
+ *  case-insensitively) removed — deliberately broader than `scrubGitEnv()`
+ *  above, which is the WRONG helper to reach for here. `scrubGitEnv()`
+ *  exists for production call sites that must still honour `GIT_INDEX_FILE`
+ *  and other `GIT_*` vars outside its narrow allowlist (see the #2216
+ *  correction above). This helper is for tests that spawn git inside a
+ *  throwaway repo built fresh in a temp dir: there is no real index or
+ *  ambient repository state for those to honour, so any inherited `GIT_*`
+ *  var — `GIT_INDEX_FILE`, `GIT_PREFIX`, `GIT_AUTHOR_DATE`, all of it — is
+ *  only ever a hazard, not a value worth preserving. A caller that still
+ *  needs one of them can re-add it after calling this, e.g.
+ *  `{ ...scrubGitEnvForThrowawayRepo(), GIT_AUTHOR_DATE: x }`. */
+export function scrubGitEnvForThrowawayRepo(env = process.env) {
+  const out = { ...env };
+  for (const key of Object.keys(out)) {
+    if (key.toUpperCase().startsWith('GIT_')) delete out[key];
+  }
+  return out;
+}

--- a/scripts/tests/bump-version.test.mjs
+++ b/scripts/tests/bump-version.test.mjs
@@ -19,7 +19,7 @@ import assert from 'node:assert/strict';
 // Pure helper from the script (import is inert — the script's procedure is
 // behind an import.meta-main guard, so loading it here doesn't run a release).
 import { pickWorkflowRun, readSidecarVersion, writeSidecarVersion, sidecarVersionPath, readPubspecVersion, writePubspecVersion, pubspecPath, pubspecBuildNumber, resolveNotesFile, staleNotesVersion, DEFAULT_NOTES_FILE, buildTagMessage, createAnnotatedTag, execGit } from '../bump-version.mjs';
-import { scrubGitEnv } from '../git-env.mjs';
+import { scrubGitEnv, scrubGitEnvForThrowawayRepo } from '../git-env.mjs';
 import { join } from 'node:path';
 import { execFileSync, spawnSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
@@ -42,17 +42,11 @@ const MOJIBAKE_EM_DASH = 'â€”'; // should decode to U+2014 —, standalone 
 // which child processes inherit. Without sanitising, the test's `git commit`
 // would write into the PARENT worktree's git instead of the temp fixture —
 // silently creating bogus commits on whatever branch invoked the hook.
-// Case-insensitive match: Windows preserves whatever casing a var was stored
-// under while lookup is case-insensitive, and git honours a lowercase
-// `git_dir` identically to `GIT_DIR` — see git-env.mjs's scrubGitEnv() header
-// for the same trap. A `startsWith('GIT_')` filter alone leaves a `git_dir`
-// (or similar) survivor that still redirects the throwaway repo's commits.
+// Thin wrapper over the shared, broader-than-scrubGitEnv() helper — see
+// git-env.mjs's scrubGitEnvForThrowawayRepo() for the case-insensitivity
+// rationale and why this needs a separate helper from scrubGitEnv().
 function cleanGitEnv() {
-  const env = { ...process.env };
-  for (const key of Object.keys(env)) {
-    if (key.toUpperCase().startsWith('GIT_')) delete env[key];
-  }
-  return env;
+  return scrubGitEnvForThrowawayRepo();
 }
 
 // Wrap execFileSync to always pass the sanitised env. Every git invocation

--- a/scripts/tests/bump-version.test.mjs
+++ b/scripts/tests/bump-version.test.mjs
@@ -43,8 +43,8 @@ const MOJIBAKE_EM_DASH = 'â€”'; // should decode to U+2014 —, standalone 
 // would write into the PARENT worktree's git instead of the temp fixture —
 // silently creating bogus commits on whatever branch invoked the hook.
 // Thin wrapper over the shared, broader-than-scrubGitEnv() helper — see
-// git-env.mjs's scrubGitEnvForThrowawayRepo() for the case-insensitivity
-// rationale and why this needs a separate helper from scrubGitEnv().
+// git-env.mjs's scrubGitEnv() docstring for the case-insensitivity rationale,
+// and why this needs a separate helper from scrubGitEnv().
 function cleanGitEnv() {
   return scrubGitEnvForThrowawayRepo();
 }

--- a/scripts/tests/git-env.test.mjs
+++ b/scripts/tests/git-env.test.mjs
@@ -81,3 +81,29 @@ test('a caller can re-add a specific GIT_* var after scrubbing via plain spread'
   assert.equal(merged.GIT_AUTHOR_DATE, 'new');
   assert.equal(merged.PATH, '/usr/bin');
 });
+
+// Regression test for the defensive-copy mutant: ensure the function returns
+// a NEW object and does NOT mutate its input argument. Passing an explicit
+// plain object (not process.env) as the argument makes this checkable without
+// having to save/restore the original.
+test('scrubGitEnvForThrowawayRepo returns a new object and does not mutate its input', () => {
+  const inputEnv = {
+    PATH: '/usr/bin',
+    GIT_DIR: '/decoy/.git',
+    GIT_WORK_TREE: '/decoy',
+    GIT_AUTHOR_DATE: '2026-01-01',
+  };
+  const scrubbed = scrubGitEnvForThrowawayRepo(inputEnv);
+
+  // The returned object must have GIT_* keys stripped
+  assert.equal(scrubbed.GIT_DIR, undefined);
+  assert.equal(scrubbed.GIT_WORK_TREE, undefined);
+  assert.equal(scrubbed.GIT_AUTHOR_DATE, undefined);
+  assert.equal(scrubbed.PATH, '/usr/bin');
+
+  // The input object must remain UNCHANGED — still contains all original keys
+  assert.equal(inputEnv.PATH, '/usr/bin');
+  assert.equal(inputEnv.GIT_DIR, '/decoy/.git');
+  assert.equal(inputEnv.GIT_WORK_TREE, '/decoy');
+  assert.equal(inputEnv.GIT_AUTHOR_DATE, '2026-01-01');
+});

--- a/scripts/tests/git-env.test.mjs
+++ b/scripts/tests/git-env.test.mjs
@@ -1,0 +1,83 @@
+// Unit tests for scripts/git-env.mjs's shared GIT_* env helpers.
+// scrubGitEnv() itself already has coverage via its callers' regression
+// suites (bump-version.test.mjs, release-body.test.mjs, verify-cache.test.mjs
+// each pin its case-insensitivity and GIT_INDEX_FILE preservation). This file
+// is for scrubGitEnvForThrowawayRepo() (#2865), the broader sibling those
+// three test files now delegate their local cleanGitEnv() to instead of each
+// hand-rolling the strip loop.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { scrubGitEnvForThrowawayRepo } from '../git-env.mjs';
+
+// Mirrors the case-insensitivity regression already pinned per-file in
+// bump-version.test.mjs / release-body.test.mjs / verify-cache.test.mjs:
+// Windows preserves whatever casing a var was stored under while lookup is
+// case-insensitive, and git honours a lowercase `git_dir` identically to
+// `GIT_DIR`. Deliberately mixed-case-only, so it cannot pass against a
+// `key.startsWith('GIT_')` filter.
+test('scrubGitEnvForThrowawayRepo strips a GIT_ override regardless of stored casing', () => {
+  const fakeEnv = {
+    PATH: '/usr/bin',
+    git_dir: '/decoy/.git',
+    Git_Work_Tree: '/decoy',
+  };
+  const scrubbed = scrubGitEnvForThrowawayRepo(fakeEnv);
+  assert.equal(scrubbed.git_dir, undefined);
+  assert.equal(scrubbed.Git_Work_Tree, undefined);
+  assert.equal(scrubbed.PATH, '/usr/bin');
+});
+
+// The one assertion that didn't already exist anywhere: this is the exact
+// behaviour that distinguishes scrubGitEnvForThrowawayRepo() from
+// scrubGitEnv() (which deliberately PRESERVES GIT_INDEX_FILE — see the #2216
+// correction in git-env.mjs). A throwaway repo built fresh in a temp dir has
+// no real index or ambient repository state to honour, so every GIT_*-named
+// key must go, GIT_INDEX_FILE and GIT_PREFIX included.
+test('scrubGitEnvForThrowawayRepo strips GIT_INDEX_FILE and GIT_PREFIX too, unlike scrubGitEnv', () => {
+  const fakeEnv = {
+    PATH: '/usr/bin',
+    GIT_DIR: '/decoy/.git',
+    GIT_WORK_TREE: '/decoy',
+    GIT_OBJECT_DIRECTORY: '/decoy/.git/objects',
+    GIT_COMMON_DIR: '/decoy/.git',
+    GIT_INDEX_FILE: '/decoy/.git/index',
+    GIT_PREFIX: 'sub/dir/',
+    GIT_AUTHOR_DATE: '2026-01-01T00:00:00Z',
+  };
+  const scrubbed = scrubGitEnvForThrowawayRepo(fakeEnv);
+  assert.equal(scrubbed.GIT_DIR, undefined);
+  assert.equal(scrubbed.GIT_WORK_TREE, undefined);
+  assert.equal(scrubbed.GIT_OBJECT_DIRECTORY, undefined);
+  assert.equal(scrubbed.GIT_COMMON_DIR, undefined);
+  assert.equal(scrubbed.GIT_INDEX_FILE, undefined);
+  assert.equal(scrubbed.GIT_PREFIX, undefined);
+  assert.equal(scrubbed.GIT_AUTHOR_DATE, undefined);
+  assert.equal(scrubbed.PATH, '/usr/bin');
+});
+
+// Default-parameter behaviour matches scrubGitEnv()'s: called with no
+// argument, it scrubs process.env, not an empty object.
+test('scrubGitEnvForThrowawayRepo defaults to scrubbing process.env', () => {
+  const saved = process.env.GIT_DIR;
+  try {
+    process.env.GIT_DIR = '/decoy/.git';
+    const scrubbed = scrubGitEnvForThrowawayRepo();
+    assert.equal(scrubbed.GIT_DIR, undefined);
+    const pathKey = Object.keys(scrubbed).find((k) => k.toUpperCase() === 'PATH');
+    assert.ok(pathKey, 'PATH must survive the scrub');
+  } finally {
+    if (saved === undefined) delete process.env.GIT_DIR;
+    else process.env.GIT_DIR = saved;
+  }
+});
+
+// The override-after-strip pattern bump-version.test.mjs's runBump() relies
+// on (re-adding GIT_AUTHOR_DATE/GIT_COMMITTER_DATE after stripping) must
+// keep working with a plain object spread — no extra API needed.
+test('a caller can re-add a specific GIT_* var after scrubbing via plain spread', () => {
+  const fakeEnv = { PATH: '/usr/bin', GIT_AUTHOR_DATE: 'old' };
+  const merged = { ...scrubGitEnvForThrowawayRepo(fakeEnv), GIT_AUTHOR_DATE: 'new' };
+  assert.equal(merged.GIT_AUTHOR_DATE, 'new');
+  assert.equal(merged.PATH, '/usr/bin');
+});

--- a/scripts/tests/git-env.test.mjs
+++ b/scripts/tests/git-env.test.mjs
@@ -1,10 +1,10 @@
 // Unit tests for scripts/git-env.mjs's shared GIT_* env helpers.
-// scrubGitEnv() itself already has coverage via its callers' regression
-// suites (bump-version.test.mjs, release-body.test.mjs, verify-cache.test.mjs
-// each pin its case-insensitivity and GIT_INDEX_FILE preservation). This file
-// is for scrubGitEnvForThrowawayRepo() (#2865), the broader sibling those
-// three test files now delegate their local cleanGitEnv() to instead of each
-// hand-rolling the strip loop.
+// scrubGitEnv() itself already has coverage in bump-version.test.mjs, which
+// pins its case-insensitivity and GIT_INDEX_FILE preservation behavior.
+// release-body.test.mjs and verify-cache.test.mjs now test only
+// scrubGitEnvForThrowawayRepo() (#2865), the broader sibling those two test
+// files delegate their local cleanGitEnv() to instead of each hand-rolling
+// the strip loop. This file is for scrubGitEnvForThrowawayRepo().
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';

--- a/scripts/tests/publish-token-git.test.mjs
+++ b/scripts/tests/publish-token-git.test.mjs
@@ -16,7 +16,7 @@ import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { nonceInHistory } from '../publish-token.mjs';
-import { scrubGitEnv } from '../git-env.mjs';
+import { scrubGitEnvForThrowawayRepo } from '../git-env.mjs';
 
 const LIVE = 'docs/live.html';
 
@@ -56,17 +56,19 @@ const LIVE = 'docs/live.html';
 //      right and this site is its exception — stated rather than assumed,
 //      because deleting this line looks like tidying.
 //
-// A FUNCTION, evaluated per spawn, not a constant snapshot taken at import. As
-// a constant it was computed before any test could inject a variable, so the
-// self-check below PASSED with the scrub deleted — the snapshot never held the
-// variable it was meant to strip, and the instrument could not fail.
-const cleanEnv = () => {
-  const env = scrubGitEnv(process.env);
-  for (const key of Object.keys(env)) {
-    if (key.toUpperCase() === 'GIT_INDEX_FILE') delete env[key];
-  }
-  return env;
-};
+// Strip GIT_* env vars before spawning git in a throwaway repo. When this
+// test runs from a git hook context (e.g. pre-commit via husky), the parent
+// `git commit` sets GIT_DIR / GIT_INDEX_FILE / GIT_WORK_TREE / GIT_PREFIX,
+// which child processes inherit. Without sanitising, the test's `git commit`
+// would write into the PARENT worktree's git instead of the temp fixture —
+// silently creating bogus commits on whatever branch invoked the hook. A
+// throwaway repo built fresh in a temp dir has no real index or ambient
+// repository state to honour, so every GIT_*-named key must go, including
+// GIT_INDEX_FILE, GIT_PREFIX, and GIT_AUTHOR_DATE. Delegated to the shared,
+// broader-than-scrubGitEnv() helper — see git-env.mjs for the case-
+// insensitivity and GIT_INDEX_FILE-preservation rationale and why
+// scrubGitEnvForThrowawayRepo() is the right choice here.
+const cleanEnv = () => scrubGitEnvForThrowawayRepo();
 
 // The same shape check-onbox-register.mjs's runGitCommand returns.
 const runner = (args, cwd) => {

--- a/scripts/tests/release-body.test.mjs
+++ b/scripts/tests/release-body.test.mjs
@@ -18,6 +18,7 @@ import { tmpdir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { normalise, readTagAnnotation } from '../release-body.mjs';
+import { scrubGitEnvForThrowawayRepo } from '../git-env.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const bodyScript = resolve(here, '..', 'release-body.mjs');
@@ -58,17 +59,11 @@ const CONFLICT_FIXTURE =
 // this for real: a stray tag landed in this worktree). Every git
 // invocation below, and every spawned `node release-body.mjs` process,
 // passes this explicit env instead of inheriting process.env.
-// Case-insensitive match: Windows preserves whatever casing a var was stored
-// under while lookup is case-insensitive, and git honours a lowercase
-// `git_dir` identically to `GIT_DIR` — see git-env.mjs's scrubGitEnv() header,
-// and bump-version.test.mjs's identical helper/fix (#2841), for the measured
-// evidence. A `startsWith('GIT_')` filter alone leaves a survivor.
+// Thin wrapper over the shared, broader-than-scrubGitEnv() helper — see
+// git-env.mjs's scrubGitEnvForThrowawayRepo() for the case-insensitivity
+// rationale and why this needs a separate helper from scrubGitEnv().
 function cleanGitEnv() {
-  const env = { ...process.env };
-  for (const key of Object.keys(env)) {
-    if (key.toUpperCase().startsWith('GIT_')) delete env[key];
-  }
-  return env;
+  return scrubGitEnvForThrowawayRepo();
 }
 
 function gitExec(args, opts = {}) {

--- a/scripts/tests/release-body.test.mjs
+++ b/scripts/tests/release-body.test.mjs
@@ -60,8 +60,8 @@ const CONFLICT_FIXTURE =
 // invocation below, and every spawned `node release-body.mjs` process,
 // passes this explicit env instead of inheriting process.env.
 // Thin wrapper over the shared, broader-than-scrubGitEnv() helper — see
-// git-env.mjs's scrubGitEnvForThrowawayRepo() for the case-insensitivity
-// rationale and why this needs a separate helper from scrubGitEnv().
+// git-env.mjs's scrubGitEnv() docstring for the case-insensitivity rationale,
+// and why this needs a separate helper from scrubGitEnv().
 function cleanGitEnv() {
   return scrubGitEnvForThrowawayRepo();
 }

--- a/scripts/tests/verify-cache.test.mjs
+++ b/scripts/tests/verify-cache.test.mjs
@@ -1414,8 +1414,8 @@ test('a --changed-only pass is never written to the verify-cache — only a full
 // `git_dir` flipped a real checkout's `core.bare` from false to true via
 // `makeGitFixture()`'s `git init` below.
 // Thin wrapper over the shared, broader-than-scrubGitEnv() helper — see
-// git-env.mjs's scrubGitEnvForThrowawayRepo() for the case-insensitivity
-// rationale and why this needs a separate helper from scrubGitEnv().
+// git-env.mjs's scrubGitEnv() docstring for the case-insensitivity rationale,
+// and why this needs a separate helper from scrubGitEnv().
 function cleanGitEnv() {
   return scrubGitEnvForThrowawayRepo();
 }

--- a/scripts/tests/verify-cache.test.mjs
+++ b/scripts/tests/verify-cache.test.mjs
@@ -44,6 +44,7 @@ import {
   STEPS,
   _internals,
 } from '../verify-cache.mjs';
+import { scrubGitEnvForThrowawayRepo } from '../git-env.mjs';
 
 const { SCHEMA_VERSION } = _internals;
 
@@ -1412,12 +1413,11 @@ test('a --changed-only pass is never written to the verify-cache — only a full
 // fixture commands at the real repo. Demonstrated live: an ambient lowercase
 // `git_dir` flipped a real checkout's `core.bare` from false to true via
 // `makeGitFixture()`'s `git init` below.
+// Thin wrapper over the shared, broader-than-scrubGitEnv() helper — see
+// git-env.mjs's scrubGitEnvForThrowawayRepo() for the case-insensitivity
+// rationale and why this needs a separate helper from scrubGitEnv().
 function cleanGitEnv() {
-  const env = { ...process.env };
-  for (const key of Object.keys(env)) {
-    if (key.toUpperCase().startsWith('GIT_')) delete env[key];
-  }
-  return env;
+  return scrubGitEnvForThrowawayRepo();
 }
 
 function gitAt(cwd, args) {


### PR DESCRIPTION
## Summary

Extracts `scrubGitEnvForThrowawayRepo()` into `scripts/git-env.mjs` — a broader sibling of `scrubGitEnv()` that strips every `GIT_*`-prefixed env var case-insensitively (including `GIT_INDEX_FILE`/`GIT_PREFIX`, which `scrubGitEnv()` deliberately preserves for production callers per the #2216 correction). `bump-version.test.mjs`, `release-body.test.mjs`, and `verify-cache.test.mjs` had each hand-rolled an identical strip loop as a local `cleanGitEnv()`; all three now delegate to the shared helper instead. Adds `scripts/tests/git-env.test.mjs` with direct coverage of the new export, including the `GIT_INDEX_FILE`/`GIT_PREFIX` distinction from `scrubGitEnv()` that had no prior coverage anywhere.

Closes #2855

## Release notes

Not applicable — internal test/tooling consolidation with no user- or operator-visible effect.

## Also fixed, found in passing

Findings from the mandatory PR review pass (pr-review-gate), all 🟡 minor/cleanup, each fixed with its own dispatched commit:

- `2f214221` — corrected a stale coverage claim in `git-env.test.mjs`'s header comment (it claimed `release-body.test.mjs`/`verify-cache.test.mjs` still pin `scrubGitEnv()`'s GIT_INDEX_FILE preservation; both now only cover `scrubGitEnvForThrowawayRepo()`, which does the opposite).
- `4545a03b` — corrected three comments that pointed to the wrong docblock for the case-insensitivity rationale (`scrubGitEnvForThrowawayRepo()` states the property but doesn't explain it; the rationale lives on `scrubGitEnv()`).
- `366a0a2c` — consolidated a fourth hand-rolled throwaway-repo scrub in `scripts/tests/publish-token-git.test.mjs` onto the shared `scrubGitEnvForThrowawayRepo()` helper; the old hand-rolled version was narrower and left `GIT_AUTHOR_DATE`/`GIT_COMMITTER_DATE`/`GIT_PREFIX` leaking into fixture commits.

## Test plan

- [x] `node --test` across all 4 touched test files (`git-env.test.mjs`, `bump-version.test.mjs`, `release-body.test.mjs`, `verify-cache.test.mjs`): 202/202 pass — verified independently by this verify pass (#2866), matching the implementer's own run.
- [x] `npm run typecheck` — exit 0, verified independently.
- [x] Mutation check: temporarily excluding `GIT_INDEX_FILE` from the strip and re-running `git-env.test.mjs` turns the new "strips GIT_INDEX_FILE and GIT_PREFIX too" test red (`AssertionError: expected undefined, got '/decoy/.git/index'`), confirming it actually exercises the GIT_INDEX_FILE/GIT_PREFIX distinction — per the implementer's #2865 AGENT DONE receipt.
- [x] `bump-version.test.mjs`'s pre-existing case-insensitivity regression test (`scrubGitEnv strips a git repo-discovery override regardless of stored casing`, ~line 669) still present and passing, unchanged.
- [x] Out-of-scope check: no changes to `scrubGitEnv()`, `GIT_ENV_SCRUB_KEYS`, `verify-cache.mjs`'s `gitEnv()`, or `git-scrub.test.mjs` — confirmed via diff (touched files are only `scripts/git-env.mjs` and the three test files plus the new `git-env.test.mjs`).
- [x] Review-round fixes (`2f214221`, `4545a03b`, `366a0a2c`) each verified via `node --test` on the affected files.
