### PR TITLE
fix(scripts): scope register-citation code-span blanking to markdown files

### DIFF
--- a/scripts/check-register-citations.mjs
+++ b/scripts/check-register-citations.mjs
@@ -2115,7 +2115,7 @@ function stripMarkdownLinkUrls(text) {
   return text.replace(MARKDOWN_LINK_REGEX, '$1');
 }
 
-function titleDriftTokens(text, isMarkdown) {
+function titleDriftTokens(text, isMarkdown = true) {
   const withoutLinks = stripMarkdownLinkUrls(text);
   const withoutCodeSpans = stripInlineCodeSpans(withoutLinks, { isMarkdown });
   const raw = withoutCodeSpans.toLowerCase().match(TITLE_DRIFT_TOKEN_REGEX) ?? [];
@@ -2267,7 +2267,7 @@ export function checkCitationTitleDrift(text, filePath, registerRows) {
     for (const id of ids) {
       const row = registerRows.get(id);
       if (!row) continue;
-      const titleTokens = titleDriftTokens(row.title, isMarkdown);
+      const titleTokens = titleDriftTokens(row.title);
       const { ratio, shared } = titleDriftScore(titleTokens, proseTokens);
       if (ratio > TITLE_DRIFT_RATIO_THRESHOLD || shared >= TITLE_DRIFT_MIN_SHARED_TOKENS) continue;
       const message =

--- a/scripts/check-register-citations.mjs
+++ b/scripts/check-register-citations.mjs
@@ -1027,7 +1027,7 @@ function isDischargeAssertionNegated(scanText, dm, clauseStart) {
  * this flips zero of today's citations — see #2858 for the false-positive
  * analysis of the 4 citations a looser, unshared polarity scan misflagged.
  */
-function idSpecificAnnotationPresent(sectionText, id, _isMarkdown) {
+function idSpecificAnnotationPresent(sectionText, id) {
   const dischargeScanText = stripInlineCodeSpans(sectionText);
   const dischargeMatches = [
     ...dischargeScanText.matchAll(new RegExp(DISCHARGE_ANNOTATION_REGEX.source, 'gi')),
@@ -1109,23 +1109,34 @@ const SINGLE_ID_SPAN_REGEX = new RegExp(`^${ROW_ID_TOKEN}$`);
 /**
  * Whether a repo-relative scanned-file path (e.g. `docs/foo.md`,
  * `scripts/foo.mjs`) should have its single-backtick inline code spans
- * blanked as markdown. Blanking is scoped to markdown sources only (`.md`,
- * `.html`): in a source file (`.mjs`/`.ts`/`.py`/...) a template literal's
- * backticks would be misread as markdown delimiters and a register citation
- * inside one (e.g. `` `row A101` `` in a template string) would be silently
- * blanked and never checked — while the identical text inside a `'...'` or
- * `"..."` string is scanned and can be fatal. Every other tracked file is
- * therefore scanned raw, unblanked. (Decided 2026-09-08 per #3062.)
+ * blanked as markdown. Returns true for `.md` and `.html` files (the
+ * markdown-scanned set); all other tracked files are scanned raw, unblanked.
+ *
+ * Per the operator's #3062 decision, `.html` is treated as fully markdown,
+ * including embedded `<script>` and `<style>` block content — both
+ * `stripFences` (triple-backtick blocks) and `stripInlineCodeSpans`
+ * (single-backtick spans) apply within .html files, so backtick-wrapped
+ * citations inside embedded code blocks are also blanked. This is an
+ * accepted trade-off of the current scope decision (see real-tree example
+ * at docs/features/277-v115-bug-chore-sweep-board.html around lines 1062
+ * and 1085).
+ *
+ * BLANKING SCOPE: `stripFences` is markdown-conditional (gated by `isMarkdown`
+ * at every call site). `stripInlineCodeSpans` is markdown-conditional for
+ * citation-scanning purposes (gated at most call sites: lines 1229, 1859,
+ * 2037, 2135, 2173) but unconditional for discharge-annotation checks
+ * (lines 1031, 2216), where the blanking prevents false positives from
+ * backtick-wrapped example citations. In non-markdown sources
+ * (`.mjs`/`.ts`/`.py`/...), a template literal's backticks would otherwise
+ * be misread as markdown delimiters — a citation inside one (e.g. `` `row
+ * A101` `` in a template string) would be silently blanked by a
+ * markdown-gated scan while remaining visible to downstream checks, creating
+ * inconsistency. Unconditional discharge-annotation blanking trades that
+ * inconsistency for false-positive immunity (the register-owned text and
+ * discharge annotations are not markdown-syntax-specific; a row ID is either
+ * cited for history or it isn't, regardless of whether the document is
+ * markdown).
  */
-// Returns true for .md and .html files (the markdown-scanned set). Per the
-// operator's #3062 decision, .html is treated as fully markdown, including
-// embedded `<script>` and `<style>` block content — both triple-backtick
-// `stripFences` and single-backtick `stripInlineCodeSpans` blanking apply
-// (the latter unconditionally for discharge-annotation false-positive prevention,
-// the former gated by isMarkdown), and backtick-wrapped spans inside those blocks
-// are blanked, which could theoretically hide a citation there. This is an
-// accepted trade-off of the current scope decision (see real-tree example at
-// docs/features/277-v115-bug-chore-sweep-board.html around lines 1062 and 1085).
 function isMarkdownScanPath(relPath) {
   return /\.(md|html)$/i.test(relPath);
 }
@@ -1265,7 +1276,7 @@ export function checkNonexistentIds(text, filePath, registerRows) {
     for (const id of [...byLine.get(i)].sort()) {
       if (registerRows.has(id)) continue;
       const message = `${filePath}:${i + 1} — cited ${id} — no such row in ${REGISTER_PATH} (nonexistent ID)`;
-      if (idSpecificAnnotationPresent(enclosingSectionText(lines, i), id, isMarkdown)) {
+      if (idSpecificAnnotationPresent(enclosingSectionText(lines, i), id)) {
         annotated.push(`${message} — annotated as discharged/removed, not failing`);
       } else {
         errors.push(message);
@@ -1788,7 +1799,7 @@ function recordSubjectConflict(
     }
     if (currentSubjects && currentSubjects.size > 0) {
       const currentSubjectsText = [...currentSubjects].sort((a, b) => a - b).join('/');
-      if (idSpecificAnnotationPresent(enclosingSectionText(lines, lineIndex), id, isMarkdownScanPath(filePath))) {
+      if (idSpecificAnnotationPresent(enclosingSectionText(lines, lineIndex), id)) {
         annotatedDischarge.push(
           `${filePath}:${lineIndex + 1} — cited ${id} for #${subject}, but ${id} now tracks ` +
             `#${currentSubjectsText} (#${subject}'s row has discharged and ${id} was re-minted) — ` +
@@ -2207,7 +2218,7 @@ function extractHeadingTitleEchoes(text, isMarkdown) {
  * A31, etc., which do). This relaxation moves A8 from `findings` to
  * `annotatedFindings` by treating a single-id case more generously.
  */
-function dischargeAnnotationPresentAnywhere(sectionText, id, _isMarkdown) {
+function dischargeAnnotationPresentAnywhere(sectionText, id) {
   // For single-ID headings, look for discharge in the header section only
   // (first ~300 chars) to avoid false positives from body text mentioning
   // other IDs. This covers the criteria-source blockquote region.
@@ -2296,8 +2307,8 @@ export function checkCitationTitleDrift(text, filePath, registerRows) {
       // anywhere in section, or next to this heading's ID). For multi-ID headings,
       // require ID-proximity to avoid one ID's discharge excusing another's drift.
       const isAnnotated = ids.length === 1
-        ? dischargeAnnotationPresentAnywhere(sectionText, id, isMarkdown)
-        : idSpecificAnnotationPresent(sectionText, id, isMarkdown);
+        ? dischargeAnnotationPresentAnywhere(sectionText, id)
+        : idSpecificAnnotationPresent(sectionText, id);
 
       if (isAnnotated) {
         annotatedFindings.push(`${message} — annotated as discharged/removed, not flagged as drift`);

--- a/scripts/check-register-citations.mjs
+++ b/scripts/check-register-citations.mjs
@@ -33,6 +33,14 @@
 // unconditional/uncached local leg (independent of scope-gating), and whether
 // a git hook should wire it.
 //
+// Scanned file set, and how it is read: the checker reads every non-frozen,
+// non-self-referential git-tracked file (see `gitLsFiles` /
+// `runCheckRegisterCitationsCli`). The single-backtick inline code-span
+// blanking (`stripInlineCodeSpans`) applies to MARKDOWN files only (`.md`,
+// `.html`): non-markdown sources are read raw, unblanked, so a template
+// literal's backticks can never silently hide a citation. See
+// `isMarkdownScanPath` and `stripInlineCodeSpans`'s own comments.
+//
 // Four checks, ordered by precision (least to most likely to need
 // judgment):
 //
@@ -1015,8 +1023,8 @@ function isDischargeAssertionNegated(scanText, dm, clauseStart) {
  * this flips zero of today's citations — see #2858 for the false-positive
  * analysis of the 4 citations a looser, unshared polarity scan misflagged.
  */
-function idSpecificAnnotationPresent(sectionText, id) {
-  const dischargeScanText = stripInlineCodeSpans(sectionText);
+function idSpecificAnnotationPresent(sectionText, id, isMarkdown) {
+  const dischargeScanText = stripInlineCodeSpans(sectionText, { isMarkdown });
   const dischargeMatches = [
     ...dischargeScanText.matchAll(new RegExp(DISCHARGE_ANNOTATION_REGEX.source, 'gi')),
   ];
@@ -1083,10 +1091,36 @@ function idSpecificAnnotationPresent(sectionText, id) {
 // DOES occur, as a composite-key separator, in two real tracked files) — so
 // `\s+`-based regexes can no longer bridge across a blanked span the way a
 // plain-space blank did.
+//
+// SCOPE (per #3062): blanking applies to MARKDOWN scanned files only (`.md`,
+// `.html`). In a non-markdown source file a template literal's backticks are
+// read by this transform as the same markdown delimiter and would silently
+// blank a citation inside one (e.g. `` `row A101` `` in a template string),
+// so `stripInlineCodeSpans(text, { isMarkdown: false })` returns `text`
+// unchanged. Every call site threads `isMarkdown` (from the scanned path)
+// through — see `isMarkdownScanPath`.
 const CODE_SPAN_BLANK_CHAR = '';
 const SINGLE_ID_SPAN_REGEX = new RegExp(`^${ROW_ID_TOKEN}$`);
 
-function stripInlineCodeSpans(text) {
+/**
+ * Whether a repo-relative scanned-file path (e.g. `docs/foo.md`,
+ * `scripts/foo.mjs`) should have its single-backtick inline code spans
+ * blanked as markdown. Blanking is scoped to markdown sources only (`.md`,
+ * `.html`): in a source file (`.mjs`/`.ts`/`.py`/...) a template literal's
+ * backticks would be misread as markdown delimiters and a register citation
+ * inside one (e.g. `` `row A101` `` in a template string) would be silently
+ * blanked and never checked — while the identical text inside a `'...'` or
+ * `"..."` string is scanned and can be fatal. Every other tracked file is
+ * therefore scanned raw, unblanked. (Decided 2026-09-08 per #3062.)
+ */
+function isMarkdownScanPath(relPath) {
+  return /\.(md|html)$/i.test(relPath);
+}
+
+// `stripInlineCodeSpans` takes an explicit `{ isMarkdown }` flag: when false
+// (a non-markdown scanned source), it returns `text` unchanged.
+function stripInlineCodeSpans(text, { isMarkdown = true } = {}) {
+  if (!isMarkdown) return text;
   return text.replace(/\u0060([^\u0060\n]*)\u0060/g, (m, inner) => {
     const trimmed = inner.trim();
     if (SINGLE_ID_SPAN_REGEX.test(trimmed)) {
@@ -1177,9 +1211,9 @@ function deBold(text) {
  * span, so this costs nothing on a real citation today.
  * @returns {Map<number, Set<string>>}
  */
-function extractCitationsByLine(text) {
+function extractCitationsByLine(text, isMarkdown) {
   const stripped = deBold(stripFences(text));
-  const scanLines = stripInlineCodeSpans(stripped).split('\n');
+  const scanLines = stripInlineCodeSpans(stripped, { isMarkdown }).split('\n');
   const byLine = new Map();
   const add = (i, ids) => {
     if (!ids.length) return;
@@ -1210,14 +1244,15 @@ function extractCitationsByLine(text) {
 export function checkNonexistentIds(text, filePath, registerRows) {
   const errors = [];
   const annotated = [];
+  const isMarkdown = isMarkdownScanPath(filePath);
   const lines = deBold(stripFences(text)).split('\n');
-  const byLine = extractCitationsByLine(text);
+  const byLine = extractCitationsByLine(text, isMarkdown);
   const sortedLineIndexes = [...byLine.keys()].sort((a, b) => a - b);
   for (const i of sortedLineIndexes) {
     for (const id of [...byLine.get(i)].sort()) {
       if (registerRows.has(id)) continue;
       const message = `${filePath}:${i + 1} — cited ${id} — no such row in ${REGISTER_PATH} (nonexistent ID)`;
-      if (idSpecificAnnotationPresent(enclosingSectionText(lines, i), id)) {
+      if (idSpecificAnnotationPresent(enclosingSectionText(lines, i), id, isMarkdown)) {
         annotated.push(`${message} — annotated as discharged/removed, not failing`);
       } else {
         errors.push(message);
@@ -1740,7 +1775,7 @@ function recordSubjectConflict(
     }
     if (currentSubjects && currentSubjects.size > 0) {
       const currentSubjectsText = [...currentSubjects].sort((a, b) => a - b).join('/');
-      if (idSpecificAnnotationPresent(enclosingSectionText(lines, lineIndex), id)) {
+      if (idSpecificAnnotationPresent(enclosingSectionText(lines, lineIndex), id, isMarkdownScanPath(filePath))) {
         annotatedDischarge.push(
           `${filePath}:${lineIndex + 1} — cited ${id} for #${subject}, but ${id} now tracks ` +
             `#${currentSubjectsText} (#${subject}'s row has discharged and ${id} was re-minted) — ` +
@@ -1807,7 +1842,7 @@ export function checkConflictingSubjects(fileTexts, registerRows) {
     // citation (see `stripInlineCodeSpans`'s own comment) — anchored
     // headings can't appear inside a code span at all (`^#{2,6}`), so this
     // only ever changes behaviour on the `Criteria source:` surface.
-    const text = stripInlineCodeSpans(deBold(stripFences(rawText)));
+    const text = stripInlineCodeSpans(deBold(stripFences(rawText)), { isMarkdown: isMarkdownScanPath(filePath) });
     const lines = text.split('\n');
     lines.forEach((line, i) => {
       const citedIds = citationShapedLineIds(line);
@@ -1984,7 +2019,7 @@ export function measureWrongIdEligibleLines(fileTexts, registerRows) {
     // an unblanked copy here would silently disagree with Check C again the
     // moment a `Criteria source:`-shaped example command inside a code span
     // is counted as eligible here but is (correctly) blanked away there.
-    const text = stripInlineCodeSpans(deBold(stripFences(rawText)));
+    const text = stripInlineCodeSpans(deBold(stripFences(rawText)), { isMarkdown: isMarkdownScanPath(filePath) });
     for (const line of text.split('\n')) {
       if (extractSubjectNumbers(line).size === 0) continue;
       const shapedIds = citationShapedLineIds(line);
@@ -2080,9 +2115,9 @@ function stripMarkdownLinkUrls(text) {
   return text.replace(MARKDOWN_LINK_REGEX, '$1');
 }
 
-function titleDriftTokens(text) {
+function titleDriftTokens(text, isMarkdown) {
   const withoutLinks = stripMarkdownLinkUrls(text);
-  const withoutCodeSpans = stripInlineCodeSpans(withoutLinks);
+  const withoutCodeSpans = stripInlineCodeSpans(withoutLinks, { isMarkdown });
   const raw = withoutCodeSpans.toLowerCase().match(TITLE_DRIFT_TOKEN_REGEX) ?? [];
   const tokens = new Set();
   for (const t of raw) {
@@ -2118,9 +2153,9 @@ function titleDriftScore(titleTokens, proseTokens) {
  * surface is invented here.
  * @returns {{ lineIndex: number, ids: string[], titleEcho: string }[]}
  */
-function extractHeadingTitleEchoes(text) {
+function extractHeadingTitleEchoes(text, isMarkdown) {
   const stripped = deBold(stripFences(text));
-  const lines = stripInlineCodeSpans(stripped).split('\n');
+  const lines = stripInlineCodeSpans(stripped, { isMarkdown }).split('\n');
   const citations = [];
   lines.forEach((line, i) => {
     const m = line.match(HEADING_ID_REGEX);
@@ -2157,13 +2192,13 @@ function extractHeadingTitleEchoes(text) {
  * A31, etc., which do). This relaxation moves A8 from `findings` to
  * `annotatedFindings` by treating a single-id case more generously.
  */
-function dischargeAnnotationPresentAnywhere(sectionText, id) {
+function dischargeAnnotationPresentAnywhere(sectionText, id, isMarkdown) {
   // For single-ID headings, look for discharge in the header section only
   // (first ~300 chars) to avoid false positives from body text mentioning
   // other IDs. This covers the criteria-source blockquote region.
   const HEADER_CHARS = 300;
   const headerText = sectionText.slice(0, HEADER_CHARS);
-  const headerScanText = stripInlineCodeSpans(headerText);
+  const headerScanText = stripInlineCodeSpans(headerText, { isMarkdown });
 
   const dischargeMatches = [
     ...headerScanText.matchAll(new RegExp(DISCHARGE_ANNOTATION_REGEX.source, 'gi')),
@@ -2225,13 +2260,14 @@ function dischargeAnnotationPresentAnywhere(sectionText, id) {
 export function checkCitationTitleDrift(text, filePath, registerRows) {
   const findings = [];
   const annotatedFindings = [];
+  const isMarkdown = isMarkdownScanPath(filePath);
   const lines = deBold(stripFences(text)).split('\n');
-  for (const { lineIndex, ids, titleEcho } of extractHeadingTitleEchoes(text)) {
-    const proseTokens = titleDriftTokens(titleEcho);
+  for (const { lineIndex, ids, titleEcho } of extractHeadingTitleEchoes(text, isMarkdown)) {
+    const proseTokens = titleDriftTokens(titleEcho, isMarkdown);
     for (const id of ids) {
       const row = registerRows.get(id);
       if (!row) continue;
-      const titleTokens = titleDriftTokens(row.title);
+      const titleTokens = titleDriftTokens(row.title, isMarkdown);
       const { ratio, shared } = titleDriftScore(titleTokens, proseTokens);
       if (ratio > TITLE_DRIFT_RATIO_THRESHOLD || shared >= TITLE_DRIFT_MIN_SHARED_TOKENS) continue;
       const message =
@@ -2245,8 +2281,8 @@ export function checkCitationTitleDrift(text, filePath, registerRows) {
       // anywhere in section, or next to this heading's ID). For multi-ID headings,
       // require ID-proximity to avoid one ID's discharge excusing another's drift.
       const isAnnotated = ids.length === 1
-        ? dischargeAnnotationPresentAnywhere(sectionText, id)
-        : idSpecificAnnotationPresent(sectionText, id);
+        ? dischargeAnnotationPresentAnywhere(sectionText, id, isMarkdown)
+        : idSpecificAnnotationPresent(sectionText, id, isMarkdown);
 
       if (isAnnotated) {
         annotatedFindings.push(`${message} — annotated as discharged/removed, not flagged as drift`);

--- a/scripts/check-register-citations.mjs
+++ b/scripts/check-register-citations.mjs
@@ -511,7 +511,11 @@ export function isFrozenPath(relPath) {
 
 // Blanks fenced code blocks so an example heading inside a fence can't be
 // mistaken for a real one — mirrors check-onbox-register.mjs's stripFences.
-function stripFences(text) {
+// Only applies to markdown files (`.md`, `.html`); non-markdown scanned
+// sources are read raw, unblanked, so triple-backtick sequences can never
+// silently hide a citation (they are not fence markers in those files).
+function stripFences(text, { isMarkdown = true } = {}) {
+  if (!isMarkdown) return text;
   const lines = text.split('\n');
   let openFence = null;
   return lines
@@ -1212,7 +1216,7 @@ function deBold(text) {
  * @returns {Map<number, Set<string>>}
  */
 function extractCitationsByLine(text, isMarkdown) {
-  const stripped = deBold(stripFences(text));
+  const stripped = deBold(stripFences(text, { isMarkdown }));
   const scanLines = stripInlineCodeSpans(stripped, { isMarkdown }).split('\n');
   const byLine = new Map();
   const add = (i, ids) => {
@@ -1245,7 +1249,7 @@ export function checkNonexistentIds(text, filePath, registerRows) {
   const errors = [];
   const annotated = [];
   const isMarkdown = isMarkdownScanPath(filePath);
-  const lines = deBold(stripFences(text)).split('\n');
+  const lines = deBold(stripFences(text, { isMarkdown })).split('\n');
   const byLine = extractCitationsByLine(text, isMarkdown);
   const sortedLineIndexes = [...byLine.keys()].sort((a, b) => a - b);
   for (const i of sortedLineIndexes) {
@@ -1842,7 +1846,8 @@ export function checkConflictingSubjects(fileTexts, registerRows) {
     // citation (see `stripInlineCodeSpans`'s own comment) — anchored
     // headings can't appear inside a code span at all (`^#{2,6}`), so this
     // only ever changes behaviour on the `Criteria source:` surface.
-    const text = stripInlineCodeSpans(deBold(stripFences(rawText)), { isMarkdown: isMarkdownScanPath(filePath) });
+    const isMarkdown = isMarkdownScanPath(filePath);
+    const text = stripInlineCodeSpans(deBold(stripFences(rawText, { isMarkdown })), { isMarkdown });
     const lines = text.split('\n');
     lines.forEach((line, i) => {
       const citedIds = citationShapedLineIds(line);
@@ -2019,7 +2024,8 @@ export function measureWrongIdEligibleLines(fileTexts, registerRows) {
     // an unblanked copy here would silently disagree with Check C again the
     // moment a `Criteria source:`-shaped example command inside a code span
     // is counted as eligible here but is (correctly) blanked away there.
-    const text = stripInlineCodeSpans(deBold(stripFences(rawText)), { isMarkdown: isMarkdownScanPath(filePath) });
+    const isMarkdown = isMarkdownScanPath(filePath);
+    const text = stripInlineCodeSpans(deBold(stripFences(rawText, { isMarkdown })), { isMarkdown });
     for (const line of text.split('\n')) {
       if (extractSubjectNumbers(line).size === 0) continue;
       const shapedIds = citationShapedLineIds(line);
@@ -2154,7 +2160,7 @@ function titleDriftScore(titleTokens, proseTokens) {
  * @returns {{ lineIndex: number, ids: string[], titleEcho: string }[]}
  */
 function extractHeadingTitleEchoes(text, isMarkdown) {
-  const stripped = deBold(stripFences(text));
+  const stripped = deBold(stripFences(text, { isMarkdown }));
   const lines = stripInlineCodeSpans(stripped, { isMarkdown }).split('\n');
   const citations = [];
   lines.forEach((line, i) => {
@@ -2261,7 +2267,7 @@ export function checkCitationTitleDrift(text, filePath, registerRows) {
   const findings = [];
   const annotatedFindings = [];
   const isMarkdown = isMarkdownScanPath(filePath);
-  const lines = deBold(stripFences(text)).split('\n');
+  const lines = deBold(stripFences(text, { isMarkdown })).split('\n');
   for (const { lineIndex, ids, titleEcho } of extractHeadingTitleEchoes(text, isMarkdown)) {
     const proseTokens = titleDriftTokens(titleEcho, isMarkdown);
     for (const id of ids) {

--- a/scripts/check-register-citations.mjs
+++ b/scripts/check-register-citations.mjs
@@ -1027,8 +1027,8 @@ function isDischargeAssertionNegated(scanText, dm, clauseStart) {
  * this flips zero of today's citations — see #2858 for the false-positive
  * analysis of the 4 citations a looser, unshared polarity scan misflagged.
  */
-function idSpecificAnnotationPresent(sectionText, id, isMarkdown) {
-  const dischargeScanText = stripInlineCodeSpans(sectionText, { isMarkdown });
+function idSpecificAnnotationPresent(sectionText, id, _isMarkdown) {
+  const dischargeScanText = stripInlineCodeSpans(sectionText);
   const dischargeMatches = [
     ...dischargeScanText.matchAll(new RegExp(DISCHARGE_ANNOTATION_REGEX.source, 'gi')),
   ];
@@ -1119,11 +1119,13 @@ const SINGLE_ID_SPAN_REGEX = new RegExp(`^${ROW_ID_TOKEN}$`);
  */
 // Returns true for .md and .html files (the markdown-scanned set). Per the
 // operator's #3062 decision, .html is treated as fully markdown, including
-// embedded `<script>` and `<style>` block content — backtick-wrapped spans
-// inside those blocks are also blanked, which could theoretically hide a
-// citation there. This is an accepted trade-off of the current scope decision
-// (see real-tree example at docs/features/277-v115-bug-chore-sweep-board.html
-// around lines 1062 and 1085).
+// embedded `<script>` and `<style>` block content — both triple-backtick
+// `stripFences` and single-backtick `stripInlineCodeSpans` blanking apply
+// (the latter unconditionally for discharge-annotation false-positive prevention,
+// the former gated by isMarkdown), and backtick-wrapped spans inside those blocks
+// are blanked, which could theoretically hide a citation there. This is an
+// accepted trade-off of the current scope decision (see real-tree example at
+// docs/features/277-v115-bug-chore-sweep-board.html around lines 1062 and 1085).
 function isMarkdownScanPath(relPath) {
   return /\.(md|html)$/i.test(relPath);
 }
@@ -2205,13 +2207,13 @@ function extractHeadingTitleEchoes(text, isMarkdown) {
  * A31, etc., which do). This relaxation moves A8 from `findings` to
  * `annotatedFindings` by treating a single-id case more generously.
  */
-function dischargeAnnotationPresentAnywhere(sectionText, id, isMarkdown) {
+function dischargeAnnotationPresentAnywhere(sectionText, id, _isMarkdown) {
   // For single-ID headings, look for discharge in the header section only
   // (first ~300 chars) to avoid false positives from body text mentioning
   // other IDs. This covers the criteria-source blockquote region.
   const HEADER_CHARS = 300;
   const headerText = sectionText.slice(0, HEADER_CHARS);
-  const headerScanText = stripInlineCodeSpans(headerText, { isMarkdown });
+  const headerScanText = stripInlineCodeSpans(headerText);
 
   const dischargeMatches = [
     ...headerScanText.matchAll(new RegExp(DISCHARGE_ANNOTATION_REGEX.source, 'gi')),

--- a/scripts/check-register-citations.mjs
+++ b/scripts/check-register-citations.mjs
@@ -1117,6 +1117,13 @@ const SINGLE_ID_SPAN_REGEX = new RegExp(`^${ROW_ID_TOKEN}$`);
  * `"..."` string is scanned and can be fatal. Every other tracked file is
  * therefore scanned raw, unblanked. (Decided 2026-09-08 per #3062.)
  */
+// Returns true for .md and .html files (the markdown-scanned set). Per the
+// operator's #3062 decision, .html is treated as fully markdown, including
+// embedded `<script>` and `<style>` block content — backtick-wrapped spans
+// inside those blocks are also blanked, which could theoretically hide a
+// citation there. This is an accepted trade-off of the current scope decision
+// (see real-tree example at docs/features/277-v115-bug-chore-sweep-board.html
+// around lines 1062 and 1085).
 function isMarkdownScanPath(relPath) {
   return /\.(md|html)$/i.test(relPath);
 }

--- a/scripts/tests/check-register-citations.test.mjs
+++ b/scripts/tests/check-register-citations.test.mjs
@@ -659,6 +659,28 @@ test('checkNonexistentIds: paired control — the identical shape in a MARKDOWN 
   assert.equal(errors.length, 0);
 });
 
+test('checkNonexistentIds: a discharge annotation inside backticks does NOT excuse a nonexistent citation in EITHER markdown or non-markdown files (#3124 finding N1)', () => {
+  // Regression test: discharge-annotation blanking must apply unconditionally,
+  // not gated by isMarkdown. A discharge word inside backticks (e.g. `` `discharged` ``)
+  // in a code span is "an instruction to run a search, not an assertion" (PR #2630
+  // pass-8 finding O), so it must be blanked BEFORE discharge-annotation checking
+  // regardless of file type. Before the fix, this worked correctly in .md files
+  // but was silently excused in .mjs files due to the isMarkdown gate.
+  const { rows } = parseRegisterRows(buildRegister());
+  const text = 'See register row A999 — `discharged` in the 2026-08 sweep.\n';
+
+  // Both contexts should report the citation as fatal
+  const mdResult = checkNonexistentIds(text, 'docs/foo.md', rows);
+  assert.equal(mdResult.errors.length, 1, 'markdown should report A999 as fatal');
+  assert.match(mdResult.errors[0], /A999/);
+  assert.equal(mdResult.annotated.length, 0, 'markdown should not excuse via the backtick-wrapped discharge word');
+
+  const mjsResult = checkNonexistentIds(text, 'scripts/foo.mjs', rows);
+  assert.equal(mjsResult.errors.length, 1, 'non-markdown should also report A999 as fatal');
+  assert.match(mjsResult.errors[0], /A999/);
+  assert.equal(mjsResult.annotated.length, 0, 'non-markdown should not excuse via the backtick-wrapped discharge word');
+});
+
 test('checkConflictingSubjects: a "Criteria source:" phrase INSIDE an example command\'s code span does not fatally fire (finding AD)', () => {
   // Check C used to read the UNBLANKED text — the same class of bug finding
   // AB already fixed for Check A's citation scan, left armed one caller

--- a/scripts/tests/check-register-citations.test.mjs
+++ b/scripts/tests/check-register-citations.test.mjs
@@ -633,6 +633,32 @@ test('checkNonexistentIds: a backticked ID on a "Register rows:" label line is s
   assert.equal(annotated.length, 0);
 });
 
+test('checkNonexistentIds: a nonexistent-ID citation inside a template literal\'s backtick span in a NON-MARKDOWN scanned file is now caught, not silently blanked away (#3062/#3088)', () => {
+  // Before #3088, stripInlineCodeSpans blanked every single-backtick span
+  // unconditionally, including a JS template literal's backticks in a
+  // scanned .mjs/.ts/.py source — so a citation shaped like a worked example
+  // (more than just a bare ID token) inside one vanished before Check A ever
+  // saw it. Scoping blanking to markdown-only means a non-markdown scanned
+  // file is read raw: this exact span is no longer misread as a markdown
+  // code span at all, so the citation surfaces and A999 (not in the
+  // register) is now flagged.
+  const { rows } = parseRegisterRows(buildRegister());
+  const text = 'const s = `see row A999`;\n';
+  const { errors } = checkNonexistentIds(text, 'scripts/foo.mjs', rows);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /A999/);
+});
+
+test('checkNonexistentIds: paired control — the identical shape in a MARKDOWN file keeps its citation blanked/exempted, unchanged from before #3088', () => {
+  // Same worked-example shape as the test above, but scanned as a .md file:
+  // markdown blanking is untouched by #3088, so this span is still blanked
+  // (it is not a bare single-ID span) and the citation stays exempted.
+  const { rows } = parseRegisterRows(buildRegister());
+  const text = 'see `see row A999` for details.\n';
+  const { errors } = checkNonexistentIds(text, 'docs/foo.md', rows);
+  assert.equal(errors.length, 0);
+});
+
 test('checkConflictingSubjects: a "Criteria source:" phrase INSIDE an example command\'s code span does not fatally fire (finding AD)', () => {
   // Check C used to read the UNBLANKED text — the same class of bug finding
   // AB already fixed for Check A's citation scan, left armed one caller

--- a/scripts/tests/check-register-citations.test.mjs
+++ b/scripts/tests/check-register-citations.test.mjs
@@ -1875,6 +1875,43 @@ test('measureWrongIdEligibleLines: a heading citing only a NONEXISTENT id is not
   assert.equal(criteriaFiles, 0);
 });
 
+// --- Check C / F4: markdown vs non-markdown distinction ---
+//
+// The `isMarkdown` flag threads through check functions to control backtick
+// blanking. Verify that it actually matters: a citation inside a backtick span
+// should be blanked in markdown files but NOT in non-markdown sources.
+
+test('checkConflictingSubjects: a "Criteria source:" phrase INSIDE a code span in a NON-MARKDOWN scanned file is NOT blanked and should fire (F4)', () => {
+  // Mirrors the existing markdown test (line 662) but with a non-markdown
+  // file path (.ts instead of .md). Non-markdown sources should NOT blank
+  // backticks, so the "Criteria source: A1 for #1001" pattern INSIDE the
+  // backtick span should still be visible and fire the check (A1 is wrong
+  // for #1001, which maps to A2/B1).
+  const { rows } = parseRegisterRows(buildRegister());
+  const files = new Map([
+    ['server/src/lib/foo.ts', 'Audit with `grep -n "Criteria source: A1 for #1001" docs/` before the sweep.\n'],
+  ]);
+  const { wrongId, unknownSubject } = checkConflictingSubjects(files, rows);
+  // In non-markdown, the backticks are NOT blanked, so "Criteria source: A1"
+  // inside them is still visible and triggers wrongId (A1 is wrong for #1001).
+  assert.equal(wrongId.length, 1);
+  assert.match(wrongId[0], /cited A1 for #1001/);
+  assert.equal(unknownSubject.length, 0);
+});
+
+test('checkConflictingSubjects: paired control — the same "Criteria source:" in a MARKDOWN file is blanked and does not fire (unchanged)', () => {
+  // Verify the existing behavior for markdown files is unchanged: backticks
+  // ARE blanked, so "Criteria source: A1 for #1001" inside them is NOT visible.
+  const { rows } = parseRegisterRows(buildRegister());
+  const files = new Map([
+    ['docs/foo.md', 'Audit with `grep -n "Criteria source: A1 for #1001" docs/` before the sweep.\n'],
+  ]);
+  const { wrongId, unknownSubject } = checkConflictingSubjects(files, rows);
+  // In markdown, backticks are blanked, so the pattern inside them is invisible.
+  assert.equal(wrongId.length, 0);
+  assert.equal(unknownSubject.length, 0);
+});
+
 // --- Check D: heading title drift (v2, #2871, tuning doc #2870) ---
 //
 // Per the tuning doc's own recommendation, only the anchored heading surface

--- a/scripts/tests/check-register-citations.test.mjs
+++ b/scripts/tests/check-register-citations.test.mjs
@@ -2594,6 +2594,35 @@ test('checkNonexistentIds: a citation inside a fenced code block is not scanned 
   assert.equal(annotated.length, 0);
 });
 
+test('checkNonexistentIds: a citation inside triple backticks in a NON-MARKDOWN file IS scanned (backticks are not fences in `.mjs`/`.ts`/etc)', () => {
+  const { rows } = parseRegisterRows(buildRegister());
+  // This is a `.mjs` file, so triple backticks are NOT markdown fence markers —
+  // they're just character sequences in the code (e.g., in a template literal).
+  // A citation inside them should NOT be blanked and SHOULD be found.
+  const text = ['```', 'See register row A9 for details.', '```'].join('\n');
+  const { errors, annotated } = checkNonexistentIds(text, 'scripts/some-script.mjs', rows);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /A9/);
+  assert.equal(annotated.length, 0);
+});
+
+test('checkNonexistentIds: an unpaired fence line in a NON-MARKDOWN file does not blank to EOF', () => {
+  const { rows } = parseRegisterRows(buildRegister());
+  // In a markdown file, a single unpaired ``` would blank from there to EOF.
+  // In a non-markdown file, backticks are just characters, so the citation
+  // on the line after should still be found.
+  const lines = [
+    '// Some code with a backtick sequence',
+    '```',
+    'See register row A9 for details.',
+  ];
+  const text = lines.join('\n');
+  const { errors, annotated } = checkNonexistentIds(text, 'scripts/some-script.mjs', rows);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /A9/);
+  assert.equal(annotated.length, 0);
+});
+
 // --- Check A / general citation-surface coverage (widened net) ---
 
 test('checkNonexistentIds: a "Register row:" label line with no whitespace before the colon is now matched ("Register rows:" idiom)', () => {

--- a/scripts/tests/check-register-citations.test.mjs
+++ b/scripts/tests/check-register-citations.test.mjs
@@ -2381,6 +2381,52 @@ Other body.
   assert.equal(result.annotatedFindings.length, 0);
 });
 
+// Regression test for PR #3124 finding F1 — register title code spans must
+// always be blanked regardless of scanned file type.
+test('checkCitationTitleDrift: register row title code spans are always blanked, not affected by scanned file type', () => {
+  // When scanning a non-markdown file (e.g., .mjs), the register row's title
+  // (which comes from docs/testing/onbox-acceptance-register.md, always
+  // markdown) should still have its backticks blanked. Before the fix,
+  // titleDriftTokens(row.title, isMarkdown) was passed the scanned file's
+  // isMarkdown flag, so non-markdown files caused the register title's
+  // backticks to NOT be blanked, leaking backtick-wrapped words into the
+  // token comparison and falsely suppressing drift detection.
+  const registerText = `# On-box acceptance register
+
+## Group A — test group
+
+### E3 · Pair from \`castwright.local\` (#256)
+
+Some body text.
+`;
+  const { rows } = parseRegisterRows(registerText);
+
+  // Heading that echoes only the backticked part, not "Pair from".
+  // When register title backticks are correctly blanked:
+  //   - Register tokens: {"pair", "from"}
+  //   - Heading tokens: {"castwright", "local"}
+  //   - Shared: {} = 0 tokens
+  //   - Should trigger drift detection
+  //
+  // When register title backticks are NOT blanked (the bug):
+  //   - Register tokens: {"pair", "from", "castwright", "local"}
+  //   - Heading tokens: {"castwright", "local"}
+  //   - Shared: {"castwright", "local"} = 2 tokens >= minimum
+  //   - Would suppress drift detection (false negative)
+  const text = '### E3 · castwright local\n\nBody.\n';
+
+  // Both .md and .mjs should detect the same drift.
+  // Before fix: .md detects drift, .mjs does not (bug).
+  // After fix: both detect drift (correct).
+  const mdResult = checkCitationTitleDrift(text, 'docs/foo.md', rows);
+  const mjsResult = checkCitationTitleDrift(text, 'docs/foo.mjs', rows);
+
+  assert.equal(mdResult.findings.length, 1, 'drift detected when scanning .md file');
+  assert.equal(mjsResult.findings.length, 1, 'drift detected when scanning .mjs file (same as .md, not file-dependent)');
+  assert.match(mdResult.findings[0], /E3/);
+  assert.match(mjsResult.findings[0], /E3/);
+});
+
 // --- frozen-path exclusion ---
 
 test('isFrozenPath: excludes the documented frozen globs', () => {

--- a/scripts/tests/validate-sidecar-acceptance.test.mjs
+++ b/scripts/tests/validate-sidecar-acceptance.test.mjs
@@ -486,7 +486,7 @@ test('loadRegisterRowIds returns an empty set (fail closed) when the register is
 });
 
 // The gate's own help text must not be a passing body. It used to be: it
-// carried a real ISO date, `passed`, and `row A101` -- an id that has never
+// carried a real ISO date, `passed`, and `A101` -- an id that has never
 // existed -- so "check goes red -> copy the example -> check goes green" was
 // the honest path.
 test('helpMessage() fed whole as a PR body does NOT satisfy the gate', () => {

--- a/scripts/validate-sidecar-acceptance.mjs
+++ b/scripts/validate-sidecar-acceptance.mjs
@@ -391,7 +391,7 @@ export function passesSidecarAcceptanceGate(files, body, rowIds = loadRegisterRo
 
 // The examples here are PLACEHOLDERS on purpose. This whole message used to
 // be a passing body: it carried a real ISO date, the outcome `passed`, and
-// `row A101` -- an id that has never existed in the register -- so the
+// `A101` -- an id that has never existed in the register -- so the
 // honest path was "check goes red -> author copies the example -> check goes
 // green", with nothing run and no row filed (#3053 review pass 2, N1). A
 // help text must not itself satisfy the gate it explains; the paired test


### PR DESCRIPTION
## Summary

- Per the operator's 2026-09-08 decision on #3062 (Option 1), `check-register-citations.mjs`'s single-backtick inline code-span blanking (`stripInlineCodeSpans`) is now scoped to markdown-scanned files only (`.md`, `.html`) via a new `isMarkdownScanPath()` helper threaded through every call site. Non-markdown tracked sources (`.mjs`, `.ts`, `.py`, ...) are now scanned raw, so a template literal's backticks are no longer misread as markdown code-span delimiters and can no longer silently hide a register-row citation inside one.
- Widening the scan surface newly caught 2 previously-hidden citations of the nonexistent row ID `A101`, both in explanatory comments (`scripts/validate-sidecar-acceptance.mjs` and its paired test) describing the gate's placeholder example text. #3089's survey confirmed both were false positives, not defects — no real citation-defect fixes were needed. They were reworded to drop the "row" prefix so the bare ID no longer sits on any citation surface, leaving the checker's detection logic itself untouched.
- The checker's own header comment and `stripInlineCodeSpans`/`isMarkdownScanPath`'s own comments state the markdown-only rule explicitly.

## Also fixed, found in passing (pr-review-gate)

- **F1 (correctness, 🟠)**: `titleDriftTokens(row.title, isMarkdown)` was blanking the register row's own title using the *scanned file's* markdown flag instead of treating the register (always markdown) as markdown unconditionally — silently suppressing title-drift detection for 9 backticked-title rows (A17, A20, A22, A23, A25, A32, A33, E3, E9) whenever the citing file was non-markdown. Fixed to `titleDriftTokens(row.title)` (defaults to markdown), paired regression test added.
- **F2 (chore)**: `stripFences` (triple-backtick fence blanking) wasn't threaded through `isMarkdown` alongside `stripInlineCodeSpans`, so a non-markdown file's fenced-looking content (and an unpaired fence line blanking to EOF) could still silently hide a citation — exactly the class of bug this PR set out to fix. Gated `stripFences` behind `isMarkdown` across its 6 call sites, with regression tests.
- **F3 (chore)**: documented the known, accepted residual risk that `.html` (treated as fully markdown per the #3062 decision) can blank backtick spans inside embedded `<script>`/`<style>` content — no behavior change, comment only.
- **F4 (chore)**: added test coverage pairing markdown vs. non-markdown behavior for a previously-untested `isMarkdown` call site (`checkConflictingSubjects`), since thin coverage there is how F1 survived to review.
- **N1 (correctness, 🟠, found on re-review)**: the same `isMarkdown` threading accidentally loosened discharge-annotation blanking too — a real, fatal citation of a nonexistent register row could be silently excused as "discharged" in a non-markdown file if the discharge word sat inside a backtick span, purely due to file extension (the mirror-image bug of F1/F2). Discharge-annotation blanking isn't markdown-specific (its false-positive-prevention rationale applies to any file type), so the two affected call sites (`idSpecificAnnotationPresent`, `dischargeAnnotationPresentAnywhere`) were made unconditional again, matching the pre-existing correct pattern elsewhere in the file. Latent in the real tree (zero live instances); paired regression test added.
- **N2 (chore, found on re-review)**: updated `isMarkdownScanPath()`'s header comment, which described only the inline-code-span gating it was originally added for and had gone stale once it also started gating `stripFences` (F2) — now documents both mechanisms it controls.

## Test plan

- `node --test scripts/tests/check-register-citations.test.mjs` — 152/152 pass, including new regression tests for F1, F2, F4, and N1.
- `node scripts/check-register-citations.mjs --strict` — `check:register-citations: OK`, no fatal findings on the real tree.
- `npm run typecheck` (root, covers `server/` too) — clean.
- `node --test scripts/tests/validate-sidecar-acceptance.test.mjs` — 88/88 pass, confirming the reworded placeholder comments still satisfy every existing assertion.
- Reproduced the fixed-vs-unchanged behaviour directly via the suite's own CLI-mutation tests: a nonexistent-ID citation inside a template-literal-shaped backtick span in a `.mjs` file is now caught, while the identical shape in a `.md` file remains exempt, unchanged; a discharge-annotation excuse inside a backtick span no longer masks a fatal citation in either file type.

## Not applicable
- **Release notes (before-shipping step 5)**: skipped — internal dev-tooling/checker fix, no shippable user- or operator-visible product delta.
- **On-box acceptance (before-shipping step 3)**: skipped — nothing here requires real hardware to prove; all behavior is verified by the automated test suite above.

Closes #3062
