### PR TITLE
docs(docs): close #3011 as doctrine after three refuted designs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1271,6 +1271,32 @@ Working practice below; this holds even under contention).
   dispatch tool reported the agent "completed" — a completed agent
   notification can still have live background children of its own still
   running commits/pushes.
+- **That process probe matches ITSELF.** The pattern you search for is in the
+  command line of the shell running the search, so a naive
+  `CommandLine -like "*<worktree-path>*"` reports phantom occupants on a
+  completely idle tree (observed 2026-09-06: five "live processes", all of them
+  the probe's own wrappers). Exclude your own **ancestry and that ancestry's
+  children** — excluding just `$PID` is not enough, because the harness spawns a
+  wrapper shell per call that is not on your ancestor chain but is a child of
+  something that is. A probe that always fires is indistinguishable from one
+  that works, so confirm it reports zero on a tree you know is idle before
+  trusting a zero on one you are about to write to.
+
+**Holding a tree against the Open Engine queue** (#3011, design of record:
+[docs/superpowers/specs/2026-09-06-worktree-exclusivity-design.md](docs/superpowers/specs/2026-09-06-worktree-exclusivity-design.md)):
+
+- **Never hand-commit in a worktree that has an open agent ticket.** Commit from
+  the primary checkout, or from a tree no ticket points at.
+- **To hold one anyway, move the ticket to `Parked`** — an existing board state
+  the gate never makes claimable. **Never `Agent Needs Input`**, which means
+  *waiting on a person*: **any comment on it is a resume trigger, including the
+  comment saying not to resume.** That is not hypothetical — it is exactly how
+  a second lane was launched into a tree a human was committing in.
+- **Announcing a park does not park it.** Change the state first.
+- **The tooling cannot see a non-lane writer.** A human, an interactive session,
+  a dispatched fix agent, and an orphaned battery are all invisible to the
+  queue's own exclusivity checks. The rules above are the protection; there is
+  no mechanism behind them.
 
 ### Planning agents
 

--- a/docs/superpowers/specs/2026-09-06-worktree-exclusivity-design.md
+++ b/docs/superpowers/specs/2026-09-06-worktree-exclusivity-design.md
@@ -1,256 +1,140 @@
-# Worktree exclusivity — design
+# Worktree exclusivity — findings and doctrine
 
 - **Date:** 2026-09-06
 - **Issue:** [#3011](https://github.com/dudarenok-maker/Castwright/issues/3011)
-- **Status:** draft, revised after one adversarial review pass
-- **Implementation lands in:** [`open-engine`](https://github.com/dudarenok-maker/open-engine) — this repo carries the design of record only
+- **Status:** closed as **doctrine, not mechanism**
+- **Outcome:** an operator rule. **No code change anywhere** — three designs and one reported defect were investigated and all four were refuted.
 
-## Problem
+Two designs were written for this and **both were refuted by adversarial review**; a third
+finding, raised by a review itself, was refuted on verification. This document records what was
+learned, so none of them is proposed again, and states the rule that replaces them.
 
-Two writers in one worktree is the failure CLAUDE.md records this repo hitting **three separate
-times** (2026-08-29, 2026-08-30, 2026-09-04/05). It produces bundled commits, contention flakes,
-and — worst — a subagent concluding the contention it caused itself is an external blocker and
-reaching for `--no-verify`.
-
-### What actually happened on 2026-09-05
+## What actually happened on 2026-09-05
 
 A lane parked #2914 at `Agent Needs Input` to hold `wt-2913-a29-retry` while a human hand-committed
-in it. A fresh tick launched a second lane into the same tree.
-
-The sequence, from `~/.open-engine/tick.log` and the issue's own comment log — **the log is the
-evidence; the comment text alone is only an inference**:
+in it. A tick launched a second lane into the same tree.
 
 | Time (UTC) | Event | Source |
 |---|---|---|
-| 22:55:15 | `AGENT BLOCKED` posted | issue #2914 |
-| 22:59:10 | board status → `Agent Needs Input` | REST timeline (`project_v2_item_status_changed`) |
+| 22:55:15 | `AGENT BLOCKED` | issue #2914 |
+| 22:59:10 | board status → `Agent Needs Input` | REST timeline |
 | **22:59:11** | **human comment: "Parking at Agent Needs Input temporarily…"** | issue #2914 |
-| 23:00:44 | `claimable: #2914[claude](answered)` | tick.log |
-| **23:08:44** | **`--- lane: claude claim #2914 (answered) via ringer ---`** | tick.log |
-| 23:14:37 | `AGENT RESUMED` posted by the second lane | issue #2914 |
+| 23:00:44 | `claimable: #2914[claude](answered)` | `tick.log` |
+| **23:08:44** | `--- lane: claude claim #2914 (answered) via ringer ---` | `tick.log` |
+| 23:14:37 | `AGENT RESUMED` from the second lane | issue #2914 |
 
-`answered` is emitted **only** by the gate's `Agent Needs Input` branch, whose rule is *newest
-comment is not an `AGENT_*` receipt ⇒ a human replied ⇒ claimable*. The 22:59:11 comment is human
-prose, so it satisfied that rule 93 seconds later.
+`answered` is emitted only by the gate's `Agent Needs Input` branch, whose rule is *newest comment
+is not an `AGENT_*` receipt ⇒ a human replied ⇒ claimable*. The parking comment is human prose, so
+it satisfied that rule 93 seconds later.
 
-**The act of announcing the park is what un-parked it.** To the gate, "do not touch this" is
-indistinguishable from a human answering the question the issue was paused on.
+**The act of announcing the park is what un-parked it.** The overlap was ~6 minutes, not the
+"few seconds" the issue describes.
 
-**The overlap was minutes, not seconds.** The lane launched at 23:08:44 and ran ~6 minutes before
-posting `AGENT RESUMED`. The issue's "a few seconds either way" framing is wrong by two orders of
-magnitude, and the exposure window is correspondingly larger.
+**The issue's stated mechanism is wrong.** It says the resumable-claim path ignores board `Status`.
+`oe-tick.ps1` branches on status explicitly and produces `resumable-claim` only under
+`Agent Working`. Remedies 1 and 2 on the issue target a defect that does not exist.
 
-### A proximate cause, not background risk
+## The two refuted designs
 
-`open-engine` commit `f741933` raised `EngineLaneCap` from 1 to 3 at 2026-09-05T20:49Z — **2h25m
-before the incident** — and the tick log shows #2914 riding that exact cap: refused at 21:08:02
-(*"only 1 runs at a time"*), admitted at 21:15:33 (*"only 3 runs at a time"*), and launched at
-23:08:44 from a slot freed under cap 3. The constant is **global**, not claude-scoped as its commit
-subject implies, and `MaxLanes = 4` still bounds total concurrency.
+### Rejected — a lock file checked in `.husky/pre-commit`
 
-Reverting that experiment is a one-line change and is **not** part of this design. It is noted
-because any measurement of whether this class recurs is confounded while the cap sits at 3.
+- **It would have inverted the incident.** The collision was a lane against a **human**. A human
+  carries no lane identity, so the lane holds the lock and the hook refuses *the human's* commit
+  while the intruder writes freely.
+- **Nothing would acquire it.** Acquisition would be runner prose — the mechanism this was meant to
+  compensate for.
+- **"Every write passes through the hook" is false.** `.husky/*` is tracked, so each worktree keeps
+  old hooks until it merges `main`; a tool-created worktree has no `.husky/_` and runs **no hook,
+  silently**.
+- **The mandated write path is invisible to a process probe.** `runner/prompt.md` requires commits
+  from a detached helper; the worktree path lives inside that helper file and never appears on a
+  command line.
 
-### There are two resume routes, not one
+### Rejected — the gate refuses a second lane on an occupied tree
 
-[#3011](https://github.com/dudarenok-maker/Castwright/issues/3011) states that "the resumable-claim
-fast path reads the ticket's comment/claim history, not the board `Status` field." That is **false
-of `oe-tick.ps1`** — its gate branches on status explicitly, and `resumable-claim` is produced only
-under `Agent Working`.
+- **It reproduces the same blind spot.** Its predicate is *lane* liveness; the incident had no
+  second lane, it had a human. It sees neither party.
+- **Tree resolution does not work.** `Find-LaneWorktrees` matches worktree name against sequence.
+  Measured against the live queue: **6 of 13 sequences resolve; the 7 failures cover 35 of 46 open
+  tickets (76%)**, because trees are named for batches, not sequences. Fail-closed on that is a
+  permanent queue halt, not a one-tick delay.
+- **The tick does not know a running lane's tree.** The lane object has no worktree field;
+  resolution happens only on the crash path, when a lane exits with no `OE-RESULT`.
+- **`Dirty`/`Ahead` cannot serve as occupancy.** **9 of 15** worktrees are dirty right now with no
+  process live in them, and the signal cannot attribute work — the log's own "work left behind by
+  lane claude" line describes files the *human* wrote.
 
-It is **true of `runner/prompt.md`**. The runner's fallback sweep matches (a) `AGENT HUMAN HOLD`
-plus a newer human comment and (b) `AGENT BLOCKED` plus a strictly-later human comment, prescribes
-*"Move it to Agent Working, leave AGENT UNBLOCKED then AGENT RESUMED"*, and **names no board status
-at all**. #2914's shape — `AGENT BLOCKED` 22:55:15, human comment 22:59:11 — satisfies (b) exactly.
+### And the board already had the state
 
-This incident travelled the gate's route, not the sweep's (the log proves the claim was
-`answered`). But the sweep is a live, status-blind resume path, and any design that closes only the
-gate leaves it open. **Both routes must be closed.**
+`Agent Reserved` was proposed on the premise that no state means "reserved." The board carries
+**12 Status options**, including **`Parked`**, `Agent Waiting`, and `Waiting/Blocked` — all of which
+already yield zero candidates, because the gate has three equality branches and no `else`.
 
-### The invariant being broken is not the one the code guards
+## A third refuted finding — the "one real defect" was not one
 
-The resource that cannot take two writers is the **worktree**. Every mechanism above asserts
-exclusivity on the **ticket**. A ticket and a worktree are not 1:1 — they diverge the moment a chain
-reassigns or a claim resets mid-flight, which both #2910 and #2914 did on the same night.
+Review pass 2 reported that `Select-Lanes`' `$seenSeq` (the one-worker-per-sequence rule) is
+initialised empty on every call while the engine cap beside it **is** seeded from running lanes —
+concluding that a mid-tick top-up could therefore start two lanes on one worktree, masked until
+`EngineLaneCap` went 1 → 3.
 
-### Why this survived #2999
+**That fix was implemented, then discarded, because the defect does not exist.** The top-up call
+site already excludes in-flight sequences before starting anything:
 
-Every other concurrency problem chased on 2026-09-05 arrived through the git hooks, and #2999
-removed that source. **This route has nothing to do with hooks.** Merging every worktree onto `main`
-does not touch it, and a quiet box is not evidence the class is closed.
+```powershell
+$busySeq = @($lanes | Where-Object { -not $_.Proc.HasExited } | ForEach-Object { [string]$_.Sequence })
+$extra   = @(Invoke-Gate -TopUp | Where-Object { $busySeq -notcontains [string]$_.Sequence })
+```
 
-## Design
+with its own comment stating the intent: *"SEQUENCES IN FLIGHT ARE EXCLUDED. Children of one parent
+share a branch and a worktree, so a top-up must never start a second lane inside a sequence this
+tick is already running. `Select-Lanes` cannot know that — it only sees the candidates handed to it
+— so the filtering happens here."*
 
-### Part 1 — the gate refuses a second lane on an occupied tree
+`$seenSeq` being unseeded is **deliberate and documented**, not an oversight. There are exactly two
+lane-start paths — `Start-Lanes` at the initial pass and at the top-up — and both are covered: the
+first by `$seenSeq`'s within-pass dedupe, the second by the caller's filter.
 
-This is the correctness floor.
+**No change was made to `open-engine`.** It would have added redundant machinery to a live
+scheduler for a defect that is already handled one layer up.
 
-**The tick can already resolve a lane's worktree; it simply never uses that to gate.** Two
-independent resolvers exist today:
+The finding was caught by the implementing agent reporting it as an incidental observation, and
+confirmed by enumerating every `Start-Lanes` and `Invoke-Gate` call site. Worth recording as a
+method note: three adversarial reviews across this issue produced three refutations, and **the third
+refutation was of a review's own finding.** A review's claim is evidence, not a verdict.
 
-- `Find-LaneWorktrees` matches `git worktree list` against the sequence by name convention — its own
-  comment notes that `wt-new.mjs` names the tree after the sequence;
-- **the ticket body declares it outright** — #2914's body reads ``Worktree `C:\Claude\Projects\wt-2913-a29-retry`, branch …``.
+## Doctrine — what actually protects a tree
 
-The tick already prints the resolved path when it reaps (`in C:/Claude/Projects/wt-2913-a29-retry`).
-So this is a gate applied to a lookup the tick performs today, not the relocation of unavailable
-context that the first draft of this document claimed.
+Mechanism cannot see a non-lane writer. The operator, an interactive Claude Code session, a
+dispatched fix agent, and an orphaned battery outliving its killed lane are all invisible to any
+lane-based predicate, and the first of those is what caused this incident. **This is stated as a
+limit rather than papered over.**
 
-**The rule:** a candidate whose resolved worktree is occupied by a lane this tick still considers
-live is dropped from `$claimable` for that tick, with a logged reason. Occupancy is derived from the
-tick's own lane bookkeeping — it launches lanes and reaps them, so it already knows which are
-running and which tree each was dispatched against.
+1. **Do not hand-commit in a worktree that has an open agent ticket.** Commit from the primary
+   checkout, or from a tree no ticket points at.
+2. **If you must, park the ticket at `Parked`** — an existing board state that yields no candidate.
+   **Not `Agent Needs Input`**: that state means *waiting on a person*, and **any comment on it is a
+   resume trigger, including the comment that says not to resume.**
+3. **Announcing a park does not park it.** Change the state first; the comment is a courtesy, and
+   on `Agent Needs Input` it is actively harmful.
+4. **Before writing in a tree an agent may hold, check for live processes against that tree** — and
+   exclude your own process ancestry *and its children* from the check, or the probe matches its own
+   command line and reports phantom occupants.
 
-**Ambiguity fails closed.** If the tree cannot be resolved for a candidate, that candidate is not
-dispatched this tick. This is the one place this design deliberately inverts the file's prevailing
-doctrine — see below.
+## What remains unsolved, and is not being solved
 
-### Part 2 — a board state that means "reserved"
+**There is no signal that a non-lane writer is in a tree.** A human or interactive session that has
+read but not yet written produces nothing observable, and `Dirty`/`Ahead` cannot attribute what it
+sees. Closing that needs a mechanism every writer participates in, which does not exist and was not
+worth inventing at the cost of two refuted designs.
 
-Add an `Agent Reserved` option to the project board's Status field, for holding a tree without
-claiming to be waiting on an answer.
+If this class recurs *between lanes*, that is new information — the two lane-start paths are both
+guarded, so a lane-versus-lane collision would mean one of those guards is wrong — and this
+document is wrong. If it recurs between a lane and a human, it is the known limit above.
 
-**The gate needs no change to honour it.** `oe-tick.ps1` has exactly three `if ($status -eq …)`
-branches — `Agent Todo`, `Agent Working`, `Agent Needs Input` — and no `else`. An unrecognised
-status contributes nothing to `$claimable`, the same way `Agent Waiting` is already ineligible by
-construction.
+## Confounder, noted and not addressed
 
-**But "no gate change" is not "no code change", and the first draft of this document wrongly
-concluded that it was.** The reserved state touches:
-
-- **`oe-doctor.ps1`**, which *does* have the `else` the tick lacks and would report every reserved
-  ticket as a defect — *"its board Status is '…' … so it is not queued"* — with the fix text *"move
-  it to Agent Todo when it is ready to run."* Left alone, the doctor instructs the operator to
-  un-reserve exactly the trees this design reserves.
-- **the hard-coded Status option-ID registry** in `~/.claude/skills/open-agent-engine/SKILL.md`.
-- **eight `open-engine/agents/*.md` files**, `oe-route.ps1`, `docs/deliverable-model.md` and
-  `docs/runbook.md`, which enumerate statuses.
-- **the board's own automation** — `github-project-automation[bot]` writes Status on this project,
-  and `add-to-project.yml` adds items. A new option interacts with built-in workflows; the schema
-  change is not inert.
-
-`Agent Needs Input` keeps its meaning, and its documentation gains the sentence that was missing:
-**a comment on it is a resume trigger, including the comment that says not to resume.**
-
-### Part 3 — close the runner's status-blind sweep
-
-`runner/prompt.md`'s fallback matches (a) and (b) must consult board status before resuming, so
-`Agent Reserved` is honoured on that route too. Without this, Part 2 protects one of the two resume
-paths and the ticket's original complaint remains true of the other.
-
-## Occupancy and staleness
-
-With the lock file dropped (below), "occupied" is no longer a file on disk with an epoch problem —
-it is **lane liveness, which the tick already tracks**. That removes three defects the first draft
-had:
-
-- no undefined lock-age epoch (per-run or per-occupancy — both were implementable, and the draft
-  did not say which);
-- no lock surviving a crashed lane for 105 minutes while the queue relaunches every ~90 s;
-- no lock file to leave behind, git-ignore, or clean up.
-
-**Uncommitted work is a third signal, and the tick already computes it.** `Get-UnpushedWork` returns
-`Ahead`/`Dirty`. A tree holding another lane's uncommitted changes must not be dispatched into even
-when no process is live — tick.log records exactly that state for `wt-2913-a29-retry`
-(*"0 unpushed commit(s) and 6 uncommitted file(s)"*). Liveness alone would have released it.
-
-**Where a staleness window is still needed** — a lane the tick has lost track of across a restart —
-reuse `Get-ClaimStaleMin`, which derives its window from the lane ceiling per engine. The concrete
-values that implies are **105 minutes hosted and 195 local** (`LaneCeilingMin = 90`,
-`LocalLaneCeilingMin = 180`, `ClaimStaleMin = 105`). Those numbers are the cost of a wrong
-fail-closed decision and belong in the plan, not buried in a helper.
-
-### The inversion, stated explicitly
-
-`oe-tick.ps1` teaches, correctly and repeatedly, that its gate **fails open**: *"if we cannot tell,
-wake the lanes."* A frozen queue costs every issue behind it.
-
-**Occupancy must fail closed.** Failing open here *is* the defect. But the cost is real and is
-stated rather than waved at: a candidate wrongly judged occupied is **delayed**, not lost — it is
-re-evaluated on the next tick, ~90 s later, and the queue behind it still moves because other
-candidates are unaffected. That is what makes fail-closed affordable here and not affordable in the
-gate at large: this refusal is per-candidate and self-healing, whereas the gate's own failure mode
-is total.
-
-## Considered and dropped: a lock file enforced in `.husky/pre-commit`
-
-The first draft made this the correctness floor. **It was wrong, and it is recorded here so it is
-not re-proposed.**
-
-- **It would not have prevented the incident on the ticket.** The collision was an OE lane versus a
-  **human hand-committing**. A human has no lane identity, so with the lane holding the lock the
-  hook refuses *the human's* commit while the intruding lane writes freely — the exact inversion of
-  intent.
-- **There is no identity to compare.** `oe-tick.ps1` exports `OE_CLAIM_ISSUE` and `OE_CLAIM_WHY` and
-  nothing else; there is no lane or engine variable anywhere in the tick or the heartbeat. The only
-  identity a hook could read is the issue number — the very noun this design argues is wrong.
-- **Nothing would acquire it.** Acquisition would have to be runner prose, which is the mechanism
-  this design exists because agents do not reliably follow.
-- **"Every write passes through the hook" is false.** `.husky/*` is tracked, so every worktree keeps
-  its old hooks until it merges `main` — **16 non-primary worktrees are registered right now**, and
-  the ops-2997 sweep needed a deliberate pass per tree. A tool-created worktree has no `.husky/_` at
-  all, so git runs no hook, **silently**. (An earlier draft said "~45 worktrees", conflating
-  registered trees with the 44 `wt-*` directories on disk; **28 of those are orphaned leftovers**,
-  which is a separate finding — ops-2997's unbuilt Part 4, worktree GC.)
-- **The mandated write path is invisible to the probe anyway.** `runner/prompt.md` requires commits
-  to run from a detached helper launched as `powershell.exe -File <temp>\helper.ps1`; the worktree
-  path lives *inside* that file via `Set-Location`, and never appears on any command line. A probe
-  that greps command lines returns zero for a tree actively being committed to.
-
-## Testing
-
-**Part 1 — occupancy.**
-
-- two candidates resolving to the same tree: the second is dropped, with its reason logged;
-- candidates resolving to different trees: both dispatch;
-- a tree whose lane has been reaped is dispatchable again;
-- a candidate whose tree cannot be resolved is **not** dispatched (fail-closed), and says why;
-- a tree that is idle but `Dirty`/`Ahead` per `Get-UnpushedWork` is **not** dispatched;
-- the reported shape end to end: status `Agent Needs Input`, newest comment a human note, a lane
-  already live on that tree ⇒ **no second lane launched**. This is the regression the issue asks for.
-
-**Part 2 — the reserved state.**
-
-- `Agent Reserved` yields no candidate, and an unrecognised status contributes nothing;
-- `Agent Needs Input` with a newer human comment **still** yields `answered` — pinning today's
-  correct behaviour so Part 2 cannot silently change it;
-- `oe-doctor.ps1` does not report a reserved ticket as a defect.
-
-**Part 3 — the sweep.** The runner's (a)/(b) matches do not resume a ticket in `Agent Reserved`.
-
-**Mutation-verify the occupancy comparison**: deleting it must redden a named test. Note explicitly
-that "both candidates dispatch when trees differ" and "an idle tree is dispatchable" both pass
-against a gate that never refuses anything — they are necessary but must never be the only
-coverage. This repo has shipped that shape before.
-
-## Risks and trade-offs
-
-- **A wrongly-occupied tree delays a candidate by one tick.** Acceptable, and self-healing —
-  but only because the refusal is per-candidate. If a future change makes it batch-wide, this
-  argument no longer holds.
-- **Tree resolution is heuristic.** Name convention and a ticket-body string are both operator-set
-  and can drift. Fail-closed on unresolvable trees converts drift into a stall rather than a
-  collision, which is the safe direction but is still a stall.
-- **`Agent Reserved` is a board schema change** — manual, per-project, not enforceable by CI, and it
-  interacts with project automation.
-- **The per-machine skill store.** `~/.claude/skills/oe-*` is not version-controlled; a status-ID
-  registry edit there has no history, no review, and no backup. That is a real exposure this design
-  depends on and does not fix — see #3000's closing note.
-
-## Out of scope
-
-- Reworking what `Agent Needs Input` means. Its rule is correct for its meaning; the gap was a
-  missing state.
-- Reverting `EngineLaneCap`. Noted as a confounder above; it is an operational decision, not this
-  design's.
-- Anything about the commit gate's cost — ops-2997's territory, closed.
-
-## Open questions
-
-- **O1 — where does occupancy state live across a tick restart?** The tick's in-memory lane
-  bookkeeping does not survive one. Options: re-derive from `git worktree list` plus live-process
-  inspection at startup, or persist alongside the existing tick state. This is the one place the
-  dropped lock file's problem genuinely recurs, and it needs an answer before implementation.
-- **O2 — is the ticket body or the name convention authoritative** when both resolve and disagree?
-- **O3 — does the sweep fix belong in prose or should the sweep move into the tick?** Part 3 as
-  written is another prose instruction, which is the mechanism this design distrusts.
+`EngineLaneCap` went 1 → 3 in `open-engine` `f741933` at 2026-09-05T20:49Z, ~2h before the
+incident, and #2914 was held back under the old cap earlier the same evening. Causation is not
+established — `answered` sorts rank 0, so the ticket would likely have taken the next freed slot
+under cap 1 as well, delayed rather than prevented. But **any measurement of whether this class
+recurs is confounded while the cap sits at 3**, and it is a one-line revert.

--- a/docs/superpowers/specs/2026-09-06-worktree-exclusivity-design.md
+++ b/docs/superpowers/specs/2026-09-06-worktree-exclusivity-design.md
@@ -1,0 +1,256 @@
+# Worktree exclusivity — design
+
+- **Date:** 2026-09-06
+- **Issue:** [#3011](https://github.com/dudarenok-maker/Castwright/issues/3011)
+- **Status:** draft, revised after one adversarial review pass
+- **Implementation lands in:** [`open-engine`](https://github.com/dudarenok-maker/open-engine) — this repo carries the design of record only
+
+## Problem
+
+Two writers in one worktree is the failure CLAUDE.md records this repo hitting **three separate
+times** (2026-08-29, 2026-08-30, 2026-09-04/05). It produces bundled commits, contention flakes,
+and — worst — a subagent concluding the contention it caused itself is an external blocker and
+reaching for `--no-verify`.
+
+### What actually happened on 2026-09-05
+
+A lane parked #2914 at `Agent Needs Input` to hold `wt-2913-a29-retry` while a human hand-committed
+in it. A fresh tick launched a second lane into the same tree.
+
+The sequence, from `~/.open-engine/tick.log` and the issue's own comment log — **the log is the
+evidence; the comment text alone is only an inference**:
+
+| Time (UTC) | Event | Source |
+|---|---|---|
+| 22:55:15 | `AGENT BLOCKED` posted | issue #2914 |
+| 22:59:10 | board status → `Agent Needs Input` | REST timeline (`project_v2_item_status_changed`) |
+| **22:59:11** | **human comment: "Parking at Agent Needs Input temporarily…"** | issue #2914 |
+| 23:00:44 | `claimable: #2914[claude](answered)` | tick.log |
+| **23:08:44** | **`--- lane: claude claim #2914 (answered) via ringer ---`** | tick.log |
+| 23:14:37 | `AGENT RESUMED` posted by the second lane | issue #2914 |
+
+`answered` is emitted **only** by the gate's `Agent Needs Input` branch, whose rule is *newest
+comment is not an `AGENT_*` receipt ⇒ a human replied ⇒ claimable*. The 22:59:11 comment is human
+prose, so it satisfied that rule 93 seconds later.
+
+**The act of announcing the park is what un-parked it.** To the gate, "do not touch this" is
+indistinguishable from a human answering the question the issue was paused on.
+
+**The overlap was minutes, not seconds.** The lane launched at 23:08:44 and ran ~6 minutes before
+posting `AGENT RESUMED`. The issue's "a few seconds either way" framing is wrong by two orders of
+magnitude, and the exposure window is correspondingly larger.
+
+### A proximate cause, not background risk
+
+`open-engine` commit `f741933` raised `EngineLaneCap` from 1 to 3 at 2026-09-05T20:49Z — **2h25m
+before the incident** — and the tick log shows #2914 riding that exact cap: refused at 21:08:02
+(*"only 1 runs at a time"*), admitted at 21:15:33 (*"only 3 runs at a time"*), and launched at
+23:08:44 from a slot freed under cap 3. The constant is **global**, not claude-scoped as its commit
+subject implies, and `MaxLanes = 4` still bounds total concurrency.
+
+Reverting that experiment is a one-line change and is **not** part of this design. It is noted
+because any measurement of whether this class recurs is confounded while the cap sits at 3.
+
+### There are two resume routes, not one
+
+[#3011](https://github.com/dudarenok-maker/Castwright/issues/3011) states that "the resumable-claim
+fast path reads the ticket's comment/claim history, not the board `Status` field." That is **false
+of `oe-tick.ps1`** — its gate branches on status explicitly, and `resumable-claim` is produced only
+under `Agent Working`.
+
+It is **true of `runner/prompt.md`**. The runner's fallback sweep matches (a) `AGENT HUMAN HOLD`
+plus a newer human comment and (b) `AGENT BLOCKED` plus a strictly-later human comment, prescribes
+*"Move it to Agent Working, leave AGENT UNBLOCKED then AGENT RESUMED"*, and **names no board status
+at all**. #2914's shape — `AGENT BLOCKED` 22:55:15, human comment 22:59:11 — satisfies (b) exactly.
+
+This incident travelled the gate's route, not the sweep's (the log proves the claim was
+`answered`). But the sweep is a live, status-blind resume path, and any design that closes only the
+gate leaves it open. **Both routes must be closed.**
+
+### The invariant being broken is not the one the code guards
+
+The resource that cannot take two writers is the **worktree**. Every mechanism above asserts
+exclusivity on the **ticket**. A ticket and a worktree are not 1:1 — they diverge the moment a chain
+reassigns or a claim resets mid-flight, which both #2910 and #2914 did on the same night.
+
+### Why this survived #2999
+
+Every other concurrency problem chased on 2026-09-05 arrived through the git hooks, and #2999
+removed that source. **This route has nothing to do with hooks.** Merging every worktree onto `main`
+does not touch it, and a quiet box is not evidence the class is closed.
+
+## Design
+
+### Part 1 — the gate refuses a second lane on an occupied tree
+
+This is the correctness floor.
+
+**The tick can already resolve a lane's worktree; it simply never uses that to gate.** Two
+independent resolvers exist today:
+
+- `Find-LaneWorktrees` matches `git worktree list` against the sequence by name convention — its own
+  comment notes that `wt-new.mjs` names the tree after the sequence;
+- **the ticket body declares it outright** — #2914's body reads ``Worktree `C:\Claude\Projects\wt-2913-a29-retry`, branch …``.
+
+The tick already prints the resolved path when it reaps (`in C:/Claude/Projects/wt-2913-a29-retry`).
+So this is a gate applied to a lookup the tick performs today, not the relocation of unavailable
+context that the first draft of this document claimed.
+
+**The rule:** a candidate whose resolved worktree is occupied by a lane this tick still considers
+live is dropped from `$claimable` for that tick, with a logged reason. Occupancy is derived from the
+tick's own lane bookkeeping — it launches lanes and reaps them, so it already knows which are
+running and which tree each was dispatched against.
+
+**Ambiguity fails closed.** If the tree cannot be resolved for a candidate, that candidate is not
+dispatched this tick. This is the one place this design deliberately inverts the file's prevailing
+doctrine — see below.
+
+### Part 2 — a board state that means "reserved"
+
+Add an `Agent Reserved` option to the project board's Status field, for holding a tree without
+claiming to be waiting on an answer.
+
+**The gate needs no change to honour it.** `oe-tick.ps1` has exactly three `if ($status -eq …)`
+branches — `Agent Todo`, `Agent Working`, `Agent Needs Input` — and no `else`. An unrecognised
+status contributes nothing to `$claimable`, the same way `Agent Waiting` is already ineligible by
+construction.
+
+**But "no gate change" is not "no code change", and the first draft of this document wrongly
+concluded that it was.** The reserved state touches:
+
+- **`oe-doctor.ps1`**, which *does* have the `else` the tick lacks and would report every reserved
+  ticket as a defect — *"its board Status is '…' … so it is not queued"* — with the fix text *"move
+  it to Agent Todo when it is ready to run."* Left alone, the doctor instructs the operator to
+  un-reserve exactly the trees this design reserves.
+- **the hard-coded Status option-ID registry** in `~/.claude/skills/open-agent-engine/SKILL.md`.
+- **eight `open-engine/agents/*.md` files**, `oe-route.ps1`, `docs/deliverable-model.md` and
+  `docs/runbook.md`, which enumerate statuses.
+- **the board's own automation** — `github-project-automation[bot]` writes Status on this project,
+  and `add-to-project.yml` adds items. A new option interacts with built-in workflows; the schema
+  change is not inert.
+
+`Agent Needs Input` keeps its meaning, and its documentation gains the sentence that was missing:
+**a comment on it is a resume trigger, including the comment that says not to resume.**
+
+### Part 3 — close the runner's status-blind sweep
+
+`runner/prompt.md`'s fallback matches (a) and (b) must consult board status before resuming, so
+`Agent Reserved` is honoured on that route too. Without this, Part 2 protects one of the two resume
+paths and the ticket's original complaint remains true of the other.
+
+## Occupancy and staleness
+
+With the lock file dropped (below), "occupied" is no longer a file on disk with an epoch problem —
+it is **lane liveness, which the tick already tracks**. That removes three defects the first draft
+had:
+
+- no undefined lock-age epoch (per-run or per-occupancy — both were implementable, and the draft
+  did not say which);
+- no lock surviving a crashed lane for 105 minutes while the queue relaunches every ~90 s;
+- no lock file to leave behind, git-ignore, or clean up.
+
+**Uncommitted work is a third signal, and the tick already computes it.** `Get-UnpushedWork` returns
+`Ahead`/`Dirty`. A tree holding another lane's uncommitted changes must not be dispatched into even
+when no process is live — tick.log records exactly that state for `wt-2913-a29-retry`
+(*"0 unpushed commit(s) and 6 uncommitted file(s)"*). Liveness alone would have released it.
+
+**Where a staleness window is still needed** — a lane the tick has lost track of across a restart —
+reuse `Get-ClaimStaleMin`, which derives its window from the lane ceiling per engine. The concrete
+values that implies are **105 minutes hosted and 195 local** (`LaneCeilingMin = 90`,
+`LocalLaneCeilingMin = 180`, `ClaimStaleMin = 105`). Those numbers are the cost of a wrong
+fail-closed decision and belong in the plan, not buried in a helper.
+
+### The inversion, stated explicitly
+
+`oe-tick.ps1` teaches, correctly and repeatedly, that its gate **fails open**: *"if we cannot tell,
+wake the lanes."* A frozen queue costs every issue behind it.
+
+**Occupancy must fail closed.** Failing open here *is* the defect. But the cost is real and is
+stated rather than waved at: a candidate wrongly judged occupied is **delayed**, not lost — it is
+re-evaluated on the next tick, ~90 s later, and the queue behind it still moves because other
+candidates are unaffected. That is what makes fail-closed affordable here and not affordable in the
+gate at large: this refusal is per-candidate and self-healing, whereas the gate's own failure mode
+is total.
+
+## Considered and dropped: a lock file enforced in `.husky/pre-commit`
+
+The first draft made this the correctness floor. **It was wrong, and it is recorded here so it is
+not re-proposed.**
+
+- **It would not have prevented the incident on the ticket.** The collision was an OE lane versus a
+  **human hand-committing**. A human has no lane identity, so with the lane holding the lock the
+  hook refuses *the human's* commit while the intruding lane writes freely — the exact inversion of
+  intent.
+- **There is no identity to compare.** `oe-tick.ps1` exports `OE_CLAIM_ISSUE` and `OE_CLAIM_WHY` and
+  nothing else; there is no lane or engine variable anywhere in the tick or the heartbeat. The only
+  identity a hook could read is the issue number — the very noun this design argues is wrong.
+- **Nothing would acquire it.** Acquisition would have to be runner prose, which is the mechanism
+  this design exists because agents do not reliably follow.
+- **"Every write passes through the hook" is false.** `.husky/*` is tracked, so every worktree keeps
+  its old hooks until it merges `main` — **16 non-primary worktrees are registered right now**, and
+  the ops-2997 sweep needed a deliberate pass per tree. A tool-created worktree has no `.husky/_` at
+  all, so git runs no hook, **silently**. (An earlier draft said "~45 worktrees", conflating
+  registered trees with the 44 `wt-*` directories on disk; **28 of those are orphaned leftovers**,
+  which is a separate finding — ops-2997's unbuilt Part 4, worktree GC.)
+- **The mandated write path is invisible to the probe anyway.** `runner/prompt.md` requires commits
+  to run from a detached helper launched as `powershell.exe -File <temp>\helper.ps1`; the worktree
+  path lives *inside* that file via `Set-Location`, and never appears on any command line. A probe
+  that greps command lines returns zero for a tree actively being committed to.
+
+## Testing
+
+**Part 1 — occupancy.**
+
+- two candidates resolving to the same tree: the second is dropped, with its reason logged;
+- candidates resolving to different trees: both dispatch;
+- a tree whose lane has been reaped is dispatchable again;
+- a candidate whose tree cannot be resolved is **not** dispatched (fail-closed), and says why;
+- a tree that is idle but `Dirty`/`Ahead` per `Get-UnpushedWork` is **not** dispatched;
+- the reported shape end to end: status `Agent Needs Input`, newest comment a human note, a lane
+  already live on that tree ⇒ **no second lane launched**. This is the regression the issue asks for.
+
+**Part 2 — the reserved state.**
+
+- `Agent Reserved` yields no candidate, and an unrecognised status contributes nothing;
+- `Agent Needs Input` with a newer human comment **still** yields `answered` — pinning today's
+  correct behaviour so Part 2 cannot silently change it;
+- `oe-doctor.ps1` does not report a reserved ticket as a defect.
+
+**Part 3 — the sweep.** The runner's (a)/(b) matches do not resume a ticket in `Agent Reserved`.
+
+**Mutation-verify the occupancy comparison**: deleting it must redden a named test. Note explicitly
+that "both candidates dispatch when trees differ" and "an idle tree is dispatchable" both pass
+against a gate that never refuses anything — they are necessary but must never be the only
+coverage. This repo has shipped that shape before.
+
+## Risks and trade-offs
+
+- **A wrongly-occupied tree delays a candidate by one tick.** Acceptable, and self-healing —
+  but only because the refusal is per-candidate. If a future change makes it batch-wide, this
+  argument no longer holds.
+- **Tree resolution is heuristic.** Name convention and a ticket-body string are both operator-set
+  and can drift. Fail-closed on unresolvable trees converts drift into a stall rather than a
+  collision, which is the safe direction but is still a stall.
+- **`Agent Reserved` is a board schema change** — manual, per-project, not enforceable by CI, and it
+  interacts with project automation.
+- **The per-machine skill store.** `~/.claude/skills/oe-*` is not version-controlled; a status-ID
+  registry edit there has no history, no review, and no backup. That is a real exposure this design
+  depends on and does not fix — see #3000's closing note.
+
+## Out of scope
+
+- Reworking what `Agent Needs Input` means. Its rule is correct for its meaning; the gap was a
+  missing state.
+- Reverting `EngineLaneCap`. Noted as a confounder above; it is an operational decision, not this
+  design's.
+- Anything about the commit gate's cost — ops-2997's territory, closed.
+
+## Open questions
+
+- **O1 — where does occupancy state live across a tick restart?** The tick's in-memory lane
+  bookkeeping does not survive one. Options: re-derive from `git worktree list` plus live-process
+  inspection at startup, or persist alongside the existing tick state. This is the one place the
+  dropped lock file's problem genuinely recurs, and it needs an answer before implementation.
+- **O2 — is the ticket body or the name convention authoritative** when both resolve and disagree?
+- **O3 — does the sweep fix belong in prose or should the sweep move into the tick?** Part 3 as
+  written is another prose instruction, which is the mechanism this design distrusts.


### PR DESCRIPTION
## Summary

Closes #3011 as **doctrine, not mechanism**. Three successive designs were investigated and all three were refuted — two by adversarial review, and the third (a defect *raised by* a review) by verification. **No code change anywhere.**

### What actually happened

A lane parked #2914 at `Agent Needs Input` to hold `wt-2913-a29-retry` while a human hand-committed in it. A tick launched a second lane into the same tree.

| Time (UTC) | Event |
|---|---|
| 22:55:15 | `AGENT BLOCKED` |
| 22:59:10 | board status → `Agent Needs Input` |
| **22:59:11** | **human comment: "Parking at Agent Needs Input temporarily…"** |
| 23:00:44 | `claimable: #2914[claude](answered)` |
| **23:08:44** | lane launched |
| 23:14:37 | `AGENT RESUMED` |

That branch's rule is *newest comment is not an `AGENT_*` receipt ⇒ a human replied ⇒ claimable*. The parking comment is human prose, so **announcing the park is what un-parked it**, 93 seconds later. The overlap was ~6 minutes, not the "few seconds" the issue describes.

**The issue's own stated mechanism is wrong.** It says the resumable-claim path ignores board `Status`; `oe-tick.ps1` branches on status explicitly and produces `resumable-claim` only under `Agent Working`. Its remedies 1 and 2 target a defect that does not exist.

### The three refutations

**A lock file in `.husky/pre-commit`** — would have *inverted* the incident. The collision was a lane against a **human**, who carries no lane identity, so the hook refuses the human while the intruder writes. Also: nothing would acquire it; `.husky/*` is tracked so each worktree keeps old hooks until it merges `main`, and tool-created trees run no hook silently; and the mandated commit path (a detached helper) never puts the worktree on a command line, so a process probe cannot see it.

**The gate refusing a second lane on an occupied tree** — reproduces the same blind spot (its predicate is *lane* liveness; the incident had a human), and measurement killed it independently: the name-convention resolver covers **6 of 13** sequences, and the failures span **76% of open tickets**; the tick records no worktree for a running lane; `Dirty`/`Ahead` reports **9 of 15** trees dirty with nothing live, and cannot attribute what it sees — the log's own "work left behind by lane claude" line describes files the *human* wrote.

**An `Agent Reserved` board state** — unnecessary. The board already carries `Parked`, `Agent Waiting` and `Waiting/Blocked`, all already unclaimable.

**And the "one real defect" was not one.** Review pass 2 reported `Select-Lanes`' `$seenSeq` as an unseeded cap letting a top-up start two lanes in one worktree. That fix was implemented, then **discarded**: the top-up call site already excludes in-flight sequences, deliberately, with a comment saying so. Both lane-start paths are covered. Recorded as method: *a review's claim is evidence, not a verdict.*

### What ships

Doctrine in CLAUDE.md's existing "One writer per worktree" section: never hand-commit in a tree with an open agent ticket; park at `Parked`, never `Agent Needs Input`; announcing a park does not park it.

Plus a **correction to that section's own process probe** — it documents `CommandLine -like "*<worktree-path>*"`, which matches the shell running the search. It reported five phantom occupants on a completely idle tree today. Now says to exclude your own ancestry *and its children*.

Stated as a limit rather than papered over: **nothing can see a non-lane writer** — a human, an interactive session, a dispatched fix agent, an orphaned battery — and that is what caused this incident.

## Test plan

Docs and process only; no runtime surface, no tests to add.

The substance was verified rather than asserted: every code claim was checked against `oe-tick.ps1`, `oe-doctor.ps1` and `runner/prompt.md`; the incident timeline against `~/.open-engine/tick.log`; the resolver and `Dirty`/`Ahead` figures measured against the live queue and the 15 non-primary worktrees; and the discarded fix confirmed unnecessary by enumerating every `Start-Lanes` and `Invoke-Gate` call site.

**Review gate: exempt** — the changed file set is entirely root-level `*.md` plus `docs/**` (`CLAUDE.md`, one spec), the same file-set test as CONTRIBUTING.md's doc-only fast-path. Noting deliberately that this *does* touch instructions agents follow literally, which the skill flags as the subclass not to wave through on substance — so for the record, the substance carried **two Premium-tier adversarial passes**, and their findings are what reversed the outcome from "ship a mechanism" to "ship a rule."

Closes #3011

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQowpfkQgdAbudiZZF7PVL
