### PR TITLE
docs(docs): stamp publish token 14 for the owed live-view republish

### DIFF
--- a/docs/testing/onbox-acceptance-register-live-view.html
+++ b/docs/testing/onbox-acceptance-register-live-view.html
@@ -165,7 +165,7 @@
   <!-- Publish token. NEVER hand-edit: run `npm run stamp:publish-token`.
        The counter orders publishes; the id proves which branch produced one.
        Attributes, not a comment: checkLiveView removes comments before reading. -->
-  <div hidden data-published-as="13" data-publish-id="a3ef6817d22b"></div>
+  <div hidden data-published-as="14" data-publish-id="b69a8bb984af"></div>
 
   <p class="lede">
     Shipped behaviour that only real hardware can prove — a live GPU, a real sidecar, a real


### PR DESCRIPTION
## Summary

The on-box register's canonical live view has been three discharged rows
behind `main` since PR #3076 merged on 2026-09-08. That PR folded **A37**,
**B2** and **D1** out of the register and narrowed **A16**/**A31**, but never
ran step 4 of the register's own publish procedure — so the artifact still
shows **55 owed against main's 52**, group **A at 36 against 35**, and **B**
and **D** each one row high. Three rows that are genuinely discharged are
being presented to the reader as outstanding debt.

This PR is the one tracked change that republish requires: a fresh publish
token, stamped by `npm run stamp:publish-token` and committed **before** the
`--against-published` run, per the register's step 0. The artifact itself is
republished from this branch before merge, which is the documented order.

### Why this went unnoticed

`#3076` edited the live view without re-stamping, so tracked and published
both read `data-published-as="13" data-publish-id="a3ef6817d22b"` while their
contents had diverged. The register's one-line disambiguator (*published
HIGHER than tracked → AHEAD; EQUAL or LOWER → BEHIND*) still lands on the
correct verdict, but only because BEHIND is the fallthrough — an unstamped
edit makes the counter uninformative rather than wrong, and the diagnosis
falls back to the row-by-row diffing that #2599/A41 built the token to
replace. Noted in the issue as worth a separate look; `#2599` already records
that the token is unenforced.

### The publish is non-destructive, and that was checked, not assumed

`npm run check:onbox-register -- --against-published <saved live page>`
reports **no BEHIND rows**. A37, B2 and D1 are absent from `origin/main` too,
which is the #2199 signature of a deliberate discharge rather than a
competing lane's pre-merge publish — the case the checker deliberately does
not report. The only finding is content-drift on **A16** and **A23**, and
those are exactly the two rows `#3076` rewrote (A23's body carried the
"A22 and B2 each prove their mechanism" sentence that B2's fold invalidated).
Local matches the `origin/main` baseline; the published page does not. That
is the register's documented BEHIND signature, and republishing `main`'s copy
is its reconciliation.

No other lane has published ahead of this one: the three open PRs that touch
the register (#3113, #3061, #3063) are all still at the wave-12 page.

## Test plan

- `npm run check:onbox-register` — OK, the tracked pair agrees.
- `npm run register:build` — no diff; the derived figures on `main` were
  already correct. Only the *published* copy was stale.
- `npm run check:onbox-register -- --against-published <saved live page>` —
  no BEHIND rows; content-drift on A16/A23 only, diagnosed above.
- Republished to the canonical URL with `url` passed, from this branch,
  before merge. Verified afterward that the live page reads token 14
  (`b69a8bb984af`), owed 52, A 35, B 1, D 1.

Release notes skipped deliberately: bookkeeping only, no user- or
operator-visible product delta.

Closes #3114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Q4SxN46A8ktP28T7NwEKz