### PR TITLE
fix(scripts): normalise Windows --file paths in flake-repro, refuse unresolvable targets

### DIFF
--- a/scripts/flake-repro.mjs
+++ b/scripts/flake-repro.mjs
@@ -55,7 +55,7 @@ const SLOW = [
 // `fullPath` is the relative or relativised path (before server/ stripping),
 // suitable for file-existence checks. `rel` is after stripping, for vitest filters.
 export function resolveTarget(file, repoRoot) {
-  // Normalize separators (Windows backslash, UNC) and strip leading ./
+  // Normalize separators (Windows backslash, UNC), strip leading ./, and resolve .. segments
   let normalized = file.replace(/\\/g, '/');
   if (normalized.startsWith('./')) {
     normalized = normalized.slice(2);
@@ -65,6 +65,16 @@ export function resolveTarget(file, repoRoot) {
   if (isAbsolute(file)) {
     const abs = resolve(file); // Resolve to absolute form
     const repoAbs = resolve(repoRoot);
+
+    // Check if on the same drive (Windows) — path.relative() can't cross drives
+    const absDrive = abs.split('/')[0]; // e.g., 'C:' or '//host/share'
+    const repoDrive = repoAbs.split('/')[0];
+    if (absDrive !== repoDrive) {
+      // Different drives (or UNC roots) — outside the repo
+      const absPath = abs.replace(/\\/g, '/');
+      return { cwd: null, rel: absPath, fullPath: absPath, isSlow: false, isOutsideRepo: true };
+    }
+
     const relativeToRepo = relative(repoAbs, abs).replace(/\\/g, '/');
     // If relative() returned a path with ../, it's outside the repo
     if (!relativeToRepo.startsWith('..')) {
@@ -146,7 +156,7 @@ function main() {
     return;
   }
 
-  // Require a real file (not a directory) that matches test-file pattern
+  // Require a real file (not a directory)
   let stats;
   try {
     stats = statSync(filePath);
@@ -166,10 +176,23 @@ function main() {
     return;
   }
 
-  // Check that the filename matches a test-file pattern
-  // Pattern: (test|spec).[cm]?[tj]sx?
-  if (!/\.(test|spec)\.[cm]?[tj]sx?$/.test(filePath)) {
-    console.error('flake-repro: not a test file (must match .(test|spec).[cm]?[tj]sx?)');
+  // Ask vitest authoritatively whether it will select this file.
+  // Run `npx vitest list` with the same cwd and config that the measured runs will use.
+  // If vitest outputs nothing, the file won't be tested under the chosen config.
+  const absoluteCwd = resolve(repoRoot, cwd);
+  const listCmd = isSlow
+    ? ['vitest', 'list', '--config', 'vitest.config.slow.ts', rel]
+    : ['vitest', 'list', rel];
+  const listResult = spawnSync('npx', listCmd, {
+    cwd: absoluteCwd,
+    encoding: 'utf8',
+    stdio: ['inherit', 'pipe', 'pipe'],
+    shell: process.platform === 'win32',
+    windowsHide: true,
+  });
+
+  if (listResult.stdout.trim() === '') {
+    console.error('flake-repro: not a test file (vitest does not select it under the chosen config)');
     console.error(`  --file      ${file}`);
     console.error(`  resolved to ${filePath}`);
     process.exitCode = 2;
@@ -188,9 +211,6 @@ function main() {
     ? ['vitest', 'run', '--config', 'vitest.config.slow.ts', rel]
     : ['vitest', 'run', rel];
 
-  // Use absolute cwd so spawn resolves correctly from any working directory
-  const absoluteCwd = resolve(repoRoot, cwd);
-
   const results = [];
   for (let i = 0; i < runs; i++) {
     const t0 = process.hrtime.bigint();
@@ -198,12 +218,15 @@ function main() {
       env: { ...process.env, RUN_QUARANTINE: '1' } }); // RUN_QUARANTINE=1 so quarantined cases run
     const ms = Number(process.hrtime.bigint() - t0) / 1e6;
 
-    // If the spawn itself failed (r.error set or r.status is null), do not report it as a measurement
-    if (r.error || r.status === null) {
+    // If the spawn itself failed (r.error set), stop and report what we have so far
+    if (r.error) {
       stopCpuLoad(); stopIoLoad();
       console.error('flake-repro: spawn failed to start');
-      if (r.error) console.error(`  error: ${r.error.message}`);
-      process.exitCode = 1;
+      console.error(`  error: ${r.error.message}`);
+      if (results.length > 0) {
+        console.log('SUMMARY', JSON.stringify(results));
+      }
+      process.exitCode = 2;
       return;
     }
 

--- a/scripts/flake-repro.mjs
+++ b/scripts/flake-repro.mjs
@@ -71,7 +71,8 @@ export function resolveTarget(file, repoRoot) {
       normalized = relativeToRepo;
     } else {
       // Return as-is; the caller will refuse it as outside the repo
-      return { cwd: null, rel: abs.replace(/\\/g, '/'), isSlow: false, isOutsideRepo: true };
+      const absPath = abs.replace(/\\/g, '/');
+      return { cwd: null, rel: absPath, fullPath: absPath, isSlow: false, isOutsideRepo: true };
     }
   }
 
@@ -187,12 +188,25 @@ function main() {
     ? ['vitest', 'run', '--config', 'vitest.config.slow.ts', rel]
     : ['vitest', 'run', rel];
 
+  // Use absolute cwd so spawn resolves correctly from any working directory
+  const absoluteCwd = resolve(repoRoot, cwd);
+
   const results = [];
   for (let i = 0; i < runs; i++) {
     const t0 = process.hrtime.bigint();
-    const r = spawnSync('npx', cmd, { cwd, stdio: 'inherit', shell: process.platform === 'win32', windowsHide: true,
+    const r = spawnSync('npx', cmd, { cwd: absoluteCwd, stdio: 'inherit', shell: process.platform === 'win32', windowsHide: true,
       env: { ...process.env, RUN_QUARANTINE: '1' } }); // RUN_QUARANTINE=1 so quarantined cases run
     const ms = Number(process.hrtime.bigint() - t0) / 1e6;
+
+    // If the spawn itself failed (r.error set or r.status is null), do not report it as a measurement
+    if (r.error || r.status === null) {
+      stopCpuLoad(); stopIoLoad();
+      console.error('flake-repro: spawn failed to start');
+      if (r.error) console.error(`  error: ${r.error.message}`);
+      process.exitCode = 1;
+      return;
+    }
+
     results.push({ run: i + 1, ms: Math.round(ms), code: r.status });
     console.log(`run ${i + 1}: ${Math.round(ms)}ms exit=${r.status}`);
   }

--- a/scripts/flake-repro.mjs
+++ b/scripts/flake-repro.mjs
@@ -1,9 +1,17 @@
 // scripts/flake-repro.mjs — measure a test file's runtime under induced load.
-// Usage: node scripts/flake-repro.mjs --file server/src/routes/analysis-pipelining.test.ts --runs 3 --cpu-load --io-load
+// Usage: node scripts/flake-repro.mjs --file <test-file> --runs <N> [--cpu-load] [--io-load]
+//
+// --file accepts a relative or absolute path to a test file (not a vitest filter).
+//   Relative paths are resolved against the repo root. Absolute paths are accepted
+//   only if they resolve to a file within the repo; paths outside the repo are refused.
+//   Test files must exist and match the test-file glob patterns from the vitest configs.
+//   Partial path filters (e.g., 'src/routes/voices') are no longer accepted as of #3081.
+//
 import { spawn, spawnSync } from 'node:child_process';
-import { rmSync, mkdtempSync, existsSync } from 'node:fs';
+import { rmSync, mkdtempSync, existsSync, statSync } from 'node:fs';
 import { tmpdir, cpus } from 'node:os';
-import { join, resolve } from 'node:path';
+import { join, resolve, relative, isAbsolute } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { isDirectlyInvoked } from './lib/is-main-module.mjs';
 
 // Decide config: slow files run via the slow config. This list is the exact
@@ -28,7 +36,7 @@ const SLOW = [
   'src/routes/analysis.interim-prune-prohibition.e2e.test.ts',
 ];
 
-// Pure function: resolve a --file argument into { cwd, rel, isSlow }.
+// Pure function: resolve a --file argument into { cwd, rel, isSlow, fullPath }.
 // PowerShell tab-completion produces backslash paths on Windows (the ordinary
 // way paths are typed on this repo's primary platform), but three separate
 // consumers below — cwd routing, server/ prefix strip, and SLOW exact-match —
@@ -37,19 +45,41 @@ const SLOW = [
 // wrong config and still reports a timing, making the silent failure hard to
 // spot (issue #3081). The three consumers are:
 //   - `cwd` choice: checks startsWith('server/')
-//   - `rel` production: strips a leading `server/`
+//   - `rel` production: strips a leading `server/` (for vitest)
 //   - `isSlow` lookup: EXACT match against SLOW's POSIX paths
-export function resolveTarget(file) {
+//
+// Absolute paths (drive-letter, UNC, or POSIX) are relativised against repoRoot.
+// Paths that resolve outside the repo are returned as-is for validation by the
+// caller (which will refuse them with an appropriate diagnostic).
+//
+// `fullPath` is the relative or relativised path (before server/ stripping),
+// suitable for file-existence checks. `rel` is after stripping, for vitest filters.
+export function resolveTarget(file, repoRoot) {
+  // Normalize separators (Windows backslash, UNC) and strip leading ./
   let normalized = file.replace(/\\/g, '/');
   if (normalized.startsWith('./')) {
     normalized = normalized.slice(2);
+  }
+
+  // If absolute, relativise against repo root (or leave as absolute if outside repo)
+  if (isAbsolute(file)) {
+    const abs = resolve(file); // Resolve to absolute form
+    const repoAbs = resolve(repoRoot);
+    const relativeToRepo = relative(repoAbs, abs).replace(/\\/g, '/');
+    // If relative() returned a path with ../, it's outside the repo
+    if (!relativeToRepo.startsWith('..')) {
+      normalized = relativeToRepo;
+    } else {
+      // Return as-is; the caller will refuse it as outside the repo
+      return { cwd: null, rel: abs.replace(/\\/g, '/'), isSlow: false, isOutsideRepo: true };
+    }
   }
 
   const cwd = normalized.startsWith('server/') ? 'server' : '.';
   const rel = normalized.replace(/^server\//, '');
   const isSlow = SLOW.includes(rel);
 
-  return { cwd, rel, isSlow };
+  return { cwd, rel, isSlow, fullPath: normalized, isOutsideRepo: false };
 }
 
 let cpuBurners = [];
@@ -81,12 +111,32 @@ function main() {
   const get = (k, d) => { const i = args.indexOf(k); return i >= 0 ? args[i + 1] : d; };
   const has = (k) => args.includes(k);
   const file = get('--file');
-  const runs = Number(get('--runs', '3'));
+  const runsArg = get('--runs', '3');
+  const runs = Number(runsArg);
+
   if (!file) { console.error('--file <relpath> required'); process.exitCode = 2; return; }
+  if (!Number.isInteger(runs) || runs <= 0) {
+    console.error(`flake-repro: --runs must be a positive integer, got '${runsArg}'`);
+    process.exitCode = 2;
+    return;
+  }
 
-  const { cwd, rel, isSlow } = resolveTarget(file);
+  // Resolve the repo root from this script's location
+  const scriptDir = fileURLToPath(new URL('.', import.meta.url));
+  const repoRoot = resolve(scriptDir, '..');
 
-  const filePath = resolve(cwd, rel);
+  const { cwd, rel, isSlow, fullPath, isOutsideRepo } = resolveTarget(file, repoRoot);
+
+  if (isOutsideRepo) {
+    console.error('flake-repro: path resolves outside the repository');
+    console.error(`  --file      ${file}`);
+    console.error(`  resolved to ${fullPath}`);
+    console.error(`  repo root   ${repoRoot}`);
+    process.exitCode = 2;
+    return;
+  }
+
+  const filePath = resolve(repoRoot, fullPath);
   if (!existsSync(filePath)) {
     console.error('flake-repro: no such test file');
     console.error(`  --file      ${file}`);
@@ -94,6 +144,41 @@ function main() {
     process.exitCode = 2;
     return;
   }
+
+  // Require a real file (not a directory) that matches test-file pattern
+  let stats;
+  try {
+    stats = statSync(filePath);
+  } catch {
+    console.error('flake-repro: cannot stat file');
+    console.error(`  --file      ${file}`);
+    console.error(`  resolved to ${filePath}`);
+    process.exitCode = 2;
+    return;
+  }
+
+  if (!stats.isFile()) {
+    console.error('flake-repro: not a regular file');
+    console.error(`  --file      ${file}`);
+    console.error(`  resolved to ${filePath}`);
+    process.exitCode = 2;
+    return;
+  }
+
+  // Check that the filename matches a test-file pattern
+  // Pattern: (test|spec).[cm]?[tj]sx?
+  if (!/\.(test|spec)\.[cm]?[tj]sx?$/.test(filePath)) {
+    console.error('flake-repro: not a test file (must match .(test|spec).[cm]?[tj]sx?)');
+    console.error(`  --file      ${file}`);
+    console.error(`  resolved to ${filePath}`);
+    process.exitCode = 2;
+    return;
+  }
+
+  // Note: process.exitCode = 2 before starting the load-inducer children is safe
+  // because the children's event loop keeps the process alive. A return after
+  // startCpuLoad() would hang (the main process exits but children keep running).
+  // Keep this early-exit block and comment together.
 
   if (has('--cpu-load')) startCpuLoad();
   if (has('--io-load')) startIoLoad();

--- a/scripts/flake-repro.mjs
+++ b/scripts/flake-repro.mjs
@@ -1,16 +1,10 @@
 // scripts/flake-repro.mjs — measure a test file's runtime under induced load.
 // Usage: node scripts/flake-repro.mjs --file server/src/routes/analysis-pipelining.test.ts --runs 3 --cpu-load --io-load
 import { spawn, spawnSync } from 'node:child_process';
-import { rmSync, mkdtempSync } from 'node:fs';
+import { rmSync, mkdtempSync, existsSync } from 'node:fs';
 import { tmpdir, cpus } from 'node:os';
-import { join } from 'node:path';
-
-const args = process.argv.slice(2);
-const get = (k, d) => { const i = args.indexOf(k); return i >= 0 ? args[i + 1] : d; };
-const has = (k) => args.includes(k);
-const file = get('--file');
-const runs = Number(get('--runs', '3'));
-if (!file) { console.error('--file <relpath> required'); process.exit(2); }
+import { join, resolve } from 'node:path';
+import { isDirectlyInvoked } from './lib/is-main-module.mjs';
 
 // Decide config: slow files run via the slow config. This list is the exact
 // set of paths in server/vitest.config.slow.ts's SLOW_FILES, mirrored here
@@ -33,9 +27,30 @@ const SLOW = [
   'src/routes/venv-bootstrap.route.test.ts',
   'src/routes/analysis.interim-prune-prohibition.e2e.test.ts',
 ];
-const cwd = file.startsWith('server/') ? 'server' : '.';
-const rel = file.replace(/^server\//, '');
-const isSlow = SLOW.includes(rel);
+
+// Pure function: resolve a --file argument into { cwd, rel, isSlow }.
+// PowerShell tab-completion produces backslash paths on Windows (the ordinary
+// way paths are typed on this repo's primary platform), but three separate
+// consumers below — cwd routing, server/ prefix strip, and SLOW exact-match —
+// all expect POSIX separators. Normalizing here once fixes all three; a
+// mismatch in any one leaves the others silently broken. The run goes to the
+// wrong config and still reports a timing, making the silent failure hard to
+// spot (issue #3081). The three consumers are:
+//   - `cwd` choice: checks startsWith('server/')
+//   - `rel` production: strips a leading `server/`
+//   - `isSlow` lookup: EXACT match against SLOW's POSIX paths
+export function resolveTarget(file) {
+  let normalized = file.replace(/\\/g, '/');
+  if (normalized.startsWith('./')) {
+    normalized = normalized.slice(2);
+  }
+
+  const cwd = normalized.startsWith('server/') ? 'server' : '.';
+  const rel = normalized.replace(/^server\//, '');
+  const isSlow = SLOW.includes(rel);
+
+  return { cwd, rel, isSlow };
+}
 
 let cpuBurners = [];
 function startCpuLoad() {
@@ -61,21 +76,45 @@ function startIoLoad() {
 }
 function stopIoLoad() { if (ioBurner) ioBurner.kill('SIGKILL'); if (ioDir) rmSync(ioDir, { recursive: true, force: true }); }
 
-if (has('--cpu-load')) startCpuLoad();
-if (has('--io-load')) startIoLoad();
+function main() {
+  const args = process.argv.slice(2);
+  const get = (k, d) => { const i = args.indexOf(k); return i >= 0 ? args[i + 1] : d; };
+  const has = (k) => args.includes(k);
+  const file = get('--file');
+  const runs = Number(get('--runs', '3'));
+  if (!file) { console.error('--file <relpath> required'); process.exitCode = 2; return; }
 
-const cmd = isSlow
-  ? ['vitest', 'run', '--config', 'vitest.config.slow.ts', rel]
-  : ['vitest', 'run', rel];
+  const { cwd, rel, isSlow } = resolveTarget(file);
 
-const results = [];
-for (let i = 0; i < runs; i++) {
-  const t0 = process.hrtime.bigint();
-  const r = spawnSync('npx', cmd, { cwd, stdio: 'inherit', shell: process.platform === 'win32', windowsHide: true,
-    env: { ...process.env, RUN_QUARANTINE: '1' } }); // RUN_QUARANTINE=1 so quarantined cases run
-  const ms = Number(process.hrtime.bigint() - t0) / 1e6;
-  results.push({ run: i + 1, ms: Math.round(ms), code: r.status });
-  console.log(`run ${i + 1}: ${Math.round(ms)}ms exit=${r.status}`);
+  const filePath = resolve(cwd, rel);
+  if (!existsSync(filePath)) {
+    console.error('flake-repro: no such test file');
+    console.error(`  --file      ${file}`);
+    console.error(`  resolved to ${filePath}`);
+    process.exitCode = 2;
+    return;
+  }
+
+  if (has('--cpu-load')) startCpuLoad();
+  if (has('--io-load')) startIoLoad();
+
+  const cmd = isSlow
+    ? ['vitest', 'run', '--config', 'vitest.config.slow.ts', rel]
+    : ['vitest', 'run', rel];
+
+  const results = [];
+  for (let i = 0; i < runs; i++) {
+    const t0 = process.hrtime.bigint();
+    const r = spawnSync('npx', cmd, { cwd, stdio: 'inherit', shell: process.platform === 'win32', windowsHide: true,
+      env: { ...process.env, RUN_QUARANTINE: '1' } }); // RUN_QUARANTINE=1 so quarantined cases run
+    const ms = Number(process.hrtime.bigint() - t0) / 1e6;
+    results.push({ run: i + 1, ms: Math.round(ms), code: r.status });
+    console.log(`run ${i + 1}: ${Math.round(ms)}ms exit=${r.status}`);
+  }
+  stopCpuLoad(); stopIoLoad();
+  console.log('SUMMARY', JSON.stringify(results));
 }
-stopCpuLoad(); stopIoLoad();
-console.log('SUMMARY', JSON.stringify(results));
+
+if (isDirectlyInvoked(import.meta.url)) {
+  main();
+}

--- a/scripts/flake-repro.mjs
+++ b/scripts/flake-repro.mjs
@@ -10,7 +10,7 @@
 import { spawn, spawnSync } from 'node:child_process';
 import { rmSync, mkdtempSync, existsSync, statSync } from 'node:fs';
 import { tmpdir, cpus } from 'node:os';
-import { join, resolve, relative, isAbsolute, posix as pathPosix } from 'node:path';
+import nodePath, { join, posix as pathPosix } from 'node:path';
 const posixNormalize = pathPosix.normalize;
 import { fileURLToPath } from 'node:url';
 import { isDirectlyInvoked } from './lib/is-main-module.mjs';
@@ -55,44 +55,49 @@ const SLOW = [
 //
 // `fullPath` is the relative or relativised path (before server/ stripping),
 // suitable for file-existence checks. `rel` is after stripping, for vitest filters.
-export function resolveTarget(file, repoRoot) {
-  // Normalize separators (Windows backslash, UNC), strip leading ./, and resolve .. segments
+/* `pathImpl` is injectable ONLY so Windows semantics are testable from any
+   OS, and that is not a nicety: `test:hooks` runs on ubuntu-latest alone
+   (verify.yml's Windows leg runs `npm test` + `npm run test:server`, not this
+   harness). The R1 regression -- every in-repo absolute path refused -- was
+   invisible to a POSIX run because BOTH operands of the broken comparison
+   were '' there. A test exercising this on `path.posix` can never fail on it,
+   so the regression cases pass `path.win32` explicitly (#3082 pass 4, N1).
+   Defaults to the platform impl for real use. */
+export function resolveTarget(file, repoRoot, pathImpl = nodePath) {
   /* posixNormalize collapses interior '.' and '..' segments, not just
-     separators. Without it 'server/./src/routes/book-state.test.ts' keeps
-     its './', fails the SLOW exact-match, and routes a slow-lane file to
-     the config that excludes it -- #3081's own mis-routing in a different
-     spelling (#3082 pass 3, R4). A leading './' is stripped after, since
-     normalize preserves that one. */
+     separators. Without it 'server/./src/routes/book-state.test.ts' keeps its
+     './', fails the SLOW exact-match, and routes a slow-lane file to the
+     config that excludes it -- #3081's own mis-routing in a different
+     spelling (#3082 pass 3, R4). A leading './' and any TRAILING separator go
+     too; a trailing '/' was one further spelling of it (#3082 pass 4, N2). */
   let normalized = posixNormalize(file.replace(/\\/g, '/'));
-  if (normalized.startsWith('./')) {
-    normalized = normalized.slice(2);
-  }
+  if (normalized.startsWith('./')) normalized = normalized.slice(2);
+  if (normalized.length > 1 && normalized.endsWith('/')) normalized = normalized.slice(0, -1);
 
-  // If absolute, relativise against repo root (or leave as absolute if outside repo)
-  if (isAbsolute(file)) {
-    const abs = resolve(file); // Resolve to absolute form
-    const repoAbs = resolve(repoRoot);
+  /* ONE containment test for every shape of input. Absolute, relative,
+     '..'-escaping and drive-relative ('D:foo') all reduce to the same
+     question: where does this land, and is that inside the repo? Guarding
+     only the absolute branch left
+     'server/../../<sibling-worktree>/server/src/routes/book-state.test.ts'
+     reaching a real test file in ANOTHER lane's worktree, refused only by the
+     oracle and with the wrong sentence (#3082 pass 4, N3).
 
-    /* Cross-root (a different Windows drive, or a UNC share) and
-       outside-the-tree are ONE test, not two: path.relative() cannot express
-       a route between two roots, so it hands back the target ABSOLUTE
-       instead. isAbsolute(relativeToRepo) IS therefore the cross-drive check.
-       A hand-rolled drive comparison was tried and shipped broken (#3082
-       review pass 3, R1): it split a path.resolve() result on '/', which on
-       Windows is backslash-separated, so both sides were the whole path and
-       EVERY in-repo absolute path was refused as 'outside the repository' --
-       while the same message printed a resolved path plainly inside the
-       printed root. Nothing could see it: test:hooks runs on ubuntu only,
-       where that comparison was '' === ''. */
-    const relativeToRepo = relative(repoAbs, abs).replace(/\\/g, '/');
-    if (!relativeToRepo.startsWith('..') && !isAbsolute(relativeToRepo)) {
-      normalized = relativeToRepo;
-    } else {
-      // Return as-is; the caller will refuse it as outside the repo
-      const absPath = abs.replace(/\\/g, '/');
-      return { cwd: null, rel: absPath, fullPath: absPath, isSlow: false, isOutsideRepo: true };
-    }
+     Cross-root and outside-the-tree are the SAME test: path.relative() cannot
+     express a route between two roots, so it returns the target absolute --
+     isAbsolute() on its output IS the cross-drive check. A hand-rolled drive
+     comparison was tried and shipped broken (#3082 pass 3, R1): it split a
+     path.resolve() result on '/', which is backslash-separated on Windows, so
+     both operands were the whole path and nothing ever matched. */
+  const repoAbs = pathImpl.resolve(repoRoot);
+  const abs = pathImpl.isAbsolute(file)
+    ? pathImpl.resolve(file)
+    : pathImpl.resolve(repoAbs, normalized);
+  const relativeToRepo = pathImpl.relative(repoAbs, abs).replace(/\\/g, '/');
+  if (relativeToRepo === '' || relativeToRepo.startsWith('..') || pathImpl.isAbsolute(relativeToRepo)) {
+    const absPath = abs.replace(/\\/g, '/');
+    return { cwd: null, rel: absPath, fullPath: absPath, isSlow: false, isOutsideRepo: true };
   }
+  normalized = relativeToRepo;
 
   const cwd = normalized.startsWith('server/') ? 'server' : '.';
   const rel = normalized.replace(/^server\//, '');
@@ -142,7 +147,7 @@ function main() {
 
   // Resolve the repo root from this script's location
   const scriptDir = fileURLToPath(new URL('.', import.meta.url));
-  const repoRoot = resolve(scriptDir, '..');
+  const repoRoot = nodePath.resolve(scriptDir, '..');
 
   const { cwd, rel, isSlow, fullPath, isOutsideRepo } = resolveTarget(file, repoRoot);
 
@@ -155,7 +160,7 @@ function main() {
     return;
   }
 
-  const filePath = resolve(repoRoot, fullPath);
+  const filePath = nodePath.resolve(repoRoot, fullPath);
   if (!existsSync(filePath)) {
     console.error('flake-repro: no such test file');
     console.error(`  --file      ${file}`);
@@ -187,7 +192,7 @@ function main() {
   // Ask vitest authoritatively whether it will select this file.
   // Run `npx vitest list` with the same cwd and config that the measured runs will use.
   // If vitest outputs nothing, the file won't be tested under the chosen config.
-  const absoluteCwd = resolve(repoRoot, cwd);
+  const absoluteCwd = nodePath.resolve(repoRoot, cwd);
   const listCmd = isSlow
     ? ['vitest', 'list', '--config', 'vitest.config.slow.ts', rel]
     : ['vitest', 'list', rel];

--- a/scripts/flake-repro.mjs
+++ b/scripts/flake-repro.mjs
@@ -10,7 +10,8 @@
 import { spawn, spawnSync } from 'node:child_process';
 import { rmSync, mkdtempSync, existsSync, statSync } from 'node:fs';
 import { tmpdir, cpus } from 'node:os';
-import { join, resolve, relative, isAbsolute } from 'node:path';
+import { join, resolve, relative, isAbsolute, posix as pathPosix } from 'node:path';
+const posixNormalize = pathPosix.normalize;
 import { fileURLToPath } from 'node:url';
 import { isDirectlyInvoked } from './lib/is-main-module.mjs';
 
@@ -56,7 +57,13 @@ const SLOW = [
 // suitable for file-existence checks. `rel` is after stripping, for vitest filters.
 export function resolveTarget(file, repoRoot) {
   // Normalize separators (Windows backslash, UNC), strip leading ./, and resolve .. segments
-  let normalized = file.replace(/\\/g, '/');
+  /* posixNormalize collapses interior '.' and '..' segments, not just
+     separators. Without it 'server/./src/routes/book-state.test.ts' keeps
+     its './', fails the SLOW exact-match, and routes a slow-lane file to
+     the config that excludes it -- #3081's own mis-routing in a different
+     spelling (#3082 pass 3, R4). A leading './' is stripped after, since
+     normalize preserves that one. */
+  let normalized = posixNormalize(file.replace(/\\/g, '/'));
   if (normalized.startsWith('./')) {
     normalized = normalized.slice(2);
   }
@@ -66,18 +73,19 @@ export function resolveTarget(file, repoRoot) {
     const abs = resolve(file); // Resolve to absolute form
     const repoAbs = resolve(repoRoot);
 
-    // Check if on the same drive (Windows) — path.relative() can't cross drives
-    const absDrive = abs.split('/')[0]; // e.g., 'C:' or '//host/share'
-    const repoDrive = repoAbs.split('/')[0];
-    if (absDrive !== repoDrive) {
-      // Different drives (or UNC roots) — outside the repo
-      const absPath = abs.replace(/\\/g, '/');
-      return { cwd: null, rel: absPath, fullPath: absPath, isSlow: false, isOutsideRepo: true };
-    }
-
+    /* Cross-root (a different Windows drive, or a UNC share) and
+       outside-the-tree are ONE test, not two: path.relative() cannot express
+       a route between two roots, so it hands back the target ABSOLUTE
+       instead. isAbsolute(relativeToRepo) IS therefore the cross-drive check.
+       A hand-rolled drive comparison was tried and shipped broken (#3082
+       review pass 3, R1): it split a path.resolve() result on '/', which on
+       Windows is backslash-separated, so both sides were the whole path and
+       EVERY in-repo absolute path was refused as 'outside the repository' --
+       while the same message printed a resolved path plainly inside the
+       printed root. Nothing could see it: test:hooks runs on ubuntu only,
+       where that comparison was '' === ''. */
     const relativeToRepo = relative(repoAbs, abs).replace(/\\/g, '/');
-    // If relative() returned a path with ../, it's outside the repo
-    if (!relativeToRepo.startsWith('..')) {
+    if (!relativeToRepo.startsWith('..') && !isAbsolute(relativeToRepo)) {
       normalized = relativeToRepo;
     } else {
       // Return as-is; the caller will refuse it as outside the repo
@@ -189,7 +197,31 @@ function main() {
     stdio: ['inherit', 'pipe', 'pipe'],
     shell: process.platform === 'win32',
     windowsHide: true,
+    /* Must match the measured run's env EXACTLY or the oracle answers a
+       different question than the one asked. `vitest list` omits skipped
+       tests, so without RUN_QUARANTINE a file whose every case is
+       quarantined lists NOTHING -- byte-identical to the refusal signal,
+       and no status check can tell those apart (#3082 pass 3, R2). */
+    env: { ...process.env, RUN_QUARANTINE: '1' },
   });
+
+  /* Empty stdout means 'selected nothing' ONLY if the oracle actually ran.
+     A failed spawn, a missing config, or a config that throws all produce
+     empty stdout too -- and on POSIX (shell:false) a failed spawn leaves
+     stdout undefined, which crashed on .trim() (#3082 pass 3, R3). Those
+     are a broken oracle, not a verdict, and must not be reported as
+     'not a test file'. */
+  if (listResult.error || listResult.status !== 0 || typeof listResult.stdout !== 'string') {
+    console.error('flake-repro: could not ask vitest which files it selects');
+    console.error(`  command     npx ${listCmd.join(' ')}`);
+    console.error(`  in          ${absoluteCwd}`);
+    if (listResult.error) console.error(`  spawn error ${listResult.error.message}`);
+    else console.error(`  exit        ${listResult.status}`);
+    const stderrHead = String(listResult.stderr || '').trim().slice(0, 200);
+    if (stderrHead) console.error(`  stderr      ${stderrHead}`);
+    process.exitCode = 2;
+    return;
+  }
 
   if (listResult.stdout.trim() === '') {
     console.error('flake-repro: not a test file (vitest does not select it under the chosen config)');

--- a/scripts/tests/flake-repro.test.mjs
+++ b/scripts/tests/flake-repro.test.mjs
@@ -12,79 +12,183 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { resolveTarget } from '../flake-repro.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+const scriptPath = resolve(here, '..', 'flake-repro.mjs');
+
+// === Unit tests: resolveTarget pure function ===
 
 // Test a slow-lane server file in all three Windows/POSIX path forms
 test('resolveTarget: slow-lane server file with forward slashes', () => {
-  const result = resolveTarget('server/src/routes/book-state.test.ts');
+  const result = resolveTarget('server/src/routes/book-state.test.ts', repoRoot);
   assert.deepStrictEqual(result, {
     cwd: 'server',
     rel: 'src/routes/book-state.test.ts',
+    fullPath: 'server/src/routes/book-state.test.ts',
     isSlow: true,
+    isOutsideRepo: false,
   });
 });
 
 test('resolveTarget: slow-lane server file with backslashes (regression)', () => {
-  const result = resolveTarget('server\\src\\routes\\book-state.test.ts');
+  const result = resolveTarget('server\\src\\routes\\book-state.test.ts', repoRoot);
   assert.deepStrictEqual(result, {
     cwd: 'server',
     rel: 'src/routes/book-state.test.ts',
+    fullPath: 'server/src/routes/book-state.test.ts',
     isSlow: true,
+    isOutsideRepo: false,
   });
 });
 
 test('resolveTarget: slow-lane server file with ./ prefix and backslashes (regression)', () => {
-  const result = resolveTarget('.\\server\\src\\routes\\book-state.test.ts');
+  const result = resolveTarget('.\\server\\src\\routes\\book-state.test.ts', repoRoot);
   assert.deepStrictEqual(result, {
     cwd: 'server',
     rel: 'src/routes/book-state.test.ts',
+    fullPath: 'server/src/routes/book-state.test.ts',
     isSlow: true,
+    isOutsideRepo: false,
   });
 });
 
-// Test a non-slow server file in all three forms
+// Test a non-slow server file in all three forms (use a real file)
 test('resolveTarget: non-slow server file with forward slashes', () => {
-  const result = resolveTarget('server/src/routes/voices.route.test.ts');
+  const result = resolveTarget('server/src/routes/voices.test.ts', repoRoot);
   assert.deepStrictEqual(result, {
     cwd: 'server',
-    rel: 'src/routes/voices.route.test.ts',
+    rel: 'src/routes/voices.test.ts',
+    fullPath: 'server/src/routes/voices.test.ts',
     isSlow: false,
+    isOutsideRepo: false,
   });
 });
 
 test('resolveTarget: non-slow server file with backslashes (regression)', () => {
-  const result = resolveTarget('server\\src\\routes\\voices.route.test.ts');
+  const result = resolveTarget('server\\src\\routes\\voices.test.ts', repoRoot);
   assert.deepStrictEqual(result, {
     cwd: 'server',
-    rel: 'src/routes/voices.route.test.ts',
+    rel: 'src/routes/voices.test.ts',
+    fullPath: 'server/src/routes/voices.test.ts',
     isSlow: false,
+    isOutsideRepo: false,
   });
 });
 
 test('resolveTarget: non-slow server file with ./ prefix and backslashes (regression)', () => {
-  const result = resolveTarget('.\\server\\src\\routes\\voices.route.test.ts');
+  const result = resolveTarget('.\\server\\src\\routes\\voices.test.ts', repoRoot);
   assert.deepStrictEqual(result, {
     cwd: 'server',
-    rel: 'src/routes/voices.route.test.ts',
+    rel: 'src/routes/voices.test.ts',
+    fullPath: 'server/src/routes/voices.test.ts',
     isSlow: false,
+    isOutsideRepo: false,
   });
 });
 
 // Test a frontend file
 test('resolveTarget: frontend file with forward slashes', () => {
-  const result = resolveTarget('src/views/listen.test.tsx');
+  const result = resolveTarget('src/views/listen.test.tsx', repoRoot);
   assert.deepStrictEqual(result, {
     cwd: '.',
     rel: 'src/views/listen.test.tsx',
+    fullPath: 'src/views/listen.test.tsx',
     isSlow: false,
+    isOutsideRepo: false,
   });
 });
 
 test('resolveTarget: frontend file with backslashes (regression)', () => {
-  const result = resolveTarget('src\\views\\listen.test.tsx');
+  const result = resolveTarget('src\\views\\listen.test.tsx', repoRoot);
   assert.deepStrictEqual(result, {
     cwd: '.',
     rel: 'src/views/listen.test.tsx',
+    fullPath: 'src/views/listen.test.tsx',
     isSlow: false,
+    isOutsideRepo: false,
   });
+});
+
+// === CLI-level tests: spawn subprocess and check behavior ===
+
+function runFlakeRepro(args) {
+  const result = spawnSync(process.execPath, [scriptPath, ...args], {
+    encoding: 'utf8',
+    stdio: 'pipe',
+  });
+  return {
+    exitCode: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+test('CLI: nonexistent file is refused with exit 2 and no SUMMARY', () => {
+  const { exitCode, stdout, stderr } = runFlakeRepro(['--file', 'nonexistent.test.ts', '--runs', '1']);
+  assert.strictEqual(exitCode, 2, `expected exit 2, got ${exitCode}`);
+  assert.strictEqual(stdout.includes('SUMMARY'), false, 'stdout should not contain SUMMARY');
+  assert.strictEqual(stderr.includes('no such test file'), true, 'stderr should mention the error');
+});
+
+test('CLI: absolute path outside repo is refused with exit 2 and no SUMMARY', () => {
+  const { exitCode, stdout, stderr } = runFlakeRepro([
+    '--file',
+    'C:\\fake\\outside\\repo\\test.test.ts',
+    '--runs',
+    '1',
+  ]);
+  assert.strictEqual(exitCode, 2, `expected exit 2, got ${exitCode}`);
+  assert.strictEqual(stdout.includes('SUMMARY'), false, 'stdout should not contain SUMMARY');
+  assert.strictEqual(stderr.includes('outside the repository'), true, 'stderr should mention the error');
+});
+
+test('CLI: directory is refused with exit 2 and no SUMMARY', () => {
+  const { exitCode, stdout, stderr } = runFlakeRepro(['--file', 'server/src/routes', '--runs', '1']);
+  assert.strictEqual(exitCode, 2, `expected exit 2, got ${exitCode}`);
+  assert.strictEqual(stdout.includes('SUMMARY'), false, 'stdout should not contain SUMMARY');
+  assert.strictEqual(stderr.includes('not a regular file'), true, 'stderr should mention it is a directory');
+});
+
+test('CLI: non-test file is refused with exit 2 and no SUMMARY', () => {
+  const { exitCode, stdout, stderr } = runFlakeRepro(['--file', 'server/src/routes/voices.ts', '--runs', '1']);
+  assert.strictEqual(exitCode, 2, `expected exit 2, got ${exitCode}`);
+  assert.strictEqual(stdout.includes('SUMMARY'), false, 'stdout should not contain SUMMARY');
+  assert.strictEqual(stderr.includes('not a test file'), true, 'stderr should mention the pattern');
+});
+
+test('CLI: missing --file is refused with exit 2 and no SUMMARY', () => {
+  const { exitCode, stdout, stderr } = runFlakeRepro(['--runs', '1']);
+  assert.strictEqual(exitCode, 2, `expected exit 2, got ${exitCode}`);
+  assert.strictEqual(stdout.includes('SUMMARY'), false, 'stdout should not contain SUMMARY');
+  assert.strictEqual(stderr.includes('--file <relpath> required'), true, 'stderr should mention missing --file');
+});
+
+test('CLI: --runs 0 is refused with exit 2 and no SUMMARY', () => {
+  const { exitCode, stdout, stderr } = runFlakeRepro(['--file', 'src/views/listen.test.tsx', '--runs', '0']);
+  assert.strictEqual(exitCode, 2, `expected exit 2, got ${exitCode}`);
+  assert.strictEqual(stdout.includes('SUMMARY'), false, 'stdout should not contain SUMMARY');
+  assert.strictEqual(stderr.includes('positive integer'), true, 'stderr should mention the validation');
+});
+
+test('CLI: --runs non-numeric is refused with exit 2 and no SUMMARY', () => {
+  const { exitCode, stdout, stderr } = runFlakeRepro(['--file', 'src/views/listen.test.tsx', '--runs', 'banana']);
+  assert.strictEqual(exitCode, 2, `expected exit 2, got ${exitCode}`);
+  assert.strictEqual(stdout.includes('SUMMARY'), false, 'stdout should not contain SUMMARY');
+  assert.strictEqual(stderr.includes('positive integer'), true, 'stderr should mention the validation');
+});
+
+test('CLI: missing --runs defaults to 3 (no error)', () => {
+  const { stderr } = runFlakeRepro(['--file', 'src/views/listen.test.tsx']);
+  // Will fail to find a test file when running with --runs missing and defaulting to 3,
+  // but should not complain about --runs itself
+  assert.strictEqual(
+    stderr.includes('positive integer'),
+    false,
+    'should not complain about missing --runs (defaults to 3)',
+  );
 });

--- a/scripts/tests/flake-repro.test.mjs
+++ b/scripts/tests/flake-repro.test.mjs
@@ -12,6 +12,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -112,6 +113,61 @@ test('resolveTarget: frontend file with backslashes (regression)', () => {
     isSlow: false,
     isOutsideRepo: false,
   });
+});
+
+/* --- Cross-root / containment, driven on win32 semantics EXPLICITLY ---
+
+   These MUST NOT rely on the host OS. `npm run test:hooks` runs on
+   ubuntu-latest only (verify.yml's Windows leg runs `npm test` +
+   `npm run test:server`, not this harness), and the R1 regression -- every
+   in-repo absolute path refused as 'outside the repository' -- was
+   structurally invisible under POSIX semantics, because both operands of the
+   broken drive comparison were '' there. 16 existing cases could not tell the
+   broken predicate from the fixed one. Passing path.win32 is what makes these
+   able to fail at all (#3082 review pass 4, N1). */
+const WIN_REPO = String.raw`C:\repo`;
+const winTarget = (p) => resolveTarget(path.win32.join(WIN_REPO, p), WIN_REPO, path.win32);
+
+test('win32: an in-repo absolute path is NOT treated as outside the repo (R1 regression)', () => {
+  const r = winTarget(String.raw`server\src\routes\book-state.test.ts`);
+  assert.strictEqual(r.isOutsideRepo, false, 'an in-repo absolute path must resolve, not be refused');
+  assert.deepStrictEqual(
+    { cwd: r.cwd, rel: r.rel, isSlow: r.isSlow },
+    { cwd: 'server', rel: 'src/routes/book-state.test.ts', isSlow: true },
+  );
+});
+
+test('win32: a different drive IS outside the repo', () => {
+  const r = resolveTarget(String.raw`D:\elsewhere\x.test.ts`, WIN_REPO, path.win32);
+  assert.strictEqual(r.isOutsideRepo, true);
+});
+
+test('win32: a sibling directory sharing the repo name prefix is outside the repo', () => {
+  const r = resolveTarget(String.raw`C:\repo-EXTRA\server\src\x.test.ts`, WIN_REPO, path.win32);
+  assert.strictEqual(r.isOutsideRepo, true);
+});
+
+test('win32: a relative .. escape into a sibling worktree is outside the repo (N3)', () => {
+  const r = resolveTarget('server/../../other-worktree/server/src/routes/book-state.test.ts', WIN_REPO, path.win32);
+  assert.strictEqual(r.isOutsideRepo, true, 'a .. escape must be refused by containment, not left to the oracle');
+});
+
+test('win32: the repo root itself is not a target', () => {
+  const r = resolveTarget(WIN_REPO, WIN_REPO, path.win32);
+  assert.strictEqual(r.isOutsideRepo, true);
+});
+
+test('posix: an in-repo absolute path resolves (same predicate, other impl)', () => {
+  const r = resolveTarget('/repo/server/src/routes/book-state.test.ts', '/repo', path.posix);
+  assert.strictEqual(r.isOutsideRepo, false);
+  assert.strictEqual(r.rel, 'src/routes/book-state.test.ts');
+  assert.strictEqual(r.isSlow, true);
+});
+
+test('a trailing separator does not defeat the SLOW match (N2)', () => {
+  const r = resolveTarget('server/src/routes/book-state.test.ts/', WIN_REPO, path.win32);
+  assert.strictEqual(r.isSlow, true, 'a trailing slash must not route a slow-lane file to the wrong config');
+  assert.strictEqual(r.cwd, 'server');
 });
 
 // === CLI-level tests: spawn subprocess and check behavior ===
@@ -225,7 +281,11 @@ test('CLI: outside-repo diagnostic does not print undefined', () => {
 });
 
 test('CLI: invoked from subdirectory (server/) still runs with correct config', () => {
-  // Change to server directory, then run flake-repro with an absolute path to a test file
+  // Runs from server/ with a REPO-RELATIVE --file (not an absolute one, despite
+  // what an earlier version of this comment said -- #3082 pass 4 named that
+  // mismatch as the exact hole the absolute-path bug fell through). The point
+  // here is the CWD: the existence check is anchored at the repo root while
+  // spawnSync's cwd was once resolved against process.cwd().
   const serverDir = resolve(repoRoot, 'server');
   const result = spawnSync(process.execPath, [scriptPath, '--file', 'server/src/routes/book-state.test.ts', '--runs', '1'], {
     encoding: 'utf8',

--- a/scripts/tests/flake-repro.test.mjs
+++ b/scripts/tests/flake-repro.test.mjs
@@ -192,3 +192,30 @@ test('CLI: missing --runs defaults to 3 (no error)', () => {
     'should not complain about missing --runs (defaults to 3)',
   );
 });
+
+test('CLI: outside-repo diagnostic does not print undefined', () => {
+  const { exitCode, stderr } = runFlakeRepro([
+    '--file',
+    'C:\\Windows\\System32\\drivers\\etc\\hosts.test.ts',
+    '--runs',
+    '1',
+  ]);
+  assert.strictEqual(exitCode, 2);
+  assert.strictEqual(stderr.includes('outside the repository'), true);
+  assert.strictEqual(stderr.includes('undefined'), false, 'should not print undefined in diagnostic');
+  assert.strictEqual(stderr.includes('C:\\Windows'), true, 'should print the resolved path');
+});
+
+test('CLI: invoked from subdirectory (server/) still runs with correct config', () => {
+  // Change to server directory, then run flake-repro with an absolute path to a test file
+  const serverDir = resolve(repoRoot, 'server');
+  const result = spawnSync(process.execPath, [scriptPath, '--file', 'server/src/routes/book-state.test.ts', '--runs', '1'], {
+    encoding: 'utf8',
+    stdio: 'pipe',
+    cwd: serverDir,
+  });
+  // Should succeed even when invoked from a subdirectory
+  assert.strictEqual(result.status, 0, `expected exit 0, got ${result.status}`);
+  assert.strictEqual(result.stdout.includes('SUMMARY'), true, 'should print SUMMARY');
+  assert.strictEqual(result.stdout.includes('RUN'), true, 'should run vitest');
+});

--- a/scripts/tests/flake-repro.test.mjs
+++ b/scripts/tests/flake-repro.test.mjs
@@ -120,6 +120,8 @@ function runFlakeRepro(args) {
   const result = spawnSync(process.execPath, [scriptPath, ...args], {
     encoding: 'utf8',
     stdio: 'pipe',
+    // Required tree-wide outside server/src by server/src/spawn-windows-hide.test.ts.
+    windowsHide: true,
   });
   return {
     exitCode: result.status,
@@ -136,9 +138,13 @@ test('CLI: nonexistent file is refused with exit 2 and no SUMMARY', () => {
 });
 
 test('CLI: absolute path outside repo is refused with exit 2 and no SUMMARY', () => {
+  // Use process.platform to construct a portable outside-repo path
+  const outsidePath = process.platform === 'win32'
+    ? 'C:\\fake\\outside\\repo\\test.test.ts'
+    : '/tmp/outside-repo-test.test.ts';
   const { exitCode, stdout, stderr } = runFlakeRepro([
     '--file',
-    'C:\\fake\\outside\\repo\\test.test.ts',
+    outsidePath,
     '--runs',
     '1',
   ]);
@@ -188,27 +194,34 @@ test('CLI: --runs non-numeric is refused with exit 2 and no SUMMARY', () => {
 });
 
 test('CLI: missing --runs defaults to 3 (no error)', () => {
-  const { stderr } = runFlakeRepro(['--file', 'src/views/listen.test.tsx']);
-  // Will fail to find a test file when running with --runs missing and defaulting to 3,
-  // but should not complain about --runs itself
+  const { stdout, stderr } = runFlakeRepro(['--file', 'server/src/analyzer/ru-diminutives.test.ts']);
+  // With default --runs=3, should run 3 times and NOT complain about --runs
   assert.strictEqual(
     stderr.includes('positive integer'),
     false,
     'should not complain about missing --runs (defaults to 3)',
   );
+  // Assert that exactly 3 runs occurred by checking the SUMMARY array
+  const summaryMatch = stdout.match(/SUMMARY\s+(\[.*?\])/);
+  assert.ok(summaryMatch, 'stdout should contain SUMMARY array');
+  const summary = JSON.parse(summaryMatch[1]);
+  assert.strictEqual(summary.length, 3, `expected 3 runs, got ${summary.length}`);
 });
 
 test('CLI: outside-repo diagnostic does not print undefined', () => {
+  // Use a path outside the repo that's portable across platforms
+  const outsidePath = process.platform === 'win32'
+    ? 'C:\\Windows\\System32\\hosts.test.ts'
+    : '/etc/passwd.test.ts';
   const { exitCode, stderr } = runFlakeRepro([
     '--file',
-    'C:\\Windows\\System32\\drivers\\etc\\hosts.test.ts',
+    outsidePath,
     '--runs',
     '1',
   ]);
   assert.strictEqual(exitCode, 2);
   assert.strictEqual(stderr.includes('outside the repository'), true);
   assert.strictEqual(stderr.includes('undefined'), false, 'should not print undefined in diagnostic');
-  assert.strictEqual(stderr.includes('C:\\Windows'), true, 'should print the resolved path');
 });
 
 test('CLI: invoked from subdirectory (server/) still runs with correct config', () => {
@@ -218,6 +231,7 @@ test('CLI: invoked from subdirectory (server/) still runs with correct config', 
     encoding: 'utf8',
     stdio: 'pipe',
     cwd: serverDir,
+    windowsHide: true,
   });
   // Should succeed even when invoked from a subdirectory
   assert.strictEqual(result.status, 0, `expected exit 0, got ${result.status}`);

--- a/scripts/tests/flake-repro.test.mjs
+++ b/scripts/tests/flake-repro.test.mjs
@@ -1,0 +1,90 @@
+// Regression coverage for scripts/flake-repro.mjs path resolution (#3081).
+//
+// The bug: Windows paths with backslashes (arrived via tab-completion in
+// PowerShell) were not normalized before matching against the server/
+// prefix logic and the SLOW list. On Windows:
+//   - 'server\src\routes\book-state.test.ts' → cwd stays '.' (wrong, should be 'server')
+//   - rel keeps the backslashes and server\ prefix (wrong, should be normalized)
+//   - SLOW.includes(rel) is false (wrong, should be true for a slow file)
+//
+// The tool then ran the test under the frontend config and reported a
+// (false) timing, silently misrepresenting zero tests as a valid measurement.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveTarget } from '../flake-repro.mjs';
+
+// Test a slow-lane server file in all three Windows/POSIX path forms
+test('resolveTarget: slow-lane server file with forward slashes', () => {
+  const result = resolveTarget('server/src/routes/book-state.test.ts');
+  assert.deepStrictEqual(result, {
+    cwd: 'server',
+    rel: 'src/routes/book-state.test.ts',
+    isSlow: true,
+  });
+});
+
+test('resolveTarget: slow-lane server file with backslashes (regression)', () => {
+  const result = resolveTarget('server\\src\\routes\\book-state.test.ts');
+  assert.deepStrictEqual(result, {
+    cwd: 'server',
+    rel: 'src/routes/book-state.test.ts',
+    isSlow: true,
+  });
+});
+
+test('resolveTarget: slow-lane server file with ./ prefix and backslashes (regression)', () => {
+  const result = resolveTarget('.\\server\\src\\routes\\book-state.test.ts');
+  assert.deepStrictEqual(result, {
+    cwd: 'server',
+    rel: 'src/routes/book-state.test.ts',
+    isSlow: true,
+  });
+});
+
+// Test a non-slow server file in all three forms
+test('resolveTarget: non-slow server file with forward slashes', () => {
+  const result = resolveTarget('server/src/routes/voices.route.test.ts');
+  assert.deepStrictEqual(result, {
+    cwd: 'server',
+    rel: 'src/routes/voices.route.test.ts',
+    isSlow: false,
+  });
+});
+
+test('resolveTarget: non-slow server file with backslashes (regression)', () => {
+  const result = resolveTarget('server\\src\\routes\\voices.route.test.ts');
+  assert.deepStrictEqual(result, {
+    cwd: 'server',
+    rel: 'src/routes/voices.route.test.ts',
+    isSlow: false,
+  });
+});
+
+test('resolveTarget: non-slow server file with ./ prefix and backslashes (regression)', () => {
+  const result = resolveTarget('.\\server\\src\\routes\\voices.route.test.ts');
+  assert.deepStrictEqual(result, {
+    cwd: 'server',
+    rel: 'src/routes/voices.route.test.ts',
+    isSlow: false,
+  });
+});
+
+// Test a frontend file
+test('resolveTarget: frontend file with forward slashes', () => {
+  const result = resolveTarget('src/views/listen.test.tsx');
+  assert.deepStrictEqual(result, {
+    cwd: '.',
+    rel: 'src/views/listen.test.tsx',
+    isSlow: false,
+  });
+});
+
+test('resolveTarget: frontend file with backslashes (regression)', () => {
+  const result = resolveTarget('src\\views\\listen.test.tsx');
+  assert.deepStrictEqual(result, {
+    cwd: '.',
+    rel: 'src/views/listen.test.tsx',
+    isSlow: false,
+  });
+});

--- a/scripts/tests/flake-repro.test.mjs
+++ b/scripts/tests/flake-repro.test.mjs
@@ -147,8 +147,13 @@ test('CLI: absolute path outside repo is refused with exit 2 and no SUMMARY', ()
   assert.strictEqual(stderr.includes('outside the repository'), true, 'stderr should mention the error');
 });
 
+// Deliberately a SMALL directory. If the isFile() guard ever regresses, this
+// test still fails -- but it fails by spawning vitest against whatever the
+// argument names first. Pointed at server/src/routes (137 test files) that
+// took minutes and looked like a hang; scripts/lib matches no vitest include
+// glob, so the regression surfaces in milliseconds instead.
 test('CLI: directory is refused with exit 2 and no SUMMARY', () => {
-  const { exitCode, stdout, stderr } = runFlakeRepro(['--file', 'server/src/routes', '--runs', '1']);
+  const { exitCode, stdout, stderr } = runFlakeRepro(['--file', 'scripts/lib', '--runs', '1']);
   assert.strictEqual(exitCode, 2, `expected exit 2, got ${exitCode}`);
   assert.strictEqual(stdout.includes('SUMMARY'), false, 'stdout should not contain SUMMARY');
   assert.strictEqual(stderr.includes('not a regular file'), true, 'stderr should mention it is a directory');

--- a/server/src/slow-lane-mirror.guard.test.ts
+++ b/server/src/slow-lane-mirror.guard.test.ts
@@ -62,11 +62,13 @@ async function loadSlowConfig(): Promise<SlowConfigModule> {
    which doesn't declare them, crashing the tool. That was found and fixed in
    PR #2998 review pass 2; this list must now be an EXACT set match against
    SLOW_FILES in both directions, not merely "every SLOW_FILES entry is
-   covered by something". A dynamic import of that module is NOT used here:
-   it reads `process.argv` at module-eval time and calls `process.exit(2)`
-   when `--file` is absent, which would kill this test process rather than
-   throw catchably. Reading the source and parsing out the `SLOW` array
-   literal is the honest way to reach it without triggering that exit. */
+   covered by something". Reading the source and parsing out the `SLOW` array
+   literal is deliberately retained instead of a dynamic import. That module is
+   now safely importable — its CLI half sits behind isDirectlyInvoked(), so it
+   no longer reads `process.argv` or exits at module-eval time, which was the
+   original reason this could not import it (#3081). The parse stays because a
+   drift guard wants the literal AS COMMITTED: it holds even if the module
+   later stops exporting the list, or exports a transformed copy of it. */
 function loadFlakeReproSlowList(): string[] {
   const srcPath = resolve(SERVER_ROOT, '..', 'scripts', 'flake-repro.mjs');
   const src = readFileSync(srcPath, 'utf8');

--- a/server/src/slow-lane-mirror.guard.test.ts
+++ b/server/src/slow-lane-mirror.guard.test.ts
@@ -67,10 +67,13 @@ async function loadSlowConfig(): Promise<SlowConfigModule> {
    now safely importable — its CLI half sits behind isDirectlyInvoked(), so it
    no longer reads `process.argv` or exits at module-eval time, which was the
    original reason this could not import it (#3081). The parse stays because a
-   drift guard wants the literal AS COMMITTED (what is in git), not what a
-   dynamic import would resolve to after module interpretation. This distinction
-   survives a future refactoring of what the module exports or how it computes
-   the list; the committed text never changes. */
+   drift guard wants the literal AS WRITTEN IN THE SOURCE TEXT -- readFileSync
+   reads this working tree, NOT git. (An earlier version of this comment said
+   "as committed (what is in git)", which was simply false: #3082 review pass
+   3, New-8.) The independence that matters is from module EVALUATION, not
+   from the index: a dynamic import reports whatever the module computes at
+   runtime, so it would keep passing if the list were built, filtered or
+   re-exported rather than declared. Parsing the declaration survives that. */
 function loadFlakeReproSlowList(): string[] {
   const srcPath = resolve(SERVER_ROOT, '..', 'scripts', 'flake-repro.mjs');
   const src = readFileSync(srcPath, 'utf8');

--- a/server/src/slow-lane-mirror.guard.test.ts
+++ b/server/src/slow-lane-mirror.guard.test.ts
@@ -67,8 +67,10 @@ async function loadSlowConfig(): Promise<SlowConfigModule> {
    now safely importable — its CLI half sits behind isDirectlyInvoked(), so it
    no longer reads `process.argv` or exits at module-eval time, which was the
    original reason this could not import it (#3081). The parse stays because a
-   drift guard wants the literal AS COMMITTED: it holds even if the module
-   later stops exporting the list, or exports a transformed copy of it. */
+   drift guard wants the literal AS COMMITTED (what is in git), not what a
+   dynamic import would resolve to after module interpretation. This distinction
+   survives a future refactoring of what the module exports or how it computes
+   the list; the committed text never changes. */
 function loadFlakeReproSlowList(): string[] {
   const srcPath = resolve(SERVER_ROOT, '..', 'scripts', 'flake-repro.mjs');
   const src = readFileSync(srcPath, 'utf8');


### PR DESCRIPTION
## Summary

`scripts/flake-repro.mjs` — the load-induction harness that is the acceptance instrument for every deterministic-test rewrite in `docs/superpowers/plans/2026-06-17-flaky-test-release-hardening.md` — **reported plausible timings for runs that executed zero tests**, and nothing in its output distinguished those from real measurements.

The reported symptom (issue #3081) was a Windows path: `--file` was resolved with two POSIX-only string operations, so a tab-completed `server\src\...` missed all three consumers keying on the POSIX shape. Observed on `main` at `8e4025ee`:

```
$ node scripts/flake-repro.mjs --file 'server\src\routes\book-state.test.ts' --runs 1
 RUN  v4.1.9 C:/Claude/Projects/Audiobook-Generator     <- repo root, frontend config
No test files found, exiting with code 1
run 1: 2720ms exit=1
SUMMARY [{"run":1,"ms":2720,"code":1}]
```

`exit=1` does not disambiguate that from a genuine result, because a flaky test failing under induced load is exactly what this tool exists to produce.

## The path bug was a symptom; the mechanism was the defect

Three review rounds each found a **fresh** way to reach that signature — absolute paths, invocation from a subdirectory, then 244 of 1142 committed test files (21%) including this PR's own new test file. They were all one bug: **a heuristic guessing what vitest would do.** The gate checked the filename's *shape* and never asked the config it was about to invoke whether that config selects the file.

So the filename check is gone. `npx vitest list <rel>` now runs once before the loop, with the **same `cwd` and `--config` the measured runs use**. It cannot disagree with the run, because it is the same config resolution. Empty selection means refuse: exit 2, no `SUMMARY`.

## What changed

- **`resolveTarget(file, repoRoot)`** — pure and exported, so this logic is reachable from a test at all. Normalises separators, collapses interior `.`/`..` segments, and relativises absolute paths against the repo root. Cross-root detection is `isAbsolute()` on `path.relative()`'s output, because `relative()` returns the target absolute when it cannot route between two roots.
- **The vitest-list oracle**, with the run's exact env (`RUN_QUARANTINE=1` included — `vitest list` omits skipped tests, so a fully-quarantined file would otherwise list nothing and read as a refusal).
- **A broken oracle is distinguished from a verdict.** A failed spawn, missing config or throwing config produces empty stdout too; those report themselves rather than masquerading as "not a test file".
- **A run that never started never yields a `SUMMARY`**, and the runs that *did* complete still report their timings.
- **The CLI half sits behind `isDirectlyInvoked()`** (`scripts/lib/is-main-module.mjs`), which is what makes the module importable.

**Declared narrowing:** `--file` now names a file, not a vitest filter. Partial filters (`--file src/routes/voices`) worked before and are refused now. That is the trade that makes "cannot report a measurement it did not take" achievable, and it is stated in the script header.

**Declared cost:** the oracle adds one vitest startup per invocation. Measured **warm**: 1.35–1.59 s against the server config, 4.37 s against the frontend one, before a tool that then runs the suite N times. The test file's own warm runtime is ~24 s.

(An earlier version of this section quoted ~4 s / ~21 s / ~72 s. Those were cold-cache numbers presented as the cost — corrected per review pass 4, N4. `--filesOnly` was considered and rejected: it answers a strictly weaker question, so a file that is selected but declares zero tests would list, run nothing, and print a `SUMMARY`.)

## Also changed, and why

`server/src/slow-lane-mirror.guard.test.ts` parses this file's `SLOW` array from its source text, and its comment justified that by a `process.exit(2)` at module-eval time that the entry-point guard removes. Corrected — including a later draft of mine that claimed the parse reads the literal "as committed (what is in git)", when `readFileSync` reads the working tree. The parse is deliberately retained: the independence that matters is from module *evaluation*.

Reviewers: that guard's regex is `/^const SLOW = (\[[\s\S]*?\]);/m`, start-of-line anchored, so `const SLOW = [` must stay unindented and un-exported. It is, and the guard is green.

## Test plan

`scripts/tests/flake-repro.test.mjs` — 25 cases via `npm run test:hooks`: `resolveTarget` across forward-slash / backslash / `.\`-prefixed forms, plus CLI-level cases that spawn the script and assert on exit code, the absence of `SUMMARY`, **and message content**.

**Mutation-proven, not assumed.** Neutering `existsSync` turns `CLI: nonexistent file` red in 58 ms with `stderr should mention the error`. The directory case was deliberately repointed from `server/src/routes` (137 files) to `scripts/lib`: with its guard neutered the original spawned vitest across the whole routes tree before it could assert — a >10-minute hang rather than a red test. Same assertion, same mutation, now red in 57 ms.

Verified on Windows, both directions:

| `--file` | Outcome |
|---|---|
| relative backslash, slow-lane file | runs under `vitest.config.slow.ts` from `server/` |
| in-repo **absolute** | runs, 8 tests |
| `server/./src/...` (dot segment) | resolves and runs |
| `server/../src/views/listen.test.tsx` | resolves to the frontend config, 45 tests |
| trailing separator | resolves and runs (no longer defeats the SLOW match) |
| `server/../../<sibling-worktree>/…` | refused by containment, naming the worktree it resolved into |
| outside the repo / another drive | refused, exit 2, no `SUMMARY` |
| config-excluded golden test | refused |
| `e2e/*.spec.ts`, `scripts/tests/*.test.mjs` | refused |
| `--runs 0`, `--runs banana`, missing `--file` | refused |

Also green: `npm run test:hooks`, `slow-lane-mirror.guard.test.ts` and `spawn-windows-hide.test.ts` (30 passed), `npx tsc -p .`, eslint.

### Checklist notes

- **Regression plan** — not applicable; the flaky-hardening plan cites this harness's CLI but describes none of the changed behaviour, and its documented usage line still works verbatim.
- **On-box acceptance** — not applicable; no hardware-only behaviour.
- **Release notes** — skipped. This is a development harness and is not in `scripts/build-release-zip.mjs`'s shipped file list, so there is no user- or operator-visible delta.

### Review history

Four passes, all folded: [pass 1](https://github.com/dudarenok-maker/Castwright/pull/3082#issuecomment-5575930094) · [triage](https://github.com/dudarenok-maker/Castwright/pull/3082#issuecomment-5576036823) · [pass 2](https://github.com/dudarenok-maker/Castwright/pull/3082#issuecomment-5576264834) · [pass 3](https://github.com/dudarenok-maker/Castwright/pull/3082#issuecomment-5576597288) · [pass 4](https://github.com/dudarenok-maker/Castwright/pull/3082#issuecomment-5581561257). The fourth ran past this repo's three-pass cap at the owner's explicit request, because rounds 2 and 3 each found a bug introduced by the previous round's fix.

Pass 4's blocker was not a code defect — the predicate was sound across 18 absolute shapes — but that **nothing could tell the fix from the bug**: 0 of 16 existing inputs distinguished them, and the obvious regression test would have passed under the bug too, because `test:hooks` runs on ubuntu-latest alone and both operands of the broken comparison are `''` under POSIX. That is why `resolveTarget` now takes an injectable path implementation and the cross-root cases drive `path.win32` explicitly.

Closes #3081
Refs #2998

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Q4SxN46A8ktP28T7NwEKz
