### PR TITLE
docs(docs): record D-02 dispatch-stall investigation as blocked

### DIFF
--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -1641,10 +1641,23 @@ self-contained mocks/fixtures unaffected by the real derivation.
   supervised) and hit a **new, different** blocker: both queued chapters enter
   Generating but zero `/synthesize` calls ever reach the sidecar, each stalls
   ~150-190s then silently restarts from scratch — an infinite loop that never
-  dispatches audio. Not side-11 (memory stays flat). Prime suspect is a
-  fabricated cast entry from a stray bracketed stage direction. Filed as
-  [#3080](https://github.com/dudarenok-maker/Castwright/issues/3080). Still
-  Blocked, for a new reason.
+  dispatches audio. Not side-11 (memory stays flat). Filed as
+  [#3080](https://github.com/dudarenok-maker/Castwright/issues/3080).
+  **Re-investigated, Castwright#3080/#3091/#3092 (2026-09-08):** two named
+  suspects were traced against the current code and both ruled out — a
+  bracketed stage direction fabricating a spurious cast entry (the
+  analyzer's only bracket-adjacent regex only ever promotes a *missing*
+  roster entry; a cloned character is already cast, so it can't fire), and
+  a dispatch/queue loop retrying silently forever (every traced failure
+  path in `synthesise-chapter.ts`/`generation.ts` — timeout, stall
+  watchdog, recycle-storm budget, unresolvable-clone, no-capacity, the
+  srv-11 circuit breaker — fails loud, not silently). No alternate root
+  cause could be confirmed without a live GPU/TTS sidecar box. **Still
+  owed:** a full-book render with a cloned character on a real box,
+  capturing `state.json` + server logs if/when the reported symptom
+  reproduces, to identify the actual mechanism — see
+  [PR #3112](https://github.com/dudarenok-maker/Castwright/pull/3112) for
+  the full investigation trace.
 - **C-05 (open — an `F`, not one of the 18 discharged above, deliberately
   excluded per its own note earlier in this row) now has two recorded
   sub-observations owed, not a new row:** [#2023](https://github.com/dudarenok-maker/Castwright/issues/2023)


### PR DESCRIPTION
## Summary

Verifies Castwright#3091's investigation of the D-02 full-book
cloned-character dispatch stall (both queued chapters stall ~150-190s with
zero `/synthesize` calls reaching the sidecar, then silently restart
forever). Two named suspects were traced against the current code and both
ruled out:

- **Fabricated cast entry from a bracketed stage direction** — the
  analyzer's only bracket-adjacent regex (`tagScanRegexesFor`,
  `server/src/analyzer/tag-grammar.ts:113-115,141-148`) only ever promotes a
  speaker *missing* from the roster (`runStage1WithRosterGuard`,
  `server/src/analyzer/roster-coverage.ts:425-469`). A cloned character is
  already cast, so `roster.has(key)` short-circuits before this path can
  fire. The canonical repro fixture cited in the parent issue
  (`server/src/__fixtures__/the-coalfall-commission.md`) contains zero `[`
  characters — it doesn't even contain the triggering pattern.
- **Dispatch/queue loop retrying silently forever** — every failure path
  traced through `server/src/tts/synthesise-chapter.ts` and
  `server/src/routes/generation.ts` fails loud, not silently:
  `ChapterSynthTimeoutError`, the stall watchdog (`ChapterStallError`),
  `RecycleStormError` (budget 2, then the queue pauses),
  `UnresolvableClonedVoiceError` (the exact "malformed cast entry" case,
  explicitly special-cased to broadcast `chapter_failed`), `NoCapacityError`,
  and the srv-11 consecutive-failure circuit breaker. None produce "stalls
  150-190s then silently restarts forever with no error."

**No alternate root cause could be confirmed without a live GPU/TTS sidecar
box** — this is a genuine, honestly-reported block per the parent issue's
own acceptance criteria (#3080, checklist item 3: "If genuinely blocked: an
explicit statement of what was tried and ruled out"). No code fix is
included because none of the traced mechanisms reproduce the reported
symptom; fabricating a fix for an unconfirmed cause would be worse than
reporting the block. This PR's only change is recording that investigation
in the on-box-acceptance register.

Full investigation trace: Castwright#3091 (`AGENT BLOCKED` receipt,
2026-09-08).

Closes #3080

## Test plan

- [x] `git diff main...HEAD` on this branch before this PR's own commit —
      empty (the investigating child made no code changes; verified
      directly, not taken on the receipt's word).
- [x] No regression test exists to re-run, because no fix was made — n/a.
- [x] Docs-only change (`docs/testing/onbox-acceptance-register.md`) —
      `npm run verify` skipped per the doc-only PR fast-path
      (CONTRIBUTING.md), confirmed by the pre-push hook's own
      "docs-only push — skipping npm run verify" line on this push.

**Full confirmation still needs a real full-book render on hardware with
the TTS sidecar running** — that on-box observation is tracked in
`docs/testing/onbox-acceptance-register.md` (D-02 row, updated by this PR)
rather than here.
