### PR TITLE
docs(docs): split live-view drift into BEHIND and AHEAD cases

### DIFF
--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -327,12 +327,43 @@ comparison, see the edge list above). The merge step that closes this, run
      (`origin/main`'s copy) to tell a genuine defect apart from an ordinary
      in-progress publish:
      - **Your local copy matches the baseline, but the published page doesn't**
-       — this edit is already merged to `origin/main`, yet the live page never
-       caught up. This is the classic A41 signature: PR #2578 review rounds
-       13-18 caught it only by manually byte-diffing the two files, because
-       nothing mechanical compared row content before this check existed. A
-       reported failure of this shape is a genuine defect — do not publish
-       until it's investigated and reconciled.
+       — **two opposite situations produce this one signature, and the check
+       cannot tell them apart.** Establish which one you are in before you
+       touch anything; do not publish under either until you have.
+       - **The live page is BEHIND** — an edit already merged to `origin/main`
+         never reached it. This is the classic A41 signature: PR #2578 review
+         rounds 13-18 caught it only by manually byte-diffing the two files,
+         because nothing mechanical compared row content before this check
+         existed. A genuine defect — investigate and reconcile before
+         publishing.
+       - **The live page is AHEAD** — another lane published from its own
+         branch, which step 4 says to do *before* merging, so the live page
+         legitimately carries rows `origin/main` has not seen yet. Nothing is
+         wrong and there is nothing to reconcile: that lane is simply in front
+         of you. **Republishing your older copy here is the destructive move**
+         — it deletes that lane's rows from the artifact, which is the #1931
+         incident one level up, and it is precisely what this signature will
+         talk you into if you read it as the BEHIND case. Leave the page
+         alone, let that PR merge, pull `main`, and only then start again from
+         step 1.
+
+       **The publish token separates them in one line, and it is the first
+       thing to check** — not the row bodies. Compare `data-published-as` on
+       the saved live page against the tracked file's:
+
+       - **published HIGHER than tracked** → someone is AHEAD of you. Name them
+         with `git log --all -S'<the live page's data-publish-id>' --
+         docs/testing/onbox-acceptance-register-live-view.html`, which
+         resolves to the exact commit that produced the live page, and
+         `gh pr list --head <its branch>` to that lane's PR.
+       - **published EQUAL or LOWER** → the BEHIND case above.
+
+       Observed 2026-09-07: live at 11 against a tracked 9 located PR #3073 in
+       one command, before any row-by-row comparison. The row-content report
+       named A1/A16/A21 — true, but it reads identically in both directions,
+       which is the whole reason to check the counter first. Note this works
+       even though nothing yet *enforces* the token (#2599): reading it by eye
+       costs nothing and does not wait on that check landing.
      - **The published page matches the baseline, but your local copy doesn't**
        — you have a local edit not yet merged to `origin/main`, and the
        published page is simply unchanged (still at baseline) because nothing


### PR DESCRIPTION
## Summary

The live-view publish runbook treated **"your local copy matches the baseline, but the published page doesn't"** as one situation with one verdict — *the live page never caught up; a genuine defect*. Two **opposite** situations produce that identical signature, and the second one is routine:

1. **The live page is BEHIND** — the documented A41 case. A genuine defect.
2. **The live page is AHEAD** — another lane published from its own branch before merging. Step 4 of this same runbook calls that *"the normal order, not a mistake"*.

They need opposite responses, and the wrong one destroys data. An operator who reads an AHEAD page as BEHIND concludes the fix is to publish their own copy — which deletes the other lane's rows from the artifact. That is the **#1931 incident one level up**, i.e. the exact failure `--against-published` was built to prevent.

The literal instruction (*"do not publish"*) is right in both cases, so the harm was bounded — but the diagnosis sends the investigation the wrong way, and the runbook already acknowledges the AHEAD shape in two other places ("Known limitation", "A live version of this same limitation"), so the document contradicted itself.

## What changed

One bullet split into the two cases, plus the diagnostic that separates them **before** any row-by-row comparison: compare `data-published-as` on the saved page against the tracked file's.

- **published HIGHER than tracked** → someone is ahead; `git log --all -S'<publish-id>'` names their commit and `gh pr list --head` their PR.
- **published EQUAL or LOWER** → the BEHIND case.

No code. The token is already stamped and committed on every publish — only the *enforcing* check waits on #2599, and reading the counter by eye does not.

## How this was found — it fired live today

Publishing was owed for **#3031**. Running the runbook produced exactly this signature:

```
row-content-drift: A1 / A16 / A21: content differs between local and published
Do not publish until this is reconciled.
```

Read as written, that is "the live page never caught up — a genuine defect." It was the opposite. The live page carried token **11** against a tracked **9**:

| | Token | Owed | Group A |
|---|---|---|---|
| `main` | 9 | 54 | 36 |
| **Live page** | **11** | 54 | 36 |
| #3073's branch | 11 | — | — |

PR #3073's wave-12 lane had already published from its unmerged branch, and that branch contains **all of `main`, including #3031's merge `0061cce9`** — so #3031's republish debt was already discharged, and its A5-discharge annotation and strip figures were verifiably live. Publishing `main`'s copy would have reverted the page to token 9 and silently deleted that lane's A1/A16/A21 wave-12 evidence.

The token gap identified this in one command. The row-content report, read alone, does not — it looks the same in both directions.

**Worth flagging separately:** #3073's own commit says *"Publishing the live view to its tracked artifact URL is NOT done in this commit — this headless run has no Artifact-publish tool — and is left as an owed step."* It **has** been published: the live page is byte-identical to that branch's tracked file (only the publisher's own `</body></html>` wrapper differs). Someone published on that lane's behalf and its commit record does not know.

## Test plan

Docs-only; no runtime surface. All four register gates green on the change:

- `npm run check:onbox-register` — OK
- `npm run register:build -- --check` — up to date
- `npm run check:register-row-citations` — OK, 52 citations across 373 files
- `npm run check:register-citations` — OK

The `A1/A16/A21` mention added here is deliberately not a citation surface for either checker (no `row`/`Row` token, no register anchor), confirmed by both passing.

### Checklist notes

- **Regression plan** — not applicable; this is a correction to a runbook, and #3074 plus this diff is the record.
- **On-box acceptance** — no row owed or discharged. Row *content* is untouched; only the publish procedure's prose changed.
- **Release notes** — skipped: process documentation, no user- or operator-visible product delta.
- **Automated test** — none available. This is prose in a manual procedure; the mechanical parts it describes (`check:onbox-register`, the token stamper) are already covered by their own tests, and nothing can assert that a paragraph reads correctly.

Closes #3074
Refs #2599
Refs #3031

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Q4SxN46A8ktP28T7NwEKz
