### PR TITLE
docs(ops): document worktree single-writer rule and TaskStop unreliability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1215,6 +1215,43 @@ feat/server-foo` and tell the agent in its prompt to check it out as its
   [docs/features/118-ci-cost-round-2.md](docs/features/118-ci-cost-round-2.md)
   is now historical.
 
+### One writer per worktree — commit/push is single-threaded
+
+A worktree's `git commit`/`push` is single-writer. Running more than one
+against the same worktree at a time — two dispatched fix agents, or a
+dispatched agent plus the dispatching session itself — doesn't corrupt the
+repo, but reliably produces the exact contention this repo has hit three
+separate times (2026-08-29, 2026-08-30, 2026-09-04/05): commits bundling
+together, hook batteries competing for CPU/GPU and throwing unrelated flaky
+failures, and — worst — a subagent concluding the contention it caused
+*itself* is an external blocker and reaching for `--no-verify` to route
+around it (never acceptable — see "Do not use `--no-verify` to bypass" under
+Working practice below; this holds even under contention).
+
+- **A subagent whose `git commit`/`push` is slow does not get to retry it as
+  a second background call.** `verify:fast:branch`/pre-push can legitimately
+  run 15–45+ minutes under load; the fix for "it's taking a while" is to
+  wait, never to fire a second attempt in parallel against the same
+  worktree. A subagent report describing multiple retry attempts against one
+  worktree is reporting a bug it caused, not a completed task — re-dispatch
+  or take over manually rather than trusting its "eventually succeeded"
+  claim.
+- **`TaskStop`'s "Successfully stopped" is not proof the underlying OS
+  process is gone.** Confirmed three times now: stopping a wrapping
+  bash/agent task does not reliably kill the child processes it spawned
+  (`git.exe`, `node`/`vitest` workers) on Windows — they can keep running,
+  still holding the git index or burning CPU, after the stop call reports
+  success. Before trusting a worktree is idle, independently check
+  `Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like
+  "*<worktree-path>*" }` and `Stop-Process -Force` anything still there —
+  don't rely on the stop confirmation alone.
+- **Before starting your own commit/push in a worktree a subagent was just
+  working in, re-verify the worktree is actually idle** (empty process list
+  per above, `git status` unchanged across a few seconds), not just that the
+  dispatch tool reported the agent "completed" — a completed agent
+  notification can still have live background children of its own still
+  running commits/pushes.
+
 ### Planning agents
 
 Plan agents (`subagent_type: "Plan"`) design strategies but don't write code,


### PR DESCRIPTION
## Summary

- Adds a "One writer per worktree" subsection to CLAUDE.md's Branching workflow, documenting a third recorded incident (PR #2877 / #2853's CI-lockfile fix, 2026-09-04/05) of concurrent commit/push processes polluting a single worktree.
- A dispatched fix-agent self-duplicated its `git commit` under pre-commit hook contention; the dispatching session then piled a third attempt on top after a stale "completed" agent notification. `TaskStop` reported "Successfully stopped" for every task ID while a live `git.exe commit` process and four orphaned `vitest` workers kept running underneath — only a direct `Get-CimInstance Win32_Process` scan plus `Stop-Process -Force` actually cleared it.
- Records the actionable rules: never retry a commit/push against the same worktree as a second background call; `TaskStop`'s success message is not proof the underlying OS process is gone; re-verify a worktree is actually idle before starting your own commit/push in one a subagent was just working in.

This extends the existing "concurrent fix agents pollute one worktree" lesson (first seen PR #2719, second variant PR #2795) with a third, TaskStop-specific data point.

## Test plan

- [x] Docs-only change (CLAUDE.md only) — no automated test applies.
- [x] Confirmed via `git diff` that only the new subsection was added; no other content changed.

Docs-only PR — exempt from the pr-review-gate mandatory review pass per CLAUDE.md's exemption rule (root-level `*.md`).

Closes #2891