### PR TITLE
chore(ops): force full server-test run on a lockfile-only diff (#2853)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -267,8 +267,9 @@ jobs:
       # change to src/test/setup.ts (runner-injected, NOT import-reachable)
       # forces a full run via forceRerunTriggers in vitest.config.ts; a root
       # dep/config bump (the `shared` scope) forces a full run via vitest's
-      # default triggers. test:a11y stays always-on as a cheap core-view gate.
-      # See docs/features/118-ci-cost-round-2.md.
+      # default triggers; a lockfile-only diff forces a full run via the
+      # LOCKFILE_TOUCHED flag (#2853). test:a11y stays always-on as a cheap
+      # core-view gate. See docs/features/118-ci-cost-round-2.md.
       # test:e2e is a deliberate extra trigger: this step also runs
       # `npm run test:a11y`, which has no STEP of its own, and an e2e-only
       # diff should still exercise the a11y battery. Dropping it would be a
@@ -280,8 +281,9 @@ jobs:
         if: fromJSON(needs.detect.outputs.scopes).step_test || fromJSON(needs.detect.outputs.scopes).step_test_e2e || fromJSON(needs.detect.outputs.scopes).shared
         run: |
           BASE="${{ github.event.pull_request.base.sha }}"
+          LOCKFILE_TOUCHED="${{ fromJSON(needs.detect.outputs.scopes).lockfile_touched }}"
           # On a manual dispatch BASE is empty (no PR) → run the full suite.
-          if [ -n "$BASE" ]; then npx vitest run --changed "$BASE"; else npx vitest run; fi
+          if [ -n "$BASE" ] && [ "$LOCKFILE_TOUCHED" != "true" ]; then npx vitest run --changed "$BASE"; else npx vitest run; fi
           npm run test:a11y
 
   server-tests:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -267,8 +267,10 @@ jobs:
       # change to src/test/setup.ts (runner-injected, NOT import-reachable)
       # forces a full run via forceRerunTriggers in vitest.config.ts; a root
       # dep/config bump (the `shared` scope) forces a full run via vitest's
-      # default triggers; a lockfile-only diff forces a full run via the
-      # LOCKFILE_TOUCHED flag (#2853). test:a11y stays always-on as a cheap
+      # default triggers; a lockfile-only OR shared-scope diff forces a full run
+      # via the LOCKFILE_TOUCHED flag (#2853) — note lockfile_touched is
+      # computed as (shared || lockfile-specific-match), so e.g. an .github/actions/**
+      # diff also triggers a full run. test:a11y stays always-on as a cheap
       # core-view gate. See docs/features/118-ci-cost-round-2.md.
       # test:e2e is a deliberate extra trigger: this step also runs
       # `npm run test:a11y`, which has no STEP of its own, and an e2e-only

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -323,14 +323,23 @@ jobs:
       # condition is the union of both steps' keys. Drops the old `sidecar`
       # disjunct deliberately.
       # (was: server || sidecar || shared).
+      #
+      # #2853/#2867: neither lockfile is in either vitest config's
+      # forceRerunTriggers, so `--changed` can select ZERO tests against a
+      # changed dependency tree. `detect`'s scopes blob already carries
+      # `lockfile_touched` (ci-scope.mjs) computed from the same PR diff this
+      # job would otherwise re-derive — reuse it rather than a second
+      # merge-base/git diff call, and force the full (non-`--changed`) run
+      # whenever it is set, even on a PR.
       # leg: test:server
       - name: Server tests (fast + slow)
         if: fromJSON(needs.detect.outputs.scopes).step_test_server || fromJSON(needs.detect.outputs.scopes).step_test_server_slow || fromJSON(needs.detect.outputs.scopes).shared
         run: |
           cd server
           BASE="${{ github.event.pull_request.base.sha }}"
+          LOCKFILE_TOUCHED="${{ fromJSON(needs.detect.outputs.scopes).lockfile_touched }}"
           # On a manual dispatch BASE is empty (no PR) → run the full suite.
-          if [ -n "$BASE" ]; then
+          if [ -n "$BASE" ] && [ "$LOCKFILE_TOUCHED" != "true" ]; then
             npx vitest run --changed "$BASE"
             npx vitest run --config vitest.config.slow.ts --changed "$BASE"
           else

--- a/scripts/ci-scope.mjs
+++ b/scripts/ci-scope.mjs
@@ -25,7 +25,8 @@ export function slugFor(stepName) {
 // `stepTouchedByDiff`'s includeLockfiles branch already routes it there —
 // consumed by verify.yml to force a full (non-`--changed`) run instead of
 // widening `shared`, which was explicitly rejected (#2853) as too broad a fix
-// for this narrow hazard.
+// for this narrow hazard. Note: lockfile_touched fires on (shared || lockfile-specific-match),
+// so it also triggers on non-lockfile shared-scope diffs like .github/actions/**.
 const CI_ONLY = {
   openapi: (files) => files.some((f) => f === 'openapi.yaml'),
   shared: (files) => computeShared(files),

--- a/scripts/ci-scope.mjs
+++ b/scripts/ci-scope.mjs
@@ -21,12 +21,13 @@ export function slugFor(stepName) {
 // cache step. shared is the root-manifest global override. lockfile_touched
 // (#2867, fixing #2853) is a hazard flag, not a leg gate: neither lockfile is
 // in either vitest config's forceRerunTriggers, so a lockfile-only diff can
-// select ZERO tests via `--changed` in the server-tests CI job even though
-// `stepTouchedByDiff`'s includeLockfiles branch already routes it there —
-// consumed by verify.yml to force a full (non-`--changed`) run instead of
-// widening `shared`, which was explicitly rejected (#2853) as too broad a fix
-// for this narrow hazard. Note: lockfile_touched fires on (shared || lockfile-specific-match),
-// so it also triggers on non-lockfile shared-scope diffs like .github/actions/**.
+// select ZERO tests via `--changed` in both the server-tests and frontend-tests
+// CI jobs even though `stepTouchedByDiff`'s includeLockfiles branch already
+// routes it there — consumed by verify.yml to force a full (non-`--changed`)
+// run instead of widening `shared`, which was explicitly rejected (#2853) as
+// too broad a fix for this narrow hazard. Note: lockfile_touched fires on
+// (shared || lockfile-specific-match), so it also triggers on non-lockfile
+// shared-scope diffs like .github/actions/**.
 const CI_ONLY = {
   openapi: (files) => files.some((f) => f === 'openapi.yaml'),
   shared: (files) => computeShared(files),

--- a/scripts/ci-scope.mjs
+++ b/scripts/ci-scope.mjs
@@ -18,10 +18,19 @@ export function slugFor(stepName) {
 }
 
 // openapi gates the CI-only "OpenAPI types up to date" drift check and has no
-// cache step. shared is the root-manifest global override.
+// cache step. shared is the root-manifest global override. lockfile_touched
+// (#2867, fixing #2853) is a hazard flag, not a leg gate: neither lockfile is
+// in either vitest config's forceRerunTriggers, so a lockfile-only diff can
+// select ZERO tests via `--changed` in the server-tests CI job even though
+// `stepTouchedByDiff`'s includeLockfiles branch already routes it there —
+// consumed by verify.yml to force a full (non-`--changed`) run instead of
+// widening `shared`, which was explicitly rejected (#2853) as too broad a fix
+// for this narrow hazard.
 const CI_ONLY = {
   openapi: (files) => files.some((f) => f === 'openapi.yaml'),
   shared: (files) => computeShared(files),
+  lockfile_touched: (files) =>
+    files.some((f) => f === 'package-lock.json' || f === 'server/package-lock.json'),
 };
 
 export function computeScopes(files, { eventName } = {}) {

--- a/scripts/tests/ci-scope.test.mjs
+++ b/scripts/tests/ci-scope.test.mjs
@@ -75,6 +75,27 @@ test('computeScopes is all-false for an unrelated diff on a PR', () => {
   assert.equal(scopes.shared, false);
 });
 
+// #2853/#2867: verify.yml's server-tests job forces a full (non-`--changed`)
+// run off this key rather than trusting `--changed`, since neither lockfile
+// is in either vitest config's forceRerunTriggers.
+test('computeScopes sets lockfile_touched for a server lockfile diff', () => {
+  const scopes = computeScopes(['server/package-lock.json'], { eventName: 'pull_request' });
+  assert.equal(scopes.lockfile_touched, true);
+});
+
+// The root lockfile already flips `shared` (computeShared) — lockfile_touched
+// must also be true here, since it shares CI_ONLY's `shared || fn(files)`
+// formula, so verify.yml can rely on one key for either lockfile.
+test('computeScopes sets lockfile_touched for a root lockfile diff', () => {
+  const scopes = computeScopes(['package-lock.json'], { eventName: 'pull_request' });
+  assert.equal(scopes.lockfile_touched, true);
+});
+
+test('computeScopes leaves lockfile_touched false for a non-lockfile diff', () => {
+  const scopes = computeScopes(['server/src/foo.ts'], { eventName: 'pull_request' });
+  assert.equal(scopes.lockfile_touched, false);
+});
+
 test('render emits GITHUB_OUTPUT lines plus the ok sentinel', () => {
   const out = render({ step_test_hooks: true, shared: false });
   assert.match(out, /^scopes=\{.*\}$/m);

--- a/scripts/tests/workflow-wiring.test.mjs
+++ b/scripts/tests/workflow-wiring.test.mjs
@@ -1080,6 +1080,71 @@ test('ffmpeg install: timeout wrapping is present with correct bounds on all apt
   );
 });
 
+test('lockfile-touched polarity: both frontend and server test steps force full run when lockfile is changed (#2853)', () => {
+  // Mutation proof: a lockfile-only diff can select ZERO tests via `--changed`,
+  // so both steps must force a full run when LOCKFILE_TOUCHED is true.
+  // This test verifies the exact polarity: when LOCKFILE_TOUCHED != "true",
+  // run with --changed; when true (or BASE unset), run full suite.
+  // Reverting to the pre-fix condition (removing LOCKFILE_TOUCHED guard or
+  // inverting the polarity) makes this test fail.
+
+  // Find both test steps by their exact names.
+  const frontendMatch = source.match(
+    /- name: Frontend tests \+ a11y\n\s*if:[^\n]+\n\s*run: \|\n((?:\s{10}[^\n]*\n)*)/,
+  );
+  const serverMatch = source.match(
+    /- name: Server tests \(fast \+ slow\)\n\s*if:[^\n]+\n\s*run: \|\n((?:\s{10}[^\n]*\n)*)/,
+  );
+
+  assert.ok(frontendMatch, 'Frontend tests + a11y step not found');
+  assert.ok(serverMatch, 'Server tests (fast + slow) step not found');
+
+  const frontendBody = frontendMatch[1];
+  const serverBody = serverMatch[1];
+
+  // Both steps must assign LOCKFILE_TOUCHED from the scopes output.
+  assert.match(
+    frontendBody,
+    /LOCKFILE_TOUCHED="\$\{\{\s*fromJSON\(needs\.detect\.outputs\.scopes\)\.lockfile_touched\s*\}\}"/,
+    'Frontend step does not assign LOCKFILE_TOUCHED from detect scopes',
+  );
+  assert.match(
+    serverBody,
+    /LOCKFILE_TOUCHED="\$\{\{\s*fromJSON\(needs\.detect\.outputs\.scopes\)\.lockfile_touched\s*\}\}"/,
+    'Server step does not assign LOCKFILE_TOUCHED from detect scopes',
+  );
+
+  // Both steps must have the correct polarity: when LOCKFILE_TOUCHED != "true",
+  // use --changed; otherwise use full run. The `if` condition checks:
+  // [ -n "$BASE" ] && [ "$LOCKFILE_TOUCHED" != "true" ]
+  // If this is true, run --changed; else run full.
+  const correctFrontendPattern = /if\s+\[\s*-n\s+"\$BASE"\s*\]\s+&&\s+\[\s*"\$LOCKFILE_TOUCHED"\s+!=\s+"true"\s*\]\s*;\s+then\s+npx\s+vitest\s+run\s+--changed/;
+  const correctServerPattern = /if\s+\[\s*-n\s+"\$BASE"\s*\]\s+&&\s+\[\s*"\$LOCKFILE_TOUCHED"\s+!=\s+"true"\s*\]\s*;\s+then/;
+
+  assert.match(
+    frontendBody,
+    correctFrontendPattern,
+    'Frontend step does not have correct LOCKFILE_TOUCHED polarity (should check != "true" for --changed branch)',
+  );
+  assert.match(
+    serverBody,
+    correctServerPattern,
+    'Server step does not have correct LOCKFILE_TOUCHED polarity (should check != "true" for --changed branch)',
+  );
+
+  // Verify the else branch runs the full suite (no --changed).
+  assert.match(
+    frontendBody,
+    /else\s+npx\s+vitest\s+run;/,
+    'Frontend step else branch does not run full vitest suite',
+  );
+  assert.match(
+    serverBody,
+    /else\s+npx\s+vitest\s+run/,
+    'Server step else branch does not run full vitest suite',
+  );
+});
+
 test('ffmpeg install: no bare apt-get install ffmpeg in workflows (use install-ffmpeg action)', () => {
   // Issue #2449: unretried `sudo apt-get update && sudo apt-get install -y ffmpeg`
   // hangs on mirror timeouts and burns entire job timeouts. This regression test

--- a/scripts/tests/workflow-wiring.test.mjs
+++ b/scripts/tests/workflow-wiring.test.mjs
@@ -1138,10 +1138,37 @@ test('lockfile-touched polarity: both frontend and server test steps force full 
     /else\s+npx\s+vitest\s+run;/,
     'Frontend step else branch does not run full vitest suite',
   );
+
+  // For the server step, we need a more structural check because it has
+  // multiple lines in both then and else branches. Extract the entire
+  // if/then/else/fi block and verify:
+  // (1) the then branch (LOCKFILE_TOUCHED != "true") runs --changed
+  // (2) the else branch (LOCKFILE_TOUCHED == "true") runs full suite
+  // Mutation proof: M7 (neuter else to --changed) and M11 (swap then/else bodies)
+  // must both fail this test.
+  const serverIfBlock = serverBody.match(
+    /if\s+\[\s*-n\s+"\$BASE"\s*\]\s+&&\s+\[\s*"\$LOCKFILE_TOUCHED"\s+!=\s+"true"\s*\]\s*;\s+then\n((?:[^\n]*\n)*?)^\s*else\n((?:[^\n]*\n)*?)^\s*fi/m,
+  );
+  assert.ok(
+    serverIfBlock,
+    'Server step: could not extract if/then/else/fi block structure',
+  );
+
+  const serverThenBranch = serverIfBlock[1];
+  const serverElseBranch = serverIfBlock[2];
+
+  // The THEN branch (when LOCKFILE_TOUCHED != "true") must contain --changed.
   assert.match(
-    serverBody,
-    /else\s+npx\s+vitest\s+run/,
-    'Server step else branch does not run full vitest suite',
+    serverThenBranch,
+    /--changed/,
+    'Server step: then branch does not use --changed (should run when lockfile NOT touched)',
+  );
+
+  // The ELSE branch (when LOCKFILE_TOUCHED == "true") must NOT contain --changed.
+  assert.doesNotMatch(
+    serverElseBranch,
+    /--changed/,
+    'Server step: else branch contains --changed (should run full suite when lockfile IS touched)',
   );
 });
 

--- a/scripts/tests/workflow-wiring.test.mjs
+++ b/scripts/tests/workflow-wiring.test.mjs
@@ -1086,7 +1086,8 @@ test('lockfile-touched polarity: both frontend and server test steps force full 
   // This test verifies the exact polarity: when LOCKFILE_TOUCHED != "true",
   // run with --changed; when true (or BASE unset), run full suite.
   // Reverting to the pre-fix condition (removing LOCKFILE_TOUCHED guard or
-  // inverting the polarity) makes this test fail.
+  // inverting the polarity) makes this test fail. Order-guard ensures the
+  // LOCKFILE_TOUCHED assignment precedes the if condition that consumes it.
 
   // Find both test steps by their exact names.
   const frontendMatch = source.match(
@@ -1112,6 +1113,39 @@ test('lockfile-touched polarity: both frontend and server test steps force full 
     serverBody,
     /LOCKFILE_TOUCHED="\$\{\{\s*fromJSON\(needs\.detect\.outputs\.scopes\)\.lockfile_touched\s*\}\}"/,
     'Server step does not assign LOCKFILE_TOUCHED from detect scopes',
+  );
+
+  // Order guard: the LOCKFILE_TOUCHED assignment must come BEFORE the if
+  // statement that consumes it. Moving the assignment after the if would
+  // use an unset/stale variable and restore the #2853 bug.
+  const frontendAssignIdx = frontendBody.indexOf('LOCKFILE_TOUCHED=');
+  const frontendIfIdx = frontendBody.indexOf('[ "$LOCKFILE_TOUCHED"');
+  assert.ok(
+    frontendAssignIdx !== -1,
+    'Frontend step: LOCKFILE_TOUCHED assignment not found',
+  );
+  assert.ok(
+    frontendIfIdx !== -1,
+    'Frontend step: if condition checking LOCKFILE_TOUCHED not found',
+  );
+  assert.ok(
+    frontendAssignIdx < frontendIfIdx,
+    `Frontend step: LOCKFILE_TOUCHED assignment (at ${frontendAssignIdx}) must precede if condition (at ${frontendIfIdx})`,
+  );
+
+  const serverAssignIdx = serverBody.indexOf('LOCKFILE_TOUCHED=');
+  const serverIfIdx = serverBody.indexOf('[ "$LOCKFILE_TOUCHED"');
+  assert.ok(
+    serverAssignIdx !== -1,
+    'Server step: LOCKFILE_TOUCHED assignment not found',
+  );
+  assert.ok(
+    serverIfIdx !== -1,
+    'Server step: if condition checking LOCKFILE_TOUCHED not found',
+  );
+  assert.ok(
+    serverAssignIdx < serverIfIdx,
+    `Server step: LOCKFILE_TOUCHED assignment (at ${serverAssignIdx}) must precede if condition (at ${serverIfIdx})`,
   );
 
   // Both steps must have the correct polarity: when LOCKFILE_TOUCHED != "true",


### PR DESCRIPTION
## Summary

`.github/workflows/verify.yml`'s "Server tests (fast + slow)" and "Frontend tests + a11y" steps chose `--changed` vs. full purely on whether `$BASE` was set, never on the diff's file list. Neither `package-lock.json` nor `server/package-lock.json` is in either vitest config's `forceRerunTriggers`, so a lockfile-only PR could select zero tests against a changed dependency tree while reporting green. Adds a `lockfile_touched` scope key to `ci-scope.mjs` (reusing the detect job's existing scopes blob) and threads it into both the server-tests and frontend-tests steps to force a full run whenever it's true, even on a PR. 

**Incidental fixes folded into this PR:** frontend guard wiring (commit `2b110850`), regression-test polarity assertion hardening (commit `6348c7fc`), and two stale comments updated to reflect both test-step consumers. Closes #2853.

## Test plan

- [x] `node --test scripts/tests/ci-scope.test.mjs` — 16/16 pass, including 3 new `lockfile_touched` cases (server lockfile, root lockfile via `shared`, non-lockfile diff).
- [x] Mutation-kill: replacing the `lockfile_touched` detector body with a bare `false` made the new "sets lockfile_touched for a server lockfile diff" case fail as expected; reverted, suite back to 16/16 (from the task commit's own verification, re-confirmed by this verify pass via re-run of the un-mutated suite).
- [x] `npm run typecheck` — clean (root `tsc --noEmit` and server typecheck).
- [x] Verified the diff touches `ci-scope.mjs`'s `CI_ONLY` map, `verify.yml`'s server-tests and frontend-tests step shell logic — no changes to `computeShared`, `STEPS[]`, or either vitest config's `forceRerunTriggers`.
- [x] Verified `test:a11y` step is untouched.
- [x] Regression test (`scripts/tests/workflow-wiring.test.mjs`) verifies polarity: when LOCKFILE_TOUCHED != "true", run with --changed; when true, run full suite. Order-guard strengthened to verify LOCKFILE_TOUCHED assignment precedes the if condition in both frontend and server steps. Mutation proof: M7 (neutering server else to --changed) and M11 (swapping server then/else bodies) both fail the test as expected.
