### PR TITLE
ci(ops,scripts): add a Windows PR-CI leg and a sidecar acceptance gate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,6 +24,13 @@ Checklist of what was run / what reviewers should look at. Examples:
 - [ ] cloud `verify.yml` (required status check) — green
 - [ ] Manual walkthrough in mock mode: <steps>
 - [ ] Reviewer: spot-check <file>:<line> against the regression plan
+
+If this PR touches server/tts-sidecar/**, the sidecar acceptance gate needs
+one of these two lines somewhere in this body (see CONTRIBUTING.md "Sidecar
+acceptance fast-path" for the full format):
+
+  Sidecar acceptance: `npm run test:sidecar` -- <YYYY-MM-DD> -- passed
+  Sidecar acceptance: see docs/testing/onbox-acceptance-register.md row <ID>
 -->
 
 - [ ] `npm run verify` — green

--- a/.github/workflows/sidecar-acceptance-gate.yml
+++ b/.github/workflows/sidecar-acceptance-gate.yml
@@ -1,0 +1,71 @@
+name: Sidecar acceptance gate
+
+# ops-74 (#3050) — commit-gate rebalance design Part 6. Mirrors
+# .github/workflows/pr-issue-link.yml's shape: a small, always-triggered
+# validator gated on a specific, checkable PR-body format -- but this one
+# only requires that format when the PR's diff touches
+# server/tts-sidecar/**, the ONE directory whose 38
+# `pytest.importorskip("torch")` tests (14 files) run exclusively via a
+# local `npm run test:sidecar` on real hardware and have no automated CI
+# equivalent (see docs/superpowers/specs/2026-09-05-commit-gate-rebalance-
+# design.md, Part 6, and CONTRIBUTING.md "Sidecar acceptance fast-path").
+#
+# Trigger path is server/tts-sidecar/** ONLY -- deliberately narrower than an
+# earlier draft that also listed server/src/tts/**, server/src/analyzer/**,
+# server/src/gpu/** (177 TypeScript test files Ubuntu CI already covers via
+# verify.yml). Do not add those back.
+
+on:
+  pull_request:
+    # Same four types as pr-issue-link.yml, for the same reason: `edited`
+    # stays because the primary way a PR satisfies this gate after opening
+    # is editing the body to add the "Sidecar acceptance:" line, not pushing
+    # a new commit -- without `edited` that fix wouldn't clear the check
+    # until the next `synchronize` push.
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Verify sidecar acceptance is recorded
+    runs-on: ubuntu-latest
+    # Tiny validator; cap explicitly so a hung run can't bill the 360-min
+    # default (same rationale as pr-title-lint.yml / pr-issue-link.yml).
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          # Full history so the scope diff below can reach the PR's merge
+          # base. A shallow clone wouldn't have it reachable.
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      - name: List changed files
+        # Same merge-base pattern as verify.yml's `detect` job: diff against
+        # the merge base, not BASE itself, so a PR branch cut from a stale
+        # main doesn't pick up every file main moved past the fork point.
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          MERGE_BASE="$(git merge-base "$BASE" "$HEAD" 2>/dev/null || echo "$BASE")"
+          git diff --name-only "$MERGE_BASE" "$HEAD" > "$RUNNER_TEMP/pr-files.txt"
+          echo "Changed files in this PR:"
+          cat "$RUNNER_TEMP/pr-files.txt"
+
+      - name: Write PR body to a temp file
+        # Same file-passing pattern as pr-issue-link.yml's PR_BODY handling
+        # — the body can't be interpreted as a shell expression this way.
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          printf '%s\n' "$PR_BODY" > "$RUNNER_TEMP/pr-body.txt"
+
+      - name: Validate sidecar acceptance
+        run: node scripts/validate-sidecar-acceptance.mjs "$RUNNER_TEMP/pr-files.txt" "$RUNNER_TEMP/pr-body.txt"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -551,13 +551,86 @@ jobs:
         if: fromJSON(needs.detect.outputs.scopes).step_build || fromJSON(needs.detect.outputs.scopes).shared
         run: npm run build
 
+  # Windows leg (ops-73 / #3049, commit-gate rebalance design Part 5).
+  # Detection latency, not new coverage: cross-os.yml already runs the full
+  # `verify:quick` battery on windows-latest twice weekly, and release.yml
+  # gates every tag on Windows. This moves Windows detection from <=3.5 days
+  # to per-PR. It does NOT close the tmpdir/handle race the old pre-push
+  # hooks were built around — that race is a concurrency artifact between
+  # co-running batteries, and this runner is single-tenant, so it structurally
+  # cannot reproduce here.
+  #
+  # Scope conditions sit on STEPS, never the job — a job-level `if:` would
+  # leave this job (and therefore the aggregator's `needs:` entry for it)
+  # PERMANENTLY SKIPPED on every docs-only PR, and the aggregator fails on
+  # `'skipped'` below, which would block merge forever. No other leg in this
+  # file uses a job-level `if:`; this one doesn't either.
+  #
+  # `cancel-in-progress: true` (workflow-wide, top of file) makes a slow
+  # Windows leg a new source of `cancelled`, which the aggregator also treats
+  # as failure — timeout-minutes is sized with that in mind.
+  #
+  # Every step pins `shell: bash` explicitly: this file sets no workflow- or
+  # job-level `defaults: run: shell:`, so a bare `run:` on windows-latest
+  # would default to pwsh, not bash.
+  windows-tests:
+    name: Windows (test + test:server)
+    needs: detect
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node + deps
+        uses: ./.github/actions/setup
+
+      # ffmpeg is needed by the server MP3 encoder (server/src/tts/mp3.ts
+      # shells out to it). See .github/actions/install-ffmpeg-windows for why
+      # this installs via choco with a winget fallback and a bounded retry.
+      # The Windows steps carry their OWN leg identifiers, not the Ubuntu
+      # ones: the two legs genuinely differ in scope. Ubuntu's `test:server`
+      # runs the fast AND slow suites, so it is gated on step_test_server_slow
+      # too; this job runs `npm run test:server`, which EXCLUDES the slow
+      # files, so a PR touching only a slow test file must not start a Windows
+      # leg that cannot execute it. Marker values also stay inside the wiring
+      # guard's grammar (lowercase, digits, `:` and `-` only) -- a ` (Windows)`
+      # suffix parses as nothing at all, which left both steps outside every
+      # guard in scripts/tests/workflow-wiring.test.mjs (#3053 review).
+      # supports: test:server:windows
+      - name: Install ffmpeg (Windows)
+        if: fromJSON(needs.detect.outputs.scopes).step_test_server || fromJSON(needs.detect.outputs.scopes).shared
+        uses: ./.github/actions/install-ffmpeg-windows
+
+      # leg: test:windows
+      - name: Frontend tests
+        if: fromJSON(needs.detect.outputs.scopes).step_test || fromJSON(needs.detect.outputs.scopes).shared
+        shell: bash
+        run: npm test
+
+      # leg: test:server:windows
+      - name: Server tests
+        if: fromJSON(needs.detect.outputs.scopes).step_test_server || fromJSON(needs.detect.outputs.scopes).shared
+        shell: bash
+        run: npm run test:server
+
   # Thin aggregator — see the top-of-file comment. Keeps the "npm run verify"
   # status-check name (required on main's branch-protection ruleset) stable
   # while the real work runs concurrently in the named jobs above.
   verify:
     name: npm run verify
     needs:
-      [detect, lint-and-checks, frontend-tests, server-tests, sidecar-tests, e2e, e2e-visual, build]
+      [
+        detect,
+        lint-and-checks,
+        frontend-tests,
+        server-tests,
+        sidecar-tests,
+        e2e,
+        e2e-visual,
+        build,
+        windows-tests,
+      ]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -590,6 +590,46 @@ docs-only push has no runtime surface for it to exercise, so paying even
 that scope computation is wasted time/CPU for zero signal. See
 [CLAUDE.md "Commit gate"](CLAUDE.md#commit-gate).
 
+### Sidecar acceptance fast-path
+
+A PR whose diff touches `server/tts-sidecar/**` is a required check
+([`.github/workflows/sidecar-acceptance-gate.yml`](.github/workflows/sidecar-acceptance-gate.yml),
+ops-74 / #3050) unless the PR body records that `npm run test:sidecar` was
+run locally, or links a row in the [on-box acceptance
+register](docs/testing/onbox-acceptance-register.md). This exists because 38
+`pytest.importorskip("torch")` tests (14 files, all under
+`server/tts-sidecar/`) run **only** on real hardware via a local
+`npm run test:sidecar` — never in CI (`verify.yml`'s sidecar leg deliberately
+installs the lean, torch-free dependency set, so those tests report as
+skipped there). A PR that doesn't touch `server/tts-sidecar/**` is unaffected
+and needs nothing in its body.
+
+Write one of these two lines plainly (not inside backticks or a code block)
+in the PR body:
+
+```
+Sidecar acceptance: `npm run test:sidecar` -- 2026-09-06 -- passed
+Sidecar acceptance: see docs/testing/onbox-acceptance-register.md row <ID>
+```
+
+The first form is checked field-by-field — a literal
+`` `npm run test:sidecar` `` (flags after it are fine), an ISO date, and an
+outcome of `passed` or `failed`; only `passed` satisfies the gate. Free
+prose ("ran the sidecar tests, all good") does not. The second form points
+at a specific register row rather than re-running locally — useful when
+acceptance is already tracked there. `<ID>` must name a row that **actually
+exists** in the register: the gate parses the register (with
+`check-register-citations.mjs`'s own row parser) and rejects an id it does
+not find, so "blocked until Q3" or "will file in v2" is not a citation. And
+"plainly" is enforced, not merely asked for — a line inside a backtick or
+tilde fence, inside an HTML comment, indented by four spaces or a tab, or
+inside an inline code span opened on an earlier line, does not satisfy the
+gate. See
+[`scripts/validate-sidecar-acceptance.mjs`](scripts/validate-sidecar-acceptance.mjs)
+for the exact patterns and
+[docs/superpowers/specs/2026-09-05-commit-gate-rebalance-design.md](docs/superpowers/specs/2026-09-05-commit-gate-rebalance-design.md)
+("Part 6") for the rationale.
+
 ## When you ship a change
 
 The full checklist lives in [CLAUDE.md → "Before-shipping checklist"](CLAUDE.md#before-shipping-checklist).

--- a/scripts/tests/validate-sidecar-acceptance.test.mjs
+++ b/scripts/tests/validate-sidecar-acceptance.test.mjs
@@ -1,0 +1,777 @@
+// Tests for the sidecar-acceptance-gate validator (ops-74 / #3050).
+// Run via `npm run test:hooks` (node --test, no extra deps).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import {
+  touchesSidecar,
+  unquoteGitPath,
+  parseFileList,
+  parseRecordedRun,
+  hasPassingRecordedRun,
+  hasRegisterLink,
+  parseRegisterLink,
+  passesSidecarAcceptanceGate,
+  helpMessage,
+  loadRegisterRowIds,
+  readRegisterRowIds,
+  failureDetail,
+} from '../validate-sidecar-acceptance.mjs';
+
+// Synthetic register row IDs, used ONLY as fixtures for this validator's
+// regex. Composed at runtime instead of written literally because
+// scripts/check-register-citations.mjs reads the literal "row <ID>" idiom in
+// any tracked file as a CITATION of a real register row -- and these are not
+// citations, they are inputs to a pattern. Written literally they made that
+// checker exit 1 on the whole tree and, through it, disarmed its own
+// mutation test (`CLI mutation: deleting Check C from fatalSections ...`),
+// which proves its fatality by asserting a mutant PASSES. The runtime string
+// each test actually exercises is unchanged.
+const row = (group, n) => `${group}${n}`;
+const FIXTURE_ROW_ID = row('A', 101);
+const FIXTURE_ROW_ID_ALT = row('E', 101);
+
+// The gate now checks that a cited row EXISTS (#3053 review pass 2, N1), so
+// every syntax-level assertion below hands it this explicit set rather than
+// the real register -- keeping the pattern fixtures synthetic, exactly as
+// the comment above requires.
+const FIXTURE_ROWS = new Set([FIXTURE_ROW_ID, FIXTURE_ROW_ID_ALT, row('C', 2)]);
+
+// The real register's row ids, for the existence half. Read through the
+// SAME parser the validator uses, so a fixture id can never drift from what
+// the register actually contains.
+const REAL_ROW_IDS = loadRegisterRowIds();
+const A_REAL_ROW_ID = [...REAL_ROW_IDS].sort()[0];
+
+const scriptPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'validate-sidecar-acceptance.mjs',
+);
+
+// --- touchesSidecar -------------------------------------------------------
+
+test('touchesSidecar: true when any file is under server/tts-sidecar/', () => {
+  assert.equal(touchesSidecar(['server/tts-sidecar/main.py']), true);
+  assert.equal(
+    touchesSidecar(['src/App.tsx', 'server/tts-sidecar/tests/test_smoke.py']),
+    true,
+  );
+});
+
+test('touchesSidecar: false for an empty list, non-array, or no sidecar path', () => {
+  assert.equal(touchesSidecar([]), false);
+  assert.equal(touchesSidecar(undefined), false);
+  assert.equal(touchesSidecar(null), false);
+  assert.equal(touchesSidecar(['src/App.tsx', 'server/src/tts/index.ts']), false);
+});
+
+// The trigger path is deliberately narrow -- server/src/tts/**,
+// server/src/analyzer/**, server/src/gpu/** must NOT trip this gate (the
+// earlier draft this issue explicitly rejected). A path that merely
+// CONTAINS the substring "tts-sidecar" elsewhere in the tree (not as this
+// exact directory prefix) must not false-positive either.
+test('touchesSidecar: does not match the rejected wider paths or a substring elsewhere', () => {
+  assert.equal(touchesSidecar(['server/src/tts/index.ts']), false);
+  assert.equal(touchesSidecar(['server/src/analyzer/ollama.ts']), false);
+  assert.equal(touchesSidecar(['server/src/gpu/active-generation-gate.ts']), false);
+  assert.equal(touchesSidecar(['docs/notes/tts-sidecar-history.md']), false);
+});
+
+// --- parseFileList ----------------------------------------------------------
+
+test('parseFileList: splits newline-separated text and drops blank lines', () => {
+  assert.deepEqual(parseFileList('a.txt\nb.txt\n\nc.txt\n'), ['a.txt', 'b.txt', 'c.txt']);
+});
+
+test('parseFileList: empty diff (empty string) yields an empty array, not ["")', () => {
+  assert.deepEqual(parseFileList(''), []);
+});
+
+test('parseFileList: non-string input yields an empty array', () => {
+  assert.deepEqual(parseFileList(undefined), []);
+});
+
+// --- parseRecordedRun / hasPassingRecordedRun ------------------------------
+
+const acceptedRecordedRuns = [
+  'Sidecar acceptance: `npm run test:sidecar` -- 2026-09-06 -- passed',
+  'Sidecar acceptance: `npm run test:sidecar -- --require-venv` -- 2026-01-05 -- passed',
+  'SIDECAR ACCEPTANCE: `npm run test:sidecar` -- 2026-09-06 -- PASSED',
+  'Intro text.\n\nSidecar acceptance: `npm run test:sidecar` — 2026-09-06 — passed\n\nMore text.',
+  // en dash -- the third accepted separator, and the one the code comment
+  // used to omit while naming a single ASCII hyphen it does not accept
+  'Sidecar acceptance: `npm run test:sidecar` – 2026-09-06 – passed',
+];
+
+for (const body of acceptedRecordedRuns) {
+  test(`hasPassingRecordedRun accepts: ${JSON.stringify(body)}`, () => {
+    assert.equal(hasPassingRecordedRun(body), true);
+  });
+}
+
+test('parseRecordedRun: extracts command, date, and outcome', () => {
+  const parsed = parseRecordedRun(
+    'Sidecar acceptance: `npm run test:sidecar` -- 2026-09-06 -- passed',
+  );
+  assert.deepEqual(parsed, {
+    command: 'npm run test:sidecar',
+    date: '2026-09-06',
+    outcome: 'passed',
+  });
+});
+
+// A recorded FAILED run is a real, parseable record -- but must not satisfy
+// the gate. This is the outcome-vocabulary check, not merely "some text
+// present".
+test('a recorded run with outcome "failed" parses but does not satisfy the gate', () => {
+  const body = 'Sidecar acceptance: `npm run test:sidecar` -- 2026-09-06 -- failed';
+  assert.deepEqual(parseRecordedRun(body), {
+    command: 'npm run test:sidecar',
+    date: '2026-09-06',
+    outcome: 'failed',
+  });
+  assert.equal(hasPassingRecordedRun(body), false);
+});
+
+const rejectedRecordedRuns = [
+  '',
+  'Ran the sidecar tests locally, all good.', // free prose, not the checkable format
+  'Sidecar acceptance: npm run test:sidecar -- 2026-09-06 -- passed', // command not backticked
+  'Sidecar acceptance: `npm test` -- 2026-09-06 -- passed', // wrong command
+  'Sidecar acceptance: `npm run test:sidecar` -- 09-06-2026 -- passed', // non-ISO date
+  'Sidecar acceptance: `npm run test:sidecar` -- 2026-09-06 -- ok', // outcome not in vocabulary
+  // A SINGLE ASCII hyphen is not one of the three accepted separators
+  // (`--`, em dash, en dash). The code comment used to claim it was; this
+  // fixture is what keeps comment and code from drifting apart again.
+  'Sidecar acceptance: `npm run test:sidecar` - 2026-09-06 - passed',
+];
+
+for (const body of rejectedRecordedRuns) {
+  test(`hasPassingRecordedRun rejects: ${JSON.stringify(body)}`, () => {
+    assert.equal(hasPassingRecordedRun(body), false);
+  });
+}
+
+test('hasPassingRecordedRun rejects non-string input', () => {
+  assert.equal(hasPassingRecordedRun(undefined), false);
+  assert.equal(hasPassingRecordedRun(null), false);
+});
+
+// --- hasRegisterLink --------------------------------------------------------
+
+const acceptedRegisterLinks = [
+  `Sidecar acceptance: see docs/testing/onbox-acceptance-register.md row ${FIXTURE_ROW_ID}`,
+  // Lowercase on purpose: GitHub lowercases heading anchors, so this is the
+  // form a real link into the register carries. It used to read #C2, which
+  // is the only form the `#` branch accepted and the one form that never
+  // occurs (#3053 review pass 3, P2).
+  `Sidecar acceptance: docs/testing/onbox-acceptance-register.md#${row('C', 2).toLowerCase()}`,
+  `sidecar acceptance: recorded at docs/testing/onbox-acceptance-register.md, row ${FIXTURE_ROW_ID_ALT}`,
+];
+
+for (const body of acceptedRegisterLinks) {
+  test(`hasRegisterLink accepts: ${JSON.stringify(body)}`, () => {
+    assert.equal(hasRegisterLink(body, FIXTURE_ROWS), true);
+  });
+}
+
+const rejectedRegisterLinks = [
+  '',
+  `See docs/testing/onbox-acceptance-register.md row ${FIXTURE_ROW_ID}`, // no "Sidecar acceptance:" prefix on the line
+  'Sidecar acceptance: docs/testing/onbox-acceptance-register.md', // no row ID
+  // The register is mentioned elsewhere in the body, but not on a line that
+  // also carries the "Sidecar acceptance:" prefix and a row id -- a bare,
+  // unrelated mention must not satisfy the gate.
+  'This references docs/testing/onbox-acceptance-register.md in passing.\n\nSidecar acceptance: pending.',
+];
+
+for (const body of rejectedRegisterLinks) {
+  test(`hasRegisterLink rejects: ${JSON.stringify(body)}`, () => {
+    assert.equal(hasRegisterLink(body, FIXTURE_ROWS), false);
+  });
+}
+
+// --- passesSidecarAcceptanceGate -------------------------------------------
+
+test('passesSidecarAcceptanceGate: a PR that does not touch the sidecar always passes', () => {
+  assert.equal(passesSidecarAcceptanceGate(['src/App.tsx'], ''), true);
+  assert.equal(passesSidecarAcceptanceGate([], 'no relevant text'), true);
+});
+
+test('passesSidecarAcceptanceGate: a sidecar-touching PR with neither form fails', () => {
+  assert.equal(
+    passesSidecarAcceptanceGate(['server/tts-sidecar/main.py'], 'Nothing relevant here.'),
+    false,
+  );
+});
+
+test('passesSidecarAcceptanceGate: a sidecar-touching PR with a passing recorded run passes', () => {
+  assert.equal(
+    passesSidecarAcceptanceGate(
+      ['server/tts-sidecar/main.py'],
+      'Sidecar acceptance: `npm run test:sidecar` -- 2026-09-06 -- passed',
+    ),
+    true,
+  );
+});
+
+test('passesSidecarAcceptanceGate: a sidecar-touching PR with a register link passes', () => {
+  assert.equal(
+    passesSidecarAcceptanceGate(
+      ['server/tts-sidecar/main.py'],
+      `Sidecar acceptance: see docs/testing/onbox-acceptance-register.md row ${FIXTURE_ROW_ID}`,
+      FIXTURE_ROWS,
+    ),
+    true,
+  );
+});
+
+// --- "written plainly": fenced blocks and HTML comments ---------------------
+// helpMessage() and CONTRIBUTING.md "Sidecar acceptance fast-path" both tell
+// the author to write the line plainly, NOT inside a code block. Without
+// stripping, that instruction was unenforced and the documented copy-paste
+// block was itself a passing body.
+
+const FENCE = '`'.repeat(3);
+
+test('a recorded run inside a fenced code block does NOT satisfy the gate', () => {
+  const body = [
+    'We did not get to the box this round.',
+    '',
+    FENCE,
+    'Sidecar acceptance: `npm run test:sidecar` -- 2026-09-06 -- passed',
+    FENCE,
+  ].join('\n');
+  assert.equal(hasPassingRecordedRun(body), false);
+  assert.equal(passesSidecarAcceptanceGate(['server/tts-sidecar/main.py'], body), false);
+});
+
+test('a register link inside a fenced code block does NOT satisfy the gate', () => {
+  const body = [
+    FENCE,
+    `Sidecar acceptance: see docs/testing/onbox-acceptance-register.md row ${FIXTURE_ROW_ID}`,
+    FENCE,
+  ].join('\n');
+  assert.equal(hasRegisterLink(body, FIXTURE_ROWS), false);
+  assert.equal(
+    passesSidecarAcceptanceGate(['server/tts-sidecar/main.py'], body, FIXTURE_ROWS),
+    false,
+  );
+});
+
+test('an acceptance line inside an HTML comment does NOT satisfy the gate', () => {
+  const body = [
+    'Nothing was run.',
+    '',
+    '<!--',
+    'Sidecar acceptance: `npm run test:sidecar` -- 2026-09-06 -- passed',
+    '-->',
+  ].join('\n');
+  assert.equal(hasPassingRecordedRun(body), false);
+  assert.equal(passesSidecarAcceptanceGate(['server/tts-sidecar/main.py'], body), false);
+});
+
+// A real, unfenced line still passes -- the stripping must not be so broad
+// that it eats the documented plain form (which legitimately carries INLINE
+// backticks around the command).
+test('stripping leaves a plainly-written line, inline backticks and all, passing', () => {
+  const body = [
+    'Some prose.',
+    '',
+    FENCE,
+    'an unrelated code sample',
+    FENCE,
+    '',
+    'Sidecar acceptance: `npm run test:sidecar` -- 2026-09-06 -- passed',
+  ].join('\n');
+  assert.equal(hasPassingRecordedRun(body), true);
+  assert.equal(passesSidecarAcceptanceGate(['server/tts-sidecar/main.py'], body), true);
+});
+
+// The strongest form of the above: the ACTUAL "Sidecar acceptance fast-path"
+// section of the real CONTRIBUTING.md, whose documented copy-paste block
+// carries a real date and a real row id. Pasting the docs is the honest
+// copy-paste path, not gaming -- and it must not pass a gate for a PR where
+// nothing was run.
+test('the real CONTRIBUTING.md, fed whole as a PR body, does NOT satisfy the gate', () => {
+  const contributing = readFileSync(
+    resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', 'CONTRIBUTING.md'),
+    'utf8',
+  );
+  // Guard the guard: if the fixture stops containing the documented example
+  // at all, this test would pass vacuously and prove nothing.
+  assert.ok(
+    contributing.includes('Sidecar acceptance: `npm run test:sidecar`'),
+    'CONTRIBUTING.md no longer carries the documented acceptance example -- fixture is stale',
+  );
+  assert.equal(passesSidecarAcceptanceGate(['server/tts-sidecar/main.py'], contributing), false);
+});
+
+// --- unquoteGitPath ---------------------------------------------------------
+// `git diff --name-only` quotes and C-escapes any path with a non-ASCII or
+// control character under the default core.quotepath=true, so the raw name
+// starts with a double quote and a bare prefix match misses it entirely.
+
+test('unquoteGitPath decodes a git-quoted, C-escaped path', () => {
+  assert.equal(
+    unquoteGitPath('"server/tts-sidecar/tests/test_caf\\303\\251.py"'),
+    'server/tts-sidecar/tests/test_cafÃ©.py',
+  );
+  // Unquoted paths pass through untouched.
+  assert.equal(unquoteGitPath('server/tts-sidecar/main.py'), 'server/tts-sidecar/main.py');
+});
+
+test('touchesSidecar fires on a git-quoted non-ASCII sidecar path', () => {
+  assert.equal(touchesSidecar(['"server/tts-sidecar/tests/test_caf\\303\\251.py"']), true);
+  // and still does not false-positive on a quoted path outside the prefix
+  assert.equal(touchesSidecar(['"server/src/tts/caf\\303\\251.ts"']), false);
+});
+
+test('a sidecar-touching PR named only by a git-quoted path still needs acceptance', () => {
+  assert.equal(
+    passesSidecarAcceptanceGate(
+      ['"server/tts-sidecar/tests/test_caf\\303\\251.py"'],
+      'Nothing relevant here.',
+    ),
+    false,
+  );
+});
+
+// --- CLI mode ----------------------------------------------------------------
+// This is what the workflow actually invokes -- unit tests above cover the
+// exported functions directly, but nothing at that level proves the CLI
+// wiring (argv, exit codes) actually works.
+
+function runCli(files, body) {
+  const dir = mkdtempSync(join(tmpdir(), 'sidecar-acceptance-'));
+  try {
+    const filesFile = join(dir, 'files.txt');
+    const bodyFile = join(dir, 'body.txt');
+    writeFileSync(filesFile, files);
+    writeFileSync(bodyFile, body);
+    return spawnSync(process.execPath, [scriptPath, filesFile, bodyFile], {
+      encoding: 'utf8',
+      windowsHide: true,
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('CLI: a non-sidecar PR passes regardless of body', () => {
+  const result = runCli('src/App.tsx\n', 'no relevant text');
+  assert.equal(result.status, 0, `expected exit 0, got ${result.status}\nstderr: ${result.stderr}`);
+});
+
+test('CLI: a sidecar-touching PR with neither form fails', () => {
+  const result = runCli('server/tts-sidecar/main.py\n', 'Nothing relevant here.');
+  assert.equal(result.status, 1, `expected exit 1, got ${result.status}\nstderr: ${result.stderr}`);
+});
+
+test('CLI: a sidecar-touching PR with a passing recorded run passes', () => {
+  const result = runCli(
+    'server/tts-sidecar/main.py\n',
+    'Sidecar acceptance: `npm run test:sidecar` -- 2026-09-06 -- passed',
+  );
+  assert.equal(result.status, 0, `expected exit 0, got ${result.status}\nstderr: ${result.stderr}`);
+});
+
+// The CLI reads the REAL register, so this fixture must cite a row that
+// really exists -- taken from the register through the validator's own
+// loader rather than hard-coded, so it cannot go stale.
+test('CLI: a sidecar-touching PR citing a REAL register row passes', () => {
+  const result = runCli(
+    'server/tts-sidecar/main.py\n',
+    `Sidecar acceptance: see docs/testing/onbox-acceptance-register.md row ${A_REAL_ROW_ID}`,
+  );
+  assert.equal(result.status, 0, `expected exit 0, got ${result.status}\nstderr: ${result.stderr}`);
+});
+
+// ... and the same line citing a row that does NOT exist must fail, with the
+// id named. Before #3053 review pass 2's N1 fix this exited 0: the gate
+// checked the id's SHAPE and never that it was a row.
+test('CLI: a sidecar-touching PR citing a NONEXISTENT register row fails', () => {
+  assert.equal(
+    REAL_ROW_IDS.has(FIXTURE_ROW_ID),
+    false,
+    `fixture is stale -- ${FIXTURE_ROW_ID} is now a real register row, so this test would pass vacuously`,
+  );
+  const result = runCli(
+    'server/tts-sidecar/main.py\n',
+    `Sidecar acceptance: see docs/testing/onbox-acceptance-register.md row ${FIXTURE_ROW_ID}`,
+  );
+  assert.equal(result.status, 1, `expected exit 1, got ${result.status}\nstderr: ${result.stderr}`);
+  assert.match(result.stderr, new RegExp(`Cited register row ${FIXTURE_ROW_ID} does not exist`));
+});
+
+test('CLI: a sidecar-touching PR with a FAILED recorded run still fails the gate', () => {
+  const result = runCli(
+    'server/tts-sidecar/main.py\n',
+    'Sidecar acceptance: `npm run test:sidecar` -- 2026-09-06 -- failed',
+  );
+  assert.equal(result.status, 1, `expected exit 1, got ${result.status}\nstderr: ${result.stderr}`);
+});
+
+// --- N1: the cited row must EXIST, and prose is not a citation --------------
+// #3053 review pass 2. The link half checked the SHAPE of an id and nothing
+// else, under a whole-pattern /i flag that made `[A-Z]` match lowercase too
+// -- so a body whose own words were "NOT RUN" satisfied a REQUIRED check by
+// parsing "until Q3." as a row citation.
+
+const SIDECAR_FILES = ['server/tts-sidecar/main.py'];
+
+const bodiesThatSayNothingWasRun = {
+  'NOT RUN ... blocked until Q3':
+    'Sidecar acceptance: NOT RUN. docs/testing/onbox-acceptance-register.md\n' +
+    'has no row yet; blocked on box time until Q3.',
+  'deferred, will file in v2':
+    'Sidecar acceptance: deferred, see docs/testing/onbox-acceptance-register.md — will file in v2',
+  'a made-up row id': `Sidecar acceptance: see docs/testing/onbox-acceptance-register.md row ${row('Z', 999)}`,
+};
+
+for (const [label, body] of Object.entries(bodiesThatSayNothingWasRun)) {
+  test(`a body that records no run does NOT satisfy the gate: ${label}`, () => {
+    assert.equal(passesSidecarAcceptanceGate(SIDECAR_FILES, body), false);
+  });
+}
+
+// The PATTERN half, separated from the EXISTENCE half on purpose: with only
+// the existence check in place, prose still PARSES as a citation and merely
+// fails to resolve, so a later widening of the id pattern would go unnoticed.
+// This pins that ordinary prose is not a citation at all.
+test('prose that merely mentions the register parses as NO citation', () => {
+  const proseBodies = [
+    'Sidecar acceptance: NOT RUN. docs/testing/onbox-acceptance-register.md\nhas no row yet; blocked on box time until Q3.',
+    'Sidecar acceptance: deferred, see docs/testing/onbox-acceptance-register.md — will file in v2',
+    // lowercase id-shaped token: the old whole-pattern /i flag made `[A-Z]`
+    // match this too
+    'Sidecar acceptance: docs/testing/onbox-acceptance-register.md row a1',
+  ];
+  for (const body of proseBodies) {
+    assert.equal(parseRegisterLink(body), null, `parsed a citation out of prose: ${body}`);
+  }
+});
+
+test('a register link whose row does not exist does NOT satisfy the gate', () => {
+  const body = `Sidecar acceptance: see docs/testing/onbox-acceptance-register.md row ${FIXTURE_ROW_ID}`;
+  // Guard the guard: the syntax half must still match, so the rejection is
+  // proven to come from the EXISTENCE check and not from the pattern.
+  assert.equal(hasRegisterLink(body, new Set([FIXTURE_ROW_ID])), true);
+  assert.equal(hasRegisterLink(body, REAL_ROW_IDS), false);
+  assert.equal(passesSidecarAcceptanceGate(SIDECAR_FILES, body), false);
+});
+
+test('a register link naming a REAL row still satisfies the gate', () => {
+  assert.ok(A_REAL_ROW_ID, 'the register parsed to zero rows -- fixture is broken');
+  assert.equal(
+    passesSidecarAcceptanceGate(
+      SIDECAR_FILES,
+      `Sidecar acceptance: see docs/testing/onbox-acceptance-register.md row ${A_REAL_ROW_ID}`,
+    ),
+    true,
+  );
+});
+
+// An unreadable register must fail CLOSED -- "cannot read the register" must
+// never read as "any id is fine".
+test('loadRegisterRowIds returns an empty set (fail closed) when the register is unreadable', () => {
+  const missing = new URL('file:///nonexistent-register-that-should-not-exist.md');
+  assert.equal(loadRegisterRowIds(missing).size, 0);
+});
+
+// The gate's own help text must not be a passing body. It used to be: it
+// carried a real ISO date, `passed`, and `row A101` -- an id that has never
+// existed -- so "check goes red -> copy the example -> check goes green" was
+// the honest path.
+test('helpMessage() fed whole as a PR body does NOT satisfy the gate', () => {
+  const help = helpMessage();
+  // Guard the guard: if the examples ever stop being present at all, this
+  // test would pass vacuously.
+  assert.ok(
+    help.includes('Sidecar acceptance: `npm run test:sidecar`'),
+    'helpMessage no longer shows the recorded-run example -- fixture is stale',
+  );
+  assert.ok(
+    help.includes('Sidecar acceptance: see docs/testing/onbox-acceptance-register.md row'),
+    'helpMessage no longer shows the register-link example -- fixture is stale',
+  );
+  assert.equal(passesSidecarAcceptanceGate(SIDECAR_FILES, help), false);
+});
+
+// --- N2: the other three CommonMark spellings of "inside a code block" ------
+// The first round stripped backtick fences only. A tilde fence, a 4-space
+// indent, a tab indent, and an inline span opened by a trailing backtick on
+// the previous line all still satisfied the gate while rendering as code.
+
+const RUN_LINE = 'Sidecar acceptance: `npm run test:sidecar` -- 2026-09-06 -- passed';
+const LINK_LINE = `Sidecar acceptance: see docs/testing/onbox-acceptance-register.md row ${FIXTURE_ROW_ID_ALT}`;
+const TILDE_FENCE = '~'.repeat(3);
+
+const codeBlockSpellings = {
+  'four-space-indented code block': ['Nothing was run.', '', `    ${RUN_LINE}`].join('\n'),
+  'tab-indented code block': ['Nothing was run.', '', `\t${RUN_LINE}`].join('\n'),
+  'tilde-fenced code block': [TILDE_FENCE, RUN_LINE, TILDE_FENCE].join('\n'),
+  'inline span opened on the previous line': [
+    'Draft, do not read as a record: `',
+    RUN_LINE,
+    '`',
+  ].join('\n'),
+};
+
+for (const [label, body] of Object.entries(codeBlockSpellings)) {
+  test(`a recorded run inside a ${label} does NOT satisfy the gate`, () => {
+    assert.equal(hasPassingRecordedRun(body), false);
+    assert.equal(passesSidecarAcceptanceGate(SIDECAR_FILES, body), false);
+  });
+}
+
+// The register-link half shares the anchors and the stripping, so it must
+// behave identically -- checked rather than assumed.
+const linkCodeBlockSpellings = {
+  'four-space-indented code block': ['Nothing was run.', '', `    ${LINK_LINE}`].join('\n'),
+  'tab-indented code block': ['Nothing was run.', '', `\t${LINK_LINE}`].join('\n'),
+  'tilde-fenced code block': [TILDE_FENCE, LINK_LINE, TILDE_FENCE].join('\n'),
+  'inline span opened on the previous line': [
+    'Draft, do not read as a record: `',
+    LINK_LINE,
+    '`',
+  ].join('\n'),
+};
+
+for (const [label, body] of Object.entries(linkCodeBlockSpellings)) {
+  test(`a register link inside a ${label} does NOT satisfy the gate`, () => {
+    assert.equal(hasRegisterLink(body, FIXTURE_ROWS), false);
+    assert.equal(passesSidecarAcceptanceGate(SIDECAR_FILES, body, FIXTURE_ROWS), false);
+  });
+}
+
+// The stripping must not be so broad that it eats honest bodies. Each of
+// these carries code ELSEWHERE and a plainly-written acceptance line, and
+// must still pass -- otherwise the fix above is just a rejection of
+// everything.
+const honestBodiesWithCodeElsewhere = {
+  'after a tilde-fenced sample': [TILDE_FENCE, 'a sample', TILDE_FENCE, '', RUN_LINE].join('\n'),
+  'after a paragraph carrying an inline span': ['See `npm test` first.', '', RUN_LINE].join('\n'),
+  'after an indented code block': ['Sample:', '', '    some code', '', RUN_LINE].join('\n'),
+  'indented up to three spaces (still a paragraph, not code)': `   ${RUN_LINE}`,
+};
+
+for (const [label, body] of Object.entries(honestBodiesWithCodeElsewhere)) {
+  test(`a plainly-written acceptance line still passes: ${label}`, () => {
+    assert.equal(hasPassingRecordedRun(body), true);
+    assert.equal(passesSidecarAcceptanceGate(SIDECAR_FILES, body), true);
+  });
+}
+
+// A tilde line inside a backtick fence is content, not a close -- otherwise
+// the fence state machine reopens and lines after it stop being stripped.
+test('a tilde line inside a backtick fence does not close it', () => {
+  const body = [FENCE, TILDE_FENCE, RUN_LINE, FENCE].join('\n');
+  assert.equal(hasPassingRecordedRun(body), false);
+});
+
+// --- P1: the placements GitHub renders as plain text ------------------------
+// #3053 review pass 3. The `^ {0,3}` anchor treated "indented" as "code" and
+// so rejected three shapes GitHub's own POST /markdown (mode: gfm) renders as
+// <li>/<p> -- most importantly the `- [ ]` checklist item that
+// .github/pull_request_template.md puts the guidance directly above. A
+// required check that rejects the placement its own template invites is worse
+// than the hole it closed.
+
+const plainlyWrittenPlacements = {
+  'a task-list checkbox (the PR template shape)': `- [ ] ${RUN_LINE}`,
+  'a bullet-list item': `- ${RUN_LINE}`,
+  'an ordered-list item': `1. ${RUN_LINE}`,
+  'a list-item continuation paragraph (4 spaces, inside the item)': [
+    '- Ran the suite on the box.',
+    '',
+    `    ${RUN_LINE}`,
+  ].join('\n'),
+  'a paragraph continuation line (4 spaces, no blank line above)': [
+    'Everything ran clean.',
+    `    ${RUN_LINE}`,
+  ].join('\n'),
+  'a blockquote': `> ${RUN_LINE}`,
+  'a bold label': '**Sidecar acceptance:** `npm run test:sidecar` -- 2026-09-06 -- passed',
+};
+
+for (const [label, body] of Object.entries(plainlyWrittenPlacements)) {
+  test(`a recorded run written plainly in ${label} satisfies the gate`, () => {
+    assert.equal(hasPassingRecordedRun(body), true);
+    assert.equal(passesSidecarAcceptanceGate(SIDECAR_FILES, body), true);
+  });
+}
+
+// The register-link half shares LINE_PREFIX, so it must accept the same
+// placements -- checked rather than assumed, the same way the N2 rejections
+// are checked on both halves.
+const plainlyWrittenLinkPlacements = {
+  'a task-list checkbox (the PR template shape)': `- [ ] ${LINK_LINE}`,
+  'a list-item continuation paragraph (4 spaces, inside the item)': [
+    '- Ran the suite on the box.',
+    '',
+    `    ${LINK_LINE}`,
+  ].join('\n'),
+  'a paragraph continuation line (4 spaces, no blank line above)': [
+    'Everything ran clean.',
+    `    ${LINK_LINE}`,
+  ].join('\n'),
+};
+
+for (const [label, body] of Object.entries(plainlyWrittenLinkPlacements)) {
+  test(`a register link written plainly in ${label} satisfies the gate`, () => {
+    assert.equal(hasRegisterLink(body, FIXTURE_ROWS), true);
+    assert.equal(passesSidecarAcceptanceGate(SIDECAR_FILES, body, FIXTURE_ROWS), true);
+  });
+}
+
+// The other direction, and the reason the P1 fix is a block pass rather than a
+// looser anchor: a GENUINE indented code block -- 4+ spaces after a blank
+// line, at top level, with no list open -- must still be rejected. That is the
+// one of the four indented shapes GitHub renders as <pre><code>, and it is
+// already covered above by `codeBlockSpellings`; this pins the pair that
+// distinguishes it from the list-item case, so a future widening cannot make
+// both pass.
+test('4-space indent: code after a blank line at top level, content inside a list item', () => {
+  const asCode = ['Nothing was run.', '', `    ${RUN_LINE}`].join('\n');
+  const asListContent = ['- Ran it on the box.', '', `    ${RUN_LINE}`].join('\n');
+  assert.equal(hasPassingRecordedRun(asCode), false);
+  assert.equal(hasPassingRecordedRun(asListContent), true);
+});
+
+// --- P2: the register anchor GitHub actually emits is lowercase -------------
+// GitHub lowercases heading anchors, which scripts/check-register-row-citations.mjs
+// already records in as many words -- so `#a1` is the real form and `#A1` is
+// the one that never occurs. The `#` branch used to accept only the latter.
+
+test('a lowercase #anchor link -- the form GitHub emits -- is a citation', () => {
+  const body = `Sidecar acceptance: docs/testing/onbox-acceptance-register.md#${row('C', 2).toLowerCase()}`;
+  // Guard the guard: the id is normalised to the register's own casing, so
+  // the existence check below is testing existence and not a casing accident.
+  assert.deepEqual(parseRegisterLink(body), { rowId: row('C', 2) });
+  assert.equal(hasRegisterLink(body, FIXTURE_ROWS), true);
+});
+
+test('an uppercase #anchor link still parses to the same row', () => {
+  const body = `Sidecar acceptance: docs/testing/onbox-acceptance-register.md#${row('C', 2)}`;
+  assert.deepEqual(parseRegisterLink(body), { rowId: row('C', 2) });
+});
+
+// Relaxing case on the `#` branch must NOT relax it on the `row`/`rows`
+// branch: there the id sits in bare prose, and a case-insensitive match is
+// exactly what let "until Q3." parse as a citation (N1). Pinned here as a
+// pair, next to the relaxation, so the two can never be widened together by
+// accident.
+test('the row/rows branch stays case-SENSITIVE after the #anchor relaxation', () => {
+  assert.equal(
+    parseRegisterLink(`Sidecar acceptance: docs/testing/onbox-acceptance-register.md row ${row('c', 2)}`),
+    null,
+  );
+  assert.equal(
+    parseRegisterLink('Sidecar acceptance: NOT RUN. docs/testing/onbox-acceptance-register.md has no row yet; blocked until Q3.'),
+    null,
+  );
+});
+
+test('CLI: a lowercase #anchor into a REAL register row passes', () => {
+  const result = runCli(
+    'server/tts-sidecar/main.py\n',
+    `Sidecar acceptance: recorded at docs/testing/onbox-acceptance-register.md#${A_REAL_ROW_ID.toLowerCase()}`,
+  );
+  assert.equal(result.status, 0, `expected exit 0, got ${result.status}\nstderr: ${result.stderr}`);
+});
+
+// --- P3: an even-length unmatched backtick run ------------------------------
+// The span tracker counted backtick CHARACTERS, so a run of two -- the
+// standard CommonMark idiom for a span containing a backtick -- left parity
+// even and the tracker reported "no span open" while GitHub rendered every
+// following line inside <code>. Verified against GitHub's POST /markdown: the
+// acceptance line below renders inside <code>, and the gate returned true.
+
+const DOUBLED = '`'.repeat(2);
+
+const doubledSpanBodies = {
+  'a recorded run': ['Nothing was run.' + ` ${DOUBLED}`, RUN_LINE, DOUBLED].join('\n'),
+  'a register link': ['Nothing was run.' + ` ${DOUBLED}`, LINK_LINE, DOUBLED].join('\n'),
+};
+
+test('an acceptance line inside a doubled-backtick span does NOT satisfy the gate', () => {
+  assert.equal(hasPassingRecordedRun(doubledSpanBodies['a recorded run']), false);
+  assert.equal(
+    passesSidecarAcceptanceGate(SIDECAR_FILES, doubledSpanBodies['a recorded run']),
+    false,
+  );
+  assert.equal(hasRegisterLink(doubledSpanBodies['a register link'], FIXTURE_ROWS), false);
+  assert.equal(
+    passesSidecarAcceptanceGate(SIDECAR_FILES, doubledSpanBodies['a register link'], FIXTURE_ROWS),
+    false,
+  );
+});
+
+// A run of three that is NOT alone on its line is an inline span, not a
+// fence, and a run of two cannot close it -- the length rule, not just
+// "some run closes some run".
+test('an unmatched run of three opens a span a run of two does not close', () => {
+  const body = ['Draft: ' + '`'.repeat(3), DOUBLED + ' still inside', RUN_LINE].join('\n');
+  assert.equal(hasPassingRecordedRun(body), false);
+});
+
+// ... and the honest body, whose command is wrapped in a run of one on each
+// side, still opens and closes on its own line.
+test('the documented plain form is unaffected by run-length tracking', () => {
+  assert.equal(hasPassingRecordedRun(['Ran it.', '', RUN_LINE, '', 'Done.'].join('\n')), true);
+});
+
+// --- P5: "cannot read the register" is not "your row does not exist" --------
+// The CLI printed `Cited register row <ID> does not exist` when the register
+// could not be read at all -- a false, specific statement about a row that
+// does exist, sending the author to change a correct line.
+
+test('failureDetail distinguishes an unreadable register from an absent row', () => {
+  const link = { rowId: FIXTURE_ROW_ID };
+  const unreadable = failureDetail(link, { rowIds: new Set(), readable: false });
+  assert.match(unreadable, /Could not read or parse/);
+  assert.doesNotMatch(unreadable, /does not exist/);
+
+  const absent = failureDetail(link, { rowIds: new Set([row('B', 7)]), readable: true });
+  assert.match(absent, new RegExp(`Cited register row ${FIXTURE_ROW_ID} does not exist`));
+
+  // A readable register plus a row that IS there, and a body with no citation
+  // at all, both leave the generic help text to speak for itself.
+  assert.equal(failureDetail(link, { rowIds: new Set([FIXTURE_ROW_ID]), readable: true }), null);
+  assert.equal(failureDetail(null, { rowIds: new Set(), readable: true }), null);
+});
+
+test('readRegisterRowIds reports readability, and loadRegisterRowIds still fails closed', () => {
+  const missing = new URL('file:///nonexistent-register-that-should-not-exist.md');
+  assert.deepEqual(readRegisterRowIds(missing), { rowIds: new Set(), readable: false });
+  assert.equal(readRegisterRowIds().readable, true);
+  assert.ok(readRegisterRowIds().rowIds.size > 0, 'the real register parsed to zero rows');
+  assert.equal(loadRegisterRowIds(missing).size, 0);
+});
+
+// The P1 widening accepts a `- [ ] ` checklist item, which is what the PR
+// template puts the acceptance guidance directly above -- so the template
+// itself, pasted whole, is now the nearest miss. It carries the guidance as
+// prose and an HTML comment, not as a filled-in record, and must still be
+// rejected: a widening that let the template pass would be the same defect
+// as helpMessage() being a passing body (N1), one file over.
+test('the real pull_request_template.md, fed whole as a PR body, does NOT satisfy the gate', () => {
+  const template = readFileSync(
+    resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '.github', 'pull_request_template.md'),
+    'utf8',
+  );
+  // Guard the guard: if the template stops mentioning this gate at all, the
+  // assertion below would pass vacuously.
+  assert.ok(
+    template.includes('Sidecar acceptance'),
+    'pull_request_template.md no longer mentions the sidecar acceptance line -- fixture is stale',
+  );
+  assert.equal(passesSidecarAcceptanceGate(SIDECAR_FILES, template), false);
+});

--- a/scripts/tests/workflow-wiring.test.mjs
+++ b/scripts/tests/workflow-wiring.test.mjs
@@ -236,18 +236,207 @@ const scopeKeysOf = (condition) =>
     .sort()
     .join('|');
 
-test('setup steps depend on the same scope keys as the leg they support', () => {
-  // Legs are tagged explicitly rather than found by "first step whose if:
-  // mentions this key". That heuristic is wrong twice over: setup steps
-  // PRECEDE their leg in every job, so first-match returns another setup
-  // step; and slugs nest (step_test is a substring of step_test_hooks /
-  // step_test_e2e; step_test_server of step_test_server_slow), so a
-  // substring match binds the wrong leg entirely.
-  const legs = new Map(
-    [...source.matchAll(/# leg: ([a-z:0-9-]+)\n\s*- name: [^\n]+\n\s*if: ([^\n]+)\n/g)].map(
+// Legs are tagged explicitly rather than found by "first step whose if:
+// mentions this key". That heuristic is wrong twice over: setup steps
+// PRECEDE their leg in every job, so first-match returns another setup
+// step; and slugs nest (step_test is a substring of step_test_hooks /
+// step_test_e2e; step_test_server of step_test_server_slow), so a
+// substring match binds the wrong leg entirely.
+//
+// The marker grammar is deliberately narrow -- lowercase letters, digits,
+// `:` and `-`. A marker outside it (e.g. the ` (Windows)` suffix the first
+// draft of the windows-tests job used) parses as NOTHING, silently, which
+// is how both Windows leg steps came to sit outside every guard in this
+// file while a `legs.size >= N` floor still passed on the Ubuntu markers
+// alone (#3053 review). A leg that must exist therefore belongs in
+// REQUIRED_LEGS below, not behind a count.
+const parseLegs = (src) =>
+  new Map(
+    [...src.matchAll(/# leg: ([a-z:0-9-]+)\n\s*- name: [^\n]+\n\s*if: ([^\n]+)\n/g)].map(
       ([, leg, condition]) => [leg, condition.trim()],
     ),
   );
+
+// Leg identifier -> the scope keys its `if:` must depend on, order-independent
+// (scopeKeysOf's `|`-joined sorted form). Named, not counted: a count cannot
+// see a leg whose marker stopped parsing, and cannot see a leg whose gate was
+// widened or narrowed either.
+//
+// The two Windows legs are their OWN entries rather than aliases of the
+// Ubuntu ones, because the jobs genuinely differ: Ubuntu's `test:server` runs
+// the fast AND slow suites (hence step_test_server_slow), while the Windows
+// job runs `npm run test:server`, which excludes the slow files -- so a PR
+// touching only a slow test file must not start a Windows leg that cannot
+// execute it. Ubuntu's `test` additionally carries step_test_e2e; Windows
+// runs no e2e.
+const REQUIRED_LEGS = {
+  test: 'shared|step_test|step_test_e2e',
+  'test:server': 'shared|step_test_server|step_test_server_slow',
+  'test:windows': 'shared|step_test',
+  'test:server:windows': 'shared|step_test_server',
+};
+
+test('every required leg is present and gated on exactly its own scope keys', () => {
+  const legs = parseLegs(source);
+  const problems = [];
+  for (const [leg, expectedKeys] of Object.entries(REQUIRED_LEGS)) {
+    const condition = legs.get(leg);
+    if (condition === undefined) {
+      problems.push(
+        `'# leg: ${leg}' is absent or unparseable (markers found: ${[...legs.keys()].join(', ')})`,
+      );
+      continue;
+    }
+    const actual = scopeKeysOf(condition);
+    if (actual !== expectedKeys) {
+      problems.push(
+        `# leg: ${leg}\n  has keys:      ${actual || '(none)'}\n  expected keys: ${expectedKeys}`,
+      );
+    }
+  }
+  assert.deepEqual(
+    problems,
+    [],
+    `required leg marker(s) missing or re-gated:\n${problems.join('\n')}`,
+  );
+});
+
+// The structural half of the same finding (#3053 review pass 2, N3).
+// REQUIRED_LEGS above names four legs; a NAMED list cannot see a fifth one
+// arriving unmarked, and neither can the `legs.size >= 11` floor below --
+// measured headroom at the time was 19 markers against a floor of 11, i.e.
+// 8 legs could go unparseable with every assertion in this file still
+// green. That is exactly how this PR's own first draft shipped two Windows
+// steps outside every guard here.
+//
+// So assert the INVARIANT rather than a list: every step whose `if:`
+// references the derived scopes is immediately preceded by its `- name:`
+// line and, above that, a marker inside the parseable grammar. 29 such
+// steps today, 0 exceptions. A new leg with no marker, or with a marker
+// outside the grammar (the ` (Windows)` suffix, an uppercase letter, a
+// trailing comment), fails HERE, whether or not anyone remembers to add it
+// to REQUIRED_LEGS.
+const MARKER_LINE = /^\s*# (?:leg|supports): [a-z:0-9-]+\s*$/;
+
+// An `if:` is YAML, not a line, and two valid Actions spellings put a derived
+// condition where a line regex cannot see it -- both mutation-verified as
+// ACCEPTED by the regex this replaces, i.e. a new leg written either way
+// carried no marker and nothing in this file noticed (#3053 review pass 3,
+// P4): a folded block scalar (`if: >-`, with the condition on the lines
+// below, which is what an author reaches for once a condition passes ~110
+// characters -- every existing one already does), and
+// `fromJSON( needs.detect.outputs.scopes )` with spaces inside the call.
+//
+// So key on the condition's MEANING rather than its formatting: fold a block
+// scalar back onto one line, then remove all whitespace. Widening the regex
+// instead would only move the next spelling one step away. The `if:` key's
+// own line index is carried through, because the marker check reads the two
+// lines above it.
+const ifConditions = (src) => {
+  const yamlLines = src.split('\n');
+  const out = [];
+  yamlLines.forEach((line, i) => {
+    const m = /^(\s*)if:[ \t]*(.*?)\s*$/.exec(line);
+    if (!m) return;
+    const [, indent, inline] = m;
+    let text = inline;
+    // A block scalar header (|, >, with an optional chomping/indent
+    // indicator) carries no condition of its own -- gather the more-indented
+    // lines that follow it.
+    if (inline === '' || /^[|>][-+]?\d*$/.test(inline)) {
+      text = '';
+      for (let j = i + 1; j < yamlLines.length; j += 1) {
+        if (yamlLines[j].trim() === '') continue;
+        if (/^\s*/.exec(yamlLines[j])[0].length <= indent.length) break;
+        text += ` ${yamlLines[j].trim()}`;
+      }
+    }
+    out.push({ line: i, text: text.replace(/\s+/g, '') });
+  });
+  return out;
+};
+
+// A named function rather than an inlined loop so the synthetic fixture
+// below can run the SAME scan the real workflow gets -- a guard whose blind
+// spots are only ever exercised against a file that happens not to contain
+// them is not a guard.
+const scanDerivedSteps = (src, path) => {
+  const yamlLines = src.split('\n');
+  const derived = [];
+  const unmarked = [];
+  for (const { line: i, text } of ifConditions(src)) {
+    if (!text.includes('fromJSON(needs.detect.outputs.scopes)')) continue;
+    derived.push(i);
+    const nameLine = yamlLines[i - 1] ?? '';
+    const markerLine = yamlLines[i - 2] ?? '';
+    if (!/^\s*- name: /.test(nameLine) || !MARKER_LINE.test(markerLine)) {
+      unmarked.push(
+        `${path}:${i + 1}\n  step:   ${nameLine.trim() || '(no `- name:` directly above the if:)'}\n  marker: ${markerLine.trim() || '(none)'}`,
+      );
+    }
+  }
+  return { derived, unmarked };
+};
+
+test('every derived step carries a parseable # leg:/# supports: marker', () => {
+  const { derived, unmarked } = scanDerivedSteps(source, workflowPath);
+
+  // Anti-vacuity: a scan that finds no derived steps at all would report
+  // "every one is marked" while proving nothing.
+  assert.ok(
+    derived.length >= 25,
+    `expected >= 25 derived step conditions, found ${derived.length} — the scan broke or the workflow lost its legs`,
+  );
+  assert.deepEqual(
+    unmarked,
+    [],
+    `derived step(s) with no parseable '# leg:'/'# supports:' marker — they sit outside every guard in this file:\n${unmarked.join('\n')}`,
+  );
+});
+
+// The scan above runs against a file that (correctly) contains none of the
+// spellings it used to miss, so it cannot prove it would catch them. This
+// feeds it a synthetic job carrying one properly-marked leg and two UNMARKED
+// ones written the two ways a line regex could not see: spaces inside the
+// fromJSON call, and a folded block scalar. Both are valid Actions YAML;
+// before the normalisation above, both were accepted silently (#3053 review
+// pass 3, P4).
+const SYNTHETIC_JOB = [
+  'jobs:',
+  '  windows-tests:',
+  '    steps:',
+  '      # leg: test:windows',
+  '      - name: Marked leg',
+  '        if: ${{ fromJSON(needs.detect.outputs.scopes).step_test || fromJSON(needs.detect.outputs.scopes).shared }}',
+  '        run: npm run test',
+  '      - name: Spaces inside fromJSON, no marker',
+  '        if: ${{ fromJSON( needs.detect.outputs.scopes ).step_test_e2e }}',
+  '        run: npm run test:e2e',
+  '      - name: Folded block scalar, no marker',
+  '        if: >-',
+  '          fromJSON(needs.detect.outputs.scopes).step_test_e2e ||',
+  '          fromJSON(needs.detect.outputs.scopes).shared',
+  '        run: npm run test:e2e',
+].join('\n');
+
+test('the derived-step scan reads an `if:` by meaning, not by formatting', () => {
+  const { derived, unmarked } = scanDerivedSteps(SYNTHETIC_JOB, 'synthetic.yml');
+  assert.equal(
+    derived.length,
+    3,
+    `expected all three derived conditions to be seen, saw ${derived.length}`,
+  );
+  const flagged = unmarked.join("\n");
+  assert.match(flagged, /Spaces inside fromJSON, no marker/);
+  assert.match(flagged, /Folded block scalar, no marker/);
+  // ... and the properly-marked leg is not flagged, so the scan is
+  // discriminating rather than merely noisy.
+  assert.doesNotMatch(flagged, /Marked leg/);
+  assert.equal(unmarked.length, 2, flagged);
+});
+
+test('setup steps depend on the same scope keys as the leg they support', () => {
+  const legs = parseLegs(source);
   const setups = [
     ...source.matchAll(/# supports: ([a-z:0-9-]+)\n\s*- name: ([^\n]+)\n\s*if: ([^\n]+)\n/g),
   ];
@@ -256,7 +445,9 @@ test('setup steps depend on the same scope keys as the leg they support', () => 
   // Playwright, plus Setup Python + Bootstrap sidecar venv for test:sidecar);
   // 13 legs (the full checklist of named leg steps, including "openapi:types"
   // and "test:sidecar" which have no LEGACY_GATES entry below but still carry
-  // markers for documentation/binding purposes).
+  // markers for documentation/binding purposes). These floors catch wholesale
+  // deletion only -- REQUIRED_LEGS above is what catches a single leg going
+  // missing or unparseable.
   assert.ok(setups.length >= 9, `expected >= 9 '# supports:' declarations, found ${setups.length}`);
   assert.ok(legs.size >= 11, `expected >= 11 '# leg:' declarations, found ${legs.size}`);
 

--- a/scripts/validate-sidecar-acceptance.mjs
+++ b/scripts/validate-sidecar-acceptance.mjs
@@ -1,0 +1,477 @@
+// Sidecar-acceptance-gate validator for the sidecar-acceptance-gate CI check
+// (.github/workflows/sidecar-acceptance-gate.yml). ops-74 / #3050 — commit-gate
+// rebalance design Part 6. See docs/superpowers/specs/2026-09-05-commit-gate-
+// rebalance-design.md ("Part 6 — Scope-triggered local acceptance for the
+// sidecar") and CONTRIBUTING.md "Sidecar acceptance fast-path" for the format
+// this validates and why it exists (the 38 `pytest.importorskip("torch")`
+// tests, 14 files, that run ONLY via a local `npm run test:sidecar` on real
+// hardware, never in CI).
+//
+// Trigger path is `server/tts-sidecar/**` ONLY — deliberately narrower than
+// an earlier draft that also listed server/src/tts/**, server/src/analyzer/**,
+// server/src/gpu/** (177 TypeScript test files Ubuntu CI already covers). Do
+// not widen this; see the design doc's Part 6 for why that draft was rejected.
+
+import { readFileSync } from 'node:fs';
+import { isDirectlyInvoked } from './lib/is-main-module.mjs';
+import { parseRegisterRows } from './check-register-citations.mjs';
+
+const SIDECAR_PREFIX = 'server/tts-sidecar/';
+
+// The register the link form of this gate points at. Parsed with
+// check-register-citations.mjs's own parseRegisterRows -- IMPORTED, not
+// reimplemented, so this gate and that checker can never disagree about what
+// counts as a row.
+const REGISTER_URL = new URL('../docs/testing/onbox-acceptance-register.md', import.meta.url);
+
+// The set of row IDs that actually exist in the register. Fails CLOSED: an
+// unreadable or unparseable register yields an empty set, so the link form
+// satisfies nothing and the author is sent to the help text. The opposite
+// (treating "cannot read the register" as "any id is fine") would put a
+// required check green on a body citing a row that does not exist, which is
+// the defect this exists to close (#3053 review pass 2, N1).
+//
+// `readable` is carried alongside the ids because failing closed and
+// DIAGNOSING closed are different jobs: with the ids alone, an unreadable
+// register is indistinguishable from a made-up row, and the CLI told the
+// author "Cited register row A1 does not exist" for a row that does exist,
+// sending them to change a correct line (#3053 review pass 3, P5). The catch
+// covers both a read failure and a parseRegisterRows throw -- from the
+// author's side those are the same fact ("this gate could not confirm your
+// row"), and neither is a defect in the PR body.
+export function readRegisterRowIds(registerUrl = REGISTER_URL) {
+  try {
+    const rows = parseRegisterRows(readFileSync(registerUrl, 'utf8')).rows;
+    return { rowIds: new Set(rows.keys()), readable: true };
+  } catch {
+    return { rowIds: new Set(), readable: false };
+  }
+}
+
+export function loadRegisterRowIds(registerUrl = REGISTER_URL) {
+  return readRegisterRowIds(registerUrl).rowIds;
+}
+
+// `git diff --name-only` (the producer -- see sidecar-acceptance-gate.yml)
+// emits a path containing any non-ASCII or control character QUOTED and
+// C-escaped under git's default `core.quotepath=true`, e.g.
+//   "server/tts-sidecar/tests/test_caf\303\251.py"
+// -- a leading double-quote, so a raw startsWith(SIDECAR_PREFIX) does not
+// match and the gate silently does not fire. Unquote before prefix-matching.
+// The \NNN escapes are UTF-8 BYTES, so decoding them per-char yields
+// mojibake for the non-ASCII tail; that is fine and deliberate here, because
+// only the ASCII directory prefix has to survive for the match to be right.
+export function unquoteGitPath(path) {
+  if (typeof path !== 'string') return path;
+  if (path.length < 2 || !path.startsWith('"') || !path.endsWith('"')) return path;
+  const inner = path.slice(1, -1);
+  const simple = { n: '\n', t: '\t', r: '\r', a: '\x07', b: '\b', f: '\f', v: '\v' };
+  let out = '';
+  for (let i = 0; i < inner.length; i += 1) {
+    if (inner[i] !== '\\') {
+      out += inner[i];
+      continue;
+    }
+    const octal = inner.slice(i + 1, i + 4);
+    if (/^[0-7]{3}$/.test(octal)) {
+      out += String.fromCharCode(parseInt(octal, 8));
+      i += 3;
+      continue;
+    }
+    const next = inner[i + 1];
+    out += Object.prototype.hasOwnProperty.call(simple, next) ? simple[next] : next;
+    i += 1;
+  }
+  return out;
+}
+
+export function touchesSidecar(files) {
+  if (!Array.isArray(files)) return false;
+  return files.some((f) => typeof f === 'string' && unquoteGitPath(f).startsWith(SIDECAR_PREFIX));
+}
+
+// Splits a newline-separated file list (the shape `git diff --name-only`
+// emits) into an array, dropping blank lines -- a diff with zero changed
+// files is an empty string, which .split('\n') would otherwise turn into
+// [''] and reject as "touches nothing" only by accident.
+export function parseFileList(text) {
+  if (typeof text !== 'string') return [];
+  return text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+// Both helpMessage() below and CONTRIBUTING.md "Sidecar acceptance
+// fast-path" tell the author to write the acceptance line PLAINLY, not
+// inside a code block. Enforce that rather than merely asking for it: the
+// documented copy-paste example in CONTRIBUTING.md is itself a fenced block
+// carrying a real date and a real row id, so without stripping, pasting that
+// file (or any commented-out draft) into a PR body passes a gate on a PR
+// where nothing was run. Mirrors scripts/validate-pr-issue-link.mjs:29-70,
+// whose own history records a code-span false positive as a real incident.
+//
+// CommonMark has FOUR ways to render a line as code, and this gate is only
+// as strong as the weakest one it handles (#3053 review pass 2, N2 -- the
+// first round covered backtick fences alone, while a tilde fence, a 4-space
+// indent, a tab indent, and a span opened on the previous line all still
+// satisfied the gate). All four are covered now:
+//   1. a backtick fence        -- stripFencedBlocks
+//   2. a tilde fence           -- stripFencedBlocks (same function, own char)
+//   3. an indented code block  -- stripIndentedCodeBlocks. NOT an indent
+//                                 limit on the line patterns below: indent
+//                                 alone does not make a line code, and an
+//                                 anchor that assumed it did rejected three
+//                                 shapes GitHub renders as plain text
+//                                 (#3053 review pass 3, P1) -- see that
+//                                 function's own comment.
+//   4. a multi-line inline span -- stripLinesInsideOpenInlineSpan
+//
+// The residual boundary, stated honestly because the comment that used to
+// stand here stated it wrongly: a SAME-LINE inline span wrapping the whole
+// line is rejected by the anchors themselves (a leading backtick is not part
+// of the accepted list/blockquote prefix, nor the literal prefix). A span OPENED
+// BY A TRAILING BACKTICK ON AN EARLIER LINE leaves the acceptance line
+// starting with the bare prefix, so the anchor matched while the rendered
+// body showed one code span -- that is the case
+// stripLinesInsideOpenInlineSpan closes. Spans are still not stripped
+// wholesale the way scripts/validate-pr-issue-link.mjs does, because this
+// gate's recorded-run format REQUIRES the command backtick-wrapped, so
+// blanking every span would blank the very token being matched.
+//
+// A fenced code block's delimiter must be alone on its own line (optionally
+// indented up to 3 spaces) per CommonMark; a stray mid-line ``` is not a
+// fence and must not open one. A fence closes only on a run of the SAME
+// character at least as long as the opener, so a tilde line inside a
+// backtick-fenced block is content, not a close.
+function stripFencedBlocks(text) {
+  const lines = text.split('\n');
+  const kept = [];
+  let fenceChar = null;
+  let fenceLength = 0;
+  for (const line of lines) {
+    const fence = /^ {0,3}(\u0060{3,}|~{3,})/.exec(line);
+    if (fence && fenceChar === null) {
+      fenceChar = fence[1][0];
+      fenceLength = fence[1].length;
+      kept.push('');
+      continue;
+    }
+    if (fence && fence[1][0] === fenceChar && fence[1].length >= fenceLength) {
+      fenceChar = null;
+      fenceLength = 0;
+      kept.push('');
+      continue;
+    }
+    kept.push(fenceChar === null ? line : '');
+  }
+  return kept.join('\n');
+}
+
+// An HTML comment is invisible in the rendered PR body, so a line inside one
+// is not a record of anything. Blanked (rather than deleted) so surrounding
+// lines keep their own line boundaries and cannot coalesce into one line
+// that then matches.
+function stripHtmlComments(text) {
+  return text.replace(/<!--[\s\S]*?-->/g, (m) => m.replace(/[^\n]/g, ' '));
+}
+
+// Tabs are code-block indentation too, and a tab stop here is four columns.
+function expandTabs(text) {
+  return text.replace(/\t/g, '    ');
+}
+
+function indentWidthOf(line) {
+  return expandTabs(/^[ \t]*/.exec(line)[0]).length;
+}
+
+// CommonMark's third code spelling, and the one where "the line is indented
+// four spaces" is NOT sufficient on its own: an indented code block may not
+// interrupt a paragraph, and inside a list item four spaces is the item's
+// own content indentation. Code-ness is therefore a BLOCK property, decided
+// here once, rather than an indent limit on the line patterns below.
+//
+// The earlier `^ {0,3}` anchor assumed indent alone settled it and so
+// rejected three shapes GitHub renders as plain text -- including a `- [ ]`
+// checklist item, which is exactly where .github/pull_request_template.md
+// invites the author to write this line (#3053 review pass 3, P1). Rendered
+// through GitHub's own POST /markdown (mode: gfm), of the four indented
+// shapes an author actually writes only the last is code:
+//
+//   - [ ] Sidecar acceptance: ...            -> <li>            (plain text)
+//   - Ran it.  <blank>  ....Sidecar: ...     -> <p> in the <li> (plain text)
+//   Ran it.  <newline>  ....Sidecar: ...     -> one <p>         (plain text)
+//   Ran it.  <blank>    ....Sidecar: ...     -> <pre><code>     (code)
+//
+// So a line is code here only when it is indented at least four columns PAST
+// the enclosing list item's content indent (zero at top level) AND it opens
+// a block -- i.e. the previous line was blank, or was itself code in the
+// same block. Runs after fence stripping, so a fenced block's own lines are
+// already blank by the time this sees them.
+function stripIndentedCodeBlocks(text) {
+  const lines = text.split('\n');
+  const kept = [];
+  let prevBlank = true; // start of document opens a block, same as a blank line
+  let inCode = false;
+  let listContentIndent = null;
+  for (const line of lines) {
+    if (line.trim() === '') {
+      // A blank line closes neither a code block nor a list item.
+      kept.push(line);
+      prevBlank = true;
+      continue;
+    }
+    const indent = indentWidthOf(line);
+    if ((inCode || prevBlank) && indent >= (listContentIndent ?? 0) + 4) {
+      inCode = true;
+      prevBlank = false;
+      kept.push('');
+      continue;
+    }
+    inCode = false;
+    prevBlank = false;
+    const marker = /^[ \t]*(?:[-*+]|\d{1,9}[.)])(?:[ \t]+|$)/.exec(line);
+    if (marker) listContentIndent = expandTabs(marker[0]).length;
+    else if (listContentIndent !== null && indent < listContentIndent) listContentIndent = null;
+    kept.push(line);
+  }
+  return kept.join('\n');
+}
+
+// A backtick run left unclosed on an earlier line of the SAME paragraph puts
+// every following line of that paragraph inside one rendered code span. An
+// inline span cannot cross a blank line (a paragraph boundary), so state is
+// tracked per paragraph and reset at every blank line.
+//
+// Tracked as CommonMark specifies it -- a run of N backticks opens a span
+// that only a later run of exactly N closes -- and not as character parity,
+// which was wrong for every even-length unmatched run: a trailing run of
+// TWO (the standard idiom for a span containing a backtick) left parity
+// even, so the counter reported "no span open" while GitHub rendered the following
+// lines inside <code> (#3053 review pass 3, P3). An honest body -- whose
+// acceptance line carries a run of one on each side of the command -- opens
+// and closes on its own line and is unaffected. Runs AFTER fence and comment
+// stripping, so backticks inside either of those cannot skew the state.
+//
+// Deliberately conservative in one direction: a run that never closes before
+// the paragraph ends renders as literal text on GitHub, but is treated here
+// as opening a span, so the lines after it are dropped. That over-rejects an
+// exotic body and never under-rejects, which is the right way round for a
+// required check.
+function stripLinesInsideOpenInlineSpan(text) {
+  const backtickRun = new RegExp(String.fromCharCode(0x60) + '+', 'g');
+  const lines = text.split('\n');
+  const kept = [];
+  let openRun = 0;
+  for (const line of lines) {
+    if (line.trim() === '') {
+      openRun = 0;
+      kept.push(line);
+      continue;
+    }
+    kept.push(openRun > 0 ? '' : line);
+    for (const run of line.matchAll(backtickRun)) {
+      if (openRun === 0) openRun = run[0].length;
+      else if (run[0].length === openRun) openRun = 0;
+    }
+  }
+  return kept.join('\n');
+}
+
+function stripNonPlainText(text) {
+  return stripLinesInsideOpenInlineSpan(
+    stripIndentedCodeBlocks(stripFencedBlocks(stripHtmlComments(text))),
+  );
+}
+
+// Checkable format (command, date, outcome) -- NOT free prose. Matches a
+// line of the shape:
+//   Sidecar acceptance: `npm run test:sidecar` -- 2026-09-06 -- passed
+// The command must be the literal `npm run test:sidecar` (optionally with
+// trailing flags, e.g. `-- --require-venv`), backtick-wrapped; the date is
+// ISO (YYYY-MM-DD); the outcome is a fixed vocabulary, matched but not
+// itself sufficient -- only "passed" satisfies the gate (see
+// hasPassingRecordedRun below). Separator is `--`, an em dash, or an en
+// dash, to tolerate a PR author's editor auto-converting `--`; a single
+// ASCII hyphen is NOT accepted (CONTRIBUTING.md documents `--` only).
+//
+// The three backticks are escaped as \u0060 rather than written literally:
+// an unpaired backtick inside a REGEX LITERAL desyncs the source scanner in
+// server/src/spawn-windows-hide.test.ts, which scans scripts/**, and that
+// guard throws rather than silently blanking the rest of this file (#2747).
+// The escape is required INSIDE A REGEX LITERAL only -- elsewhere in this
+// file (comments, strings) a literal backtick is fine and preferred.
+//
+// What may precede the prefix on its line, shared by both patterns below.
+// Code-ness is settled by stripIndentedCodeBlocks, so this carries no indent
+// limit of its own; what it does carry is the ordinary markdown furniture an
+// author puts in front of a sentence -- each of which GitHub renders as
+// plain text, and each of which the previous `^ {0,3}` anchor rejected
+// (#3053 review pass 3, P1): any indentation, blockquote markers, a bullet
+// or ordered-list marker, a task-list checkbox (the shape
+// .github/pull_request_template.md itself invites), and a bold label.
+// Mirrors the tolerance of the sibling this file follows,
+// scripts/validate-pr-issue-link.mjs, which carries no line anchor at all.
+const LINE_PREFIX =
+  '^[ \\t]*(?:>[ \\t]*)*(?:[-*+]|\\d{1,9}[.)])?[ \\t]*(?:\\[[ xX]\\][ \\t]*)?(?:\\*\\*|__)?';
+const RECORDED_RUN_PATTERN = new RegExp(
+  LINE_PREFIX + 'sidecar acceptance:(?:\\*\\*|__)?' + '\\s*\\u0060(npm run test:sidecar(?:[^\\u0060\\n]*)?)\\u0060\\s*(?:--|—|–)\\s*(\\d{4}-\\d{2}-\\d{2})\\s*(?:--|—|–)\\s*(passed|failed)\\s*$',
+  'im',
+);
+
+export function parseRecordedRun(body) {
+  if (typeof body !== 'string') return null;
+  const match = stripNonPlainText(body).match(RECORDED_RUN_PATTERN);
+  if (!match) return null;
+  return { command: match[1].trim(), date: match[2], outcome: match[3].toLowerCase() };
+}
+
+export function hasPassingRecordedRun(body) {
+  const parsed = parseRecordedRun(body);
+  return parsed !== null && parsed.outcome === 'passed';
+}
+
+// Alternative to a recorded run: a line naming this acceptance and pointing
+// at a specific onbox-acceptance-register.md row (its ID scheme is a
+// letter-group prefix plus digits -- see that file's "next-id" convention).
+// Requires the register filename, the literal word `row`/`rows`, and the id
+// itself, all on the SAME line as the "Sidecar acceptance:" prefix -- not
+// merely present anywhere in the body, since a bare, unrelated mention of
+// the register elsewhere in a large PR body must not satisfy this gate.
+//
+// Three things this deliberately does NOT do, each of which let a body that
+// says the run was not done pass a REQUIRED check (#3053 review pass 2, N1):
+//   - it does not match an id case-insensitively. The prefix half is matched
+//     case-insensitively on its own line below, so the id half can stay
+//     case-SENSITIVE; under a whole-pattern /i flag, `[A-Z]` also matched
+//     lowercase and "until Q3." parsed as a row citation.
+//   - it does not accept a bare id-shaped token anywhere on the line. The
+//     id must be introduced either by the word `row`/`rows` or as the
+//     register link's own `#` anchor, so ordinary prose ("will file in v2",
+//     "blocked until Q3") is not a citation.
+//   - it does not stop at shape. hasRegisterLink below checks the cited row
+//     EXISTS in the register -- see loadRegisterRowIds.
+const REGISTER_LINK_PREFIX_PATTERN = new RegExp(LINE_PREFIX + 'sidecar acceptance:', 'i');
+const REGISTER_LINK_ROW_PATTERN =
+  /onbox-acceptance-register\.md(?:#([A-Za-z]\d{1,3})\b|\b.*\brows?:?\s+([A-Z]\d{1,3})\b)/;
+
+export function parseRegisterLink(body) {
+  if (typeof body !== 'string') return null;
+  for (const line of stripNonPlainText(body).split('\n')) {
+    if (!REGISTER_LINK_PREFIX_PATTERN.test(line)) continue;
+    const match = REGISTER_LINK_ROW_PATTERN.exec(line);
+    // The `#` anchor half is matched case-INSENSITIVELY and normalised
+    // here, because GitHub lowercases heading anchors -- so #a1, not #A1,
+    // is the form a real link into the register carries (the same fact
+    // scripts/check-register-row-citations.mjs:26-28 already records).
+    // The `row`/`rows` half stays case-SENSITIVE on purpose: there the id
+    // sits in ordinary prose with no delimiter of its own, and a
+    // case-insensitive `[A-Z]` is what let "until Q3." parse as a row
+    // citation (#3053 review pass 2, N1). A literal `#` immediately
+    // before the id is the delimiter that prose lacks, so relaxing case
+    // on that branch alone reopens nothing (#3053 review pass 3, P2).
+    if (match) return { rowId: match[1] ? match[1].toUpperCase() : match[2] };
+  }
+  return null;
+}
+
+// `rowIds` is the set of ids the register actually contains; it defaults to
+// reading the register off disk (the gate workflow does a full checkout, so
+// it is always there in CI). Passed explicitly by the tests so a fixture id
+// need not be a real row.
+export function hasRegisterLink(body, rowIds = loadRegisterRowIds()) {
+  const parsed = parseRegisterLink(body);
+  return parsed !== null && rowIds.has(parsed.rowId);
+}
+
+export function passesSidecarAcceptanceGate(files, body, rowIds = loadRegisterRowIds()) {
+  if (!touchesSidecar(files)) return true;
+  return hasPassingRecordedRun(body) || hasRegisterLink(body, rowIds);
+}
+
+// The examples here are PLACEHOLDERS on purpose. This whole message used to
+// be a passing body: it carried a real ISO date, the outcome `passed`, and
+// `row A101` -- an id that has never existed in the register -- so the
+// honest path was "check goes red -> author copies the example -> check goes
+// green", with nothing run and no row filed (#3053 review pass 2, N1). A
+// help text must not itself satisfy the gate it explains; the paired test
+// `helpMessage() fed whole as a PR body does NOT satisfy the gate` pins that.
+export function helpMessage() {
+  return [
+    `This PR touches server/tts-sidecar/**, which carries 38`,
+    `pytest.importorskip("torch") tests (14 files) that run ONLY via a local`,
+    `"npm run test:sidecar" on real hardware -- never in CI.`,
+    ``,
+    `Record acceptance in the PR body, written plainly (not inside backticks`,
+    `or a code block), as one of -- filling in the <placeholders>:`,
+    ``,
+    '  Sidecar acceptance: `npm run test:sidecar` -- <YYYY-MM-DD> -- passed',
+    `  Sidecar acceptance: see docs/testing/onbox-acceptance-register.md row <ID>`,
+    ``,
+    `<ID> must be a row that EXISTS in that register (e.g. the row this`,
+    `acceptance is tracked on); a made-up id is rejected.`,
+    ``,
+    `See CONTRIBUTING.md "Sidecar acceptance fast-path" for the full format.`,
+  ].join('\n');
+}
+
+// The diagnosis that precedes the generic help text, or null
+// when the generic text says it all. Separated from the CLI so both
+// branches are testable without a subprocess -- the register-unreadable
+// branch is otherwise reachable only from a checkout with no docs/ tree.
+//
+// The two failures it distinguishes are NOT the same fact and used to
+// print the same sentence: an unreadable register made the gate say
+// "Cited register row A1 does not exist" about a row that does exist,
+// sending the author to change a correct line (#3053 review pass 3, P5).
+export function failureDetail(link, { rowIds, readable }) {
+  if (!readable) {
+    return [
+      'Could not read or parse docs/testing/onbox-acceptance-register.md, so no',
+      'cited row could be confirmed. This gate fails closed. Your PR body may',
+      'well be correct -- check the register is present and parseable in this',
+      'checkout before changing the body.',
+    ].join('\n');
+  }
+  if (link && !rowIds.has(link.rowId)) {
+    return `Cited register row ${link.rowId} does not exist in docs/testing/onbox-acceptance-register.md.`;
+  }
+  return null;
+}
+
+// CLI mode: node scripts/validate-sidecar-acceptance.mjs <pr-files-file> <pr-body-file>
+// <pr-files-file> is a newline-separated list of changed files (the shape
+// `git diff --name-only` emits); <pr-body-file> is the raw PR body.
+if (isDirectlyInvoked(import.meta.url)) {
+  const filesPath = process.argv[2];
+  const bodyPath = process.argv[3];
+  if (!filesPath || !bodyPath) {
+    console.error(
+      'Usage: validate-sidecar-acceptance.mjs <pr-files-file> <pr-body-file>',
+    );
+    process.exit(2);
+  }
+  const files = parseFileList(readFileSync(filesPath, 'utf8'));
+  const body = readFileSync(bodyPath, 'utf8');
+  if (!touchesSidecar(files)) {
+    console.log(
+      'This PR does not touch server/tts-sidecar/** -- sidecar acceptance gate does not apply.',
+    );
+    process.exit(0);
+  }
+  const register = readRegisterRowIds();
+  if (!passesSidecarAcceptanceGate(files, body, register.rowIds)) {
+    // A cited-but-nonexistent row, and a register this gate could not read
+    // at all, are the two failures the generic help text does not explain.
+    // Name whichever applies before printing that text.
+    const detail = failureDetail(parseRegisterLink(body), register);
+    if (detail !== null) {
+      console.error(detail);
+      console.error('');
+    }
+    console.error(helpMessage());
+    process.exit(1);
+  }
+  console.log('Sidecar acceptance recorded.');
+  process.exit(0);
+}


### PR DESCRIPTION
## Summary

Parts **5** and **6** of the [commit-gate rebalance design](docs/superpowers/specs/2026-09-05-commit-gate-rebalance-design.md), grouped exactly as its rollout order groups them.

### Part 5 — a Windows leg in PR-time CI (#3049)

A `windows-latest` job running `npm test` and `npm run test:server`, added to the aggregator's `needs:` list so it is not decorative — the `jq -r 'keys[]'` loop already iterates all of `needs`, so no second edit was required and the required-check name is unchanged.

Three wiring traps, all avoided deliberately and commented in place:

- **Scope conditions sit on STEPS, never the job.** The aggregator fails on `'skipped'`, so a job-level `if:` would leave this job permanently skipped on every docs-only PR and block merge forever. No other leg in the file uses one; this one doesn't either.
- **Every step pins `shell: bash`.** The file sets no `defaults: run: shell:`, so a bare `run:` on `windows-latest` would default to pwsh.
- **`cancel-in-progress: true`** makes a slow Windows leg a new source of `cancelled`, which the aggregator also treats as failure — `timeout-minutes: 30` is sized with that in mind.

**The payoff is detection latency, not coverage**, and the PR says so rather than overselling it. `cross-os.yml` already runs full `verify:quick` + audits + build on `windows-latest` twice weekly, and `release.yml` gates every tag on Windows; this moves Windows detection from ≤3.5 days to per-PR. It does **not** close the tmpdir/handle race — that is a concurrency artifact between co-running batteries, and a `windows-latest` runner is single-tenant, so it structurally cannot reproduce there.

### Part 6 — scope-triggered local acceptance for the sidecar (#3050)

`.github/workflows/sidecar-acceptance-gate.yml` mirrors `pr-issue-link.yml`'s shape: a PR touching `server/tts-sidecar/**` fails unless its body either records the local run (a backticked `` `npm run test:sidecar` ``, an ISO date, and an outcome) or links an on-box acceptance register row.

Mechanised rather than left as a checklist item, because it supplements an *automatic* trigger and an unenforced item is strictly weaker than what it supplements.

- **Trigger path is `server/tts-sidecar/**` only.** An earlier design draft also listed `server/src/{tts,analyzer,gpu}/**` — 177 TypeScript test files Ubuntu CI already covers. Verified the matcher does not fire on those, nor on an incidental substring.
- **Only `passed` satisfies the gate.** A recorded `failed` run parses correctly and still fails the check.
- **The register-link alternative requires the filename *and* a row id on the same `Sidecar acceptance:` line**, not a bare mention anywhere in the body.

Format documented where an author actually reads it: a new CONTRIBUTING.md section, sibling to "Doc-only PR fast-path", and the Test-plan comment block in the PR template.

## Test plan

`scripts/tests/validate-sidecar-acceptance.test.mjs` — **35 tests**, unit and CLI level, all green; full `npm run test:hooks` battery (1957 tests) green.

**Mutation-verified** — each mutation reddened a named test, then was restored:

| Mutation | Test that reddened |
|---|---|
| `touchesSidecar` forced false | its positive-match test |
| dropped the `outcome === 'passed'` restriction | the "failed run parses but doesn't satisfy" unit test **and** its CLI counterpart |
| widened the register-link regex to drop the same-line prefix | the "no prefix" reject case |
| broke `parseFileList`'s blank-line filter | both of its tests |
| `passesSidecarAcceptanceGate` short-circuited to `true` | both the unit and CLI "neither form fails" tests |

**Scope conditions traced through three diff shapes** against `ci-scope.mjs`'s existing machinery (unchanged here):

- **docs-only** — every scope key false, both Windows steps skip, the gate's file list is empty, both new checks report green fast.
- **`server/tts-sidecar/**`** — the gate now requires a recorded run or register link. (Correction, from review: the Windows steps do **not** uniformly skip. A sidecar path such as `server/tts-sidecar/main.py` also matches `server/**`, so `step_test_server` is true and the Windows server step runs. The original claim here was wrong.)
- **frontend-only** — Windows "Frontend tests" runs, "Server tests" skips; the gate passes with nothing required.

The YAML was parsed with `js-yaml` to confirm `windows-tests` is in `verify.needs` and carries no job-level `if:`.

## Not done, deliberately

Acceptance criterion 5 of #3050 — wiring the new check into `main`'s required status checks — is a branch-protection ruleset change, not a file in this repo, and it cannot be made until the check has run at least once. It is a follow-up action on the repo settings, tracked on #3050.

Before-shipping steps not applicable: **1** (no plan doc — the design doc is the plan and already covers these parts), **3** (no hardware-provable behaviour), **4** (no plan added or moved), **5** (CI/process only, no shippable delta).

Closes #3049
Refs #3050
Refs #2997

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQowpfkQgdAbudiZZF7PVL

