### PR TITLE
fix(scripts): close the same polarity-blind gap in check-register-row-citations

### DIFF
--- a/scripts/check-register-row-citations.mjs
+++ b/scripts/check-register-row-citations.mjs
@@ -196,7 +196,7 @@ function isDischargeAssertionNegated(text, dischargeMatch) {
 
   // Apostrophes are '-escaped so this regex literal doesn't desync quote-tracking
   const hasNegationWord =
-    /\b(?:NOT|no\b(?!\s+longer\s+exists?)|never|isn't|aren't|wasn't|weren't|hasn't|haven't|cannot|can't|far\s+from|nothing)\b/i.test(
+    /\b(?:NOT|no\b(?!\s+longer\s+exists?)|never|isn\u0027t|aren\u0027t|wasn\u0027t|weren\u0027t|hasn\u0027t|haven\u0027t|cannot|can\u0027t|far\s+from|nothing)\b/i.test(
       polarityContext,
     );
 

--- a/scripts/check-register-row-citations.mjs
+++ b/scripts/check-register-row-citations.mjs
@@ -165,12 +165,54 @@ function normalizeLineContext(lines, lineNum) {
   return context;
 }
 
+// Check if a discharge/removal annotation is negated by a negation word that
+// precedes it. Mirrors the polarity check from check-register-citations.mjs's
+// dischargedSubjectsMentionedIn function. Returns true if the discharge word
+// is negated (e.g., "NOT discharged", "undischarged"), false if affirmative.
+//
+// Recognizes these negation patterns:
+//   - "NOT", "no" (complete words; "no" excludes "no longer exist(s)",
+//     since that's an affirmative annotation phrase)
+//   - "never", "isn't", "aren't", "wasn't", "weren't" (contractions)
+//   - "hasn't", "haven't" (auxiliary verbs with "have")
+//   - "cannot", "can't" (modal verbs)
+//   - "far from" (degree modifier)
+//   - "nothing" (negating existential)
+//   - "un-" or "un-" prefix directly on the discharge word itself
+//
+// The proximity window is 30 characters backward from the discharge word match
+// position, matching the "nearby" heuristic from check-register-citations.mjs.
+function isDischargeAssertionNegated(text, dischargeMatch) {
+  // Check for "un-" or "un" prefix on the discharge word itself (e.g., "undischarged", "un-discharged")
+  const isUnPrefixed = /un-?discharged\b/i.test(
+    text.slice(Math.max(0, dischargeMatch.index - 10), dischargeMatch.index + dischargeMatch[0].length)
+  );
+  if (isUnPrefixed) return true;
+
+  // Check for negation words in a 30-character window before the discharge word
+  const POLARITY_PROXIMITY_CHARS = 30;
+  const polarityScanStart = Math.max(0, dischargeMatch.index - POLARITY_PROXIMITY_CHARS);
+  const polarityContext = text.slice(polarityScanStart, dischargeMatch.index);
+
+  // Apostrophes are '-escaped so this regex literal doesn't desync quote-tracking
+  const hasNegationWord =
+    /\b(?:NOT|no\b(?!\s+longer\s+exists?)|never|isn't|aren't|wasn't|weren't|hasn't|haven't|cannot|can't|far\s+from|nothing)\b/i.test(
+      polarityContext,
+    );
+
+  return hasNegationWord;
+}
+
 // Check if a citation (identified by its row ID) has a discharge/removal
 // annotation that is specifically tied to that citation (not another citation
 // on the same logical line). Uses a "nearest citation" rule: for each
 // annotation phrase, the annotation applies to the citation nearest to its
 // left. This prevents cross-contamination from multiple citations on the
 // same line and handles hard-wrapped continuations.
+//
+// POLARITY CHECK: an annotation is only treated as a real discharge if the
+// discharge word is NOT negated. A sentence like "was NOT discharged" or
+// "undischarged" does not exempt the citation.
 function isCitationAnnotated(id, lines, lineNum) {
   const context = normalizeLineContext(lines, lineNum);
 
@@ -204,6 +246,11 @@ function isCitationAnnotated(id, lines, lineNum) {
 
   // For each annotation, check if our citation is the nearest one to its left
   for (const annotation of annotations) {
+    // POLARITY CHECK: skip this annotation if it's negated
+    if (isDischargeAssertionNegated(context, annotation)) {
+      continue;
+    }
+
     const annotationPos = annotation.index;
 
     // Find all citations to the left of this annotation

--- a/scripts/tests/check-register-row-citations.test.mjs
+++ b/scripts/tests/check-register-row-citations.test.mjs
@@ -735,3 +735,83 @@ test('CLI mutation: if REGISTER_PATH points at a nonexistent file, the check wou
     );
   }
 });
+
+// --- Polarity check tests (PR #2879 bugfix for negated discharge words) ---
+
+test('negated discharge word: "was NOT discharged" does NOT exempt the citation', () => {
+  // This is the reviewer's repro from PR #2879: a negated discharge sentence
+  // should not be treated as a real discharge annotation.
+  // Before the fix, this would incorrectly mark the citation as annotated.
+  const files = {
+    [REGISTER_PATH]: REGISTER_TEXT,
+    'docs/testing/plan.md': 'Register row A99 — was NOT discharged; it is still live.',
+  };
+  const { failures, annotated } = checkRegisterRowCitations({
+    files: [REGISTER_PATH, 'docs/testing/plan.md'],
+    readFile: fakeReadFile(files),
+  });
+  // A99 is nonexistent, the discharge word is negated, so it should FAIL, not be annotated
+  assert.deepEqual(failures, [{ file: 'docs/testing/plan.md', line: 1, id: 'A99' }]);
+  assert.deepEqual(annotated, []);
+});
+
+test('affirmative discharge word: "was discharged" DOES exempt the citation', () => {
+  // Control: affirmative discharge should still work as before.
+  const files = {
+    [REGISTER_PATH]: REGISTER_TEXT,
+    'docs/testing/plan.md': 'Register row A99 — was discharged; it is no longer live.',
+  };
+  const { failures, annotated } = checkRegisterRowCitations({
+    files: [REGISTER_PATH, 'docs/testing/plan.md'],
+    readFile: fakeReadFile(files),
+  });
+  // A99 is nonexistent but the discharge is affirmative, so it should be annotated
+  assert.deepEqual(failures, []);
+  assert.deepEqual(annotated, [{ file: 'docs/testing/plan.md', line: 1, id: 'A99' }]);
+});
+
+test('negation variant: "no longer" in a negative context is not the discharge word', () => {
+  // "no longer" by itself is in ANNOTATION_REGEX, but "no\b(?!\s+longer\s+exists?)" in the
+  // negation regex explicitly excludes "no longer" — test that negation words
+  // don't interfere with legitimate "no longer exists" annotations.
+  const files = {
+    [REGISTER_PATH]: REGISTER_TEXT,
+    'docs/testing/plan.md': 'Register row A99 no longer exists after the 2026-08-26 cleanup.',
+  };
+  const { failures, annotated } = checkRegisterRowCitations({
+    files: [REGISTER_PATH, 'docs/testing/plan.md'],
+    readFile: fakeReadFile(files),
+  });
+  // A99 is nonexistent, "no longer exists" is affirmative, so it should be annotated
+  assert.deepEqual(failures, []);
+  assert.deepEqual(annotated, [{ file: 'docs/testing/plan.md', line: 1, id: 'A99' }]);
+});
+
+test('un- prefix: "undischarged" negates the discharge', () => {
+  // "un-" prefixed discharge words should not exempt the citation.
+  const files = {
+    [REGISTER_PATH]: REGISTER_TEXT,
+    'docs/testing/plan.md': 'Row A99 is undischarged and still needs work.',
+  };
+  const { failures, annotated } = checkRegisterRowCitations({
+    files: [REGISTER_PATH, 'docs/testing/plan.md'],
+    readFile: fakeReadFile(files),
+  });
+  // A99 is nonexistent, "undischarged" is negated, so it should FAIL, not be annotated
+  assert.deepEqual(failures, [{ file: 'docs/testing/plan.md', line: 1, id: 'A99' }]);
+  assert.deepEqual(annotated, []);
+});
+
+test('un- prefix with hyphen: "un-discharged" negates the discharge', () => {
+  const files = {
+    [REGISTER_PATH]: REGISTER_TEXT,
+    'docs/testing/plan.md': 'Row A99 is un-discharged and still needs work.',
+  };
+  const { failures, annotated } = checkRegisterRowCitations({
+    files: [REGISTER_PATH, 'docs/testing/plan.md'],
+    readFile: fakeReadFile(files),
+  });
+  // A99 is nonexistent, "un-discharged" is negated, so it should FAIL, not be annotated
+  assert.deepEqual(failures, [{ file: 'docs/testing/plan.md', line: 1, id: 'A99' }]);
+  assert.deepEqual(annotated, []);
+});


### PR DESCRIPTION
## Summary

`check-register-row-citations.mjs` (added after #2879's branch was cut) had
the same polarity-blind bug #2879 just fixed in the sibling script
`check-register-citations.mjs`: its `ANNOTATION_REGEX` matched a discharge
word near a cited nonexistent register-row ID without checking what the
discharge word actually asserts, so a negated sentence like "was NOT
discharged; it is still live" was silently exempted from the fatal-error
gate — indistinguishable from a genuinely-discharged citation.

Found via the independent review pass on PR #2879
(https://github.com/dudarenok-maker/Castwright/pull/2879#issuecomment-5546687949),
which located the same bug class in this sibling file.

Ports the `isDischargeAssertionNegated` polarity check (negation words,
`un-?discharged` prefix, 30-char proximity window — the same shape #2879
introduced) into `isCitationAnnotated`, so a negated discharge assertion no
longer exempts a citation from the fatal check.

Closes #2902

## Test plan

- [x] `node --test scripts/tests/check-register-row-citations.test.mjs` — 38/38 pass, including 5 new regression tests (negated discharge, affirmative control, "no longer exists" non-confusion, `undischarged`, `un-discharged`)
- [x] Real-corpus check: unchanged (40 citations / 7 annotated, before and after)
- [x] Release notes: skipped — internal audit-script hardening fix, no user- or operator-visible behavior change on today's real corpus