### PR TITLE
fix(ops): arm idSpecificAnnotationPresent with the shared polarity check (#2858)

### DIFF
--- a/scripts/check-register-citations.mjs
+++ b/scripts/check-register-citations.mjs
@@ -739,6 +739,11 @@ const ANNOTATION_WINDOW_LINES = 25;
 // paragraph.
 const ID_PROXIMITY_CHARS = 120;
 
+// How close a negation word must sit BEFORE a discharge-word match for
+// isDischargeAssertionNegated to treat it as negating that match — see that
+// function's own comment for why 30 (not the full clause) is the right cap.
+const POLARITY_PROXIMITY_CHARS = 30;
+
 // A bare ID token, used to find every ID mention in a section so a discharge
 // word can be bound to the right one(s) — see idSpecificAnnotationPresent's
 // own comment for why "within 120 chars" alone isn't enough.
@@ -883,6 +888,42 @@ function clauseBounds(text, pos) {
 }
 
 /**
+ * Whether the discharge-word match `dm` (against `scanText`, a
+ * stripInlineCodeSpans'd copy) is negated — e.g. "was NOT discharged" or
+ * "un-discharged" — rather than an affirmative discharge/removal assertion.
+ * `clauseStart` bounds the backward scan to the SAME clause `clauseBounds`
+ * already computed for `dm`, so an unrelated negation across a clause/
+ * list-item boundary cannot bleed in.
+ *
+ * Shared by `idSpecificAnnotationPresent` (Check A's fatal-path citation
+ * matcher) and `dischargedSubjectsMentionedIn` (Check C's own-history scan) —
+ * extracted from the latter, pass-11/pass-15/pass-16 review of PR #2846 (see
+ * `dischargedSubjectsMentionedIn`'s own comment for the full history of why
+ * this exists and why the window is backward-only and 30-char-capped, not
+ * clause-wide or bidirectional): a "clause" here is a full paragraph, since
+ * CLAUSE_BOUNDARY_REGEX does not treat ". " as a boundary, and the register's
+ * real affirmative discharge records measure their genuine negations at
+ * 4-10 chars back vs. false suppressions at 85+ chars back in the same
+ * paragraph. The negation-word set is deliberately broad (NOT/no/never/
+ * isn't/aren't/wasn't/weren't/hasn't/haven't/cannot/can't/an "un-" prefix
+ * fused to the discharge word/"far from"/"nothing"), since a first cut of
+ * just "NOT"/"no" missed most real negation phrasings.
+ */
+function isDischargeAssertionNegated(scanText, dm, clauseStart) {
+  const polarityScanStart = Math.max(clauseStart, dm.index - POLARITY_PROXIMITY_CHARS);
+  const polarityContext = scanText.slice(polarityScanStart, dm.index);
+  // Apostrophes are '-escaped (not literal) so this regex literal
+  // doesn't desync spawn-windows-hide.test.ts's quote-tracking scanner --
+  // see that guard's own regexLiteralDesyncsQuoteTracking comment.
+  const hasNegationWord =
+    /\b(?:NOT|no\b(?!\s+longer\s+exists?)|never|isn\u0027t|aren\u0027t|wasn\u0027t|weren\u0027t|hasn\u0027t|haven\u0027t|cannot|can\u0027t|far\s+from|nothing)\b/i.test(
+      polarityContext,
+    );
+  const isUnPrefixed = /un-?discharged\b/i.test(scanText.slice(Math.max(0, dm.index - 10), dm.index + dm[0].length));
+  return hasNegationWord || isUnPrefixed;
+}
+
+/**
  * Whether `sectionText` contains a discharge/removal annotation that
  * actually references `id` — not merely a discharge word somewhere in the
  * section, which a paired injection proved lets unrelated prose excuse a
@@ -952,6 +993,14 @@ function clauseBounds(text, pos) {
  * that real annotation (measured: `docs/superpowers/plans/2026-08-05-
  * device-token-scope.md`'s `F2`/`F3` citations went from correctly-excused
  * to falsely-flagged the first time this was tried).
+ *
+ * #2858: also polarity-checks the discharge word via the same
+ * `isDischargeAssertionNegated` helper `dischargedSubjectsMentionedIn` uses,
+ * so a negated sentence ("Register row: A18 — was NOT discharged; it is
+ * still live") can no longer be misread as affirmatively excusing A18 from
+ * Check A's fatal nonexistent-ID gate. Measured against the real corpus:
+ * this flips zero of today's citations — see #2858 for the false-positive
+ * analysis of the 4 citations a looser, unshared polarity scan misflagged.
  */
 function idSpecificAnnotationPresent(sectionText, id) {
   const dischargeScanText = stripInlineCodeSpans(sectionText);
@@ -961,6 +1010,7 @@ function idSpecificAnnotationPresent(sectionText, id) {
   if (dischargeMatches.length === 0) return false;
   for (const dm of dischargeMatches) {
     const { start, end } = clauseBounds(sectionText, dm.index);
+    if (isDischargeAssertionNegated(dischargeScanText, dm, start)) continue;
     ANY_ID_TOKEN_REGEX.lastIndex = start;
     let occ;
     while ((occ = ANY_ID_TOKEN_REGEX.exec(sectionText)) && occ.index < end) {
@@ -1340,16 +1390,15 @@ export function findUnclassifiedRunSheetMentions(registerRows) {
  * Pass-11 review of PR #2846 (finding #1, CRITICAL): polarity-check the
  * discharge word — "NOT discharged" (and similar negated contexts like "is
  * why A16 below is not fully discharged") must not match as affirmative
- * discharges. This is a polarity check `idSpecificAnnotationPresent` itself
- * does NOT have (it is unconcerned with polarity, since it only answers
- * whether a discharge word and a specific ID token co-occur in a clause, not
- * what either one asserts) — added here, scoped to `clauseBounds`, because
- * this function's answer of "did this row historically track this subject"
- * is exactly the kind of claim a negated sentence can falsify. Pass-15
- * review (finding new-B, SIGNIFICANT): the negation-word set is deliberately
- * broad (NOT/no/never/isn't/aren't/wasn't/weren't/hasn't/haven't/cannot/
- * can't/an "un-" prefix fused to the discharge word/"far from"/"nothing"),
- * since the first cut (just "NOT"/"no") missed most real negation phrasings.
+ * discharges, scoped to `clauseBounds`, because this function's answer of
+ * "did this row historically track this subject" is exactly the kind of
+ * claim a negated sentence can falsify. Pass-15 review (finding new-B,
+ * SIGNIFICANT): the negation-word set is deliberately broad (NOT/no/never/
+ * isn't/aren't/wasn't/weren't/hasn't/haven't/cannot/can't/an "un-" prefix
+ * fused to the discharge word/"far from"/"nothing"), since the first cut
+ * (just "NOT"/"no") missed most real negation phrasings. #2858: this
+ * polarity check is now shared, via `isDischargeAssertionNegated`, with
+ * `idSpecificAnnotationPresent` — which was polarity-blind until then.
  * Also applies the same ID_PROXIMITY_CHARS cap `idSpecificAnnotationPresent`
  * uses so a subject number far from its discharge word (>120 chars) is not
  * incorrectly attributed to a row that merely MENTIONS it in passing (e.g.
@@ -1368,38 +1417,10 @@ function dischargedSubjectsMentionedIn(rowBodyText) {
     // Get clause bounds first so we can use them for both polarity and subject scanning.
     const { start, end } = clauseBounds(scanText, dm.index);
 
-    // Polarity check: scan for negation markers that would negate the
-    // discharge word. Bound the scan to BOTH the same clause (not a flat
-    // window, so an unrelated negation across a clause/list-item boundary
-    // cannot bleed in -- pass-15/new-B) AND a proximity cap of its own
-    // (pass-16/new-G: clause-bounding alone is too wide -- a "clause" here
-    // is a full paragraph, since CLAUSE_BOUNDARY_REGEX does not treat ". "
-    // as a boundary, and the register's real affirmative discharge
-    // records measure their genuine negations at 4-10 chars back vs. false
-    // suppressions at 85+ chars back in the same paragraph). Recognize a
-    // broad set of negation patterns:
-    // - "NOT", "no" (complete words; "no" excludes "no longer exist(s)",
-    //   since that's one of DISCHARGE_ANNOTATION_REGEX's OWN
-    //   affirmative phrases, not a negation of one)
-    // - "never", "isn't", "aren't", "wasn't", "weren't" (contractions)
-    // - "hasn't", "haven't" (auxiliary verbs with "have")
-    // - "cannot", "can't" (modal verbs)
-    // - "far from" (degree modifier)
-    // - "nothing" (negating existential)
-    const POLARITY_PROXIMITY_CHARS = 30;
-    const polarityScanStart = Math.max(start, dm.index - POLARITY_PROXIMITY_CHARS);
-    const polarityContext = scanText.slice(polarityScanStart, dm.index);
-    // Apostrophes are '-escaped (not literal) so this regex literal
-    // doesn't desync spawn-windows-hide.test.ts's quote-tracking scanner --
-    // see that guard's own regexLiteralDesyncsQuoteTracking comment.
-    const hasNegationWord =
-      /\b(?:NOT|no\b(?!\s+longer\s+exists?)|never|isn\u0027t|aren\u0027t|wasn\u0027t|weren\u0027t|hasn\u0027t|haven\u0027t|cannot|can\u0027t|far\s+from|nothing)\b/i.test(
-        polarityContext,
-      );
-    // Also check if the discharge word itself is prefixed with "un-" (e.g., "undischarged", "un-discharged")
-    const isUnPrefixed = /un-?discharged\b/i.test(scanText.slice(Math.max(0, dm.index - 10), dm.index + dm[0].length));
-    if (hasNegationWord || isUnPrefixed) {
-      // This discharge word is negated, skip it.
+    // Polarity check (#2858: extracted into the shared isDischargeAssertionNegated
+    // helper, also used by idSpecificAnnotationPresent) -- skip a discharge word
+    // that is actually negated ("was NOT discharged", "un-discharged").
+    if (isDischargeAssertionNegated(scanText, dm, start)) {
       continue;
     }
 

--- a/scripts/check-register-citations.mjs
+++ b/scripts/check-register-citations.mjs
@@ -742,6 +742,16 @@ const ID_PROXIMITY_CHARS = 120;
 // How close a negation word must sit BEFORE a discharge-word match for
 // isDischargeAssertionNegated to treat it as negating that match — see that
 // function's own comment for why 30 (not the full clause) is the right cap.
+//
+// #2858 NOTE: This 30-char cap was originally measured/tuned for Check C
+// (conflicting subjects). Check A (nonexistent IDs) now reuses the shared
+// isDischargeAssertionNegated helper and this constant without independent
+// re-measurement for Check A's own citation-text shapes. Zero real-corpus hits
+// of a boundary-flip as of this PR (e.g., `"Nothing further owed - A999
+// discharged ..."` at the 30-char boundary), but a future false-negative or
+// false-positive near this cap for Check A specifically should prompt
+// re-measuring the cap for Check A's own text patterns rather than assuming
+// Check C's tuning transfers without measurement.
 const POLARITY_PROXIMITY_CHARS = 30;
 
 // A bare ID token, used to find every ID mention in a section so a discharge

--- a/scripts/tests/check-register-citations.test.mjs
+++ b/scripts/tests/check-register-citations.test.mjs
@@ -297,6 +297,33 @@ test('checkNonexistentIds: paired control — the same discharge word DOES excus
   assert.match(annotated[0], /A9/);
 });
 
+// #2858: idSpecificAnnotationPresent was polarity-blind — it only asked
+// whether a discharge word and a specific ID token co-occur in a clause, not
+// what the discharge word actually asserts. A negated discharge sentence
+// ("was NOT discharged") could therefore be misread as affirmatively
+// excusing a nonexistent-ID citation from Check A's fatal path. This is now
+// closed by wiring idSpecificAnnotationPresent to the same
+// isDischargeAssertionNegated helper dischargedSubjectsMentionedIn already
+// used (#2721/#2846) — this is the synthetic regression fixture proving it,
+// since no row in the real corpus exercises this shape today.
+test('checkNonexistentIds: a NEGATED discharge annotation does not excuse the cited ID (finding #2858)', () => {
+  const { rows } = parseRegisterRows(buildRegister());
+  const text = 'Register row: A9 — was NOT discharged; it is still live.\n';
+  const { errors, annotated } = checkNonexistentIds(text, 'docs/foo.md', rows);
+  assert.equal(annotated.length, 0);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /A9/);
+});
+
+test('checkNonexistentIds: paired control — the same shape WITHOUT negation still excuses the cited ID (#2858)', () => {
+  const { rows } = parseRegisterRows(buildRegister());
+  const text = 'Register row: A9 — was discharged; it is no longer live.\n';
+  const { errors, annotated } = checkNonexistentIds(text, 'docs/foo.md', rows);
+  assert.equal(errors.length, 0);
+  assert.equal(annotated.length, 1);
+  assert.match(annotated[0], /A9/);
+});
+
 // --- Pass-8 review of PR #2630 (finding O): the clause-bound annotation
 // rule was defeated by ordinary markdown shapes a bare newline (not a blank
 // line) doesn't bound — table rows, list items, a blockquote continuation,


### PR DESCRIPTION
## Summary

`idSpecificAnnotationPresent` (Check A's fatal-path citation matcher) was
polarity-blind: it only asked whether a discharge word and a specific ID
token co-occur in a clause, not what the discharge word actually asserts. A
negated discharge sentence ("was NOT discharged; it is still live") could be
misread as affirmatively excusing a citation from the nonexistent-ID gate.
Extracts `dischargedSubjectsMentionedIn`'s backward-scan + 30-char-capped
negation check (`POLARITY_PROXIMITY_CHARS`, same negation regex + `un-?discharged`
check) into a shared `isDischargeAssertionNegated` helper and wires
`idSpecificAnnotationPresent` to it too. This is latent hardening, not a
functional change to today's docs: no real corpus citation changes
classification — `check-register-citations.mjs --strict` produces
byte-identical output against the primary checkout (unfixed, `e8c2474e`) and
this branch (fixed). Closes #2858.

## Test plan

- [x] `node --test scripts/tests/check-register-citations.test.mjs` — 121/121 pass, including the new synthetic regression fixture (finding #2858) and its paired affirmative control
- [x] Re-ran the mutation kill myself: reverted the `isDischargeAssertionNegated` call in `idSpecificAnnotationPresent`, confirmed the new test fails with the pre-fix behavior (1 annotated instead of 0), then restored the fix (working tree clean afterward)
- [x] Re-ran the no-op-on-real-corpus check myself: `node scripts/check-register-citations.mjs --strict` against the primary checkout (`main`@e8c2474e, unfixed) and this branch (fixed) — byte-identical output, same annotated/fatal counts
- [x] `npm run typecheck` — green
- [x] Diff confirmed code-only: `scripts/check-register-citations.mjs` + `scripts/tests/check-register-citations.test.mjs`, no changes under `docs/testing/**` or `docs/features/**`

5. **Release notes**: skipped — this is an internal audit-script hardening fix with no user- or operator-visible behavior change (verified byte-identical `--strict` output against the real corpus before/after, see Test plan above).
