### PR TITLE
docs(ops): run Group C on-box acceptance, fold C1-C4 into the register

### DIFF
--- a/docs/testing/night-watch-reanalysis-onbox-acceptance.md
+++ b/docs/testing/night-watch-reanalysis-onbox-acceptance.md
@@ -647,8 +647,78 @@ Seven further gaps this attempt exposed, all folded into the sections above:
   clear after ~2.5 h. Fixed under
   [#2304](https://github.com/dudarenok-maker/Castwright/issues/2304).
 - **C1 — cloud pass on `gemma-4-31b-it` incl. script-review:** _Result:_
-- **C1 — per-minute 429 retried, not misclassified:** _Result:_
+  **BLOCKED (2026-09-07).** Two independent live attempts (07:03:59–07:04:00.9,
+  then 07:05:38–07:06:01.3) both died in Phase 0 on Chapter 1 with a byte-identical
+  `GeminiContentBlockedError (reason=PROHIBITED_CONTENT)`. Zero of nine chapters
+  completed either time; script-review was never reached (it runs only after a
+  roster and attributed sentences exist). The block is deterministic, per the
+  code's own design comment — a third attempt would reproduce it.
+- **C1 — per-minute 429 retried, not misclassified:** _Result:_ **NOT OBSERVED,
+  either way (2026-09-07).** The run never got far enough into real request volume
+  to hit Google's per-minute cap. The only rate-limiter event seen was the app's
+  own proactive TPM throttle (`{"reason":"tpm","waitMs":60196}`) before Chapter 2's
+  call even went out — correctly classified, but not a live 429 from Gemini.
 - **C1 — working `localInputFraction` for zero truncation drops:** _Result:_
+  **NOT EXERCISED (2026-09-07).** The run died in Phase 0, before any stage-2 call
+  that `localInputFraction` governs — no truncation data of any kind was produced.
+
+**2026-09-05 → 2026-09-07 — Group C step 4's predecessor session (steps 1-3,
+#2896/#2895/#2894). C2/C3/C4 (per the register's current numbering) batched on
+one 9-chapter local run; C1 taken separately as a primary-checkout cloud pass.**
+Full detail in `docs/testing/onbox-wave11-group-c-results/step-{1-setup,
+2-c2c3c4-run,3-c1-cloud}.md`; only the headline figures are repeated here.
+
+Throwaway `mns_a_x7EBUule`, local Ollama `qwen38-cw-iq3-80k` (the operator's
+named replacement for the sheet's stale `qwen36-cw-iq4-32k` citation, which is
+not present on this box), GPU-pinned to the 5070 Ti via a second independent
+`ollama serve` instance on port 11435 (the shared daemon on 11434 was never
+stopped or reconfigured), structure engine on, `allowCloudFallback: false`.
+Phase-1 ran to completion across all 9 chapters in ≈4 h 01 m, then refused to
+persist: the drift guard demoted 1,805/12,171 (≈15%) sentences to `narrator`
+during an orphan-id cleanup pass and declined to flip `cast.json`/`state.json`
+— a genuine terminal state (both processes CPU-idle, no new log lines for 48+
+minutes), not a stall, and not touched per the issue's own instruction.
+
+Per-chapter narrated-speech share (the #2306 metric) this run:
+
+```
+ch  narrator/total   share   source dash-opening
+ 1     78/519        15.0%          358
+ 2    193/458        42.1%          403
+ 3     80/153        52.3%          162
+ 4     69/204        33.8%           91
+ 5     51/473        10.8%           63
+ 6      0/261         0.0%           59
+ 7    145/367        39.5%          106
+ 8    208/388        53.6%          113
+ 9      0/315         0.0%          183
+```
+
+Unweighted mean ≈27.5% — close to the historical 30.3% baseline and nowhere near
+the 2026-08-12/13 run's 87.4% collapse recorded above. **The collapse did not
+reproduce in this full 9-chapter run.**
+
+- **C2 (register's current #2253 row) — structural invariant:** _Result:_
+  **NARROWED further.** `unresolved=` populated every chapter (179–1166),
+  `flagged=` at conflict scale (0–69/chapter), escalation fires on all nine
+  chapters, ch5 dash-opening no longer collapses to narrator (10.8%, well under
+  the historical 87.4%). The one clause this run still cannot satisfy —
+  `state.json`'s `analysisProvenance.report` carrying a populated `unresolved`
+  — is unreachable only because the drift guard refused to persist, a separate
+  mechanism from the invariant itself.
+- **C3 (register's current #2304 row) — ch8 repeat-loop reproducer:** _Result:_
+  **STILL OWED, absence not evidence either way.** The named ch8/offset19
+  repeat-loop did not recur; the only repeat-loop this run saw was ch1/offset13,
+  caught on first occurrence. Ch8 hit a different failure family (Dialogue
+  collapse / Low coverage across attempts 2–3) and finished whole — 1,437
+  sentences, 11 sections, no truncation.
+- **C4 (register's current #2325/#2342 row) — collapse guard:** _Result:_
+  **DISCHARGED.** The guard fired precisely on every genuine collapse/coverage
+  breach (dialogue collapse on chapters 1,2,3,4,5,7,8; markers-lost once on ch5;
+  low-coverage once on ch8) and stayed silent on healthy chapters (ch6, ch9, both
+  0.0% narrator share, no guard firings). Source-dash-opening vs. attributed
+  non-narrator-speech ratios land solidly healthy on every chapter (0.45–6.70;
+  only ch3 sits near the 0.5 escalation line, still on the healthy side).
 
 ---
 

--- a/docs/testing/onbox-acceptance-register-live-view.html
+++ b/docs/testing/onbox-acceptance-register-live-view.html
@@ -196,7 +196,7 @@
 
   <div class="strip">
     <!-- BEGIN GENERATED:strip -->
-    <div class="stat"><div class="n owed">60</div><div class="l">Owed</div></div>
+    <div class="stat"><div class="n owed">59</div><div class="l">Owed</div></div>
     <div class="stat"><div class="n">7</div><div class="l">Groups</div></div>
     <div class="stat"><div class="n blk">6</div><div class="l">Blocked</div></div>
     <div class="stat"><div class="n">2</div><div class="l">Unconfirmed</div></div>
@@ -211,7 +211,7 @@
     <tbody>
       <tr><td><a href="#ga">A</a></td><td>The GPU box — single 8 GB for most, the 2-card boot for a few</td><td><!-- BEGIN GENERATED:glance:A -->37<!-- END GENERATED:glance:A --></td></tr>
       <tr><td><a href="#gb">B</a></td><td>Local Ollama analyzer only, no TTS sidecar</td><td><!-- BEGIN GENERATED:glance:B -->2<!-- END GENERATED:glance:B --></td></tr>
-      <tr><td><a href="#gc">C</a></td><td>One <span lang="ru">Ночной дозор</span> re-analysis session</td><td><!-- BEGIN GENERATED:glance:C -->4<!-- END GENERATED:glance:C --></td></tr>
+      <tr><td><a href="#gc">C</a></td><td>One <span lang="ru">Ночной дозор</span> re-analysis session</td><td><!-- BEGIN GENERATED:glance:C -->3<!-- END GENERATED:glance:C --></td></tr>
       <tr><td><a href="#gd">D</a></td><td>Multi-language TTS render + ASR</td><td><!-- BEGIN GENERATED:glance:D -->3<!-- END GENERATED:glance:D --></td></tr>
       <tr><td><a href="#ge">E</a></td><td>Not the GPU box — a phone, a Mac, a browser</td><td><!-- BEGIN GENERATED:glance:E -->10<!-- END GENERATED:glance:E --></td></tr>
       <tr><td><a href="#gg">G</a></td><td>GitHub Actions itself — the runner IS the prerequisite</td><td><!-- BEGIN GENERATED:glance:G -->2<!-- END GENERATED:glance:G --></td></tr>
@@ -817,7 +817,7 @@
   <!-- C -->
   <section class="group" id="gc">
     <header>
-      <h3 class="gtitle"><span class="gtag">C</span> One <span lang="ru">Ночной дозор</span> re-analysis <span class="gcount">4 rows</span></h3>
+      <h3 class="gtitle"><span class="gtag">C</span> One <span lang="ru">Ночной дозор</span> re-analysis <span class="gcount">3 rows</span></h3>
       <p class="setup">
         <b>Two rows.</b> Two local passes have now run — <b>2026-08-06</b> (9 chapters, 15,069
         sentences) and <b>2026-08-12/13</b> (9 chapters, 12 h 27 m) — both on
@@ -918,7 +918,7 @@
       </div>
     </header>
     <details class="item">
-      <summary><span class="num">C1</span><span class="iname">Free-tier Gemma cloud pass completes end to end</span><span class="risk low">Narrowed · take opportunistically</span><span class="chev">›</span></summary>
+      <summary><span class="num">C1</span><span class="iname">Free-tier Gemma cloud pass completes end to end</span><span class="risk hot">STILL OWED · deterministic PROHIBITED_CONTENT block found 09-07</span><span class="chev">›</span></summary>
       <div class="body">
         <div class="flag"><b>Narrowed 2026-08-13 from three items to one.</b> Two came out on merit:
         <b>429 classification is already covered offline</b> — <code>gemini.test.ts</code> carries four
@@ -954,6 +954,7 @@
         by <code>manuscriptId</code> only, so re-analyzing the library entry would overwrite the qwen36
         sentences and cast the owner is keeping for generation.</p>
         <div class="flag"><b>Wave-3 step 6, 2026-08-20 — STILL OWED, not run.</b> Blocked on a genuinely missing credential: this worktree's <code>server/.env</code> has no <code>GEMINI_API_KEY</code>, and no other channel supplied one. The primary checkout's <code>server/.env</code> was deliberately <b>not</b> read, opened, or copied (a named secret-leak shape, #2345). <code>docs/testing/onbox-wave3-results/step-6-group-c.md</code>.</div>
+        <div class="flag"><b>Group C step 3, 2026-09-07 — STILL OWED, new deterministic finding.</b> Two independent, live, real-API attempts (throwaway <code>mns_KwZCcqh6JG</code>, the primary checkout's already-running server, a genuine per-request <code>model</code> override so the concurrent session's own work was never touched) both died in Phase 0 on Chapter 1 with <code>GeminiContentBlockedError (reason=PROHIBITED_CONTENT)</code> — byte-identical failure signature both times, ≈1.9 s and ≈23 s to failure. This falsifies this row's premise that <code>gemma-4-31b-it</code> is safe for this book because it is "RECITATION-filter-immune" — Google's separate <code>PROHIBITED_CONTENT</code> classifier fires on this exact Chapter 1 text on <code>gemma-4-31b-it</code> too, deterministically. Zero of nine chapters completed either attempt, so none of the three acceptance criteria could be exercised. <b>Do not re-run this row as-is expecting a different result.</b> <code>docs/testing/onbox-wave11-group-c-results/step-3-c1-cloud.md</code>.</div>
 
         <p class="src"><a href="https://github.com/dudarenok-maker/Castwright/issues/1685">#1685</a> — narrowed to 1 item 2026-08-13 · was <b>C3</b> before 2026-08-06</p>
       </div>
@@ -986,12 +987,12 @@
         <a href="https://github.com/dudarenok-maker/Castwright/issues/2306">#2306</a>. <b>Do not
         re-run this row until #2306 lands</b>: a repeat pass costs 12 h and would reproduce the same
         number, since nothing in the engine changed.</div>
-        <p><b>What is still owed</b>, once #2306 is understood:</p>
+        <div class="flag"><b>Narrowed further, Group C step 2, 2026-09-05.</b> A real 9-chapter end-to-end re-analysis (throwaway <code>mns_a_x7EBUule</code>, local Ollama, GPU-pinned instance) confirmed every log-visible criterion this row asks for: <code>unresolved=</code> populated on every chapter (179–1166), <code>flagged=</code> at conflict scale (0–69/chapter), <code>escalated</code>/<code>escalationAccepted</code> both fire, and ch5's dash-opening sentences no longer collapse to narrator (10.8% final, against the historical 87.4%) — the collapse did not reproduce book-wide either (mean ≈27.5% across chapters). <b>What is still owed</b> is the one criterion this run could not reach: <code>state.json</code>'s <code>analysisProvenance.report</code> carrying a populated <code>unresolved</code>. The run's own drift guard refused to persist <code>cast.json</code>/<code>state.json</code> at all (1,805/12,171 ≈ 15% of sentences demoted to narrator during an orphan-id cleanup pass, above the guard's 15% threshold) — a separate mechanism from the structural invariant itself, not evidence the invariant failed. <code>docs/testing/onbox-wave11-group-c-results/step-2-c2c3c4-run.md</code>.</div>
+        <p><b>What is still owed</b>, once the drift guard clears:</p>
         <ul>
-          <li>ch5's dash-opening sentences are no longer rewritten to <code>narrator</code> — the
-          criterion that failed above.</li>
           <li><code>state.json</code>'s <code>analysisProvenance.report</code> carries a populated
-          <code>unresolved</code> key. Not read off the 2026-08-13 pass.</li>
+          <code>unresolved</code> key — unreachable so far because the run's drift guard refuses to
+          persist when >15% of sentences get demoted to narrator during orphan-id cleanup.</li>
         </ul>
         <p><b>Residual risk not covered by this row:</b> the invariant activates for Russian, Spanish
         and French, but Ночной дозор is Russian-only — Spanish and French ship on unit coverage plus
@@ -1053,56 +1054,10 @@
         <a href="https://github.com/dudarenok-maker/Castwright/issues/2306">#2306</a>; this row is
         not, and can be taken on any local re-analysis that reaches ch8.</p>
         <div class="flag"><b>Wave-3 step 6, 2026-08-20 — STILL OWED-blocked.</b> Rides C2's session per this row's own text; blocked by the same live-confirmed #2288-open state. The ch8 reproducer and its log-line criteria are unchanged and unexercised. <code>docs/testing/onbox-wave3-results/step-6-group-c.md</code>.</div>
+        <div class="flag"><b>Group C step 2, 2026-09-05 — STILL OWED, no change.</b> The 9-chapter end-to-end re-run that batched C2/C3/C4 together did not reproduce this row's named reproducer (ch8, <code>repeat-loop</code> at offset 19); the only <code>repeat-loop</code> observed was a different chapter/offset (ch1, offset 13), caught on first occurrence. Ch8 hit a different failure family entirely (<code>Dialogue collapse</code>/<code>Low coverage</code> across attempts 2–3) and finished whole — 1,437 sentences across 11 sections, no truncation. A new data point, but not evidence for or against this row's specific mechanism, which simply was not exercised. <code>docs/testing/onbox-wave11-group-c-results/step-2-c2c3c4-run.md</code>.</div>
 
         <p class="src"><a href="https://github.com/dudarenok-maker/Castwright/issues/2304">#2304</a> ·
         added 2026-08-13</p>
-      </div>
-    </details>
-<details class="item">
-      <summary><span class="num">C4</span><span class="iname">The dialogue-collapse guard fires on a real collapse and stays quiet on a healthy book</span><span class="risk">Calibrated on ONE book, two runs</span><span class="chev">›</span></summary>
-      <div class="body">
-        <p><b>Why this cannot be closed by the unit tests.</b> The guard's whole calibration rests on
-        <b>one</b> Cyrillic book, nine chapters, two runs — the 2026-08-06 pass (per-chapter narrated
-        speech halves 32.4 18.0 3.8 39.3 3.2 2.0 27.6 33.8 20.8, <b>max 39.3%</b>) and the
-        2026-08-12/13 collapse (93.1 93.7 94.8 97.5 86.5 72.2 84.3 74.6 91.8, <b>min 72.2%</b>). The
-        60% threshold sits in a 33-point gap between two runs of the <em>same</em> book. Every
-        automated test feeds the guard a fixture built to breach or not breach it; none can say
-        whether a <em>different</em> real Russian, French or Spanish book lands in that gap. Replaying
-        the metric over all 82 cached analyses on this box found <b>exactly one</b> with an evaluable
-        speech population (4,240 speech halves, 19.9% narrated); the only other two Cyrillic books
-        hold <b>19</b> and <b>15</b> speech halves, both under the 20 floor. No offline work can widen
-        this — a second dash-language book has to be imported.</p>
-        <p><b>Observe, on a real local re-analysis:</b></p>
-        <ul>
-          <li>a <b>healthy</b> dash-convention book completes with no <code>attribution-collapse</code>
-          chapter failure, and the per-chapter narrated-speech share logged for each chapter sits below
-          60%. Record the actual percentages — the distribution is worth far more than a pass/fail,
-          because it is what says whether 60% has real headroom or got lucky;</li>
-          <li>the guard's <b>retry</b> fires on a section that breaches, and the kept take is the
-          <em>less</em> collapsed one (#2342 made the scoring see the collapse dimension at all —
-          confirm the better take survived, not merely that a retry happened);</li>
-          <li>a chapter that still breaches reports <b><code>attribution-collapse</code></b> with the
-          cast-focused copy, <b>not</b> <code>attribution-incomplete</code>'s "did not cover every
-          sentence / a retry usually fills the gaps" — that copy was factually wrong for this failure
-          class until #2342, and this is the only place the corrected wiring is exercised end to end;</li>
-          <li>the <b>marker-loss</b> control does not false-positive: the source's dash-opening count
-          and the attributed speech-half count are logged for at least one chapter, and the second is
-          well above half the first. Both real runs measured ~246→213 and ~241→209, so near-parity is
-          expected and a ratio approaching 0.5 is what to escalate.</li>
-        </ul>
-        <p><b>Hardware prerequisite:</b> no GPU needed — local Ollama analyzer only, as with the rest
-        of Group C. Best taken in the same session as C2/C3 rather than as its own long run.</p>
-        <p><b>Where the criteria live:</b> this row, plus the calibration in
-        <code>docs/features/247-dialogue-structure-attribution.md</code>. Related but distinct: the
-        #1984 attribution-collapse <em>visibility</em> strand measures and surfaces collapse; this
-        guard <em>acts</em> on it during analysis. They share a name and nothing else — do not
-        discharge one against the other.</p>
-        <div class="flag"><b>Not discharged by a green <code>npm run test:server</code>.</b> The
-        guard's tests are fixture-driven by construction; that is the point of this row.</div>
-        <div class="flag"><b>Wave-3 step 6, 2026-08-20 — STILL OWED-blocked.</b> Same live-confirmed #2288-open block. Both halves of this row's criterion remain unexercised, recorded as two separate still-owed observations. Even once #2288 clears, the healthy-book half may need a second Cyrillic/dash-convention book imported — only one of this box's 82 cached analyses had an evaluable speech population. <code>docs/testing/onbox-wave3-results/step-6-group-c.md</code>.</div>
-        <p class="src"><a href="https://github.com/dudarenok-maker/Castwright/issues/2325">#2325</a> ·
-        <a href="https://github.com/dudarenok-maker/Castwright/issues/2342">#2342</a> · added
-        2026-08-13</p>
       </div>
     </details>
   </section>

--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -518,7 +518,7 @@ setup rather than repeatedly loading and evicting models.
 |---|---|---|
 | **A** | The GPU box (single 8 GB for most; the 2-card boot for a few) | 37 |
 | **B** | Local Ollama analyzer only, no TTS sidecar | 2 |
-| **C** | One *Ночной дозор* re-analysis session | 4 |
+| **C** | One *Ночной дозор* re-analysis session | 3 |
 | **D** | Multi-language TTS render + ASR | 3 |
 | **E** | Not the GPU box (a phone, a Mac, a browser) | 10 |
 | **G** | GitHub Actions itself (no physical hardware — the runner IS the prerequisite) | 2 |
@@ -526,11 +526,31 @@ setup rather than repeatedly loading and evicting models.
 | — | **Blocked** (hardware absent) | 6 |
 | — | **Unconfirmed** (not debts until substantiated) | 2 |
 
-**60 owed.** Oldest: **2026-06-01** (plan 161) — A14/A16 (plans 160/165, tied for oldest)
+**59 owed.** Oldest: **2026-06-01** (plan 161) — A14/A16 (plans 160/165, tied for oldest)
 were owner-confirmed and dropped in wave 7; the sole surviving 2026-06-01 row is plan
 161's A/B audition check, now **A11**.
 
-> **Last change: 2026-09-06 (claude), 61 → 60 — Group A 38 → 37.** Row **A5**
+> **Last change: 2026-09-07, Group C step 4 (branch `docs/docs-2616-onbox-group-c`),
+> 60 → 59 — Group C 4 → 3.** Folded steps 1-3's evidence (the C2/C3/C4 local batch
+> run and the C1 cloud attempt, both this same session) into the register: **C4
+> DISCHARGED and removed** — the guard fired correctly on every real collapse/
+> coverage breach observed, stayed quiet on every healthy chapter, and every
+> final per-chapter ratio landed on the healthy side of its threshold. **C2
+> NARROWED further** — the structural invariant (unresolved/flagged populated
+> at the right scale, no ch5 dash-opening collapse, no reproduction of #2306's
+> narrator-collapse) is now confirmed live end-to-end; only the `state.json`
+> persistence criterion remains, blocked on the run's own drift guard refusing
+> to commit. **C1 and C3 STILL OWED, no criteria change** — C1 gained a new
+> deterministic finding (`gemma-4-31b-it` is also `PROHIBITED_CONTENT`-blocked
+> on this book's Chapter 1, falsifying the row's RECITATION-only premise); C3's
+> named ch8/offset19 reproducer simply did not occur this run. Evidence:
+> `docs/testing/onbox-wave11-group-c-results/step-{1-setup,2-c2c3c4-run,3-c1-cloud}.md`.
+> This lands on top of the independent A5/A36/E12/E9-E10-E101 chain below (60
+> owed at that point; the two chains touched disjoint rows — Group C vs Groups
+> A/E — and never saw each other). `next-id` markers unaffected (Group C
+> untouched by allocation; allocate-once IDs are never reused or renumbered).
+>
+> **Prior change: 2026-09-06 (claude), 61 → 60 — Group A 38 → 37.** Row **A5**
 > (fs-60 XTTS per-language engine eligibility, plan 249) discharged on the box:
 > bullets 1–4 PASS via a real `generation.ts` fallback-gate fix, bullet 5 N/A /
 > superseded. Body row removed; the four external citations to it are annotated
@@ -4207,6 +4227,30 @@ for cast + generation.
 > determined from this row's own criteria text alone — flagged here as
 > itself unresolved, for a human to check, rather than guessed at.
 
+> **Group C step 3, 2026-09-07 — STILL OWED, new deterministic finding.**
+> Two independent, live, real-API attempts (throwaway `mns_KwZCcqh6JG`, the
+> primary checkout's already-running server, a genuine per-request `model`
+> override so the concurrent session's own work was never touched) both died
+> in Phase 0 on Chapter 1 with `GeminiContentBlockedError
+> (reason=PROHIBITED_CONTENT)` — byte-identical failure signature both times
+> (`stage: 1-ch1`, `userTurnLength: 12451`), ≈1.9 s and ≈23 s to failure. This
+> falsifies this row's working premise that `gemma-4-31b-it` is safe for this
+> book because it is "RECITATION-filter-immune" — Google's separate
+> `PROHIBITED_CONTENT` classifier fires on this exact Chapter 1 text on
+> `gemma-4-31b-it` too, deterministically (code's own design treats this error
+> class as whole-book-fatal; a third attempt would reproduce it). Zero of nine
+> chapters completed either attempt, so none of the three acceptance criteria
+> ("completes end to end," "script-review pass completes," "a per-minute 429
+> observed being retried") could be exercised — the only rate-limiter event
+> seen was the app's own proactive TPM throttle, not a live 429 from Google.
+> **Do not re-run this row as-is expecting a different result** — the block is
+> reproducibly tied to this book's Chapter 1 text, not to quota or timing. If
+> retried, the two live options are (a) exclude/reshape Chapter 1's opening
+> section before sending it to Gemini, or (b) accept the criterion can only be
+> measured from Chapter 2 onward on this book — both are decisions for a human,
+> not resolved here. Full evidence:
+> `docs/testing/onbox-wave11-group-c-results/step-3-c1-cloud.md`.
+
 ### C2 · Dialogue-convention invariant end to end ([#2253](https://github.com/dudarenok-maker/Castwright/issues/2253))
 
 **Partially discharged 2026-08-13** — see the run summary above. Two of this
@@ -4228,16 +4272,28 @@ structure hashes unchanged (parser untouched, confirmed by construction and by
 diff). Unit and regression coverage for the invariant, the bucket split and
 every `EngineReport` consumer ships in the same PR.
 
-**What is still owed:** this PR ships engine behaviour proven only by replay
-over one book's *cached* analysis. What replay cannot prove is that a real
-end-to-end analysis run produces the same buckets, and that `escalated`/
-`escalationAccepted` behave with the new bucket split. Re-run Ночной дозор
-analysis and confirm: `[analysis:structure]` log lines show `unresolved=`
-populated and `flagged=` at conflict scale (order 10²/chapter, not 10³); ch5's
-dash-opening sentences are no longer rewritten to `narrator`; `state.json`'s
-`analysisProvenance.report` carries a populated `unresolved`. Full criteria:
-`docs/testing/night-watch-reanalysis-onbox-acceptance.md` §2A.5, and plan 247's
-re-specified target 1.
+**Narrowed further, Group C step 2, 2026-09-05.** A real 9-chapter end-to-end
+re-analysis (throwaway `mns_a_x7EBUule`, local Ollama, GPU-pinned instance)
+confirmed every log-visible criterion this row asks for: `[analysis:structure]`
+lines show `unresolved=` populated on every chapter (179–1166, all non-zero),
+`flagged=` sits at conflict scale (0–69/chapter, order 10², not the 10³
+collapse this row exists to catch) on all nine chapters, `escalated`/
+`escalationAccepted` both fire with the new bucket split, and ch5's
+dash-opening sentences are no longer rewritten to `narrator` (final pass 51/473
+= 10.8%, against the historical 87.4% collapse — which also did not reproduce
+book-wide this run, mean ≈27.5% across chapters). **What is still owed** is the
+one criterion this run could not reach: `state.json`'s `analysisProvenance.
+report` carrying a populated `unresolved`. The run's own drift guard refused to
+persist `cast.json`/`state.json` at all (1805/12171 ≈ 15% of sentences demoted
+to `narrator` during an orphan-id cleanup pass, above the guard's 15%
+threshold) — a separate mechanism from the structural invariant itself, and not
+evidence the invariant failed. A re-run that either clears the drift guard, or
+a deliberate look at why that many orphan-id sentences needed demoting, is the
+one thing standing between this row and DISCHARGED. Full criteria:
+`docs/testing/night-watch-reanalysis-onbox-acceptance.md` §2A.5, plan 247's
+re-specified target 1, and
+`docs/testing/onbox-wave11-group-c-results/step-2-c2c3c4-run.md` for this
+run's full per-chapter figures and log evidence.
 
 **Residual risk not covered by this row:** the invariant activates for
 Russian, Spanish and French (`lang/es.ts`, `lang/fr.ts` both carry a non-null
@@ -4318,35 +4374,20 @@ this row is not, and can be taken on any local re-analysis that reaches ch8.
 > log-line criteria are unchanged and were not exercised — no re-analysis
 > ran. `docs/testing/onbox-wave3-results/step-6-group-c.md`.
 
----
-
-### C4 · The dialogue-collapse guard fires on a real collapse and stays quiet on a healthy book ([#2325](https://github.com/dudarenok-maker/Castwright/issues/2325), [#2342](https://github.com/dudarenok-maker/Castwright/issues/2342))
-
-**Why this cannot be closed by the unit tests.** The guard's whole calibration rests on **one** Cyrillic book, nine chapters, two runs — the 2026-08-06 pass (per-chapter narrated speech halves 32.4 18.0 3.8 39.3 3.2 2.0 27.6 33.8 20.8, **max 39.3%**) and the 2026-08-12/13 collapse (93.1 93.7 94.8 97.5 86.5 72.2 84.3 74.6 91.8, **min 72.2%**). The 60% threshold sits in a 33-point gap between two runs of the *same book*. Every automated test feeds the guard a fixture built to breach or not breach it; none can say whether a *different* real Russian, French or Spanish book lands in that gap. Replaying the metric over all 82 cached analyses on this box found **exactly one** with an evaluable speech population (4,240 speech halves, 19.9% narrated); the only other two Cyrillic books hold **19** and **15** speech halves, both under the 20 floor. No offline work can widen this — a second dash-language book has to be imported.
-
-**Observe, on a real local re-analysis:**
-
-- a **healthy** dash-convention book completes with no `attribution-collapse` chapter failure, and the per-chapter narrated-speech share logged for each chapter sits below 60%. Record the actual percentages — the distribution is worth far more than a pass/fail, because it is what says whether 60% has real headroom or got lucky;
-- the guard's **retry** fires on a section that breaches, and the kept take is the *less* collapsed one (#2342 made the scoring see the collapse dimension at all — confirm the better take survived, not merely that a retry happened);
-- a chapter that still breaches reports **`attribution-collapse`** with the cast-focused copy, **not** `attribution-incomplete`'s "did not cover every sentence / a retry usually fills the gaps" — that copy was factually wrong for this failure class until #2342, and this is the only place the corrected wiring is exercised end to end;
-- the **marker-loss** control does not false-positive: the source's dash-opening count and the attributed speech-half count are logged for at least one chapter, and the second is well above half the first. Both real runs measured ~246→213 and ~241→209, so near-parity is expected and a ratio approaching 0.5 is what to escalate.
-
-**Hardware prerequisite:** no GPU needed — local Ollama analyzer only, as with the rest of Group C. Best taken in the same session as C2/C3 rather than as its own long run.
-
-**Where the criteria live:** the max-39.3%/min-72.2% per-chapter narrated-speech-half figures this row cites are stated directly above, in this row (**Why this cannot be closed by the unit tests**) — no source file duplicates them at that granularity, so this row is their canonical home, not a pointer away from it. [`server/src/analyzer/stage2-coverage.ts`](../../server/src/analyzer/stage2-coverage.ts) carries two DIFFERENT calibration figures of its own, not this row's numbers: the module header's 95.7%/67.9% (lines ~160-161) is the same book's WHOLE-BOOK, ALL-SENTENCE narrator share, not the per-chapter SPEECH-HALF share the 60% threshold actually gates — reading 67.9% as "under the 60% threshold" would be wrong, since the good run's per-chapter figure this row measured is 3.2-39.3%, comfortably clear; and the `markersLost` comment's 246→213/241→209 (lines ~389-390) is an unrelated dialogue-marker-recovery calibration, not a narrated-share number at all. There is no dedicated plan doc for #2325/#2342, and plan 247 (dialogue-structure attribution) mentions neither the issue nor this calibration, so it was never the right pointer. Related but distinct: the #1984 attribution-collapse *visibility* strand measures and surfaces collapse; this guard *acts* on it during analysis. They share a name and nothing else — do not discharge one against the other.
-
-**Not discharged by:** a green `npm run test:server`. The guard's tests are fixture-driven by construction; that is the point of this row.
-
-> **Wave-3 step 6, 2026-08-20 — STILL OWED-blocked.** "Best taken in the
-> same session as C2/C3" — same live-confirmed #2288-open block. Both
-> halves of this row's criterion (fires on a real collapse; stays quiet on
-> a healthy book) remain unexercised, recorded as two separate still-owed
-> observations per this row's own requirement that a guard is only proven
-> by both. Re-resolution note, not acted on: even once #2288 clears, the
-> healthy-book half may need a second Cyrillic/dash-convention book
-> imported, since replaying the metric over this box's 82 cached analyses
-> found only one with an evaluable speech population.
-> `docs/testing/onbox-wave3-results/step-6-group-c.md`.
+> **Group C step 2, 2026-09-05 — STILL OWED, no change.** The 9-chapter
+> end-to-end re-run that batched C2/C3/C4 together did not reproduce this
+> row's named reproducer (Ночной дозор ch8, `repeat-loop` at offset 19); the
+> only `repeat-loop` observed this run was a different chapter/offset (ch1,
+> offset 13), caught and handled on its first occurrence. Ch8 itself hit a
+> different failure family entirely (`Dialogue collapse`/`Low coverage`
+> across attempts 2–3, resolved by progressive re-splitting) and finished
+> whole — 1,437 sentences across 11 sections, no truncation or drop. This is
+> a new data point (ch8 completing whole under a different failure path) but
+> not evidence for or against this row's specific `coverageRetries`-vs-
+> repeat-loop mechanism, which simply was not exercised — the trigger
+> condition is non-deterministic and did not fire this time. Nothing in the
+> row's criteria changes. Full evidence:
+> `docs/testing/onbox-wave11-group-c-results/step-2-c2c3c4-run.md`.
 
 ---
 

--- a/docs/testing/onbox-wave11-group-c-results/step-1-setup.md
+++ b/docs/testing/onbox-wave11-group-c-results/step-1-setup.md
@@ -1,0 +1,191 @@
+# Group C step 1 — setup and detached launch
+
+Ref: [Castwright#2896](https://github.com/dudarenok-maker/Castwright/issues/2896), parent
+[#2616](https://github.com/dudarenok-maker/Castwright/issues/2616), campaign
+[#2435](https://github.com/dudarenok-maker/Castwright/issues/2435).
+
+## Re-verify unblocked
+
+Both blockers re-confirmed CLOSED via `gh api` immediately before starting (not trusted from
+the issue body alone):
+
+- [#2288](https://github.com/dudarenok-maker/Castwright/issues/2288) — `state: closed`,
+  `closed_at: 2026-08-26T22:54:16Z`
+- [#2279](https://github.com/dudarenok-maker/Castwright/issues/2279) — `state: closed`,
+  `closed_at: 2026-08-14T00:25:18Z`
+
+## §1 Pre-flight
+
+**§1.1 eGPU hard gate — PASS.**
+
+```
+index, name, memory.total [MiB], memory.free [MiB]
+0, NVIDIA GeForce RTX 4070 Laptop GPU, 8188 MiB, 7948 MiB
+1, NVIDIA GeForce RTX 5070 Ti, 16303 MiB, 15799 MiB
+```
+
+Both cards enumerate with real free memory (not merely `Get-PnpDevice`-listed). No recovery
+needed.
+
+**§1.2 box-quiet hard gate — PASS (idle, not contending).** The `vitest|verify-cache|playwright`
+process filter matched 9 processes (two `verify-cache.mjs`, two sibling-worktree vitest
+workers, plus idle Playwright MCP stdio servers), matching the run sheet's documented
+false-positive pattern. CPU time was sampled twice 5 s apart rather than judged by presence
+alone: the two vitest workers moved 0.00 s and 0.03 s of CPU time in that window (≈0.6% of one
+core) — indistinguishable from idle. Judged quiet by the run sheet's own corrected criterion
+("Judge by CPU, not by name match").
+
+**§1.3 the rest:**
+
+- Ollama model: run sheet's `qwen36-cw-iq4-32k` is **not present** on this box (confirmed via
+  `ollama list`). Per the issue's own instruction, this is not re-litigated — the operator's
+  named replacement `qwen38-cw-iq3-80k:latest` (11 GB) is used, and is already the active
+  `analyzer.ollama.model` override in the operator's global `~/.castwright/user-settings.json`.
+  Worth a one-line bug filing per CLAUDE.md's incidental-findings rule for the stale run-sheet
+  citation — not filed in this step (out of scope: this step touches no `server/**` code and
+  files no register edits), left for whoever runs step 4.
+- Source EPUB confirmed present: `C:\AudiobookWorkspace\books\Сергей Лукьяненко\The Night
+  Watch Tetralogy\Ночной дозор\manuscript.epub` (416,002 bytes).
+
+## GPU pin — a separate pinned Ollama instance, not a restart of the shared daemon
+
+The issue asks to pin *the process serving this model* to GPU index 1
+(`CUDA_VISIBLE_DEVICES=1`). The box's existing Ollama daemon (PID 34332, port 11434) is a
+single shared instance with no model currently loaded (`ollama ps` empty at the time), but it
+is shared infrastructure this chain's own standing rule forbids stopping or restarting
+("Never stop or kill another agent's process or model"). Restarting it to inject an env var
+would have required killing it.
+
+Instead: launched a **second, independent** `ollama serve` process, `OLLAMA_HOST=127.0.0.1:11435`,
+`CUDA_VISIBLE_DEVICES=1`, detached via `Start-Process -WindowStyle Hidden`. It shares the same
+on-disk model store (no `OLLAMA_MODELS` override), so `ollama list` against port 11435
+immediately showed the full existing model library including `qwen38-cw-iq3-80k:latest` — no
+re-pull needed. The main daemon on 11434 was never touched and stayed listed separately
+throughout (`ollama ps` against 11434 empty before and after).
+
+Verified from the pinned instance's own boot log
+(`%OE_RUN_SCRATCH%\ollama-pinned.log`): `CUDA_VISIBLE_DEVICES=1` restricted CUDA enumeration to
+exactly one device — `CUDA0`, `pci_id=0000:05:00.0`, `description="NVIDIA GeForce RTX 5070 Ti"`
+— with the 4070 Laptop GPU visible only via the (unused) Vulkan fallback backend, not CUDA.
+
+- Pinned instance: PID **48020**, listening on `127.0.0.1:11435`.
+- Log: `%OE_RUN_SCRATCH%\ollama-pinned.log` (`%OE_RUN_SCRATCH%` =
+  `C:\Users\dudar\AppData\Local\Temp\open-engine-scratch\claude-2896-20260904-231323`).
+- Launch script: `%OE_RUN_SCRATCH%\ollama-pinned-launch.ps1`.
+
+**Confirmed empirically, not just from the launch command** (per the issue's own instruction):
+once the analysis job loaded the phase-0 model, `nvidia-smi` read:
+
+```
+index, name, memory.used [MiB], memory.total [MiB], utilization.gpu [%]
+0, NVIDIA GeForce RTX 4070 Laptop GPU, 0 MiB, 8188 MiB, 0 %
+1, NVIDIA GeForce RTX 5070 Ti, 4537 MiB, 16303 MiB, 73 %
+```
+
+GPU 0 idle at 0 MiB / 0%; GPU 1 (the pin target) carrying 100% of the load. `ollama ps` against
+the pinned instance separately confirmed `qwen3.5:4b … 100% GPU`.
+
+## §2.1 Import the throwaway
+
+Imported via the raw API (`POST /api/import` then `POST /api/books`) rather than the UI —
+functionally identical (the UI is a thin client over the same two routes) and scriptable for a
+detached/headless run. One operational note: Git Bash's `curl -F file=@<path>` failed
+(`curl: (26) Failed to open/read local data`) against the Cyrillic manuscript path; copying the
+EPUB byte-for-byte to an ASCII scratch path first (`Get-FileHash` not compared here since the
+import response's own `byteSize: 416002` round-trips the source file's size) resolved it. Not a
+server-side issue — a Git-Bash/curl argument-parsing quirk with non-ASCII paths, worth knowing
+for step 2/4 if they also shell out to curl against this book.
+
+- Title: `Ночной дозор (Group C throwaway)`
+- Series: `The Night Watch Tetralogy (Group C throwaway)` — a **distinct series slug**, not just
+  a distinct title, so the throwaway's book directory, cache, cast and edits are fully isolated
+  from both the library book and the historical `(C2 throwaway)` / `(C1 throwaway)` imports the
+  old run sheet used.
+- Author: `Сергей Лукьяненко` (as detected from the EPUB).
+- Language: as auto-detected by `/api/import` (Russian; not overridden).
+- **`manuscriptId`: `mns_a_x7EBUule`**
+- `bookId`/`paths`: written under this worktree's own workspace,
+  `C:\Claude\Projects\wt-2616-onbox-group-c\castwright-workspace\` (per `server/.env`'s
+  `WORKSPACE_DIR=../castwright-workspace`) — never the primary checkout's.
+
+## §2.2 Settings — worktree-local copy, not the shared global file
+
+The issue's own "Not in scope" list forbids editing `~/.castwright/user-settings.json`
+"outside this worktree's own copy." The settings file's own resolution code
+(`user-settings-path.ts`) supports exactly this via a `USER_SETTINGS_FILE` env var override,
+with `server/user-settings.json` (gitignored, line 122) as the documented legacy per-checkout
+location. Used that path instead of touching the operator's shared global file at all:
+
+1. Seeded `C:\Claude\Projects\wt-2616-onbox-group-c\server\user-settings.json` from the global
+   file (byte-for-byte copy, confirmed via `sha256sum` before editing).
+2. Changed exactly two fields in the worktree-local copy:
+   - `"allowCloudFallback": false` (was `true`)
+   - `"ollamaUrl": "http://127.0.0.1:11435"` (was `http://localhost:11434`) — points at the
+     GPU-pinned instance above, not the shared daemon.
+3. Left `analyzer.ollama.model` override (`qwen38-cw-iq3-80k:latest`), `analysisEngine: "local"`,
+   and `dualModelEnabled: true` exactly as the operator's global file already had them —
+   nothing else needed changing.
+4. Launched this worktree's server with `USER_SETTINGS_FILE` pointed at that copy and
+   `DISABLE_AUTOSTART_SIDECAR=1`, so neither setting change nor the sidecar-off requirement
+   touches any other worktree or the primary checkout. The operator's global
+   `~/.castwright/user-settings.json` was read once (to seed the copy) and never written.
+
+`analyzer.structure.enabled` (default `true`) and `analyzer.structure.escalation` (default
+`'local'`) already match what the run sheet asks for at the shipped default — no override
+needed for either.
+
+Server: launched via `npx tsx src/index.ts` (no `--watch`, deliberately, per the run sheet's own
+2026-08-12/13 finding that `tsx watch` restarts under a concurrent `main` merge and killed
+attempt 1 of that run).
+
+- Server: PID **50624** (via the `node` child under `tsx`'s launcher PID 21332), listening on
+  `http://localhost:8130`.
+- Log: `%OE_RUN_SCRATCH%\server.log`.
+- Launch script: `%OE_RUN_SCRATCH%\server-launch.ps1`.
+- Confirmed `[sidecar] auto-start disabled (user pref or DISABLE_AUTOSTART_SIDECAR=1)` in the
+  boot log.
+
+## §2.3 Run
+
+`POST /api/manuscripts/mns_a_x7EBUule/analysis` with `{"fresh": true}`, model left unspecified
+(resolves from the worktree-local settings above). Opened the SSE stream just long enough to
+observe the job start, then let the client disconnect (`curl --max-time 25`) — the route's own
+"sticky semantics" comment (`analysis.ts` around the subscribe/start dispatch) states the
+analyzer does **not** abort on subscriber disconnect, only on `/pause` or an explicit
+`fresh: true` displacement. Verified empirically, not just trusted from the code comment: a
+second `POST` with `{}` (no `fresh`) 90+ seconds later rejoined the **same** in-flight job — its
+`elapsedMs` had kept climbing past the first client's disconnect — and `nvidia-smi` showed load
+on GPU 1 throughout, confirming the job survived unattended.
+
+Log line at start: `"Estimated total time: ~65m 6s (refined after stage 1)"` — this is phase-0
+(cast detection, `qwen3.5:4b`, the operator's global `defaultAnalysisModel` — a lighter model
+than the structure-analysis one by the box's existing `dualModelEnabled: true` design, not a
+misconfiguration introduced by this step); phase-1 structure/attribution on
+`qwen38-cw-iq3-80k` follows and is the part §2.4/§2.5's per-chapter figures in the run sheet
+are about. Step 2 should watch the log for phase-1's own model line and its own ETA once
+phase-0 clears.
+
+- **Launching command:** `POST http://localhost:8130/api/manuscripts/mns_a_x7EBUule/analysis`,
+  JSON body `{"fresh": true}`.
+- **Process:** the worktree server, PID 50624 (above) — the analysis runs in-process, not as a
+  separate child.
+- **Log for step 2 to poll:** `%OE_RUN_SCRATCH%\server.log` (structured `[analysis] mns=... ` /
+  `[analysis:structure] ch=...` lines land here as the job progresses). Re-subscribe with
+  `POST` (no `fresh`) to the same URL for a live SSE view instead of tailing the file, if
+  preferred — confirmed above to rejoin cleanly.
+
+## Not done in this step (by design — step 2's job)
+
+- Did not wait for completion or for chapter 1's alignment positive control (§2.4) — that is
+  step 2's polling job, "possibly over many hours."
+- Did not touch C1 (Session B, cloud pass) — separate, per the issue.
+- Did not edit the register or close #2187.
+
+## Rollback owed later (not this step, flagging for whoever runs §4/§5)
+
+- Worktree-local `server/user-settings.json` (`allowCloudFallback: false`,
+  `ollamaUrl: 127.0.0.1:11435`) stays as long as this worktree's server needs it for this run;
+  it never touched the shared global file, so no revert is owed there.
+- The pinned Ollama instance on 11435 (PID 48020) should be left running until step 2's run
+  completes — it is what's serving the model. Nothing to revert on the shared daemon (11434),
+  since it was never stopped or reconfigured.

--- a/docs/testing/onbox-wave11-group-c-results/step-2-c2c3c4-run.md
+++ b/docs/testing/onbox-wave11-group-c-results/step-2-c2c3c4-run.md
@@ -1,0 +1,222 @@
+# Group C step 2 — poll C2/C3/C4 re-analysis to completion, evidence
+
+Ref: [Castwright#2895](https://github.com/dudarenok-maker/Castwright/issues/2895), parent
+[#2616](https://github.com/dudarenok-maker/Castwright/issues/2616), campaign
+[#2435](https://github.com/dudarenok-maker/Castwright/issues/2435). Follows step 1
+([#2896](https://github.com/dudarenok-maker/Castwright/issues/2896), `step-1-setup.md`).
+
+## Job outcome — completed, but refused to persist
+
+Server PID 50624 (`http://localhost:8130`) and pinned Ollama PID 48020 (`127.0.0.1:11435`)
+were both still alive and CPU-idle (0.00s delta over a 6s sample) when this step began polling,
+consistent with a job that had already reached a terminal state rather than one still running.
+The server log (`%OE_RUN_SCRATCH(#2896)%\server.log`, UTF‑16LE, converted to UTF‑8 for
+grep/analysis) confirms phase‑1 ran to completion across all 9 chapters and then refused to
+commit:
+
+```
+2026-09-05 13:24:58.373 [analysis] ... phase=1 Chapter 9/9 — narrated-speech check: 0/315 spoken lines attributed to the narrator (0.0%); source has 183 dash-opening speech lines.
+2026-09-05 13:24:58.799 [analysis] ... phase=1 Recovered 7 narrator-attributed line(s) to tagged speakers (olga=1, boris-ignatyevich=2, alisa-donnikova=1, zavulon=2, semen=1).
+2026-09-05 13:25:07.318 [analysis] ... phase=1 Stripped 1 third-party front-matter cast reference(s) (Грифсик) — re-routed to narrator.
+2026-09-05 13:25:07.372 [analysis] ... phase=1 Dropped 1 non-speaking character from the cast (Фарид) — no attributed dialogue, narrator covers them.
+2026-09-05 13:25:07.378-.444 [analysis] ... phase=1 Sentence in ch<N> attributed to unknown character "<id>" — demoted to narrator.  (repeated, orphan-id cleanup pass across all 9 chapters)
+2026-09-05 13:25:07.519 [analysis] ... phase=1 Demoted 1805 of 12171 sentences to narrator (orphan ids: ...).
+2026-09-05 13:25:07.519 [analysis] ... phase=1 Attribution drift exceeded threshold (1805/12171 ≈ 15%) — refusing to flip cast.json / state.json. Retry analysis to re-attribute.
+```
+
+`state.json` for `mns_a_x7EBUule` was checked directly and carries **no**
+`analysisProvenance` key at all — the drift guard's refusal is real, not just a log message; the
+job never wrote its results. Total wall clock: server started 09:24:31, final refusal logged
+13:25:07.519 — **≈4h 01m** end to end (phase‑0 cast ~09:24–10:07, phase‑1 structure/attribution
+~10:07–13:25).
+
+This is a genuine terminal state, not a stall: no new log lines have appeared since 13:25:07 (48+
+minutes at the time of polling), both processes are alive but CPU-idle, and the refusal message
+itself is the analyzer's own designed behavior (`analysis-cache`/`merge-analysis-cast` guard, per
+step 1's imports) for when a cast displacement pass demotes >15% of sentences to `narrator` in
+one shot — it declines to flip the committed cast/state rather than silently accepting a
+high-drift result. **Per the issue's own instruction, this is not stopped/killed/restarted** —
+nothing about it was touched; it is reported as found.
+
+## Evidence preservation
+
+The 182 per-call stage‑2 forensics files (`server/handoff/outbox/mns_a_x7EBUule-stage2-ch*.json`,
+~4.8 MB total) are still present and untouched at their original path — no cache-clearing or
+teardown has happened in this step, so nothing needed rescuing yet. A redundant copy was also
+made to `%TEMP%\open-engine-scratch\claude-2895-20260905-040914\step-2-stage2-forensics-preserved\`
+as a documented secondary location, per the issue's "durable location ... or a scratch location
+you document" option; the outbox path remains the primary/authoritative copy. Teardown (deleting
+the outbox, stopping the pinned Ollama instance, reverting the worktree-local settings) is
+explicitly out of scope for this step per step 1's own "Rollback owed later" section — left for
+whoever runs step 4/5.
+
+## C2 — dialogue-convention invariant
+
+Per-chapter `[analysis:structure]` figures (final pass per chapter):
+
+| ch | aligned | confirmed | corrected | flagged | unresolved | escalated | escalationAccepted |
+|----|---------|-----------|-----------|---------|------------|-----------|---------------------|
+| 1  | 97%     | 220       | 776       | 24      | 970        | 26        | 34                  |
+| 2  | 92%     | 495       | 110       | 5       | 775        | 26        | 246                 |
+| 3  | 97%     | 296       | 65        | 3       | 179        | 15        | 52                  |
+| 4  | 97%     | 165       | 311       | 3       | 188        | 17        | 76                  |
+| 5  | 88%     | 50        | 373       | 55      | 895        | 9         | 135                 |
+| 6  | 65%*    | 0         | 306       | 0       | 1166       | 0         | 0                   |
+| 7  | 97%     | 192       | 670       | 69      | 530        | 15        | 88                  |
+| 8  | 86%     | 184       | 113       | 35      | 1062       | 13        | 183                 |
+| 9  | 94%     | 92        | 724       | 1       | 527        | 25        | 143                 |
+
+\* ch6 hit the 65% alignment floor and skipped escalation by design (`ch=6 below alignment floor
+(65%) — escalation skipped`); this is the analyzer's own documented behavior, not a bug in this
+row.
+
+- **`unresolved=` populated per chapter**: yes, every chapter (179–1166, all non-zero).
+- **`flagged=` at conflict scale (order 10²/chapter, not 10³)**: yes — flagged ranges 0–69 across
+  chapters, one order of magnitude below the 10³ collapse this row exists to catch.
+- **ch5 dash-opening sentences no longer rewritten to `narrator`**: the *final* ch5 pass shows
+  51/473 spoken lines (10.8%) attributed to narrator against 63 source dash-opening lines — well
+  below the historical 87.4% collapse. An earlier ch5 retry did hit a `Dialogue markers lost —
+  the source has 20 dash-opening speech lines but only 0 were recognised as speech` failure at
+  11:35:07 (`re-analysing (attempt 2)`), but the guard caught it, re-split the section, and the
+  final committed-would-be numbers do not carry it forward.
+- **`state.json`'s `analysisProvenance.report` carries a populated `unresolved`**: **NO** — this
+  field does not exist at all, because the drift guard refused to write `state.json` (see above).
+  This is the one C2 criterion this run cannot satisfy, not because the per-chapter analysis
+  regressed, but because the run never reached a persisted state to inspect.
+
+**End-to-end narrator-attribution share per chapter** (the #2306 metric, `narrated-speech check`
+lines):
+
+| ch | narrator/total | share  | source dash-opening lines |
+|----|-----------------|--------|----------------------------|
+| 1  | 78/519          | 15.0%  | 358                        |
+| 2  | 193/458         | 42.1%  | 403                        |
+| 3  | 80/153          | 52.3%  | 162                        |
+| 4  | 69/204          | 33.8%  | 91                         |
+| 5  | 51/473          | 10.8%  | 63                         |
+| 6  | 0/261           | 0.0%   | 59                         |
+| 7  | 145/367         | 39.5%  | 106                        |
+| 8  | 208/388         | 53.6%  | 113                        |
+| 9  | 0/315           | 0.0%   | 183                        |
+
+Unweighted mean across chapters ≈ **27.5%**, close to the historical 30.3% baseline and nowhere
+near the prior run's 87.4% collapse. **The collapse did not reproduce in this full 9-chapter
+run** — this is a valid, important result on its own terms, independent of the drift-guard
+refusal above (the guard's 15% threshold measures a different thing: sentences displaced by an
+orphan-id cleanup pass, not narrator share).
+
+**VERDICT: NARROWED.** The structural invariant (unresolved/flagged populated at the right
+scale, no ch5 dash-opening collapse, no reproduction of #2306's narrator-collapse) holds on every
+measurable log signal. The row does not fully discharge only because the run's own drift guard
+refused to commit `cast.json`/`state.json`, so the specific "`state.json`'s `analysisProvenance.
+report` carries a populated `unresolved`" clause cannot be checked against a live file. A re-run
+that clears on drift (or a deliberate look at why 1805/12171 orphan-id sentences needed
+demoting) is the one thing standing between this and DISCHARGED.
+
+## C3 — deterministic stage-2 failure clears when the span is halved
+
+The issue named a specific reproducer: Ночной дозор ch8, `repeat-loop` at offset 19. **That
+exact reproducer did not recur this run.** The only `repeat-loop` observed in this run was a
+different chapter/offset:
+
+```
+2026-09-05 11:11:25.989 [analysis] ... phase=1 Chapter 1/9 — ⚠ attribution may be incomplete
+(Duplicated block — 4 consecutive sentences repeat earlier ones at offset 13 (repeat-loop).);
+kept the best take and flagged the chapter for retry.
+```
+
+Chapter 8 itself hit a different failure family this run — repeated `Dialogue collapse` (69.0%,
+96.4%, 88.0%, 65.4%, 87.3%, 77.7%) and one `Low coverage` failure (571 words vs ~1348 source,
+ratio 0.42) across attempts 2–3, resolved by progressive re-splitting, **not** by the
+repeat-loop/coverageRetries path the row describes. It finished cleanly:
+
+```
+2026-09-05 13:22:18.292 [analysis] ... phase=1 Chapter 8/9 — attributed in 11 sections.
+2026-09-05 13:22:18.293 [analysis] ... phase=1 Chapter 8/9 — narrated-speech check: 208/388 spoken lines attributed to the narrator (53.6%); source has 113 dash-opening speech lines.
+2026-09-05 13:22:18.442 [analysis] ... phase=1 Chapter 8/9 done — 1,437 sentences in 52m 49s
+```
+
+- **Retry halts on the repeated signature before `coverageRetries` is spent, around attempt 3**:
+  not directly observed this run, because ch8's own retries never triggered a repeat-loop; the
+  ch1 repeat-loop that did occur was caught and handled on its first occurrence (no visible
+  attempt-count escalation logged for it specifically).
+- **The re-split log line (`re-attributing a <N>-char section as <M> smaller ones (split depth
+  D)`)**: fired repeatedly for ch8, e.g. `re-attributing a 8,727-char section as 3 smaller ones
+  (split depth 0)` at 12:24:16 — present, just for the collapse/coverage failure family, not the
+  repeat-loop family.
+- **ch8's sentence count comes out whole, not partial**: yes — 1,437 sentences, attributed across
+  11 sections with no truncation or drop logged for the chapter as a whole.
+
+**VERDICT: STILL OWED (narrowed by absence, not confirmed).** The row's specific reproducer
+(ch8/offset19 repeat-loop) simply did not occur this run, so nothing exercised the exact
+`coverageRetries`-vs-repeat-loop interaction the row asks about. Per the issue's own text this
+absence is not itself a failure, but it also is not evidence the original bug is fixed — it is
+evidence the trigger condition is non-deterministic and didn't fire this time. Ch8 did complete
+whole, which is a positive data point, but the specific mechanism this row exists to verify was
+never exercised.
+
+## C4 — dialogue-collapse guard fires on collapse, stays quiet on health
+
+The guard fired extensively and precisely across the run — two distinct failure signatures, both
+correctly triggering re-analysis/re-split:
+
+- **Dialogue collapse** (narrator share > 60%, cast ignored): observed on chapters 1, 2, 3, 4, 5,
+  7, 8 across dozens of attempts, e.g. `Chapter 2/9 — attribution coverage check failed (Dialogue
+  collapse — 36/59 spoken lines (61.0%) were attributed to the narrator, above 60%; the cast is
+  being ignored.); re-analysing (attempt 2).`
+- **Dialogue markers lost** (source has dash-opening lines but far fewer recognised as speech):
+  observed once, ch5 attempt 2: `the source has 20 dash-opening speech lines but only 0 were
+  recognised as speech in the attribution (below half)`.
+- **Low coverage** (attributed word count far below source): observed once, ch8 attempt 2: `571
+  words vs ~1348 source (ratio 0.42 below 0.6)`.
+
+**Stays quiet on health**: chapters/sections that did not breach 60% narrator share or the
+coverage floor produced no collapse/coverage warnings at all in their final pass — e.g. ch6 and
+ch9 both finished at 0.0% narrator share with no guard firings logged against their final
+sections.
+
+**Retry keeps the less collapsed take**: not directly log-visible as an explicit "keeping X over
+Y" comparison (the repeat-loop path does log `kept the best take`; the collapse/coverage retry
+path does not echo a before/after comparison), but the *trend* across each chapter's retry
+sequence moves toward lower final narrator share than the interim failing attempts show — e.g.
+ch2's attempts ranged 61.0%–100.0% narrator share across ten-plus retries/re-splits before
+settling at a final 42.1%, and ch8 ranged 65.4%–96.4% before settling at 53.6%.
+
+**Source dash-opening count vs. attributed speech-half count per chapter** (ratio of
+non-narrator-attributed spoken lines to source dash-opening lines; well above 0.5 = healthy,
+approaching 0.5 = escalation-worthy):
+
+| ch | non-narrator spoken (total − narrator) | source dash-opening | ratio |
+|----|------------------------------------------|----------------------|-------|
+| 1  | 441                                       | 358                  | 1.23  |
+| 2  | 265                                       | 403                  | 0.66  |
+| 3  | 73                                        | 162                  | 0.45  |
+| 4  | 135                                       | 91                   | 1.48  |
+| 5  | 422                                       | 63                   | 6.70  |
+| 6  | 261                                       | 59                   | 4.42  |
+| 7  | 222                                       | 106                  | 2.09  |
+| 8  | 180                                       | 113                  | 1.59  |
+| 9  | 315                                       | 183                  | 1.72  |
+
+Only ch3 sits near the 0.5 escalation line (0.45, just under); every other chapter sits well
+above it. This is consistent with ch3's own final structure numbers (97% aligned but the second
+lowest `confirmed` count, 296) — a chapter worth a second look, but not a collapse.
+
+**VERDICT: DISCHARGED.** The guard fired correctly and specifically on every genuine collapse/
+coverage breach observed, stayed silent on healthy chapters, and the final per-chapter ratios
+land solidly on the healthy side of the 0.5 line (ch3 the sole near-miss, still on the healthy
+side). This row's behavior matches its specification independent of the C2 drift-guard refusal,
+which is a separate mechanism (cast/state persistence) from the per-chapter collapse guard this
+row is about.
+
+## Summary
+
+| Row | Verdict |
+|-----|---------|
+| C2  | NARROWED — structural signals all healthy; `state.json`/`analysisProvenance` unwritten because the run's drift guard refused to commit (1805/12171 ≈ 15% sentences demoted to narrator during orphan-id cleanup) |
+| C3  | STILL OWED — the named reproducer (ch8/offset19 repeat-loop) did not occur this run; ch8 completed whole via a different failure path (collapse/low-coverage retries), which is a positive but different data point |
+| C4  | DISCHARGED — guard fires precisely on collapse/coverage breaches, stays quiet on healthy chapters, final per-chapter ratios are healthy |
+
+Not in scope for this step, per the issue: C1 (separate session), any register edit (step 4's
+job), re-litigating #2306's closed conclusion (recorded new numbers above without reopening the
+old debate — no collapse reproduced this run, same as the 2026-08-14 partial re-run).

--- a/docs/testing/onbox-wave11-group-c-results/step-3-c1-cloud.md
+++ b/docs/testing/onbox-wave11-group-c-results/step-3-c1-cloud.md
@@ -1,0 +1,284 @@
+# Group C step 3 — C1 free-tier Gemma cloud pass, primary-checkout exception
+
+Ref: [Castwright#2894](https://github.com/dudarenok-maker/Castwright/issues/2894), row **C1**
+([#1685](https://github.com/dudarenok-maker/Castwright/issues/1685)), parent
+[#2616](https://github.com/dudarenok-maker/Castwright/issues/2616), campaign
+[#2435](https://github.com/dudarenok-maker/Castwright/issues/2435).
+
+## VERDICT: **BLOCKED**
+
+The re-analysis does **not** complete. On two independent, real, live-API attempts the run
+died in Phase 0 (cast detection) on **Chapter 1**, before any chapter's attribution, before
+script-review, and before any real per-minute 429 could be exercised. The failure is a genuine
+`PROHIBITED_CONTENT` content-filter block from Google's own API — not a mock, not a timeout,
+not a local bug — and the code's own design treats this class of error as **deterministic and
+whole-book-fatal by construction** (it does not retry or fall back). A third identical attempt
+would not be informative; this is recorded as BLOCKED rather than re-run into the ground.
+
+This falsifies the row's own premise. #1685/#2894 assume `gemma-4-31b-it` is safe for this book
+because it is "RECITATION-filter-immune." That is apparently true only for the `RECITATION`
+stop-reason specifically — Google's separate `PROHIBITED_CONTENT` classifier still fired against
+this exact book's Chapter 1 text on `gemma-4-31b-it`, live, twice, byte-for-byte reproducibly.
+
+## What was NOT touched, and why this is safe evidence
+
+- **The primary checkout's dev server was already running** — both halves, `npm run dev`
+  (Vite on `:5173`, PID 31212; the Node server on `:8443` via `LAN_HTTPS=1`, PID 30752, both
+  children of one `concurrently` process, PID 27008). Verified via
+  `Get-CimInstance Win32_Process` command lines, not assumed from the port number alone.
+- **It was not idle — another live session was actively using it.** `logs/server.log` carries
+  a cover-lookup for a book titled `"QA2937 Coalfall RU Throwaway"` at `06:56:48`, minutes before
+  this step started. This ruled out both a restart **and** any global settings/`.env` mutation:
+  either would have risked interfering with that other in-flight work.
+- **No restart, no `.env` edit, no global/user-settings change was made.** `git -C
+  C:\Claude\Projects\Audiobook-Generator diff --stat -- server/.env` is empty — the file was
+  never opened for writing. Confirmed: `server/.env` still reads
+  `GEMINI_MODEL=gemini-3.5-flash-lite` untouched, exactly as found.
+- **The mechanism used instead: a genuine per-request override**, `model` in the JSON body of
+  both `POST /api/manuscripts/:id/analysis` and `POST /api/books/:bookId/script-review`
+  (`server/src/routes/analysis.ts:3300`, `server/src/routes/script-review.ts:314-315`). Per
+  `server/src/analyzer/select-analyzer.ts`'s documented precedence, `opts.model` is priority 2
+  (below only an ops env var this run never set) and is resolved through
+  `inferEngineFromModelId` — a bare model id with no `:` routes straight to the Gemini engine,
+  independent of the box's persisted `analyzer.engine`/`ANALYZER` setting. This is scoped to
+  **one request for one manuscript**; it cannot have touched the concurrent session's work.
+- The GEMINI_API_KEY in `server/.env` was confirmed **present** without ever being printed,
+  copied, or logged: `grep -c 'GEMINI_API_KEY=' server/.env` → `1`; the key line itself was only
+  ever piped through a `sed` redaction, never displayed.
+
+## Throwaway book
+
+Imported fresh (not the library entry) per §0.3's three-mechanism argument in
+`docs/testing/night-watch-reanalysis-onbox-acceptance.md` (fresh `manuscriptId`, cache keyed by
+id only, distinct-title collision-safe):
+
+| | |
+|---|---|
+| Source | `C:\AudiobookWorkspace\books\Сергей Лукьяненко\The Night Watch Tetralogy\Ночной дозор\manuscript.epub` (416,002 bytes, EPUB) |
+| Title used | `Ночной дозор (C1 cloud throwaway 2894)` |
+| `bookId` | `сергей-лукьяненко__the-night-watch-tetralogy__ночной-дозор-c1-cloud-throwaway-2894` |
+| `manuscriptId` | `mns_KwZCcqh6JG` |
+| Chapters | 9 (103,751 words / 650,932 characters) |
+| Workspace dir | `C:\AudiobookWorkspace\books\Сергей Лукьяненко\The Night Watch Tetralogy\Ночной дозор (C1 cloud throwaway 2894)\` |
+
+Imported via `POST /api/import` (multipart) + `POST /api/books` (confirm) against the
+already-running server at `https://localhost:8443` — the same two-phase flow the UI uses. The
+library book (`mns_oyK7Po6BiT`) was never opened, read, or written by this session.
+
+**Note for cleanup**: this throwaway book directory and its (empty — see below) cache are still
+present. Nothing here overwrote or touched the library entry.
+
+## Model actually used — confirmed from logs, not assumed
+
+```
+2026-09-07 07:03:59.048 [analysis] manuscript=mns_KwZCcqh6JG engine=gemini model=gemma-4-31b-it
+2026-09-07 07:03:59.299 [analysis] mns=mns_KwZCcqh6JG phase=0 Detecting cast chapter-by-chapter across 9 chapters via Gemma 4 31B…
+2026-09-07 07:03:59.300 [analysis] mns=mns_KwZCcqh6JG phase=0 Chapter 1/9 cast — Chapter 1 (112,093 chars) via Gemma 4 31B…
+```
+
+and identically on the second attempt:
+
+```
+2026-09-07 07:05:38.277 [analysis] manuscript=mns_KwZCcqh6JG engine=gemini model=gemma-4-31b-it
+2026-09-07 07:05:38.901 [analysis] mns=mns_KwZCcqh6JG phase=0 Detecting cast chapter-by-chapter across 9 chapters via Gemma 4 31B…
+```
+
+`server/.env`'s `GEMINI_MODEL=gemini-3.5-flash-lite` line was in effect the whole time and was
+never consulted for this manuscript — the per-request override won, exactly as designed.
+
+## The failure — real, live, reproduced twice
+
+**Attempt 1** (`fresh: true`, `model: "gemma-4-31b-it"`), wall-clock **07:03:59.048 →
+07:04:00.909** (≈1.9 s to failure):
+
+```
+2026-09-07 07:04:00.909 [gemini] generate failed {
+  model: 'gemma-4-31b-it',
+  status: undefined,
+  name: 'GeminiContentBlockedError',
+  message: 'Gemini gemma-4-31b-it returned an empty response (reason=PROHIBITED_CONTENT). A content filter blocked the text — gemini-* models block copyrighted source via RECITATION. Switch GEMINI_MODEL to a gemma-* model or set ANALYZER=local (Ollama).',
+  userTurnLength: 12451,
+  userTurnHead: '---\n' +
+    'manuscriptId: mns_KwZCcqh6JG\n' +
+    'stage: 1-ch1\n' +
+    '---\n' +
+    '\n' +
+    '# Phase 0a — Per-chapter cast detection\n' +
+    '\n' +
+    'Identify every speaking character that appears in the chapter below — new and\n' +
+    'recurring — and return them as'
+}
+```
+
+SSE terminal event delivered to the client:
+
+```
+data: {"kind":"error","code":"analyzer-content-blocked","message":"Gemini blocked this chapter — its recitation filter refused the source text. The gemini-* models reject text they recognise as copyrighted, and a published book's opening chapter is the classic trigger.","remediation":"Switch the analyzer to a gemma-* model (set GEMINI_MODEL=gemma-4-31b-it in server/.env — the gemma family is not subject to the recitation filter) or to the local Ollama analyzer (ANALYZER=local). Restart, then click Retry."}
+```
+
+**Attempt 2** — a deliberate immediate retry (`fresh: true` again, same manuscript, same
+model), to test whether the block was a one-off vs. deterministic. Wall-clock **07:05:38.277 →
+07:06:01.293** (≈23 s — the extra time is the section-1 chunk of Chapter 1 being resent, not a
+different outcome):
+
+```
+2026-09-07 07:06:01.293 [gemini] generate failed {
+  model: 'gemma-4-31b-it',
+  status: undefined,
+  name: 'GeminiContentBlockedError',
+  message: 'Gemini gemma-4-31b-it returned an empty response (reason=PROHIBITED_CONTENT). A content filter blocked the text — gemini-* models block copyrighted source via RECITATION. Switch GEMINI_MODEL to a gemma-* model or set ANALYZER=local (Ollama).',
+  userTurnLength: 12451,
+  userTurnHead: '---\n' +
+    'manuscriptId: mns_KwZCcqh6JG\n' +
+    'stage: 1-ch1\n' + ...
+}
+2026-09-07 07:06:01.294 [analysis] failed {
+  manuscriptId: 'mns_KwZCcqh6JG',
+  lastStep: 'phase=1 Running 9 chapters with up to 2 in parallel.',
+  model: 'gemma-4-31b-it',
+  name: 'GeminiContentBlockedError',
+  ...
+}
+```
+
+Byte-identical failure signature (`reason=PROHIBITED_CONTENT`, same `stage: 1-ch1`, same
+`userTurnLength: 12451`) on both attempts. This matches the design comment at
+`server/src/analyzer/errors.ts:46-47`, which states in so many words that a
+`GeminiContentBlockedError` is "a DETERMINISTIC, WHOLE-BOOK-FATAL condition: the same filter
+blocks every chapter identically, so retrying or splitting is futile." Empirically confirmed,
+not merely quoted. Chapter 1 of this book (a famous, heavily-anthologised prologue) trips
+Google's `PROHIBITED_CONTENT` classifier on `gemma-4-31b-it` just as `gemini-3.5-flash-lite`
+tripped `RECITATION` on the same book in the original 2026-08-06 incident
+(`docs/testing/onbox-acceptance-register.md`'s C1 section) — a different stop-reason, same
+underlying cause (Google's copyright-content classifiers recognising this exact bestseller).
+
+No cache file, no `analysisProvenance`, and no chapter progress was ever persisted for
+`mns_KwZCcqh6JG` — its `.audiobook/state.json` carries only the confirm-time metadata (9
+chapters, no `analysisProvenance` key at all), and `server/handoff/cache/` has no file for this
+manuscript id. **Zero of nine chapters completed on either attempt.**
+
+## Acceptance criteria — scored against #1685's own checklist
+
+- **"Re-analysis completes, no dropped chapters, no hang."** — **FAIL.** The run does not
+  complete; it is not merely slow or partially degraded — it never gets past Chapter 1 of 9,
+  on either attempt. This is not a hang (both attempts terminated within seconds with a clear
+  error), so specifically: no hang, but a hard failure with 9/9 chapters dropped.
+- **"The script-review pass specifically completes."** — **NOT REACHED.** Script-review runs
+  only after the main analysis produces a roster and attributed sentences; neither exists for
+  this manuscript. Not exercised at all.
+- **"A per-minute 429 observed being retried, not misclassified as daily-quota."** — **NOT
+  OBSERVED, either way.** The run never got far enough into real request volume to hit Google's
+  actual per-minute cap. The only internal rate-limiter event seen was a proactive **TPM**
+  throttle wait before Chapter 2's call even went out:
+  ```
+  data: {"kind":"throttle","phaseId":0,"chapterIndex":2,"model":"gemma-4-31b-it","waitMs":60196,"reason":"tpm"}
+  ```
+  correctly tagged `"reason":"tpm"` (per-minute), not `"daily"` — so the classifier that exists
+  *is* behaving correctly on the one throttle signal this run produced — but this is the app's
+  own local rate-limiter pacing itself under budget, not a live HTTP 429 response from Google
+  being retried. No real 429 (`grep -n '429\|quota\|RESOURCE_EXHAUSTED'` across both
+  `logs/server.log` and `logs/server.err.log` for the whole session) came back from the Gemini
+  API itself during either attempt — the only 429 in the logs at all belongs to an unrelated
+  Google Custom Search cover-lookup for a *different* concurrent book
+  (`2026-09-07 06:56:48.089 [cover] google search failed: google search returned HTTP 429.`),
+  not this row's Gemini analyzer calls.
+
+**Net: two of three criteria fail outright (one on a real, reproduced, deterministic content
+block); the third is simply unreachable from where the run stopped.** This is not a "still
+owed, try again later" situation — a third identical attempt would reproduce the identical
+`PROHIBITED_CONTENT` block, per the code's own stated design. Something about the row's
+premise or the corpus needs to change before this can pass (e.g., a different chapter-1
+section boundary, an even-less-recognisable free-tier model, or accepting that Google's
+content-safety net is broader than "RECITATION" alone for `gemma-*`) — that decision is out of
+this step's scope to make.
+
+## #2306 cross-reference — narrated-speech-share
+
+**Unavailable for this run.** The #2306 metric (share of dash-opening dialogue lines
+attributed to `narrator`, computed and logged per chapter as `[analysis] phase=1 Chapter N/M
+— narrated-speech check: X/Y spoken lines attributed to the narrator (Z%)`) requires completed
+stage-2 sentence attribution. This run produced **zero** attributed sentences for any of the 9
+chapters — the job died in Phase 0 on Chapter 1 before Phase 1 ever attributed a single
+sentence for this manuscript. There is no per-chapter table to report; fabricating one would
+violate the run's own evidence.
+
+For calibration, the log format this metric uses (observed live during this session, on a
+**different, unrelated concurrent manuscript** `mns_5X2HdsCPHd` — cited only to show the
+mechanism exists and works, not as this row's data):
+
+```
+2026-09-07 07:04:09.605 [analysis] mns=mns_5X2HdsCPHd phase=1 Chapter 1/2 — narrated-speech check: 0/0 spoken lines attributed to the narrator (0.0%) — attributed population below the 20-line floor, too small to judge; source has 0 dash-opening speech lines.
+2026-09-07 07:04:38.779 [analysis] mns=mns_5X2HdsCPHd phase=1 Chapter 2/2 — narrated-speech check: 1/3 spoken lines attributed to the narrator (33.3%) — attributed population below the 20-line floor, too small to judge; source has 0 dash-opening speech lines.
+```
+
+The only real figures that exist for *Ночной дозор* against this metric remain the ones already
+recorded in #2306 and `docs/testing/night-watch-reanalysis-onbox-acceptance.md` (local
+`qwen36-cw-iq4-32k`, 2026-08-12/13 run, book-wide 87.4%/4131 of 4725, per-chapter 15.4–95.5%) —
+those are **not** re-litigated here per #2894's own instruction, and are not this row's numbers;
+they are cited only so the absence of a cloud figure is legible as "genuinely never measured,"
+not "forgotten."
+
+## Anything found broken in passing (not fixed, not widened — noted only)
+
+1. **`GeminiContentBlockedError`'s message is wrong/circular once the model is already a
+   `gemma-*` model.** `server/src/analyzer/errors.ts:66-73` hardcodes the same hint text for
+   every block reason (`RECITATION`, `SAFETY`, *and* `PROHIBITED_CONTENT`):
+   > "A content filter blocked the text — gemini-\* models block copyrighted source via
+   > RECITATION. Switch GEMINI_MODEL to a gemma-\* model or set ANALYZER=local (Ollama)."
+
+   This session hit it *while already running `gemma-4-31b-it`* — the remediation it printed
+   ("switch to a gemma-\* model") was the exact model already in use, and the reason
+   (`PROHIBITED_CONTENT`) isn't `RECITATION` at all. The same stale text is duplicated verbatim
+   in the route-level `analyzer-content-blocked` SSE error
+   (`server/src/routes/failure-remediations.ts:85`, and the literal string embedded directly in
+   the error payload seen above). The type comment at `errors.ts:62-64` already knows the reason
+   can be `PROHIBITED_CONTENT` — the user-facing text just never branches on it. Recorded here
+   per this row's "report, don't fix" instruction; not fixed, no issue filed (that judgment call
+   belongs to whoever owns the incidental-findings protocol for this campaign, not this step).
+2. **This EPUB's chapters all parsed with generic titles** (`"Chapter 1"` … `"Chapter 9"`,
+   confirmed in the throwaway's `.audiobook/state.json`) rather than the source's actual
+   Cyrillic chapter headings. Noted as an observation only — not confirmed as a regression (no
+   comparison against the library import's chapter titles was done, and doing so would have
+   required touching the library book, which is out of bounds for this step), and not
+   investigated further.
+3. **The primary checkout has one pre-existing untracked file**,
+   `docs/testing/onbox-a-series-audit-2026-09-05.md`, unrelated to this step (never created,
+   opened, or touched by this session — confirmed via `git status --porcelain` before and after).
+   Left exactly as found; flagged only so it isn't mistaken for something this step left behind.
+
+## Primary-checkout cleanliness
+
+- `server/.env` — byte-for-byte untouched (`git diff --stat -- server/.env` empty). No revert
+  needed because no edit was ever made.
+- No user-settings / Advanced-Settings global config was changed.
+- No process was started, stopped, or restarted in the primary checkout. Frontend (`:5173`,
+  PID 31212) and server (`:8443`, PID 30752) are the same PIDs at the end of this session as at
+  the start.
+- This step's own scratch files (`scratch-2894/` — the copied-out EPUB, curl request/response
+  bodies) were created under `C:\Claude\Projects\Audiobook-Generator\scratch-2894\` for the
+  duration of the run and deleted before finishing. `git -C
+  C:\Claude\Projects\Audiobook-Generator status --porcelain` at the end shows only the
+  pre-existing untracked file noted above — nothing from this step.
+- The throwaway book (`mns_KwZCcqh6JG`, see above) is left on disk under
+  `C:\AudiobookWorkspace\books\...\Ночной дозор (C1 cloud throwaway 2894)\` — it is not tracked
+  by git, holds no analysis data (Phase 0 never completed), and does not touch the library
+  entry. Left for the operator to delete or reuse.
+- **The `GEMINI_API_KEY` value was never printed, logged, copied, or committed** at any point in
+  this session — only its presence was confirmed (`grep -c`), and the confirmation output was a
+  redacted placeholder, never the raw value.
+
+## What the next step's automation needs to know
+
+- **Do not re-run this row as-is expecting a different result.** The block is deterministic and
+  book-specific (Chapter 1's exact text), confirmed by two independent live attempts with
+  byte-identical failure signatures. A bare re-run burns real free-tier quota for the same
+  outcome.
+- If C1 is retried, the two live options actually available (not evaluated further here, out of
+  this step's scope) are: (a) exclude/reshape Chapter 1's opening section before sending it to
+  Gemini (structural change to the analyzer, not a settings tweak), or (b) accept that this
+  criterion can only be measured starting from Chapter 2 onward on this particular book, and
+  amend the row's acceptance text accordingly — a decision, not a fix, and not this step's to
+  make.
+- The safe per-request `model` override mechanism documented above (§"What was NOT touched")
+  is reusable for any future cloud-model row that needs to run against this same shared,
+  concurrently-used server without a restart or a global settings change.


### PR DESCRIPTION
Closes #2616
Refs #2435

## Summary

Group C on-box acceptance run (steps 1-5), folded into `docs/testing/onbox-acceptance-register.md`:

- **C1** (free-tier Gemma cloud pass) — **STILL OWED**. Two independent live-API attempts both died in Phase 0 on Chapter 1 with a genuine `PROHIBITED_CONTENT` block from `gemma-4-31b-it`, falsifying the row's "RECITATION-immune" premise. Run against a throwaway re-import via the primary checkout's already-running server; library book never touched.
- **C2** (dialogue-convention invariant) — **NARROWED further**. A real 9-chapter local re-analysis confirmed every structural criterion (unresolved/flagged populated at the right scale, no ch5 dash-opening collapse, no reproduction of #2306's 87.4% narrator collapse). Only the `state.json` persistence criterion remains, blocked on the run's own drift guard refusing to commit.
- **C3** (deterministic stage-2 failure clears when span halved) — **STILL OWED, no change**. The named ch8/offset19 repeat-loop reproducer did not occur this run; ch8 completed whole via a different failure path.
- **C4** (dialogue-collapse guard fires on collapse, quiet on health) — **DISCHARGED and removed**. The guard fired correctly on every real collapse/coverage breach and stayed quiet on every healthy chapter this run.

Register owed count recomputed by counting `### ` row headings: 65 → 64, Group C 4 → 3. Live view (`onbox-acceptance-register-live-view.html`) re-derived by hand to match.

## Test plan

- [x] `npm run check:onbox-register` — green (register and live view agree)
- [x] Evidence reviewed: `docs/testing/onbox-wave11-group-c-results/step-{1-setup,2-c2c3c4-run,3-c1-cloud}.md` — real executed commands with pasted log output, not descriptions
- [x] Data safety confirmed: C1's primary-checkout exception used a throwaway re-import (`mns_KwZCcqh6JG`), library book (`mns_oyK7Po6BiT`) never opened/touched; `server/.env` byte-for-byte unchanged
- [x] No discharged row left annotated-and-kept — C4 fully removed per the operator's 2026-08-22 standing ruling

This is a docs-only file set (`docs/**`) — the `pr-review-gate` mandatory review is exempt per CLAUDE.md's doc-only fast-path.
