### PR TITLE
fix(server): poll for the intercepted read instead of sleeping 300ms

### DIFF
--- a/server/src/routes/analysis.fresh-cast-lock.test.ts
+++ b/server/src/routes/analysis.fresh-cast-lock.test.ts
@@ -82,6 +82,11 @@ const SERIES = 'Standalones';
 const TITLE = 'Fresh Lock Book';
 const CHAPTER_BODY = 'Nova said the plan out loud.';
 
+/* Shared synchronization-wait budget (finding 4, PR #3009 review pass 1) —
+   one named constant so a raised timeout can't silently diverge from a
+   hardcoded copy in an error message. */
+const SYNC_WAIT_TIMEOUT_MS = 5_000;
+
 let workspaceRoot: string;
 let app: Express;
 
@@ -306,9 +311,9 @@ describe('#1981 Task 11 — "Start fresh" cast.json delete races a concurrent ca
           new Promise<never>((_, reject) =>
             setTimeout(
               () => reject(new Error(
-                'add-alias never reached its intercepted in-lock read within 5000ms',
+                `add-alias never reached its intercepted in-lock read within ${SYNC_WAIT_TIMEOUT_MS}ms`,
               )),
-              5_000,
+              SYNC_WAIT_TIMEOUT_MS,
             ),
           ),
         ]);
@@ -322,9 +327,28 @@ describe('#1981 Task 11 — "Start fresh" cast.json delete races a concurrent ca
         });
         jobPromise.catch(() => {}); // don't let a later stub-shape error surface here
 
-        // Generous head start: the delete either completes immediately
-        // (unlocked — the bug window) or queues behind add-alias's held
-        // lock (locked — the fix). Not a tight window either way.
+        // Finding 3 (PR #3009 review pass 1) — a `clearAnalysisCache`-completion
+        // signal was tried here as a replacement for this fixed sleep. It
+        // deadlocks: `readPriorCastForMerge` (analysis.ts:3535, unconditional
+        // whenever bookDir exists, and unconditionally BEFORE this
+        // `requestedFresh` block) takes the SAME cast lock add-alias is
+        // holding open below, so the job cannot reach `clearAnalysisCache`
+        // (analysis.ts:3639) — let alone signal its completion — until
+        // add-alias's lock is released. But `released()` below is gated on
+        // that very signal, so nothing ever fires; observed
+        // `LockAcquisitionTimeoutError` after 10s and the test's own 5s wait
+        // timing out. That also means a duration-free synchronization point
+        // for this head start does not exist with the current interceptor
+        // shape: the job cannot even attempt this lock until add-alias
+        // releases it, so there is no earlier test-visible edge to poll or
+        // await. Kept as the pre-existing fixed sleep; the fact that it does
+        // not gate anything meaningful is the subject of the "CRITICAL CHECK"
+        // finding below the core assertion — this needs a design pass (filed as #3022), not a
+        // synchronization swap, so it is deliberately left rather than
+        // "fixed" into something else. Generous head start: the delete either
+        // completes immediately (unlocked — the bug window) or queues behind
+        // add-alias's held lock (locked — the fix). Not a tight window either
+        // way.
         await new Promise((r) => setTimeout(r, 100));
 
         released();
@@ -342,7 +366,7 @@ describe('#1981 Task 11 — "Start fresh" cast.json delete races a concurrent ca
               throw new Error('cast.json still exists; delete has not completed');
             }
           },
-          { timeout: 5_000, interval: 10 },
+          { timeout: SYNC_WAIT_TIMEOUT_MS, interval: 10 },
         );
 
         // Capture disk state NOW, before Phase 0 (still gated) is allowed to
@@ -363,7 +387,17 @@ describe('#1981 Task 11 — "Start fresh" cast.json delete races a concurrent ca
       expect(resAlias!.status).toBe(200);
       /* The core assertion: whichever side acquired the lock first,
          cast.json ends up deleted, never resurrected with add-alias's stale
-         snapshot. */
+         snapshot.
+
+         #3022 — READ THIS BEFORE TRUSTING THIS TEST AS A GATE. It does not
+         currently detect removal of the `withCastLock` at analysis.ts:3660,
+         the regression it was written for: replacing that wrapper with a
+         passthrough leaves this test fully green (verified twice, PR #3009).
+         `readPriorCastForMerge` (analysis.ts:220, called unconditionally at
+         :3535, BEFORE this block) takes the same cast lock, so add-alias's
+         write has already landed by the time the job reaches the delete at
+         all — the ordering is forced upstream whether or not the delete is
+         wrapped. #3022 names the decision owed. */
       expect(castExistsAfterRace).toBe(false);
     },
     30_000,

--- a/server/src/routes/analysis.fresh-cast-lock.test.ts
+++ b/server/src/routes/analysis.fresh-cast-lock.test.ts
@@ -87,6 +87,12 @@ const CHAPTER_BODY = 'Nova said the plan out loud.';
    hardcoded copy in an error message. */
 const SYNC_WAIT_TIMEOUT_MS = 5_000;
 
+/* How long to let a late resurrection write land before sampling disk (PR
+   #3009 review pass 2, finding 1). NOT a synchronisation guess: the delete is
+   polled for separately, and this window exists purely to give a wrong writer
+   time to be wrong in. Longer is strictly safer here, so it is not tuned. */
+const RESURRECTION_SETTLE_MS = 400;
+
 let workspaceRoot: string;
 let app: Express;
 
@@ -275,13 +281,19 @@ describe('#1981 Task 11 — "Start fresh" cast.json delete races a concurrent ca
         if (!intercepted && path === raceCastPath) {
           intercepted = true;
           const value = await actual.readJson(path); // real bytes, now — happens-before the delete
-          /* Signalled AFTER the real read, not at interceptor entry (PR #2232
-             review, finding 1). The invariant this edge exists to establish is
-             "add-alias's read genuinely happens-before the delete" — resolving on
-             entry would release the delete while the read was still pending, which
-             is harmless while the route holds withCastLock but gives the
-             lock-removed mutation strictly LESS slack than the 300ms sleep did.
-             Signal what the comment actually claims. */
+          /* Signalled AFTER the real read, not at interceptor entry (PR #3009
+             review pass 1, finding 1). The SHAPE follows the sibling precedent
+             in book-state-preserve-voices.test.ts (#2215/#2232); the finding
+             that this file needed it is this PR's own, so credit both rather
+             than copying the sibling's attribution wholesale (pass 2, finding
+             4). The invariant this edge exists to establish is "add-alias's
+             read genuinely happens-before the delete" — resolving on entry
+             would release the delete while the read was still pending, which
+             is harmless while the route holds withCastLock but gives strictly
+             LESS slack than the 300ms sleep did. Deliberately NOT argued from
+             the lock-removed mutation, the way the sibling's comment is: per
+             #3022 this file cannot detect that mutation, so citing it here
+             would be reasoning from an experiment that does not run. */
           signalIntercepted();
           await gate; // hold the RESOLUTION open until released below
           return value;
@@ -306,17 +318,28 @@ describe('#1981 Task 11 — "Start fresh" cast.json delete races a concurrent ca
         // is the genuine happens-before edge, deterministic regardless of machine
         // load. A poll on a boolean at entry (the old pattern) gave a shorter
         // critical window than even the 300ms fixed sleep it replaced.
-        await Promise.race([
-          interceptedSignal,
-          new Promise<never>((_, reject) =>
-            setTimeout(
-              () => reject(new Error(
-                `add-alias never reached its intercepted in-lock read within ${SYNC_WAIT_TIMEOUT_MS}ms`,
-              )),
-              SYNC_WAIT_TIMEOUT_MS,
-            ),
-          ),
-        ]);
+        /* The deadline timer is captured, unref'd and cleared (PR #3009 review
+           pass 2, finding 3). Left dangling it holds a live handle for the full
+           SYNC_WAIT_TIMEOUT_MS past the normal path — the exact hazard
+           workspace/file-lock.ts:239-247 names and defends against, in a repo
+           that already fights "Worker exited unexpectedly" teardown noise. */
+        let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+        try {
+          await Promise.race([
+            interceptedSignal,
+            new Promise<never>((_, reject) => {
+              deadlineTimer = setTimeout(
+                () => reject(new Error(
+                  `add-alias never reached its intercepted in-lock read within ${SYNC_WAIT_TIMEOUT_MS}ms`,
+                )),
+                SYNC_WAIT_TIMEOUT_MS,
+              );
+              deadlineTimer.unref?.();
+            }),
+          ]);
+        } finally {
+          if (deadlineTimer) clearTimeout(deadlineTimer);
+        }
         expect(intercepted).toBe(true);
 
         const recordRef = getManuscript(manuscriptId)!;
@@ -337,11 +360,16 @@ describe('#1981 Task 11 — "Start fresh" cast.json delete races a concurrent ca
         // add-alias's lock is released. But `released()` below is gated on
         // that very signal, so nothing ever fires; observed
         // `LockAcquisitionTimeoutError` after 10s and the test's own 5s wait
-        // timing out. That also means a duration-free synchronization point
-        // for this head start does not exist with the current interceptor
-        // shape: the job cannot even attempt this lock until add-alias
-        // releases it, so there is no earlier test-visible edge to poll or
-        // await. Kept as the pre-existing fixed sleep; the fact that it does
+        // timing out. No duration-free synchronization point is AVAILABLE for
+        // this head start with the current interceptor shape: the job cannot
+        // even attempt this lock until add-alias releases it, so there is no
+        // earlier test-visible edge to poll or await. Stated as availability,
+        // not non-existence (PR #3009 review pass 2) — a lock-queue-ENTRY
+        // edge (workspace/file-lock.ts:232, synchronous, fires while add-alias
+        // still holds) would not deadlock; it is simply not exposed to a test
+        // today, and adding that seam to production is part of #3022's
+        // decision rather than something to smuggle in here.
+        // Kept as the pre-existing fixed sleep; the fact that it does
         // not gate anything meaningful is the subject of the "CRITICAL CHECK"
         // finding below the core assertion — this needs a design pass (filed as #3022), not a
         // synchronization swap, so it is deliberately left rather than
@@ -368,6 +396,21 @@ describe('#1981 Task 11 — "Start fresh" cast.json delete races a concurrent ca
           },
           { timeout: SYNC_WAIT_TIMEOUT_MS, interval: 10 },
         );
+
+        /* Settle window, RESTORED (PR #3009 review pass 2, finding 1). The poll
+           above returns at the first instant of absence, so sampling absence
+           immediately after it is tautological — that assertion could not
+           fail, and a real resurrection would instead surface as the poll's own
+           "delete has not completed" message, blaming contention for what is
+           actually a resurrection. The regression this file exists to catch is
+           a write landing AFTER the delete, so the sample has to be taken at a
+           moment the poll did not choose. Both properties kept: poll for the
+           delete (no fixed duration gating "has it happened yet"), THEN settle
+           before sampling. A fixed duration is correct here and is not the
+           mistake this PR fixes elsewhere — it is a window for a late
+           writer to be caught in, not a guess at how long something takes, so
+           erring long only makes the check stronger. */
+        await new Promise((r) => setTimeout(r, RESURRECTION_SETTLE_MS));
 
         // Capture disk state NOW, before Phase 0 (still gated) is allowed to
         // proceed to the job's own later, legitimate cast.json write.
@@ -400,20 +443,28 @@ describe('#1981 Task 11 — "Start fresh" cast.json delete races a concurrent ca
          wrapped. #3022 names the decision owed. */
       expect(castExistsAfterRace).toBe(false);
     },
-    /* Runaway backstop, not a synchronisation deadline — deliberately
-       generous (finding 5, PR #3009 review pass 1). Measured: the test BODY,
-       which is all this budget covers, ran 10.4s then 22.0s across two
-       back-to-back isolation runs on an UNLOADED box — a 2.1x spread with no
-       contention at all, the second within 8s of the old 30_000. (The ~21-24s
-       file totals usually quoted here include transform/setup/import, which
-       sit OUTSIDE this budget; quoting those understates how tight it was.)
-       Two of six runs under `flake-repro.mjs --cpu-load` blew it outright.
-       Raising it is NOT the "wider constant" mistake this PR fixes elsewhere:
-       that sleep gated an ASSERTION on a timing guess, while this only bounds
-       a hang. The real detectors are the internal bounded waits
-       (SYNC_WAIT_TIMEOUT_MS above, withKeyLock's 10s per #2260), which held
-       across all six contended runs and fail naming what never happened; this
-       catches only what they cannot see, so generosity costs no diagnostic. */
-    120_000,
+    /* Runaway backstop, not a synchronisation deadline. 60_000 is this suite's
+       house norm for the class (51 uses vs 17 of 30_000).
+
+       Corrected in PR #3009 review pass 2, finding 2. Pass 1 raised this citing
+       a test BODY of "10.4s then 22.0s on an UNLOADED box". That box was NOT
+       unloaded — three sibling worktrees were running node/python at the
+       time — and the claim was never checked before it was written down.
+       Five quiet isolation runs measure 3.56 / 4.85 / 4.74 / 6.28 / 4.54s, so
+       the honest body is ~5s and the old 30_000 already had ~5x headroom, not
+       the 1.4x pass 1 asserted. (#3007's own 25.23s figure for this shape came
+       from a contended box too.) The raise still stands, but only on the half
+       of the evidence that survives: two of six runs under
+       `flake-repro.mjs --cpu-load` blew 30_000 outright.
+
+       60_000 not 120_000: suite-wide `retry: 1` means a genuine wedge costs
+       twice the budget in fast-lane wall clock, so the ceiling is not free.
+       Raising it at all is still NOT the "wider constant" mistake this PR
+       fixes elsewhere — that sleep gated an ASSERTION on a timing guess,
+       while this only bounds a hang. The real detectors are the internal
+       bounded waits (SYNC_WAIT_TIMEOUT_MS above, withKeyLock's 10s per #2260),
+       which held across all six contended runs and fail naming what never
+       happened; this catches only what they cannot see. */
+    60_000,
   );
 });

--- a/server/src/routes/analysis.fresh-cast-lock.test.ts
+++ b/server/src/routes/analysis.fresh-cast-lock.test.ts
@@ -400,6 +400,20 @@ describe('#1981 Task 11 — "Start fresh" cast.json delete races a concurrent ca
          wrapped. #3022 names the decision owed. */
       expect(castExistsAfterRace).toBe(false);
     },
-    30_000,
+    /* Runaway backstop, not a synchronisation deadline — deliberately
+       generous (finding 5, PR #3009 review pass 1). Measured: the test BODY,
+       which is all this budget covers, ran 10.4s then 22.0s across two
+       back-to-back isolation runs on an UNLOADED box — a 2.1x spread with no
+       contention at all, the second within 8s of the old 30_000. (The ~21-24s
+       file totals usually quoted here include transform/setup/import, which
+       sit OUTSIDE this budget; quoting those understates how tight it was.)
+       Two of six runs under `flake-repro.mjs --cpu-load` blew it outright.
+       Raising it is NOT the "wider constant" mistake this PR fixes elsewhere:
+       that sleep gated an ASSERTION on a timing guess, while this only bounds
+       a hang. The real detectors are the internal bounded waits
+       (SYNC_WAIT_TIMEOUT_MS above, withKeyLock's 10s per #2260), which held
+       across all six contended runs and fail naming what never happened; this
+       catches only what they cannot see, so generosity costs no diagnostic. */
+    120_000,
   );
 });

--- a/server/src/routes/analysis.fresh-cast-lock.test.ts
+++ b/server/src/routes/analysis.fresh-cast-lock.test.ts
@@ -262,10 +262,22 @@ describe('#1981 Task 11 — "Start fresh" cast.json delete races a concurrent ca
         released = resolve;
       });
       let intercepted = false;
+      let signalIntercepted!: () => void;
+      const interceptedSignal = new Promise<void>((resolve) => {
+        signalIntercepted = resolve;
+      });
       const spy = vi.mocked(stateIo.readJson).mockImplementation(async (path: string) => {
         if (!intercepted && path === raceCastPath) {
           intercepted = true;
           const value = await actual.readJson(path); // real bytes, now — happens-before the delete
+          /* Signalled AFTER the real read, not at interceptor entry (PR #2232
+             review, finding 1). The invariant this edge exists to establish is
+             "add-alias's read genuinely happens-before the delete" — resolving on
+             entry would release the delete while the read was still pending, which
+             is harmless while the route holds withCastLock but gives the
+             lock-removed mutation strictly LESS slack than the 300ms sleep did.
+             Signal what the comment actually claims. */
+          signalIntercepted();
           await gate; // hold the RESOLUTION open until released below
           return value;
         }
@@ -284,23 +296,23 @@ describe('#1981 Task 11 — "Start fresh" cast.json delete races a concurrent ca
           .send({ characterId: 'nova', aliasName: 'Supernova' });
         aliasPromise.catch(() => {}); // supertest is lazy — force real dispatch now
         // Let add-alias acquire the cast lock and reach (and get stuck
-        // behind) its intercepted in-lock read. Poll for it (vi.waitFor,
-        // per #2262's precedent in docs/testing/flaky-register.md) rather
-        // than sleeping a fixed duration — this file's first supertest
-        // request pays a cold Express/module-init cost a warmer file (many
-        // prior requests already run) wouldn't, and that cost is not
-        // bounded enough to hardcode: a loaded box can blow well past any
-        // fixed constant, while a fast one clears it in a few ms.
-        await vi.waitFor(
-          () => {
-            if (!intercepted) {
-              throw new Error(
+        // behind) its intercepted in-lock read. Wait for the interceptedSignal,
+        // which resolves only AFTER the real read completes (not at entry) — this
+        // is the genuine happens-before edge, deterministic regardless of machine
+        // load. A poll on a boolean at entry (the old pattern) gave a shorter
+        // critical window than even the 300ms fixed sleep it replaced.
+        await Promise.race([
+          interceptedSignal,
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () => reject(new Error(
                 'add-alias never reached its intercepted in-lock read within 5000ms',
-              );
-            }
-          },
-          { timeout: 5_000, interval: 5 },
-        );
+              )),
+              5_000,
+            ),
+          ),
+        ]);
+        expect(intercepted).toBe(true);
 
         const recordRef = getManuscript(manuscriptId)!;
         jobPromise = runMainAnalyzerJob(job, recordRef as never, phase0Selection, {

--- a/server/src/routes/analysis.fresh-cast-lock.test.ts
+++ b/server/src/routes/analysis.fresh-cast-lock.test.ts
@@ -284,11 +284,23 @@ describe('#1981 Task 11 — "Start fresh" cast.json delete races a concurrent ca
           .send({ characterId: 'nova', aliasName: 'Supernova' });
         aliasPromise.catch(() => {}); // supertest is lazy — force real dispatch now
         // Let add-alias acquire the cast lock and reach (and get stuck
-        // behind) its intercepted in-lock read. Generous — this file's first
-        // supertest request pays a cold Express/module-init cost a warmer
-        // file (many prior requests already run) wouldn't.
-        await new Promise((r) => setTimeout(r, 300));
-        expect(intercepted).toBe(true);
+        // behind) its intercepted in-lock read. Poll for it (vi.waitFor,
+        // per #2262's precedent in docs/testing/flaky-register.md) rather
+        // than sleeping a fixed duration — this file's first supertest
+        // request pays a cold Express/module-init cost a warmer file (many
+        // prior requests already run) wouldn't, and that cost is not
+        // bounded enough to hardcode: a loaded box can blow well past any
+        // fixed constant, while a fast one clears it in a few ms.
+        await vi.waitFor(
+          () => {
+            if (!intercepted) {
+              throw new Error(
+                'add-alias never reached its intercepted in-lock read within 5000ms',
+              );
+            }
+          },
+          { timeout: 5_000, interval: 5 },
+        );
 
         const recordRef = getManuscript(manuscriptId)!;
         jobPromise = runMainAnalyzerJob(job, recordRef as never, phase0Selection, {

--- a/server/src/routes/analysis.fresh-cast-lock.test.ts
+++ b/server/src/routes/analysis.fresh-cast-lock.test.ts
@@ -330,8 +330,20 @@ describe('#1981 Task 11 — "Start fresh" cast.json delete races a concurrent ca
         released();
         resAlias = await aliasPromise;
         /* #2015 — three handoffs now, not one: add-alias releases, the job's
-           locked capture acquires+releases, then the delete acquires. */
-        await new Promise((r) => setTimeout(r, 400));
+           locked capture acquires+releases, then the delete acquires. Poll for
+           the delete to complete (file removal) rather than sleeping a fixed
+           duration, which can fail under lock-contention delays. No
+           resurrection write is possible after resAlias resolves, since the
+           add-alias write has already landed on disk (writeJsonAtomic happens
+           before the HTTP response) and Phase 0 is still gated. */
+        await vi.waitFor(
+          () => {
+            if (existsSync(castPath)) {
+              throw new Error('cast.json still exists; delete has not completed');
+            }
+          },
+          { timeout: 5_000, interval: 10 },
+        );
 
         // Capture disk state NOW, before Phase 0 (still gated) is allowed to
         // proceed to the job's own later, legitimate cast.json write.


### PR DESCRIPTION
## Summary

`server/src/routes/analysis.fresh-cast-lock.test.ts` waited a **fixed 300 ms** and then asserted a background interception had already happened. A fixed sleep before an assertion is a race — and the comment already named the hazard (the wait must cover a cold Express/module-init *plus* a lock acquisition) before picking a constant anyway.

Under load 300 ms isn't enough, so `intercepted` was still `false` and the run died on `expected false to be true`.

| Run | Conditions | Outcome |
|---|---|---|
| 2026-09-05 contended | full `test:server` | **failed**, 34479 ms |
| 2026-09-05 contended, retry | full `test:server` | **failed**, 39117 ms |
| 2026-09-06 | full `test:server`, 8228 tests | **failed** — sole failure of the run, which burned 1306 s |
| quiet box | full `test:server` | passed |
| isolation, `--retry=0` | single file | passed |

vitest's `retry: 1` fires and still loses — the retried attempt hits the same starved-CPU window.

**The fix polls the condition** rather than guessing a duration, failing with a message naming what never happened rather than a bare boolean. Deliberately **not** a larger constant: that reproduces the same bug with a wider window.

`vi.waitFor` is this repo's established idiom for exactly this — the flaky register's graduated entry for **#2262** (`script-review.test.ts`) records the identical bug fixed the same way.

## ⚠️ What this PR does NOT do — please read before merging

**This test cannot currently detect the regression it exists for, and this PR does not change that.** Filed as **#3022**.

Verified twice, independently: removing the `withCastLock` wrapper at `analysis.ts:3660` — the #1981 Task 11 invariant this file is named for — leaves the test **fully green**. Not even the weaker `expect(resAlias!.status).toBe(200)` fires.

The cause is structural and upstream. `readPriorCastForMerge` (`analysis.ts:220`) opens with `withCastLock(bookDir, …)`, and it is called at `analysis.ts:3534` for **any book with a `recordRef.bookDir`** — strictly *before* the `requestedFresh` block. `add-alias` is parked inside that same lock, so the job cannot pass that call until add-alias releases — by which point its write has already landed. The ordering the delete's own lock is meant to prove is forced upstream whether or not that delete is wrapped.

That is independent of how the test waits. It held for the original fixed sleeps and for every synchronisation form tried here, so **it is not caused by this PR** — this branch merely ran the mutation that exposed it.

**So: what merges here is a real fix to a real flake, and a test that is honest about gating less than its name implies.** #3022 names the three defensible outcomes and the decision owed. The test's comments carry that warning at the core assertion.

## Review findings and their resolutions

**Pass 1** (depth medium, head `1e7027fd`) — five findings:

| # | Finding | Resolution |
|---|---|---|
| 1 | 🟠 the poll watched a flag set at interceptor **entry**, *before* `await actual.readJson(path)` — strictly **less** slack than the 300 ms sleep it replaced | `1cd2cef6` — signal after the real read, raced against a deadline, plus `expect(intercepted).toBe(true)`. Follows the `signalIntercepted`/`interceptedSignal` precedent from #2215/#2232 |
| 2 | the 400 ms settle sleep | `4512e253` — replaced with a `vi.waitFor` poll. **This turned out to be a regression**; see pass 2 finding 1 |
| 3 | 🟠 the 100 ms head start should become a real happens-before edge | **Deferred to #3022, with evidence** — the suggested repair deadlocks |
| 4 | the 5 s deadline duplicated between wait and error message | `dd755722` — hoisted to `SYNC_WAIT_TIMEOUT_MS` |
| 5 | the file's own `it()` budget is too tight | `245cfe4d`, **corrected** by `a2045e33` — see below |

Finding 1 was a genuine bug in my original fix, and the repo had already solved it next door.

**Pass 2** (depth medium, head `245cfe4d`) — no 🔴, no 🟠, four 🟡. All four fixed in `a2045e33`:

1. **The core assertion could no longer fail.** Pass 1's finding-2 fix replaced the settle with a poll for absence — so the poll returned at the first instant of absence and the assertion then re-checked absence. Tautological. Worse, a genuine resurrection would have surfaced as the poll's own `cast.json still exists; delete has not completed` message, blaming contention for a resurrection. Now: poll for the delete, **then** settle, then sample. **Verified by mutation** — a writer scheduled inside the settle window fails the test at `expect(castExistsAfterRace).toBe(false)` with `expected true to be false`; tree restored byte-identical.
2. **My finding-5 measurement did not reproduce.** See below — this is the one worth reading.
3. **The 5 s deadline timer was neither cleared nor `unref`'d**, holding a live handle past the normal path — the hazard `workspace/file-lock.ts:239-247` explicitly names.
4. **A comment credited "PR #2232 review, finding 1"** — copied verbatim from the sibling file where it *is* correct. It also argued from the lock-removed mutation, which per #3022 this file cannot detect.

### Finding 5 / pass 2 finding 2 — I got the measurement wrong

`245cfe4d` raised the budget 30 s → 120 s citing a test body of **"10.4 s then 22.0 s across two back-to-back isolation runs on an UNLOADED box"**.

**The box was not unloaded.** Three sibling worktrees were running `node`/`python` at the time. I asserted a control condition without checking it, and then wrote it into a permanent in-file comment.

Five quiet isolation runs measure **3.56 / 4.85 / 4.74 / 6.28 / 4.54 s**. The honest body is ~5 s, so the old 30 s already had ~5× headroom — not the 1.4× I claimed. (#3007's own 25.23 s figure for this shape came from a contended box too.)

**The raise still stands, but only on the half of the evidence that survives**: two of six runs under `flake-repro.mjs --cpu-load` blew 30 s outright. `a2045e33` drops it to **60 s**, this suite's house norm for the class (51 uses vs 17 of `30_000`), because suite-wide `retry: 1` means a genuine wedge costs twice the budget in fast-lane wall clock.

Still not the "wider constant" mistake this PR fixes elsewhere: that sleep gated an *assertion* on a timing guess; this only bounds a hang, and the internal bounded waits (`SYNC_WAIT_TIMEOUT_MS`, `withKeyLock`'s 10 s per #2260) are the real detectors and held across all six contended runs.

### Finding 3 — why it is filed rather than fixed

The suggested repair was tried and **deadlocks**. The job cannot reach `clearAnalysisCache` (`analysis.ts:3639`) until add-alias releases the lock, but the release was gated on that signal. Observed: `clearAnalysisCache never completed within 5000ms`, plus a real `LockAcquisitionTimeoutError`.

I initially triaged this as *not* a design pass, on the grounds that only the implementation was open. The deadlock evidence reversed that. The in-file comment claiming no duration-free synchronisation point *exists* has also been softened to *available* — a lock-queue-entry edge (`file-lock.ts:232`) would not deadlock; it simply isn't exposed to a test today, and adding that seam is part of #3022's decision.

## Test plan

- **Isolation**, `--retry=0`: passes. Bodies 5.81 s / 6.42 s / 6.28 s post-fix.
- **Full `test:server`**: green in cloud CI at `245cfe4d` (20/20). Re-running at `a2045e33`.
- **The poll's timeout branch is reachable** — commenting out the line that sets `intercepted` fails with `add-alias never reached its intercepted in-lock read within 5000ms`. Restored and verified by `git diff`.
- **The core assertion is reachable** — the resurrection mutation above. This is the check that pass 2 showed was missing.
- **Under contention** via `flake-repro.mjs --cpu-load`: 4 of 6 passed (24.07 s, 19.23 s, 11.58 s, 26.46 s); the other 2 hit the `it()` budget now raised.
- **The mutation that matters** — replacing the delete's `withCastLock` with a passthrough of identical arity: still `Tests 1 passed (1)`. That is the #3022 disclosure, run rather than assumed.
- `tsc -p .` exit 0, `eslint` exit 0.

**One acceptance criterion from #3007 remains partly undischarged:** "passes in isolation **and** as part of a full `test:server` run **on a loaded box**". The cloud run covers full-suite; the *loaded-box* half rests on the contended local runs, not a clean full-suite run on a busy machine.

### Checklist notes

- **Regression plan** — not applicable; the issue body plus the changed test is the spec.
- **On-box acceptance** — not applicable; no hardware-only behaviour.
- **Release notes** — skipped: test-infrastructure only, no user- or operator-visible delta.
- **Flaky register** — no row added, deliberately. The register tracks live debt, so a row for a test fixed in the same round would be false on arrival.

Closes #3007
Refs #3022

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Q4SxN46A8ktP28T7NwEKz
