### PR TITLE
docs(ops): verify where a dispatched agent actually wrote

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1298,6 +1298,30 @@ Working practice below; this holds even under contention).
   queue's own exclusivity checks. The rules above are the protection; there is
   no mechanism behind them.
 
+**Verify where a dispatched agent actually wrote**
+([#3044](https://github.com/dudarenok-maker/Castwright/issues/3044)):
+
+- **Capture the primary checkout's `git status --porcelain` before a dispatch
+  round and again after each agent returns.** Any entry that is not yours is a
+  **failed dispatch** — revert it and re-dispatch; do not adopt it. This is the
+  same before/after tree check the [`pr-review-gate`
+  skill](.claude/skills/pr-review-gate/SKILL.md#the-tree-check) already runs
+  around a reviewer pass, applied to the tree the agent was told *not* to touch.
+- **Check every tree the dispatch does not own**, not just the primary. The
+  observed writes went to the primary because that is the path most likely to be
+  resolved against by mistake, but nothing about the mechanism is specific to it.
+- **Inspecting the diff cannot tell you this happened.** Four occurrences are on
+  record across at least two sessions, and in the clearest one the content was
+  *byte-for-byte correct* — near-identical to entries already properly committed
+  on the branch that owned them. It is a path bug, not a content bug, so the
+  change looks right in every way except where it is. Had it been committed it
+  would have landed on `main` with no PR, and collided with two open ones.
+- **Do not rely on the brief.** Every occurrence involved a brief that already
+  named the absolute worktree path, in some cases with an explicit "do NOT work
+  anywhere else". Strengthening the prose has been tried and has not held; the
+  agent is not misunderstanding the instruction, it is resolving a path against
+  the wrong root mid-task.
+
 ### Planning agents
 
 Plan agents (`subagent_type: "Plan"`) design strategies but don't write code,


### PR DESCRIPTION
## Summary

Records the **option 1** decision on #3044 — the dispatching session verifies the primary checkout's tree state around every dispatch round — as doctrine under CLAUDE.md's "One writer per worktree" section, which is the issue's own acceptance item 3 ("documented where dispatchers will actually read it").

Four bullets, each carrying a fact the failures established rather than general advice:

- **before/after `git status --porcelain`**, so the signal is a delta rather than a judgement about what looks like this branch's work. Cites the identical before/after tree check `pr-review-gate` already runs around a reviewer pass.
- **every tree the dispatch does not own**, not only the primary — the primary is the likeliest wrong root, not a special one.
- **the diff cannot reveal it.** In the clearest occurrence the content was byte-for-byte correct, near-identical to entries already properly committed on the branch that owned them. Path bug, not content bug.
- **the brief does not hold.** Every occurrence already named the absolute worktree path, some with an explicit "do NOT work anywhere else".

## Why `Refs`, not `Closes`

Option 1 is detection, and the issue's acceptance item 2 asks for a *check* that would have caught the 2026-09-06 occurrence. A probe run alongside this change established that **option 2 is buildable** — Claude Code's `PreToolUse` hooks fire for `Write`/`Edit`/`Bash`, receive `tool_input.file_path` (or the raw `command`) plus the session `cwd`, and can refuse a call via exit 2 or `permissionDecision: "deny"`. Notably the hook can live in **subagent frontmatter**, i.e. `.claude/agents/*.md` — the one part of `.claude/` this repo does not gitignore — so it can be version-controlled and reach a fresh clone, which a `.claude/settings.json` hook could not.

One unknown remains before option 2 ships: whether a frontmatter-declared hook actually fires for an Agent-tool dispatch is undocumented and needs an empirical test. Option 2 supersedes this as the gate when it lands; this stays as the backstop.

## Test plan

Documentation-only — no runtime surface, no test owed. Verified the rendered anchor
`.claude/skills/pr-review-gate/SKILL.md#the-tree-check` resolves against the existing heading.

Before-shipping steps not applicable and why: **1** (no behaviour change to plan), **2** (no code), **3** (no hardware-provable behaviour), **4** (no plan added or moved), **5** (process-only, no shippable delta), **7** (no runtime surface for the branch-scoped battery).

Refs #3044

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQowpfkQgdAbudiZZF7PVL
