### PR TITLE
fix(scripts): add windowsHide to unguarded spawns in scripts/tests

### DIFF
--- a/scripts/tests/build-register-live-view.test.mjs
+++ b/scripts/tests/build-register-live-view.test.mjs
@@ -537,7 +537,7 @@ test('the real register and its real live view agree (register:build --check)', 
   const result = spawnSync(
     process.execPath,
     [CLI_PATH_FOR_REGISTER_BUILD, '--check'],
-    { cwd: REPO_ROOT, encoding: 'utf8' },
+    { cwd: REPO_ROOT, encoding: 'utf8', windowsHide: true },
   );
   assert.equal(result.status, 0, result.stderr || result.stdout);
 });

--- a/scripts/tests/bump-version.test.mjs
+++ b/scripts/tests/bump-version.test.mjs
@@ -52,7 +52,7 @@ function cleanGitEnv() {
 // Wrap execFileSync to always pass the sanitised env. Every git invocation
 // in this test goes through this helper.
 function gitExec(args, opts = {}) {
-  return execFileSync('git', args, { ...opts, env: cleanGitEnv() });
+  return execFileSync('git', args, { ...opts, env: cleanGitEnv(), windowsHide: true });
 }
 
 function mkLockfile(name, version) {
@@ -147,6 +147,7 @@ function runBump(dir, args) {
     cwd: dir,
     encoding: 'utf8',
     env: cleanGitEnv(),
+    windowsHide: true,
   });
 }
 
@@ -161,6 +162,7 @@ function runBumpWithEnv(dir, args, envOverrides) {
     cwd: dir,
     encoding: 'utf8',
     env: { ...cleanGitEnv(), ...envOverrides },
+    windowsHide: true,
   });
 }
 
@@ -434,7 +436,7 @@ test('bump-version resolves DEFAULT_NOTES_FILE against repoRoot, not the invocat
     const out = spawnSync(
       'node',
       [resolve(dir, 'scripts', 'bump-version.mjs'), '--level', 'patch', '--notes-file', notes, '--skip-cross-os'],
-      { cwd: resolve(dir, 'server'), encoding: 'utf8', env: cleanGitEnv() },
+      { cwd: resolve(dir, 'server'), encoding: 'utf8', env: cleanGitEnv(), windowsHide: true },
     );
     rmSync(notes, { force: true });
     assert.notEqual(out.status, 0, out.stdout + out.stderr);

--- a/scripts/tests/check-no-budget-poll.test.mjs
+++ b/scripts/tests/check-no-budget-poll.test.mjs
@@ -104,7 +104,7 @@ test('CLI exits non-zero against a planted budgeted-poll + oversized-timeout fil
     const result = spawnSync(
       process.execPath,
       ['scripts/check-no-budget-poll.mjs', dir],
-      { cwd: repoRoot, stdio: 'pipe', encoding: 'utf8' },
+      { cwd: repoRoot, stdio: 'pipe', encoding: 'utf8', windowsHide: true },
     );
     exitCode = result.status;
   } finally {
@@ -133,7 +133,7 @@ test('CLI exits 0 against a clean temp directory', () => {
     const result = spawnSync(
       process.execPath,
       ['scripts/check-no-budget-poll.mjs', dir],
-      { cwd: repoRoot, stdio: 'pipe', encoding: 'utf8' },
+      { cwd: repoRoot, stdio: 'pipe', encoding: 'utf8', windowsHide: true },
     );
     exitCode = result.status;
   } finally {

--- a/scripts/tests/check-onbox-register-cli-no-flags.test.mjs
+++ b/scripts/tests/check-onbox-register-cli-no-flags.test.mjs
@@ -82,6 +82,7 @@ function runFixtureCli(root) {
   return spawnSync(process.execPath, [join(root, 'scripts', 'check-onbox-register.mjs')], {
     encoding: 'utf8',
     timeout: 30000,
+    windowsHide: true,
   });
 }
 
@@ -207,7 +208,7 @@ test('CLI (no flags), real subprocess: a many-mismatch register exits 1 and repo
     for (const letter of LETTERS) {
       assert.match(
         combined,
-        new RegExp(`Live view's Group ${letter} section has row ${letter}3 that the register's Group ${letter} does not`),
+        new RegExp(`Live view's Group ${letter} section has row ${letter}3 that the register\u0027s Group ${letter} does not`),
         `missing extra-row line for Group ${letter} — full output:\n${combined}`,
       );
       assert.match(
@@ -221,7 +222,7 @@ test('CLI (no flags), real subprocess: a many-mismatch register exits 1 and repo
     // duplicate-row error shapes — a coarse count check that catches an
     // accidental duplicate or a silently-skipped group even if the
     // per-letter regexes above somehow both matched something unintended.
-    const extraRowCount = (combined.match(/section has row [A-L]3 that the register's Group [A-L] does not/g) ?? []).length;
+    const extraRowCount = (combined.match(/section has row [A-L]3 that the register\u0027s Group [A-L] does not/g) ?? []).length;
     const duplicateRowCount = (combined.match(/lists [A-L]3 more than once/g) ?? []).length;
     assert.equal(extraRowCount, GROUP_COUNT, `expected ${GROUP_COUNT} extra-row lines, got ${extraRowCount}`);
     assert.equal(duplicateRowCount, GROUP_COUNT, `expected ${GROUP_COUNT} duplicate-row lines, got ${duplicateRowCount}`);

--- a/scripts/tests/check-onbox-register-cli-no-flags.test.mjs
+++ b/scripts/tests/check-onbox-register-cli-no-flags.test.mjs
@@ -208,7 +208,7 @@ test('CLI (no flags), real subprocess: a many-mismatch register exits 1 and repo
     for (const letter of LETTERS) {
       assert.match(
         combined,
-        new RegExp(`Live view's Group ${letter} section has row ${letter}3 that the register\u0027s Group ${letter} does not`),
+        new RegExp(`Live view's Group ${letter} section has row ${letter}3 that the register's Group ${letter} does not`),
         `missing extra-row line for Group ${letter} — full output:\n${combined}`,
       );
       assert.match(

--- a/scripts/tests/check-onbox-register.test.mjs
+++ b/scripts/tests/check-onbox-register.test.mjs
@@ -2489,6 +2489,7 @@ function runCli(args, envOverrides) {
     encoding: 'utf8',
     timeout: 60000,
     env: envOverrides ? { ...process.env, ...envOverrides } : process.env,
+    windowsHide: true,
   });
 }
 
@@ -2772,7 +2773,7 @@ test('--against-published gives an unreadable ONBOX_TEST_BASELINE_FILE its own h
     // failed when git was never invoked at all.
     assert.doesNotMatch(
       r.stderr,
-      /`git show FETCH_HEAD:/,
+      /\u0060git show FETCH_HEAD:/,
       'must not claim git show failed when the override path was simply unreadable',
     );
   });
@@ -3593,12 +3594,12 @@ test('#2599 review round 2: replaying real live-view.html history as ordinary pe
   const commits = spawnSync(
     'git',
     ['-C', REPO_ROOT, 'log', '--format=%H', '-25', '--', lvRelPath],
-    { encoding: 'utf8' },
+    { encoding: 'utf8', windowsHide: true },
   ).stdout.trim().split('\n').filter(Boolean);
   assert.ok(commits.length > 0, 'fixture assumption: real commit history exists for the live-view file');
 
   function show(ref, path) {
-    const r = spawnSync('git', ['-C', REPO_ROOT, 'show', `${ref}:${path}`], { encoding: 'utf8' });
+    const r = spawnSync('git', ['-C', REPO_ROOT, 'show', `${ref}:${path}`], { encoding: 'utf8', windowsHide: true });
     return r.status === 0 ? r.stdout : null;
   }
 

--- a/scripts/tests/check-register-citations.test.mjs
+++ b/scripts/tests/check-register-citations.test.mjs
@@ -2851,7 +2851,7 @@ test('CLI: with --strict, Check D finds title drift but does NOT fail the gate (
 
     // The finding must be Check D's OWN message for THIS injected heading —
     // not merely some unrelated "cited <id>" substring elsewhere in the much
-    // larger combined CLI output (Check C\u0027s exploratory findings use that
+    // larger combined CLI output (Check C's exploratory findings use that
     // exact word too, e.g. "cited A3 for #1230"). Match the single real line
     // precisely: file:line, "heading cites <id>", and the injected echo text,
     // all on one line, with no 's' (dotall) flag to allow cross-output drift.

--- a/scripts/tests/check-register-citations.test.mjs
+++ b/scripts/tests/check-register-citations.test.mjs
@@ -31,7 +31,7 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const CLI_PATH = join(HERE, '..', 'check-register-citations.mjs');
 
 function runCli(args) {
-  return spawnSync(process.execPath, [CLI_PATH, ...args], { encoding: 'utf8', timeout: 60000 });
+  return spawnSync(process.execPath, [CLI_PATH, ...args], { encoding: 'utf8', timeout: 60000, windowsHide: true });
 }
 
 // A minimal but structurally real register: two groups, a run-sheet
@@ -2648,7 +2648,7 @@ test('CLI: without --strict, Check C\'s exploratory half does not print and the 
   const result = runCli([]);
   assert.equal(result.status, 0);
   assert.doesNotMatch(result.stdout, /Check C — subject not found/);
-  assert.match(result.stdout, /Check C's exploratory .* did NOT run/);
+  assert.match(result.stdout, /Check C\u0027s exploratory .* did NOT run/);
 });
 
 test('CLI: with --strict, Check C\'s exploratory half runs and prints under its own opt-in label, still non-fatal', () => {
@@ -2658,7 +2658,7 @@ test('CLI: with --strict, Check C\'s exploratory half runs and prints under its 
     result.stdout,
     /Check C — subject not found in any current register heading \(--strict, exploratory, not failing/,
   );
-  assert.match(result.stdout, /Check C's exploratory .* found \d+ warning\(s\) above/);
+  assert.match(result.stdout, /Check C\u0027s exploratory .* found \d+ warning\(s\) above/);
 });
 
 test('CLI: Check C\'s wrongId half is FATAL and runs whether or not --strict is passed', () => {
@@ -2851,7 +2851,7 @@ test('CLI: with --strict, Check D finds title drift but does NOT fail the gate (
 
     // The finding must be Check D's OWN message for THIS injected heading —
     // not merely some unrelated "cited <id>" substring elsewhere in the much
-    // larger combined CLI output (Check C's exploratory findings use that
+    // larger combined CLI output (Check C\u0027s exploratory findings use that
     // exact word too, e.g. "cited A3 for #1230"). Match the single real line
     // precisely: file:line, "heading cites <id>", and the injected echo text,
     // all on one line, with no 's' (dotall) flag to allow cross-output drift.

--- a/scripts/tests/check-register-row-citations.test.mjs
+++ b/scripts/tests/check-register-row-citations.test.mjs
@@ -20,7 +20,7 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const CLI_PATH = join(HERE, '..', 'check-register-row-citations.mjs');
 
 function runCli(args) {
-  return spawnSync(process.execPath, [CLI_PATH, ...args], { encoding: 'utf8', timeout: 60000 });
+  return spawnSync(process.execPath, [CLI_PATH, ...args], { encoding: 'utf8', timeout: 60000, windowsHide: true });
 }
 
 // A minimal register carrying two real rows: A1 and E1. Every fixture below
@@ -716,7 +716,7 @@ test('CLI mutation: if REGISTER_PATH points at a nonexistent file, the check wou
 
   // Mutate REGISTER_PATH to point at a nonexistent file
   const mutated = original.replace(
-    /export const REGISTER_PATH = '[^']*';/,
+    /export const REGISTER_PATH = \u0027[^\u0027]*\u0027;/,
     "export const REGISTER_PATH = 'docs/testing/nonexistent-register.md';"
   );
   assert.notEqual(mutated, original, 'mutation should have changed REGISTER_PATH');

--- a/scripts/tests/cross-os-ffmpeg-install.test.mjs
+++ b/scripts/tests/cross-os-ffmpeg-install.test.mjs
@@ -145,7 +145,7 @@ function probePowerShell(exe) {
   const args = ['-NoProfile', '-NonInteractive'];
   if (process.platform === 'win32') args.push('-ExecutionPolicy', 'Bypass');
   args.push('-Command', '$PSVersionTable.PSVersion.ToString()');
-  return spawnSync(exe, args, { encoding: 'utf8' });
+  return spawnSync(exe, args, { encoding: 'utf8', windowsHide: true });
 }
 
 function findPowerShell() {
@@ -185,7 +185,7 @@ function runPowerShellFile(scriptPath, extraArgs = [], env = process.env) {
   const args = ['-NoProfile', '-NonInteractive'];
   if (process.platform === 'win32') args.push('-ExecutionPolicy', 'Bypass');
   args.push('-File', scriptPath, ...extraArgs);
-  return spawnSync(PWSH_EXE, args, { encoding: 'utf8', env });
+  return spawnSync(PWSH_EXE, args, { encoding: 'utf8', env, windowsHide: true });
 }
 
 // Uses PowerShell's OWN parser — System.Management.Automation.Language.Parser

--- a/scripts/tests/dialogue-verbs-drift.test.mjs
+++ b/scripts/tests/dialogue-verbs-drift.test.mjs
@@ -25,7 +25,7 @@ function readCanonicalVerbs() {
   const m = src.match(/DIALOGUE_VERBS[^=]*=\s*\[([\s\S]*?)\];/);
   assert.ok(m, 'could not locate DIALOGUE_VERBS array in dialogue-verbs.ts');
   const withoutComments = m[1].replace(/\/\/[^\n]*/g, '');
-  return [...withoutComments.matchAll(/'([^']+)'/g)].map((x) => x[1]);
+  return [...withoutComments.matchAll(/\u0027([^\u0027]+)\u0027/g)].map((x) => x[1]);
 }
 
 test('the .mjs verb list matches the canonical TS list (no drift)', () => {

--- a/scripts/tests/entry-point-guards.test.mjs
+++ b/scripts/tests/entry-point-guards.test.mjs
@@ -99,7 +99,7 @@ function withRepoLink(fn) {
 test('ci-scope.mjs invoked through a junction/symlink still runs main() (#2291)', { skip: LINK_SKIP_REASON ?? false }, () => {
   withRepoLink((linkPath) => {
     const target = join(linkPath, 'scripts', 'ci-scope.mjs');
-    const r = spawnSync(process.execPath, [target, '--files=src/app.tsx'], { encoding: 'utf8' });
+    const r = spawnSync(process.execPath, [target, '--files=src/app.tsx'], { encoding: 'utf8', windowsHide: true });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     // The reviewer's exact repro was 0 bytes of stdout through a junction.
     // A real run must emit the scopes=...  / ok=true payload render() builds.
@@ -117,7 +117,7 @@ test('ci-scope.mjs imported as a module does not execute main() (no argv[1] matc
       `import ${JSON.stringify(pathToFileURL(join(REPO_ROOT, 'scripts', 'ci-scope.mjs')).href)};\n` +
         "console.log('IMPORT-OK');\n",
     );
-    const r = spawnSync(process.execPath, [entry], { encoding: 'utf8' });
+    const r = spawnSync(process.execPath, [entry], { encoding: 'utf8', windowsHide: true });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     // main()'s own output is `scopes=...\nok=true\n` — that must NOT appear;
     // only the entry script's own marker should.
@@ -136,6 +136,7 @@ test('check-import-cycles.mjs invoked through a junction/symlink still runs main
     const r = spawnSync(process.execPath, [target], {
       encoding: 'utf8',
       env: { ...process.env, CHECK_IMPORT_CYCLES_PROBE_GUARD_ONLY: '1' },
+      windowsHide: true,
     });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     assert.match(
@@ -158,6 +159,7 @@ test('check-import-cycles.mjs imported as a module does not execute main() (no a
     const r = spawnSync(process.execPath, [entry], {
       encoding: 'utf8',
       env: { ...process.env, CHECK_IMPORT_CYCLES_PROBE_GUARD_ONLY: '1' },
+      windowsHide: true,
     });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     assert.doesNotMatch(r.stdout, /direct-invocation guard resolved TRUE/);
@@ -176,7 +178,7 @@ test('check-import-cycles.mjs imported as a module does not execute main() (no a
 test('build-release-zip.mjs invoked through a junction/symlink still runs main() (#2291)', { skip: LINK_SKIP_REASON ?? false }, () => {
   withRepoLink((linkPath) => {
     const target = join(linkPath, 'scripts', 'build-release-zip.mjs');
-    const r = spawnSync(process.execPath, [target, '--dry-run', '--version', 'v0.0.0-test'], { encoding: 'utf8' });
+    const r = spawnSync(process.execPath, [target, '--dry-run', '--version', 'v0.0.0-test'], { encoding: 'utf8', windowsHide: true });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     // The pre-fix bug through a junction was 0 bytes of stdout, exit 0 —
     // indistinguishable from success without checking the byte count.
@@ -195,7 +197,7 @@ test('build-release-zip.mjs imported as a module does not execute main() (no arg
       `import ${JSON.stringify(pathToFileURL(join(REPO_ROOT, 'scripts', 'build-release-zip.mjs')).href)};\n` +
         "console.log('IMPORT-OK');\n",
     );
-    const r = spawnSync(process.execPath, [entry], { encoding: 'utf8' });
+    const r = spawnSync(process.execPath, [entry], { encoding: 'utf8', windowsHide: true });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     assert.doesNotMatch(r.stdout, /\[SCAN\]/);
     assert.match(r.stdout, /IMPORT-OK/);
@@ -262,6 +264,7 @@ test(
               APP_RUN_DIR: runDir,
               APP_LOG_DIR: logDir,
             },
+            windowsHide: true,
           });
           // The pre-fix bug through a junction was exit 0 with zero output — a
           // launcher that silently does nothing, which is worse than a crash.
@@ -288,7 +291,7 @@ test('start-app-prod.mjs imported as a module does not execute main() (no argv[1
       `import ${JSON.stringify(pathToFileURL(join(REPO_ROOT, 'scripts', 'start-app-prod.mjs')).href)};\n` +
         "console.log('IMPORT-OK');\n",
     );
-    const r = spawnSync(process.execPath, [entry], { encoding: 'utf8' });
+    const r = spawnSync(process.execPath, [entry], { encoding: 'utf8', windowsHide: true });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     assert.doesNotMatch(r.stderr, /\[FAIL\]/);
     assert.match(r.stdout, /IMPORT-OK/);

--- a/scripts/tests/eslint-guardrail.test.mjs
+++ b/scripts/tests/eslint-guardrail.test.mjs
@@ -45,6 +45,7 @@ function runEslint(args) {
     cwd: repoRoot,
     encoding: 'utf8',
     shell: IS_WIN,
+    windowsHide: true,
   });
   if (result.error) {
     throw result.error;

--- a/scripts/tests/eval-attribution.test.mjs
+++ b/scripts/tests/eval-attribution.test.mjs
@@ -232,7 +232,7 @@ test('CLI: exits 0 for a good cast.json and prints PASS', () => {
     }));
     writeFileSync(gtPath, JSON.stringify(GT));
 
-    const out = spawnSync(process.execPath, [evalScript, castPath, gtPath], { encoding: 'utf8' });
+    const out = spawnSync(process.execPath, [evalScript, castPath, gtPath], { encoding: 'utf8', windowsHide: true });
     assert.equal(out.status, 0, `CLI should exit 0 for PASS. stderr: ${out.stderr}`);
     assert.match(out.stdout, /PASS/, 'stdout should contain PASS');
     assert.match(out.stdout, /RECALL 4\/4/, 'stdout should show recall 4/4');
@@ -255,7 +255,7 @@ test('CLI: exits 1 for a degraded cast.json with low recall', () => {
     }));
     writeFileSync(gtPath, JSON.stringify(GT));
 
-    const out = spawnSync(process.execPath, [evalScript, castPath, gtPath], { encoding: 'utf8' });
+    const out = spawnSync(process.execPath, [evalScript, castPath, gtPath], { encoding: 'utf8', windowsHide: true });
     assert.equal(out.status, 1, `CLI should exit 1 for FAIL. stderr: ${out.stderr}`);
     assert.match(out.stdout, /FAIL/, 'stdout should contain FAIL');
   } finally {

--- a/scripts/tests/gh-chokepoint.test.mjs
+++ b/scripts/tests/gh-chokepoint.test.mjs
@@ -167,7 +167,7 @@ const SHELL_CANONICAL_NAMES = ['execSync', 'exec'];
 // there, so Q is deliberately not reused for this one). `[^}]*` spans
 // newlines with no `/s` flag needed, so a specifier list broken across
 // multiple lines is still captured whole.
-const CHILD_PROCESS_IMPORT_RE = /import\s*\{([^}]*)\}\s*from\s*(['"])node:child_process\2/g;
+const CHILD_PROCESS_IMPORT_RE = /import\s*\{([^}]*)\}\s*from\s*([\u0027\u0022])node:child_process\2/g;
 
 /** Finds every local alias this file's own `node:child_process` import(s)
  *  bind to execSync/exec — e.g. `import { execSync as sh } from

--- a/scripts/tests/git-scrub.test.mjs
+++ b/scripts/tests/git-scrub.test.mjs
@@ -224,9 +224,9 @@ function buildShellCallRe(names) {
 // Recognizes both the ESM `import { execSync as sh } from
 // 'node:child_process'` alias form and the CommonJS `const { execSync: sh }
 // = require('node:child_process')` alias form (pinokio-scripts is CJS).
-const CHILD_PROCESS_IMPORT_RE = /import\s*\{([^}]*)\}\s*from\s*(['"])node:child_process\2/g;
+const CHILD_PROCESS_IMPORT_RE = /import\s*\{([^}]*)\}\s*from\s*([\u0027\u0022])node:child_process\2/g;
 const CHILD_PROCESS_REQUIRE_RE =
-  /(?:const|let|var)\s*\{([^}]*)\}\s*=\s*require\(\s*(['"])node:child_process\2\s*\)/g;
+  /(?:const|let|var)\s*\{([^}]*)\}\s*=\s*require\(\s*([\u0027\u0022])node:child_process\2\s*\)/g;
 
 function collectShellAliases(source) {
   const shell = new Set(SHELL_CANONICAL_NAMES);

--- a/scripts/tests/gitignore-secrets.test.mjs
+++ b/scripts/tests/gitignore-secrets.test.mjs
@@ -28,6 +28,7 @@ function isGitIgnored(filePath) {
   const result = spawnSync('git', ['check-ignore', '-q', '--no-index', filePath], {
     cwd: repoRoot,
     env: scrubGitEnv(),
+    windowsHide: true,
   });
   if (result.error || result.status === null) {
     throw new Error(

--- a/scripts/tests/is-main-module.test.mjs
+++ b/scripts/tests/is-main-module.test.mjs
@@ -160,7 +160,7 @@ test('probe.mjs invoked through a symlink/junction still resolves DIRECT (#2291)
   const linkDir = join(linkContainer, 'link');
   try {
     symlinkSync(root, linkDir, IS_WIN ? 'junction' : 'dir');
-    const r = spawnSync(process.execPath, [join(linkDir, 'scripts', 'probe.mjs')], { encoding: 'utf8' });
+    const r = spawnSync(process.execPath, [join(linkDir, 'scripts', 'probe.mjs')], { encoding: 'utf8', windowsHide: true });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     assert.match(r.stdout, /^DIRECT/, `expected DIRECT through the link; got: ${JSON.stringify(r.stdout)}`);
   } finally {
@@ -183,7 +183,7 @@ test('probe.mjs invoked through a symlink/junction with --preserve-symlinks-main
     const r = spawnSync(
       process.execPath,
       ['--preserve-symlinks-main', join(linkDir, 'scripts', 'probe.mjs')],
-      { encoding: 'utf8' },
+      { encoding: 'utf8', windowsHide: true },
     );
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     assert.match(r.stdout, /^DIRECT/, `expected DIRECT through the link; got: ${JSON.stringify(r.stdout)}`);
@@ -200,7 +200,7 @@ test('probe.mjs invoked with an unrelated script as argv[1] resolves NOT-DIRECT 
     // Import probe.mjs from a second, unrelated entry file so argv[1] names
     // that file rather than probe.mjs itself.
     writeFileSync(join(root, 'scripts', 'other-entry.mjs'), "import './probe.mjs';\n");
-    const r = spawnSync(process.execPath, [join(root, 'scripts', 'other-entry.mjs')], { encoding: 'utf8' });
+    const r = spawnSync(process.execPath, [join(root, 'scripts', 'other-entry.mjs')], { encoding: 'utf8', windowsHide: true });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     assert.match(r.stdout, /^NOT-DIRECT/);
   } finally {

--- a/scripts/tests/launch-install-layout.test.mjs
+++ b/scripts/tests/launch-install-layout.test.mjs
@@ -68,7 +68,7 @@ function buildVersionedInstall() {
 test('launch.mjs boots at the documented versioned-install layout (scripts/lib/ absent at the install root)', () => {
   const installRoot = buildVersionedInstall();
   try {
-    const r = spawnSync(process.execPath, [join(installRoot, 'launch.mjs')], { encoding: 'utf8' });
+    const r = spawnSync(process.execPath, [join(installRoot, 'launch.mjs')], { encoding: 'utf8', windowsHide: true });
     assert.doesNotMatch(
       r.stderr,
       /ERR_MODULE_NOT_FOUND/,
@@ -96,7 +96,7 @@ test('launch.mjs still runs as a plain dev-checkout no-op (unaffected by the ins
     cpSync(join(REPO_ROOT, 'launch.mjs'), join(installRoot, 'launch.mjs'));
     mkdirSync(join(installRoot, 'scripts'), { recursive: true });
     writeFileSync(join(installRoot, 'scripts', 'start-app-prod.mjs'), "console.log('STUB-STARTED');\n");
-    const r = spawnSync(process.execPath, [join(installRoot, 'launch.mjs')], { encoding: 'utf8' });
+    const r = spawnSync(process.execPath, [join(installRoot, 'launch.mjs')], { encoding: 'utf8', windowsHide: true });
     assert.doesNotMatch(r.stderr, /ERR_MODULE_NOT_FOUND/, `stderr: ${r.stderr}`);
     assert.equal(r.status, 0, `stdout: ${r.stdout} stderr: ${r.stderr}`);
     assert.match(r.stdout, /\[launch\] dev checkout \(no releases\/ \+ \.current-version\)/);

--- a/scripts/tests/launch-junction.test.mjs
+++ b/scripts/tests/launch-junction.test.mjs
@@ -94,7 +94,7 @@ function runThroughJunction(nodeArgs = []) {
   try {
     symlinkSync(fixtureRoot, linkPath, IS_WIN ? 'junction' : 'dir');
     const target = join(linkPath, 'launch.mjs');
-    return spawnSync(process.execPath, [...nodeArgs, target], { encoding: 'utf8' });
+    return spawnSync(process.execPath, [...nodeArgs, target], { encoding: 'utf8', windowsHide: true });
   } finally {
     removeLink(linkPath);
     rmSync(container, { recursive: true, force: true });

--- a/scripts/tests/module-graph.test.mjs
+++ b/scripts/tests/module-graph.test.mjs
@@ -152,7 +152,7 @@ function gitRepo(files, ignore) {
   // fixture — a real risk if this suite ever runs alongside an ambient
   // GIT_DIR export, not just the read-only hazard classifyIgnored's own
   // scrub (module-graph.mjs) already guards against.
-  execFileSync('git', ['init', '-q'], { cwd: dir, env: scrubGitEnv() });
+  execFileSync('git', ['init', '-q'], { cwd: dir, env: scrubGitEnv(), windowsHide: true });
   writeFileSync(join(dir, '.gitignore'), ignore, 'utf8');
   return dir;
 }

--- a/scripts/tests/publish-token-git.test.mjs
+++ b/scripts/tests/publish-token-git.test.mjs
@@ -78,6 +78,7 @@ const runner = (args, cwd) => {
       encoding: 'utf8',
       stdio: 'pipe',
       env: cleanEnv(),
+      windowsHide: true,
     });
     return { status: 0, stdout };
   } catch (err) {
@@ -86,7 +87,7 @@ const runner = (args, cwd) => {
 };
 
 const git = (repo, ...args) =>
-  execFileSync('git', args, { cwd: repo, stdio: 'pipe', env: cleanEnv() });
+  execFileSync('git', args, { cwd: repo, stdio: 'pipe', env: cleanEnv(), windowsHide: true });
 const token = (n, nonce) => `<p data-published-as="${n}" data-publish-id="${nonce}">x</p>\n`;
 
 function writeToken(repo, n, nonce) {
@@ -136,6 +137,7 @@ test('git: the env scrub actually isolates the throwaway repo (self-check)', () 
           cwd: decoy,
           encoding: 'utf8',
           env: cleanEnv(),
+          windowsHide: true,
         });
         assert.equal(decoyFiles.trim(), '', `${dirKey} leaked: the decoy repo was written to`);
       } finally {
@@ -199,6 +201,7 @@ test('git: a nonce born in a MERGE CONFLICT RESOLUTION is found (pass 6 / F1)', 
         cwd: repo,
         encoding: 'utf8',
         env: cleanEnv(),
+        windowsHide: true,
       }),
       /nRESOLV/,
     );

--- a/scripts/tests/release-body.test.mjs
+++ b/scripts/tests/release-body.test.mjs
@@ -67,7 +67,7 @@ function cleanGitEnv() {
 }
 
 function gitExec(args, opts = {}) {
-  return execFileSync('git', args, { ...opts, env: cleanGitEnv() });
+  return execFileSync('git', args, { ...opts, env: cleanGitEnv(), windowsHide: true });
 }
 
 function setupRepo() {
@@ -108,6 +108,7 @@ function makeAnnotatedTag(dir, tagName, message) {
     input: message,
     encoding: 'utf8',
     env: cleanGitEnv(),
+    windowsHide: true,
   });
 }
 
@@ -128,6 +129,7 @@ function setupDecoyRepoWithTag(tagName, message) {
     input: message,
     encoding: 'utf8',
     env,
+    windowsHide: true,
   });
   return dir;
 }
@@ -145,6 +147,7 @@ function runReleaseBody(dir, tag, outRelPath) {
     cwd: dir,
     encoding: 'utf8',
     env: cleanGitEnv(),
+    windowsHide: true,
   });
 }
 

--- a/scripts/tests/release-notes-gate.test.mjs
+++ b/scripts/tests/release-notes-gate.test.mjs
@@ -57,6 +57,7 @@ function runGate(dir, args) {
   return spawnSync('node', [resolve(dir, 'scripts', 'release-notes-gate.mjs'), ...args], {
     cwd: dir,
     encoding: 'utf8',
+    windowsHide: true,
   });
 }
 
@@ -298,7 +299,7 @@ test('pasting the suggested marker and re-running still flags genuine corruption
   assert.match(res1.reason, /2 double-UTF-8-encoded mojibake span/);
 
   // Extract the suggested marker line from the failure message
-  const markerMatch = res1.reason.match(/<!-- release-notes-gate: allow "[^"]*" -->/);
+  const markerMatch = res1.reason.match(/<!-- release-notes-gate: allow \u0022[^\u0022]*\u0022 -->/);
   assert.ok(markerMatch, 'should find the suggested marker');
   const suggestedMarker = markerMatch[0];
 
@@ -328,10 +329,10 @@ test('no marker is suggested when the surrounding token would break the marker s
   const text = `He said "CAFÉ™" yesterday.`;
   const res = checkMojibake(text, 'test.md');
   assert.equal(res.ok, false);
-  assert.equal(/<!-- release-notes-gate: allow "[^"]*" -->/.test(res.reason), false, res.reason);
+  assert.equal(/<!-- release-notes-gate: allow \u0022[^\u0022]*\u0022 -->/.test(res.reason), false, res.reason);
   // The right reason: context exists, it just cannot be quoted.
   assert.match(res.reason, /sit inside a word carrying a double-quote/, res.reason);
-  assert.match(res.reason, /terminate the marker's own quoting/, res.reason);
+  assert.match(res.reason, /terminate the marker\u0027s own quoting/, res.reason);
   // And NOT the standalone sentence, which is false for this input.
   assert.equal(/no surrounding word to name/.test(res.reason), false, res.reason);
 });
@@ -347,7 +348,7 @@ test('a genuinely standalone span is told it has no surrounding word to name', (
     /stand alone between spaces, with no surrounding word to name/,
     res.reason,
   );
-  assert.equal(/terminate the marker's own quoting/.test(res.reason), false, res.reason);
+  assert.equal(/terminate the marker\u0027s own quoting/.test(res.reason), false, res.reason);
 });
 
 // #1982 round 2 - the third reason, and the one the whitespace guard CREATES.
@@ -364,7 +365,7 @@ test('no marker is suggested when the span itself straddles whitespace', () => {
   const res = checkMojibake(text, 'test.md');
   assert.equal(res.ok, false);
   // No marker line at all - and in particular not one the allowlist would drop.
-  assert.equal(/<!-- release-notes-gate: allow "[^"]*" -->/.test(res.reason), false, res.reason);
+  assert.equal(/<!-- release-notes-gate: allow \u0022[^\u0022]*\u0022 -->/.test(res.reason), false, res.reason);
   assert.match(res.reason, /straddle a whitespace character themselves/, res.reason);
 });
 
@@ -387,7 +388,7 @@ test('every marker line the gate prints is one its own allowlist accepts', () =>
   for (const body of samples) {
     const res = checkMojibake(body, 'test.md');
     if (res.ok) continue;
-    const m = /<!-- release-notes-gate: allow "([^"]*)" -->/.exec(res.reason);
+    const m = /<!-- release-notes-gate: allow \u0022([^\u0022]*)\u0022 -->/.exec(res.reason);
     if (!m) continue; // nothing offered is always a legal answer
     const pasted = `${m[0]}\n\n${body}`;
     const found = findMojibake(pasted).length;
@@ -416,7 +417,7 @@ test('replaying the suggested markers can never drive a corrupted file green', (
     'ðŸš€', // 4-byte 🚀
   ];
   let text = spans.map((s, n) => `- line ${n} has a ${s} in it\n`).join('');
-  const MARKER_RE = /<!-- release-notes-gate: allow "[^"]*" -->/;
+  const MARKER_RE = /<!-- release-notes-gate: allow \u0022[^\u0022]*\u0022 -->/;
   let rounds = 0;
   let res = checkMojibake(text, 'test.md');
   assert.match(res.reason, /6 double-UTF-8-encoded mojibake span\(s\)/);

--- a/scripts/tests/repair-missing-book-language.test.mjs
+++ b/scripts/tests/repair-missing-book-language.test.mjs
@@ -64,6 +64,7 @@ test('repair-missing-book-language: full suite (real detect-language/state-migra
       cwd: REPO_ROOT,
       env: childEnv,
       encoding: 'utf8',
+      windowsHide: true,
     });
   } catch (err) {
     // Surface the full inner-suite output (which test(s) failed) rather than

--- a/scripts/tests/review-gate-mechanism.test.mjs
+++ b/scripts/tests/review-gate-mechanism.test.mjs
@@ -75,7 +75,7 @@ function parseRoleTable() {
   assert.ok(section, 'model-routing/SKILL.md has no "## Named dispatch roles" section');
   const rows = [];
   for (const line of section[1].split('\n')) {
-    const m = /^\|\s*`([^`]+)`\s*\|\s*([^|]+?)\s*\|\s*`([^`]+)`\s*\|\s*`([^`]+)`\s*\|/.exec(line);
+    const m = /^\|\s*\u0060([^\u0060]+)\u0060\s*\|\s*([^|]+?)\s*\|\s*\u0060([^\u0060]+)\u0060\s*\|\s*\u0060([^\u0060]+)\u0060\s*\|/.exec(line);
     if (m) rows.push({ name: m[1], tier: m[2], model: m[3], effort: m[4] });
   }
   return rows;
@@ -250,7 +250,7 @@ function stripFencedBlocks(text) {
   const out = [];
   let inFence = false;
   for (const line of text.split('\n')) {
-    if (/^\s*```/.test(line)) {
+    if (/^\s*\u0060\u0060\u0060/.test(line)) {
       inFence = !inFence;
       continue;
     }
@@ -395,7 +395,7 @@ const TIER_MODEL = { Premium: 'opus', Default: 'sonnet', Cheap: 'haiku' };
 
 test('every role-table row has a tracked definition file whose frontmatter matches', () => {
   const tracked = new Set(
-    execFileSync('git', ['ls-files', '.claude/agents'], { cwd: REPO_ROOT, encoding: 'utf8' })
+    execFileSync('git', ['ls-files', '.claude/agents'], { cwd: REPO_ROOT, encoding: 'utf8', windowsHide: true })
       .split('\n')
       .filter(Boolean)
       .map((p) => basename(p, '.md')),

--- a/scripts/tests/run-golden-audio.test.mjs
+++ b/scripts/tests/run-golden-audio.test.mjs
@@ -319,6 +319,7 @@ test('a junction/symlink earlier in the invoked path does not silently no-op the
       encoding: 'utf8',
       timeout: 30000,
       env: { ...process.env, CUDA_VISIBLE_DEVICES: '', RUN_GOLDEN_AUDIO_PROBE_GUARD_ONLY: '1' },
+      windowsHide: true,
     });
     assert.equal(
       r.status,

--- a/scripts/tests/run-sidecar-tests.test.mjs
+++ b/scripts/tests/run-sidecar-tests.test.mjs
@@ -109,7 +109,7 @@ function worksWhenRelocated(pythonExe) {
     } catch {
       copyFileSync(pythonExe, target);
     }
-    const probe = spawnSync(target, ['--version'], { encoding: 'utf8' });
+    const probe = spawnSync(target, ['--version'], { encoding: 'utf8', windowsHide: true });
     return probe.status === 0;
   } catch {
     return false;
@@ -133,6 +133,7 @@ function findRealPython() {
     const label = [cmd, ...baseArgs].join(' ');
     const probe = spawnSync(cmd, [...baseArgs, '-c', 'import sys; print(sys.executable)'], {
       encoding: 'utf8',
+      windowsHide: true,
     });
     if (probe.error) {
       attempts.push(`${label}: not found on PATH (${probe.error.code ?? probe.error.message})`);
@@ -254,6 +255,7 @@ function runEntryPoint(root, args, env = {}, execArgv = []) {
   return spawnSync(process.execPath, [...execArgv, join(root, 'scripts', 'run-sidecar-tests.mjs'), ...args], {
     encoding: 'utf8',
     env: { ...process.env, ...env },
+    windowsHide: true,
   });
 }
 

--- a/scripts/tests/stamp-publish-token.test.mjs
+++ b/scripts/tests/stamp-publish-token.test.mjs
@@ -107,6 +107,7 @@ function runCli(args, cwd) {
       cwd,
       encoding: 'utf8',
       stdio: 'pipe',
+      windowsHide: true,
     });
     return { code: 0, stdout, stderr: '' };
   } catch (err) {

--- a/scripts/tests/validate-pr-issue-link.test.mjs
+++ b/scripts/tests/validate-pr-issue-link.test.mjs
@@ -109,6 +109,7 @@ test('CLI: a dependabot[bot]-authored PR with no Closes/Refs still passes the ch
     );
     const result = spawnSync(process.execPath, [scriptPath, bodyFile, 'dependabot[bot]'], {
       encoding: 'utf8',
+      windowsHide: true,
     });
     assert.equal(
       result.status,
@@ -134,6 +135,7 @@ test('CLI: a human-authored PR with no Closes/Refs still fails the check', () =>
     );
     const result = spawnSync(process.execPath, [scriptPath, bodyFile, 'some-human'], {
       encoding: 'utf8',
+      windowsHide: true,
     });
     assert.equal(
       result.status,
@@ -154,6 +156,7 @@ test('CLI: a human-authored PR with a Closes link still passes', () => {
     writeFileSync(bodyFile, 'Closes #123\n');
     const result = spawnSync(process.execPath, [scriptPath, bodyFile, 'some-human'], {
       encoding: 'utf8',
+      windowsHide: true,
     });
     assert.equal(
       result.status,

--- a/scripts/tests/verify-cache.test.mjs
+++ b/scripts/tests/verify-cache.test.mjs
@@ -1421,7 +1421,7 @@ function cleanGitEnv() {
 }
 
 function gitAt(cwd, args) {
-  const r = spawnSync('git', args, { cwd, encoding: 'utf8', env: cleanGitEnv() });
+  const r = spawnSync('git', args, { cwd, encoding: 'utf8', env: cleanGitEnv(), windowsHide: true });
   if (r.status !== 0) {
     throw new Error(`git ${args.join(' ')} failed: ${r.stderr}`);
   }
@@ -1624,6 +1624,7 @@ test('stagedDiffFiles: honours an ambient GIT_INDEX_FILE pointing at a temporary
     cwd: repoDir,
     encoding: 'utf8',
     env: { ...cleanGitEnv(), GIT_INDEX_FILE: tempIndexPath },
+    windowsHide: true,
   });
   assert.equal(populateTempIndex.status, 0, populateTempIndex.stderr);
 

--- a/server/src/spawn-windows-hide.test.ts
+++ b/server/src/spawn-windows-hide.test.ts
@@ -21,7 +21,12 @@
  *      bootstraps spawn through a function pointer the bare scan can't see),
  *   3. the prod launcher + start/stop + model-installer scripts that live
  *      OUTSIDE server/src (a hidden parent does not stop a grandchild pip /
- *      python from popping its own console). */
+ *      python from popping its own console) — this scan now ALSO covers
+ *      `scripts/tests/` (previously excluded), since `npm run test:hooks`
+ *      spawns those test files with `windowsHide: true` and no console of
+ *      its own, so any spawn call inside them missing the flag pops its own
+ *      visible window (worst offender: cross-os-ffmpeg-install.test.mjs's
+ *      module-load-time pwsh probe). */
 
 import { readdirSync, readFileSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
@@ -227,7 +232,10 @@ function applyExclusions(files: string[], exclusions: string[]): string[] {
 
    Directory scope (derived from the old 49-entry hand list):
    - REPO_ROOT non-recursive, .mjs/.ts (covers launch.mjs, vite.config.ts)
-   - scripts/ recursive, .mjs/.cjs/.js, EXCLUDING scripts/tests/
+   - scripts/ recursive, .mjs/.cjs/.js, INCLUDING scripts/tests/ (previously
+     excluded — that exclusion let an unguarded module-load-time pwsh spawn
+     in cross-os-ffmpeg-install.test.mjs pop a visible window on every
+     `npm run test:hooks` run; see externalFilesFloor()'s scripts/ comment)
    - server/tts-sidecar/scripts/ recursive, .mjs
    - pinokio-scripts/lib/ recursive, .js/.mjs
 
@@ -243,13 +251,16 @@ function externalFilesFloor(): string[] {
     }
   }
 
-  // scripts/ recursive, .mjs/.cjs/.js, EXCLUDING scripts/tests/
+  // scripts/ recursive, .mjs/.cjs/.js, INCLUDING scripts/tests/ (the old
+  // exclusion of scripts/tests/ was itself the bug: those test files spawn
+  // real child processes as part of their own test logic, and a spawn there
+  // missing windowsHide pops its own visible console/PowerShell window when
+  // run under a parent with no console of its own (e.g. `npm run test:hooks`,
+  // which spawns `node --test scripts/tests/*.test.mjs` WITH windowsHide) —
+  // see cross-os-ffmpeg-install.test.mjs's module-load-time pwsh probe, the
+  // worst offender this exclusion let slip through).
   const scriptsDir = join(REPO_ROOT, 'scripts');
-  const scriptsFiles = listFilesRecursive(scriptsDir, ['.mjs', '.cjs', '.js'])
-    .filter(f => {
-      const rel = f.slice(scriptsDir.length + 1).replace(/\\/g, '/');
-      return !rel.startsWith('tests/');
-    });
+  const scriptsFiles = listFilesRecursive(scriptsDir, ['.mjs', '.cjs', '.js']);
 
   // server/tts-sidecar/scripts/ recursive, .mjs
   const ttsDir = join(REPO_ROOT, 'server', 'tts-sidecar', 'scripts');


### PR DESCRIPTION
## Summary

`npm run test:hooks` (`scripts/run-hooks-tests.mjs`) runs `scripts/tests/*.test.mjs` via `node --test` with `windowsHide: true` — so that process has no console of its own on Windows. Any spawn made *inside* those test files that itself lacked `windowsHide` therefore popped its own fresh, visible console window: a PowerShell popup for `pwsh`/`powershell.exe`, a console flash for `git`/`node`/`npx`. `cross-os-ffmpeg-install.test.mjs` was the worst offender — `findPowerShell()`/`probePowerShell()` ran a real `spawnSync` at module load time, guaranteeing a visible pwsh window on every single `npm run test:hooks` run (pre-commit/pre-push).

The existing windowsHide invariant guard (`server/src/spawn-windows-hide.test.ts`) never caught this because `externalFilesFloor()` deliberately excluded `scripts/tests/` from its scan.

- Added `windowsHide: true` to every real `spawnSync`/`execFileSync` call in `scripts/tests/*.mjs` that was missing it. Fixture strings inside `gh-chokepoint.test.mjs`/`git-scrub.test.mjs`'s `findRawGhCalls()`/`findUnscrubbedGitCalls()` checker-input literals were left untouched — those are test data for a different guard, not real invocations.
- Removed the `scripts/tests/` exclusion from `spawn-windows-hide.test.ts`'s `externalFilesFloor()` so this can't regress, and updated its comment blocks accordingly.
- Widening the scan surfaced several pre-existing ambiguous regex literals (unescaped quote/backtick inside a regex body) that would desync the guard's comment/string blanking across 8 of those files — escaped each as `\uXXXX` per the guard's own established convention.

**Also fixed, found in passing:** the ambiguous-regex-literal fixes above — the widened scan is what surfaced them; each was a latent blind spot in the guard itself, not a live windowsHide defect.

**Also fixed, found in passing (PR review gate):** two of those `\uXXXX` escapes were stray/unneeded — one landed inside a `//` comment (`check-register-citations.test.mjs:2854`), one inside a backtick template literal (`check-onbox-register-cli-no-flags.test.mjs:211`) — both outside any regex-literal branch the guard's comment/string blanking needs to worry about. Reverted both to plain apostrophes; `server/src/spawn-windows-hide.test.ts` still passes 22/22.

## Test plan

- [x] `npm run test:hooks` — 1901/1901 passed
- [x] `cd server && npx vitest run src/spawn-windows-hide.test.ts` — 22/22 passed
- [ ] Cloud `verify.yml` (required check) — pending

Local `verify:fast:scoped`/`verify:fast:branch` were skipped for this push (`--no-verify`, operator's explicit call) due to sustained contention from other concurrent sessions on this box making the local battery take 15+ minutes; cloud `verify.yml` is the enforcing gate here.

Release notes: skipped — dev-tooling only (fixes local `npm run test:hooks` popping console/PowerShell windows), no shippable user- or operator-visible delta.

Closes #3002
