### PR TITLE
feat(voice-library): warn when a cloned voice language mismatches the book (#1998)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2627,14 +2627,20 @@ paths:
                     type: string
                     nullable: true
                     description: |
-                      Non-fatal advisory. Carries one of two mutually exclusive
-                      (by provenance) signals, never both:
+                      Non-fatal advisory. Carries one of three signals:
 
                       - (#1953) set when a DESIGNED voice's baked manifest language
                         differs from the book's language. Applies on an English book
                         as well as a non-English one. Absent for a cloned/imported
                         entry (which has no baked design language) and for a
                         matching-language designed voice.
+                      - (#1998) set when a CLONED voice's `languageCode` (BCP-47,
+                        persisted by the clone pipeline at validation time) differs
+                        from the book's language. The comparison is code-versus-code
+                        (`entry.languageCode` against the book's `language` code),
+                        never code-versus-sidecar-word. Absent for an entry with no
+                        `languageCode` (unknown source language) and for a
+                        matching-language cloned voice.
                       - (#1933) set when a CLONED entry's OTHER clone-capable engine
                         (not the one this assign routed to) is not derivable — its
                         slot is terminally failed, or has no derivable source (no
@@ -2643,6 +2649,10 @@ paths:
                         regardless of which one this assign routed to, so this warns
                         about the one left unusable rather than letting it surface
                         silently the next time the character is switched to it.
+
+                      When both (#1933) and (#1998) apply to the same cloned entry,
+                      the (#1933) advisory takes priority (engine-readiness is the
+                      more actionable message).
 
                       Either way the assignment still succeeds; this is a warning,
                       never a 409 (see the cloned-voice per-engine-readiness 409

--- a/server/src/routes/voice-library.test.ts
+++ b/server/src/routes/voice-library.test.ts
@@ -3255,6 +3255,89 @@ describe('POST /:uuid/assign — designed-voice language mismatch warning (#1953
   });
 });
 
+/* #1998 — cloned-voice language mismatch warning. Sibling of the designed-
+   voice warning (#1953) above: when a cloned voice's `languageCode` (the
+   BCP-47 code the clone pipeline validated and persisted) differs from the
+   book's language, the assign succeeds with a 200 but attaches a warning
+   naming the character, the clone's language, and the book's. The comparison
+   is CODE-vs-CODE (`entry.languageCode` against `bookLanguage`), never
+   code-vs-sidecar-word — mutation 2 below pins that trap. */
+describe('POST /:uuid/assign — cloned-voice language mismatch warning (#1998)', () => {
+  async function seedClonedWithLang(voiceUuid: string, languageCode?: string) {
+    const { writeEntry } = await import('../workspace/voice-library.js');
+    await writeEntry({
+      voiceUuid, name: 'Clone Voice', provenance: 'cloned',
+      tags: [], pinned: false, languageCode,
+      engines: { qwen: { status: 'ready', baseModel: 'qwen3-0.6b' } },
+      master: {
+        clipFile: 'master.wav', sampleRate: 24_000, durationSeconds: 5,
+        transcript: 'hello there', transcriptSource: 'whisper',
+        captureMethod: 'record', languageCode,
+      },
+      consent: {
+        personName: 'Test', relationship: 'family-with-permission',
+        permittedUse: 'personal', attestedAt: '2026-01-01T00:00:00Z',
+        attestedBy: 'test',
+      },
+      createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z',
+    });
+    writeFileSync(join(vl.entryDir(voiceUuid), 'master.wav'), 'fake-wav-bytes');
+  }
+
+  it('warns (200) when a cloned voice in Russian is assigned to an English book', async () => {
+    await seedClonedWithLang('clone-ru-en', 'ru');
+    writeBookOnDisk(dir, 'Della Renwick', 'The Hollow Tide', 'Book One', 'book-clone-ru-en', [
+      { id: 'char-nik', name: 'Nikolai', ttsEngine: 'qwen' },
+    ]);
+    const res = await request(app)
+      .post('/api/voice-library/clone-ru-en/assign')
+      .send({ bookId: 'book-clone-ru-en', characterId: 'char-nik' });
+    expect(res.status).toBe(200);
+    expect(res.body.warning).toMatch(/Nikolai/);
+    expect(res.body.warning).toMatch(/Russian/);
+    expect(res.body.warning).toMatch(/English/);
+    expect(res.body.warning).toMatch(/cloned in/);
+  });
+
+  it('does not warn when the cloned voice language matches the book language', async () => {
+    await seedClonedWithLang('clone-en-en', 'en');
+    writeBookOnDisk(dir, 'Della Renwick', 'The Hollow Tide', 'Book One', 'book-clone-en-en', [
+      { id: 'char-ada', name: 'Ada', ttsEngine: 'qwen' },
+    ]);
+    const res = await request(app)
+      .post('/api/voice-library/clone-en-en/assign')
+      .send({ bookId: 'book-clone-en-en', characterId: 'char-ada' });
+    expect(res.status).toBe(200);
+    expect(res.body.warning).toBeUndefined();
+  });
+
+  it('does not warn when the cloned voice has no languageCode (unknown language)', async () => {
+    await seedClonedWithLang('clone-undef');
+    writeBookOnDisk(dir, 'Della Renwick', 'The Hollow Tide', 'Book One', 'book-clone-undef', [
+      { id: 'char-ada', name: 'Ada', ttsEngine: 'qwen' },
+    ]);
+    const res = await request(app)
+      .post('/api/voice-library/clone-undef/assign')
+      .send({ bookId: 'book-clone-undef', characterId: 'char-ada' });
+    expect(res.status).toBe(200);
+    expect(res.body.warning).toBeUndefined();
+  });
+
+  /* Mutation 1 — invert the comparison so it fires on a MATCH instead of a
+     mismatch. The match-case test ("does not warn when…matches") must go
+     red. Pins that the guard tests inequality, not just presence.
+     To verify: change `entry.languageCode !== bookLanguage` to
+     `entry.languageCode === bookLanguage`, re-run the match test — fails. */
+
+  /* Mutation 2 — change the comparand from `bookLanguage` (BCP-47 code)
+     back to `expectedSidecarLang` (human-readable sidecar word). The match-
+     case test must go red: 'en' !== 'English' is always true, so the guard
+     fires on every correctly-matched assignment. Pins the code-vs-word trap.
+     To verify: change `entry.languageCode !== bookLanguage` to
+     `entry.languageCode !== expectedSidecarLang`, re-run the match test. */
+});
+
+
 /* Fix wave 2 (review) — the guard's first cut computed the effective engine
    purely from the PERSISTED account default (getResolvedTtsModelKey()), which
    is not what actually renders: the Voices-page engine picker (and the

--- a/server/src/routes/voice-library.ts
+++ b/server/src/routes/voice-library.ts
@@ -1714,10 +1714,14 @@ voiceLibraryRouter.post('/:voiceUuid/assign', async (req: Request, res: Response
          route. With no registry entry there is no sidecar word to compare
          the manifest against, so there is no mismatch to assert either way:
          skip the warning, exactly like the pre-#1953 behaviour, never 500. */
+      /* #1998 — `bookLanguage` is needed by BOTH provenance branches below
+         (designed-voice sidecar mismatch at #1953, cloned-voice `languageCode`
+         mismatch at #1998), so it stays here, outside either `if`, rather than
+         being re-derived inside each one. */
+      const bookLanguage = bookStateLanguage(located.state);
       let expectedSidecarLang: string | undefined;
       let designedManifest: { language?: string } | null = null;
       if (entry.provenance === 'designed') {
-        const bookLanguage = bookStateLanguage(located.state);
         try {
           expectedSidecarLang = sidecarLanguageName(bookLanguage);
         } catch {
@@ -1740,13 +1744,15 @@ voiceLibraryRouter.post('/:voiceUuid/assign', async (req: Request, res: Response
 
         const character = characters[charIndex];
 
-        /* #1933 — `clonedAdvisory` and `languageWarning` (declared together,
-           set inside their own respective provenance-scoped blocks below) are
-           mutually exclusive by construction: `clonedAdvisory` is only ever set
-           inside a `provenance === 'cloned'` branch, `languageWarning` only
-           inside a `provenance === 'designed'` one — an entry is never both —
-           so the two can share the single `warning` response field with no
-           collision to disambiguate. */
+        /* #1933/#1998 — `clonedAdvisory` and `languageWarning` share the
+           single `warning` response field. `clonedAdvisory` is only ever set
+           inside a `provenance === 'cloned'` branch (engine-readiness);
+           `languageWarning` is set inside EITHER provenance — designed
+           (#1953 sidecar mismatch) or cloned (#1998 `languageCode` mismatch)
+           — but never both at once because an entry is never both cloned
+           and designed. When a cloned voice triggers BOTH `clonedAdvisory`
+           AND `languageWarning`, the `??` below picks the advisory (the
+           engine-readiness message is the more actionable of the two). */
         let clonedAdvisory: string | undefined;
         let languageWarning: string | undefined;
 
@@ -1851,6 +1857,36 @@ voiceLibraryRouter.post('/:voiceUuid/assign', async (req: Request, res: Response
           }
         }
 
+        /* #1998 — sibling of the designed-voice warning above: a CLONED voice
+           whose source clip was recorded in a language different from the
+           book's renders at ~0.23 ECAPA cosine identity (vs ~0.60 same-
+           language — see #1998's own measurement table). Warn, do not block:
+           the owner's v1 decision is expectation-setting, not engine re-
+           routing. The comparison is CODE-vs-CODE (`entry.languageCode`
+           against `bookLanguage`), never code-vs-sidecar-word — comparing
+           against `expectedSidecarLang` would silently fire on every
+           correctly-matched assignment because a BCP-47 code is never equal
+           to its human-readable sidecar name. Pinned by mutation 2 in the
+           paired test block. */
+        if (entry.provenance === 'cloned') {
+          if (
+            entry.languageCode &&
+            bookLanguage &&
+            entry.languageCode !== bookLanguage
+          ) {
+            let cloneLangName: string | undefined;
+            let bookLangName: string | undefined;
+            try { cloneLangName = sidecarLanguageName(entry.languageCode); } catch { /* unregistered — skip */ }
+            try { bookLangName = sidecarLanguageName(bookLanguage); } catch { /* unregistered — skip */ }
+            if (cloneLangName && bookLangName) {
+              languageWarning =
+                `"${character.name ?? characterId}"'s voice was cloned in ${cloneLangName} but this ` +
+                `book is ${bookLangName} — the audio will be unintelligible. Re-clone the voice in ` +
+                `${bookLangName} to fix it.`;
+            }
+          }
+        }
+
         /* Review I-4 — a prior DESIGNED voice's minted emotion `variants` are
            anchored to that base identity (qwen-<old-uuid>__<emotion>). Assigning
            a library voice swaps the base identity to qwen-<voiceUuid>, and
@@ -1901,9 +1937,10 @@ voiceLibraryRouter.post('/:voiceUuid/assign', async (req: Request, res: Response
            disagree. Order mirrors the write: qwen is unconditional, coqui is
            conditional. */
         const written: CloneEngine[] = shouldWriteCoquiSlot ? ['qwen', 'coqui'] : ['qwen'];
-        /* #1933 — `clonedAdvisory` and `languageWarning` are mutually exclusive
-           by construction (see their shared declaration comment above), so
-           there is no collision picking one over the other here. */
+        /* #1933/#1998 — `clonedAdvisory` wins when both are set for a cloned
+           voice (see their shared declaration comment above). For a designed
+           voice only `languageWarning` can be set; for a cloned voice either
+           or both, with the advisory taking priority. */
         const warning = clonedAdvisory ?? languageWarning;
         return res.status(200).json({ updated: 1, written, ...(warning ? { warning } : {}) });
       });


### PR DESCRIPTION
﻿## Summary

When a cloned voice whose languageCode (BCP-47, persisted by the clone pipeline) differs from the book language, the assign endpoint now returns a 200 with a warning field naming the character, the clone language, and the book language.

The comparison is code-vs-code (entry.languageCode against bookLanguage), never code-vs-sidecar-word.

The warning does NOT block the assignment (warn, not 409) — the owner decision is expectation-setting, not engine rerouting.

## Changes

### server/src/routes/voice-library.ts
- Moved bookLanguage computation outside the provenance-scoped if blocks (both #1953 and #1998 need it)
- Added cloned-voice language mismatch warning (#1998) after the designed-voice warning (#1953)
- Updated mutual-exclusivity comments to reflect that languageWarning can now fire for either provenance
- When both #1933 clonedAdvisory and #1998 languageWarning apply, clonedAdvisory takes priority via ??

### server/src/routes/voice-library.test.ts
- New describe block: cloned-voice language mismatch warning (#1998)
  - warns (200) for ru-cloned voice on en book
  - no warning for matching en-cloned voice on en book
  - no warning for voice with no languageCode (unknown language)
  - Mutation 1 (documented): invert comparison fires on match
  - Mutation 2 (documented): code-vs-sidecar-word fires on match

### openapi.yaml
- Updated warning field documentation: three signals (#1953, #1998, #1933) instead of two, with priority rules

## Mutations

### Mutation 1 — inverted comparison
Change entry.languageCode !== bookLanguage to entry.languageCode === bookLanguage. The match-case test goes red because a warning fires where none should.

### Mutation 2 — code-vs-sidecar-word comparand
Change entry.languageCode !== bookLanguage to entry.languageCode !== expectedSidecarLang. The match-case test goes red because 'en' !== 'English' is always true.

Fixes #1998
