### PR TITLE
ci(ops): enforce the live view's publish token via --stamped-since

### DIFF
--- a/.github/workflows/onbox-register-check.yml
+++ b/.github/workflows/onbox-register-check.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
 
       - name: Set up Node
         uses: actions/setup-node@v7
@@ -45,18 +47,15 @@ jobs:
         run: node scripts/check-onbox-register.mjs
 
       - name: Check the generated live-view surfaces are up to date
+        if: ${{ !cancelled() }}
         run: node scripts/build-register-live-view.mjs --check
 
       # #3116: mandatory-but-unenforced until now. The register's own
       # procedure says every publish must bump the live view's publish
-      # token; nothing checked it. A shallow `actions/checkout@v7` has no
-      # base ref available, so fetch just the PR's base commit (not
-      # `fetch-depth: 0` — that would pull the whole history for a single
-      # commit) before invoking the check.
-      - name: Fetch PR base for the publish-token check
-        if: github.event_name == 'pull_request'
-        run: git fetch --depth=1 origin ${{ github.event.pull_request.base.sha }}
-
+      # token; nothing checked it. With fetch-depth: 2, the merge
+      # commit's first parent (the base ref at merge time) is available
+      # as HEAD^1. This check verifies that any change to the live view's
+      # RENDERED content is accompanied by a stamp bump.
       - name: Check the live view was re-stamped if its content changed
-        if: github.event_name == 'pull_request'
-        run: node scripts/check-onbox-register.mjs --stamped-since ${{ github.event.pull_request.base.sha }}
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+        run: node scripts/check-onbox-register.mjs -- --stamped-since HEAD^1

--- a/.github/workflows/onbox-register-check.yml
+++ b/.github/workflows/onbox-register-check.yml
@@ -58,4 +58,4 @@ jobs:
       # RENDERED content is accompanied by a stamp bump.
       - name: Check the live view was re-stamped if its content changed
         if: ${{ !cancelled() && github.event_name == 'pull_request' }}
-        run: node scripts/check-onbox-register.mjs -- --stamped-since HEAD^1
+        run: node scripts/check-onbox-register.mjs --stamped-since HEAD^1

--- a/.github/workflows/onbox-register-check.yml
+++ b/.github/workflows/onbox-register-check.yml
@@ -18,8 +18,11 @@ on:
       - 'scripts/check-onbox-register.mjs'
       # #3116: the publish-token check (--stamped-since) depends on
       # publish-token.mjs's parsePublishToken and publishTokenRegex functions,
-      # so changes to those must exercise the real register too.
+      # and on git-env.mjs and lib/is-main-module.mjs, so changes to those
+      # must exercise the real register too.
       - 'scripts/publish-token.mjs'
+      - 'scripts/git-env.mjs'
+      - 'scripts/lib/is-main-module.mjs'
       - 'scripts/build-register-live-view.mjs'
       - '.github/workflows/onbox-register-check.yml'
 

--- a/.github/workflows/onbox-register-check.yml
+++ b/.github/workflows/onbox-register-check.yml
@@ -43,3 +43,17 @@ jobs:
 
       - name: Check the generated live-view surfaces are up to date
         run: node scripts/build-register-live-view.mjs --check
+
+      # #3116: mandatory-but-unenforced until now. The register's own
+      # procedure says every publish must bump the live view's publish
+      # token; nothing checked it. A shallow `actions/checkout@v7` has no
+      # base ref available, so fetch just the PR's base commit (not
+      # `fetch-depth: 0` — that would pull the whole history for a single
+      # commit) before invoking the check.
+      - name: Fetch PR base for the publish-token check
+        if: github.event_name == 'pull_request'
+        run: git fetch --depth=1 origin ${{ github.event.pull_request.base.sha }}
+
+      - name: Check the live view was re-stamped if its content changed
+        if: github.event_name == 'pull_request'
+        run: node scripts/check-onbox-register.mjs --stamped-since ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/onbox-register-check.yml
+++ b/.github/workflows/onbox-register-check.yml
@@ -16,6 +16,10 @@ on:
       # editing the checker exercises it against the real register, rather
       # than only ever running against a register that hasn't changed.
       - 'scripts/check-onbox-register.mjs'
+      # #3116: the publish-token check (--stamped-since) depends on
+      # publish-token.mjs's parsePublishToken and publishTokenRegex functions,
+      # so changes to those must exercise the real register too.
+      - 'scripts/publish-token.mjs'
       - 'scripts/build-register-live-view.mjs'
       - '.github/workflows/onbox-register-check.yml'
 

--- a/.github/workflows/onbox-register-check.yml
+++ b/.github/workflows/onbox-register-check.yml
@@ -12,18 +12,14 @@ on:
       # change to either side has to fire it — a live-view-only edit is exactly
       # the shape that drifts the published page away from the markdown.
       - 'docs/testing/onbox-acceptance-register-live-view.html'
-      # Also fire on the checker itself (and its own workflow file) so
-      # editing the checker exercises it against the real register, rather
-      # than only ever running against a register that hasn't changed.
-      - 'scripts/check-onbox-register.mjs'
-      # #3116: the publish-token check (--stamped-since) depends on
-      # publish-token.mjs's parsePublishToken and publishTokenRegex functions,
-      # and on git-env.mjs and lib/is-main-module.mjs, so changes to those
-      # must exercise the real register too.
-      - 'scripts/publish-token.mjs'
-      - 'scripts/git-env.mjs'
-      - 'scripts/lib/is-main-module.mjs'
-      - 'scripts/build-register-live-view.mjs'
+      # Fire on any scripts/* change (and the workflow file itself) so editing
+      # the checkers or their transitive dependencies exercises them against the
+      # real register. The transitive local-import graph is under-listed on the
+      # third attempt to enumerate it (#1847, #2216, #3055 hit this exact shape
+      # in scripts/verify-cache.mjs and resolved it the same way). A glob is
+      # durable: the walk over relative imports in scripts/lib/module-graph.mjs
+      # proves the dependencies; a hand list drifts after the first new import.
+      - 'scripts/**/*.mjs'
       - '.github/workflows/onbox-register-check.yml'
 
 permissions:

--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -75,24 +75,14 @@ Bumping the counter without minting a new id is that same failure with an extra
 step. Two of the eight designs considered for this token died on precisely that,
 which is why the stamper does both halves or neither.
 
-The token is now LIVE: `npm run check:onbox-register --stamped-since <ref>` 
-(#3116) checks in CI that the live view's content did not change without the 
-counter moving — catching cases where a branch reverts the live view to an 
-older revision, or where a conflict was resolved by taking one side wholesale 
-over the other. The check reads the two copies at the PR base and HEAD and 
-**reports** an unstamped change in content (see #3138 for the decision whether 
-to enforce it as a merge gate). **Any PR that changes the live view's RENDERED 
-content should re-stamp it.**
-
-**One more thing has to happen before that check can pass, and it is easy to
-miss because it is not a code change: the live view must be PUBLISHED at least
-once with a token on it.** The comparator reads three copies — the tracked file,
-`origin/main`'s, and the *saved live page* — and the live page only acquires a
-token when someone publishes after this change merged. Until then the check
-reports that the published page carries none while `origin/main` does, and
-names the transition explicitly rather than guessing. So the first publish after
-this merges clears it, and the wording of that error is written for exactly that
-window.
+The token is now LIVE: `npm run check:onbox-register -- --stamped-since <ref>`
+(#3116) checks in CI that the live view's content did not change without the
+counter moving — catching cases where a branch reverts the live view to an
+older revision, or where a conflict was resolved by taking one side wholesale
+over the other. The check reads the two copies at `merge(base, head)` and
+**reports** an unstamped change in content (see #3138 for the decision whether
+to enforce it as a merge gate). **Any PR that changes the live view's RENDERED
+content must re-stamp it.**
 
 The live view carries derived figures — owed count, per-group counts, oldest
 debt — that are **generated** on every build. Rows can be right while the
@@ -109,6 +99,7 @@ section. Both fail CI when rows are added, removed, or miscounted, so
 includes any markdown-only edit that moves a count (even though only the
 markdown changed, the live view's `<!-- BEGIN GENERATED -->` section regenerates
 with the new count, so `--stamped-since` sees rendered content that moved).
+
 Know its edges, because three of them are wide:
 
 - **A wording-only edit to a numbered Group row does not fail — but the same

--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -79,10 +79,13 @@ The token is now LIVE: `npm run check:onbox-register -- --stamped-since <ref>`
 (#3116) checks in CI that the live view's content did not change without the
 counter moving — catching cases where a branch reverts the live view to an
 older revision, or where a conflict was resolved by taking one side wholesale
-over the other. The check reads the two copies at `merge(base, head)` and
-**reports** an unstamped change in content (see #3138 for the decision whether
-to enforce it as a merge gate). **Any PR that changes the live view's RENDERED
-content must re-stamp it.**
+over the other. The check reads the base ref's copy and the working tree's,
+which on a PR is `merge(base, head)`, and **reports** an unstamped change in
+content (see #3138 for the decision whether to enforce it as a merge gate).
+**Any PR that changes the live view's RENDERED content must re-stamp it** — this
+includes any markdown-only edit that moves a count (even though only the
+markdown changed, the live view's `<!-- BEGIN GENERATED -->` section regenerates
+with the new count, so `--stamped-since` sees rendered content that moved).
 
 The live view carries derived figures — owed count, per-group counts, oldest
 debt — that are **generated** on every build. Rows can be right while the
@@ -94,11 +97,6 @@ floor — the floor gates the NEXT id a group may mint, not the ids already in
 use), and that each group's glance-table count matches the rows in its body
 section. Both fail CI when rows are added, removed, or miscounted, so
 **adding or removing a row here and missing the live view build fails CI**.
-
-**A PR that changes the live view's RENDERED content must re-stamp it** — this
-includes any markdown-only edit that moves a count (even though only the
-markdown changed, the live view's `<!-- BEGIN GENERATED -->` section regenerates
-with the new count, so `--stamped-since` sees rendered content that moved).
 
 Know its edges, because three of them are wide:
 
@@ -358,9 +356,10 @@ comparison, see the edge list above). The merge step that closes this, run
        Observed 2026-09-07: live at 11 against a tracked 9 located PR #3073 in
        one command, before any row-by-row comparison. The row-content report
        named A1/A16/A21 — true, but it reads identically in both directions,
-       which is the whole reason to check the counter first. Note this works
-       even though nothing yet *enforces* the token (#2599): reading it by eye
-       costs nothing and does not wait on that check landing.
+       which is the whole reason to check the counter first. Note that nothing
+       yet enforces the token *at publish time* (#2599 — `comparePublishTokens`
+       still has no production consumer), so reading it by eye costs nothing and
+       does not wait on that enforcement landing.
      - **The published page matches the baseline, but your local copy doesn't**
        — you have a local edit not yet merged to `origin/main`, and the
        published page is simply unchanged (still at baseline) because nothing

--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -82,10 +82,11 @@ older revision, or where a conflict was resolved by taking one side wholesale
 over the other. The check reads the base ref's copy and the working tree's,
 which CI makes `merge(base, head)`, and **reports** an unstamped change in
 content (see #3138 for the decision whether to enforce it as a merge gate).
-In CI, `<ref>` is `HEAD^1` (the base ref at merge time). By hand, pass the
-target ref explicitly (e.g. `origin/main`) — `HEAD^1` is your branch's previous
-commit, so on a local branch it compares the live view against itself and passes
-unstamped edits. To get the same comparison as CI, merge the target first
+In CI, `<ref>` is `HEAD^1` (the base branch's tip at merge time). By hand, pass
+the target ref explicitly (e.g. `origin/main`), never `HEAD^1`: after a local
+`git merge origin/main`, `HEAD^1` is your branch's own pre-merge tip, so main's
+newer stamp is credited to your branch and an unstamped edit passes. To get the
+same comparison as CI, merge the target first
 (e.g. `git fetch origin && git merge origin/main`), then pass that ref.
 **Any PR that changes the live view's RENDERED content must re-stamp it** — this
 includes any markdown-only edit that moves a count. After a markdown edit that

--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -82,10 +82,16 @@ older revision, or where a conflict was resolved by taking one side wholesale
 over the other. The check reads the base ref's copy and the working tree's,
 which CI makes `merge(base, head)`, and **reports** an unstamped change in
 content (see #3138 for the decision whether to enforce it as a merge gate).
+In CI, `<ref>` is `HEAD^1` (the base ref at merge time). By hand, bring your
+branch up to date with the target ref first (e.g. `git fetch origin && git merge origin/main`),
+then pass that ref (e.g. `origin/main`) so the check compares the merged state.
 **Any PR that changes the live view's RENDERED content must re-stamp it** — this
-includes any markdown-only edit that moves a count. The `register:build` rebuild
-that CI's `--check` step requires moves the generated section, so `--stamped-since`
-then sees rendered content that moved.
+includes any markdown-only edit that moves a count. After a markdown edit that
+changes any generated figures, run `npm run register:build` locally (it regenerates
+the summary strip and derived counts), then `npm run stamp:publish-token` to bump
+the live view's publish counter — both changes must land together or CI's
+`register:build --check` will fail (generated figures stale) and `--stamped-since`
+will fail (content changed without re-stamping).
 
 The live view carries derived figures — owed count, per-group counts, oldest
 debt — that are **generated** on every build. Rows can be right while the

--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -80,12 +80,12 @@ The token is now LIVE: `npm run check:onbox-register -- --stamped-since <ref>`
 counter moving — catching cases where a branch reverts the live view to an
 older revision, or where a conflict was resolved by taking one side wholesale
 over the other. The check reads the base ref's copy and the working tree's,
-which on a PR is `merge(base, head)`, and **reports** an unstamped change in
+which CI makes `merge(base, head)`, and **reports** an unstamped change in
 content (see #3138 for the decision whether to enforce it as a merge gate).
 **Any PR that changes the live view's RENDERED content must re-stamp it** — this
-includes any markdown-only edit that moves a count (even though only the
-markdown changed, the live view's `<!-- BEGIN GENERATED -->` section regenerates
-with the new count, so `--stamped-since` sees rendered content that moved).
+includes any markdown-only edit that moves a count. The `register:build` rebuild
+that CI's `--check` step requires moves the generated section, so `--stamped-since`
+then sees rendered content that moved.
 
 The live view carries derived figures — owed count, per-group counts, oldest
 debt — that are **generated** on every build. Rows can be right while the
@@ -97,7 +97,6 @@ floor — the floor gates the NEXT id a group may mint, not the ids already in
 use), and that each group's glance-table count matches the rows in its body
 section. Both fail CI when rows are added, removed, or miscounted, so
 **adding or removing a row here and missing the live view build fails CI**.
-
 Know its edges, because three of them are wide:
 
 - **A wording-only edit to a numbered Group row does not fail — but the same

--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -83,10 +83,11 @@ over the other. The check reads the base ref's copy and the working tree's,
 which CI makes `merge(base, head)`, and **reports** an unstamped change in
 content (see #3138 for the decision whether to enforce it as a merge gate).
 In CI, `<ref>` is `HEAD^1` (the base branch's tip at merge time). By hand, pass
-the target ref explicitly (e.g. `origin/main`), never `HEAD^1`: after a local
-`git merge origin/main`, `HEAD^1` is your branch's own pre-merge tip, so main's
-newer stamp is credited to your branch and an unstamped edit passes. To get the
-same comparison as CI, merge the target first
+the target ref explicitly (e.g. `origin/main`), never `HEAD^1`: outside CI's
+merge commit, `HEAD^1` is a commit on your own branch — your previous commit, or
+after a local `git merge origin/main` your own pre-merge tip — and whenever it
+already contains your unstamped edit, that edit is on both sides of the
+comparison and passes. To get the same comparison as CI, merge the target first
 (e.g. `git fetch origin && git merge origin/main`), then pass that ref.
 **Any PR that changes the live view's RENDERED content must re-stamp it** — this
 includes any markdown-only edit that moves a count. After a markdown edit that

--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -75,13 +75,14 @@ Bumping the counter without minting a new id is that same failure with an extra
 step. Two of the eight designs considered for this token died on precisely that,
 which is why the stamper does both halves or neither.
 
-The token is inert today: nothing reads it yet. The check that does — a
-comparison against the live page's own token, to catch a lane publishing over
-work it never saw — lands separately (#2599). It is seeded first and on its own
-because a guard cannot ship in the same change as the data it requires: the
-checker validates `origin/main`'s copy, so the data has to be on `main` already
-or the guard's first run fails on its own delivery. That is the same
-data-then-guard split the stable row IDs needed (#2629).
+The token is now LIVE: `npm run check:onbox-register --stamped-since <ref>` 
+(#3116) checks in CI that the live view's content did not change without the 
+counter moving — catching cases where a branch reverts the live view to an 
+older revision, or where a conflict was resolved by taking one side wholesale 
+over the other. The check reads the two copies at the PR base and HEAD and 
+**reports** an unstamped change in content (see #3138 for the decision whether 
+to enforce it as a merge gate). **Any PR that changes the live view's RENDERED 
+content should re-stamp it.**
 
 **One more thing has to happen before that check can pass, and it is easy to
 miss because it is not a code change: the live view must be PUBLISHED at least
@@ -103,6 +104,11 @@ floor — the floor gates the NEXT id a group may mint, not the ids already in
 use), and that each group's glance-table count matches the rows in its body
 section. Both fail CI when rows are added, removed, or miscounted, so
 **adding or removing a row here and missing the live view build fails CI**.
+
+**A PR that changes the live view's RENDERED content must re-stamp it** — this
+includes any markdown-only edit that moves a count (even though only the
+markdown changed, the live view's `<!-- BEGIN GENERATED -->` section regenerates
+with the new count, so `--stamped-since` sees rendered content that moved).
 Know its edges, because three of them are wide:
 
 - **A wording-only edit to a numbered Group row does not fail — but the same

--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -82,13 +82,14 @@ older revision, or where a conflict was resolved by taking one side wholesale
 over the other. The check reads the base ref's copy and the working tree's,
 which CI makes `merge(base, head)`, and **reports** an unstamped change in
 content (see #3138 for the decision whether to enforce it as a merge gate).
-In CI, `<ref>` is `HEAD^1` (the base branch's tip at merge time). By hand, pass
-the target ref explicitly (e.g. `origin/main`), never `HEAD^1`: outside CI's
-merge commit, `HEAD^1` is a commit on your own branch — your previous commit, or
-after a local `git merge origin/main` your own pre-merge tip — and whenever it
-already contains your unstamped edit, that edit is on both sides of the
-comparison and passes. To get the same comparison as CI, merge the target first
-(e.g. `git fetch origin && git merge origin/main`), then pass that ref.
+In CI, `<ref>` is `HEAD^1` (the base branch's tip at merge time). **By hand,
+never pass `HEAD^1`**: outside CI's merge commit it is not the base your branch
+will merge onto, so the check can fail to catch an unstamped edit — for example
+when `HEAD^1` already contains the edit, or when a stamp main landed in between
+is credited to your branch. Instead, merge the target in and pass it explicitly
+(`git fetch origin && git merge origin/main`, then
+`npm run check:onbox-register -- --stamped-since origin/main`); that reproduces
+CI's comparison.
 **Any PR that changes the live view's RENDERED content must re-stamp it** — this
 includes any markdown-only edit that moves a count. After a markdown edit that
 changes any generated figures, run `npm run register:build` locally (it regenerates

--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -82,16 +82,18 @@ older revision, or where a conflict was resolved by taking one side wholesale
 over the other. The check reads the base ref's copy and the working tree's,
 which CI makes `merge(base, head)`, and **reports** an unstamped change in
 content (see #3138 for the decision whether to enforce it as a merge gate).
-In CI, `<ref>` is `HEAD^1` (the base ref at merge time). By hand, bring your
-branch up to date with the target ref first (e.g. `git fetch origin && git merge origin/main`),
-then pass that ref (e.g. `origin/main`) so the check compares the merged state.
+In CI, `<ref>` is `HEAD^1` (the base ref at merge time). By hand, pass the
+target ref explicitly (e.g. `origin/main`) — `HEAD^1` is your branch's previous
+commit, so on a local branch it compares the live view against itself and passes
+unstamped edits. To get the same comparison as CI, merge the target first
+(e.g. `git fetch origin && git merge origin/main`), then pass that ref.
 **Any PR that changes the live view's RENDERED content must re-stamp it** — this
 includes any markdown-only edit that moves a count. After a markdown edit that
 changes any generated figures, run `npm run register:build` locally (it regenerates
 the summary strip and derived counts), then `npm run stamp:publish-token` to bump
-the live view's publish counter — both changes must land together or CI's
-`register:build --check` will fail (generated figures stale) and `--stamped-since`
-will fail (content changed without re-stamping).
+the live view's publish counter. Skip the rebuild and CI's `register:build --check`
+will fail (generated figures stale); skip the stamp and `--stamped-since` will fail
+(content changed without re-stamping).
 
 The live view carries derived figures — owed count, per-group counts, oldest
 debt — that are **generated** on every build. Rows can be right while the

--- a/scripts/check-onbox-register.mjs
+++ b/scripts/check-onbox-register.mjs
@@ -1528,18 +1528,20 @@ export function resolveBaselineTexts(
 // In CI this is guaranteed: `actions/checkout@v7` on a pull_request event
 // checks out `refs/pull/N/merge`, GitHub's `Merge <head> into <base>` commit,
 // rebuilt on the base's current tip. Its first parent is that tip, available
-// as HEAD^1 (the tip, not the merge-base). On hand-run invocations from a branch,
-// pass origin/main (or your target ref) explicitly, never HEAD^1: outside CI's merge
-// commit, HEAD^1 is a commit on your own branch -- your previous commit, or after a
-// local `git merge origin/main` your own pre-merge tip -- and whenever it already
-// contains your unstamped edit, that edit is on both sides of the comparison and
-// passes. Un-merged against the real base, an unstamped edit is still refused,
-// correctly, but if main has stamped a higher counter since your branch opened the
-// message reads BEHIND and says rebase instead of stamp; and a branch that never
-// touched the live view is falsely refused whenever main's rendered content
-// changed. Merge the target in first. The comparison is only meaningful when the
-// working tree is merge(base, head) and `ref` is that base -- what CI's merge
-// commit is, and what merging the target in first gives you by hand.
+// as HEAD^1 (the tip, not the merge-base). By hand, never pass HEAD^1: outside
+// CI's merge commit it is not the base your branch will merge onto (it may be,
+// for example, your previous commit, your own pre-merge tip, or after a
+// fast-forward main's previous tip), so the comparison runs against the wrong
+// tree. That can fail to catch an unstamped edit -- for example when HEAD^1
+// already contains the edit, or when a stamp main landed in between is credited
+// to your branch. Pass the target ref explicitly after merging it in
+// (`git fetch origin && git merge origin/main`, then `--stamped-since
+// origin/main`): that is CI's comparison. Un-merged against the target, the
+// result mixes main's changes with yours: an unstamped edit is still refused,
+// but the message can read BEHIND when main's counter is higher than your
+// branch's, and a branch that never touched the live view can be refused
+// because of main's change. The comparison is only meaningful when the working
+// tree is merge(base, head) and `ref` is that base.
 //
 // `git show <ref>:<path>` exits 128 for BOTH "path missing at that ref" and
 // "ref doesn't resolve at all"; the only way to tell them apart is the
@@ -1650,13 +1652,12 @@ function runCheckOnboxRegisterCli() {
   // merged onto the base branch's tip. In CI, actions/checkout@v7 with
   // fetch-depth: 2 checks out refs/pull/N/merge (`Merge <head> into <base>`,
   // rebuilt on the base's current tip), whose first parent HEAD^1 is that tip.
-  // Hand-run: pass the target ref explicitly (e.g. origin/main), never HEAD^1.
-  // Outside CI's merge commit, HEAD^1 is a commit on your own branch (your previous
-  // commit, or after a local merge your pre-merge tip); whenever it already contains
-  // your unstamped edit, that edit is on both sides and passes. Un-merged, your
-  // unstamped edit is still refused, correctly (BEHIND if main stamped a higher
-  // counter); a branch that never touched the live view is falsely refused if
-  // main's rendered content changed. Merge the target in first.
+  // Hand-run: never pass HEAD^1. Outside CI's merge commit it is not the base your
+  // branch will merge onto, so the check can fail to catch an unstamped edit (for
+  // example when HEAD^1 already contains it, or when a stamp main landed in
+  // between is credited to your branch). Merge the target in, then pass it
+  // explicitly -- that is CI's comparison. Un-merged, the result mixes main's
+  // changes with yours; see the header comment on resolveStampedSinceBaseline.
   const stampedSinceIdx = process.argv.indexOf('--stamped-since');
   if (stampedSinceIdx !== -1) {
     // #3116 review finding 2: --stamped-since is incompatible with

--- a/scripts/check-onbox-register.mjs
+++ b/scripts/check-onbox-register.mjs
@@ -608,6 +608,9 @@ export function checkStampedSince({ workingHtml, baselineHtml }) {
         '`npm run stamp:publish-token` — never hand-edit the number — then commit the result.',
     ];
   }
+  // w.n > b.n is unconditionally true here (both earlier branches returned), but stating
+  // it documents the predicate: when counter is higher AND nonce is unchanged, that's a
+  // hand-edit. Keeping it guards against future branch reordering.
   if (w.n > b.n && w.nonce === b.nonce) {
     return [
       `Publish token: the counter moved (${b.n} → ${w.n}), but the nonce stayed the same. ` +

--- a/scripts/check-onbox-register.mjs
+++ b/scripts/check-onbox-register.mjs
@@ -1528,11 +1528,12 @@ export function resolveBaselineTexts(
 // In CI this is guaranteed: `actions/checkout@v7` on a pull_request event
 // checks out `refs/pull/N/merge`, GitHub's `Merge <head> into <base>` commit,
 // rebuilt on the base's current tip. Its first parent is that tip, available
-// as HEAD^1 (the tip, not the merge-base). On hand-run invocations from a branch that has not been
-// merged or rebased onto the base ref (the opposite of recommended practice),
-// both failure modes occur: comparing un-merged trees might report OK when they
-// genuinely differ (false accept), or might report a difference that exists only
-// because the base ref has advanced (false refuse). The comparison is only
+// as HEAD^1 (the tip, not the merge-base). On hand-run invocations from a branch,
+// use origin/main (or your target ref) explicitly — if you pass HEAD^1 after a
+// local merge, it is your branch's pre-merge tip, not CI's merge-base, so the
+// check compares the live view against itself and passes unstamped edits. The
+// un-merged case against the real base gives a false refuse if main has published
+// since your branch opened, with a misleading remedy. The comparison is only
 // meaningful when the working tree contains the base ref's content.
 //
 // `git show <ref>:<path>` exits 128 for BOTH "path missing at that ref" and
@@ -1629,13 +1630,13 @@ function runCheckOnboxRegisterCli() {
     return true;
   };
 
-  // --stamped-since <ref> (#3116): opt-in, invoked by CI with the PR's base
-  // sha. Answers ONE question — did the live view's rendered content change
-  // since <ref> without the publish counter moving — and stays independent
-  // of the register-vs-live-view comparison below: it reads neither REGISTER
-  // (no `read(REGISTER)` above this block, deliberately) nor does it require
-  // LIVE_VIEW to exist (a newly-added file has nothing to compare against;
-  // see the ENOENT handling below). No network fetch here — that would make
+  // --stamped-since <ref> (#3116): opt-in, invoked by CI with HEAD^1 (the
+  // merge commit's first parent, the base tip at merge time). Answers ONE
+  // question — did the live view's rendered content change since <ref> without
+  // the publish counter moving — and stays independent of the register-vs-live-view
+  // comparison below: it reads neither REGISTER (no `read(REGISTER)` above this
+  // block, deliberately) nor does it require LIVE_VIEW to exist (a newly-added
+  // file has nothing to compare against; see the ENOENT handling below). No network fetch here — that would make
   // the no-flag run's offline guarantee a lie if this block ever grew a
   // dependency on it; the caller (the workflow, or an operator by hand) is
   // responsible for making `ref` resolvable locally first.
@@ -1644,10 +1645,10 @@ function runCheckOnboxRegisterCli() {
   // merged onto the base branch's tip. In CI, actions/checkout@v7 with
   // fetch-depth: 2 checks out refs/pull/N/merge (`Merge <head> into <base>`,
   // rebuilt on the base's current tip), whose first parent HEAD^1 is that tip.
-  // Hand-run: bring the branch up to date with `ref` first (fetch, then merge
-  // or rebase `ref` into the branch), or the check will give both false accepts
-  // (un-merged content reads as unchanged) and false refuses (the base ref has
-  // advanced and is detected as a difference).
+  // Hand-run: pass the target ref explicitly (e.g. origin/main), never HEAD^1.
+  // After a local merge, HEAD^1 is your branch's pre-merge tip, so the check
+  // compares the live view against itself and passes unstamped edits. If you
+  // don't merge locally, you get a false refuse with a misleading remedy.
   const stampedSinceIdx = process.argv.indexOf('--stamped-since');
   if (stampedSinceIdx !== -1) {
     // #3116 review finding 2: --stamped-since is incompatible with

--- a/scripts/check-onbox-register.mjs
+++ b/scripts/check-onbox-register.mjs
@@ -32,6 +32,7 @@ import { fileURLToPath } from 'node:url';
 import { createHash } from 'node:crypto';
 import { scrubGitEnv } from './git-env.mjs';
 import { isDirectlyInvoked } from './lib/is-main-module.mjs';
+import { parsePublishToken, publishTokenRegex } from './publish-token.mjs';
 
 // Deliberately out of scope: the "Blocked" and "Unconfirmed" sections. They
 // use a different structure (one uses `###` headings, the other a bullet
@@ -542,6 +543,66 @@ export function stripHtmlComments(html) {
     if (next === out) return out;
     out = next;
   }
+}
+
+// #3116: "did the live view's RENDERED content change since <ref> without the
+// publish counter moving." A stamp commit sitting somewhere in a branch's
+// history proves nothing about its LATEST content — only comparing the tip
+// against a base ref catches an unstamped edit landed after that stamp. This
+// is deliberately weaker than publish-token.mjs's `comparePublishTokens` (no
+// nonce-in-history search, no rebase/behind-main diagnosis): it answers one
+// question — "did content drift while the counter sat still" — for a check
+// that must also stay `git`-free at its core so it is unit-testable without a
+// scratch repo (the CLI layer supplies the two HTML strings; see
+// `resolveStampedSinceBaseline` for how the `<ref>` side is read).
+//
+// Content comparison ignores HTML comments (the header comment and the
+// `<!-- BEGIN GENERATED:... -->` markers are not rendered) and ignores the
+// token itself (`stripHtmlComments` already strips comments elsewhere in this
+// file; reused here rather than reimplemented, same reasoning as sharing
+// `parsePublishToken` with the stamper). Blanking the token's two attribute
+// values — not stripping the whole marker — keeps the rest of the diff
+// positional, though nothing here depends on that.
+//
+// A missing or malformed token on EITHER side fails closed: a missing token
+// is not "no change", it's "cannot tell whether there was a change".
+export function checkStampedSince({ workingHtml, baselineHtml }) {
+  const blankToken = (html) =>
+    stripHtmlComments(html).replace(publishTokenRegex(), 'data-published-as="" data-publish-id=""');
+
+  if (blankToken(workingHtml) === blankToken(baselineHtml)) return [];
+
+  const w = parsePublishToken(workingHtml);
+  const b = parsePublishToken(baselineHtml);
+
+  if (w === null) {
+    return [
+      "Publish token: the live view's content changed, but the tracked copy has no publish " +
+        'token at all. Run `npm run stamp:publish-token` — never hand-edit the counter.',
+    ];
+  }
+  if (w.malformed) {
+    return [`Publish token (tracked): ${w.malformed}. Fix it, then run \`npm run stamp:publish-token\`.`];
+  }
+  if (b === null) {
+    return [
+      "Publish token: the live view's content changed since the base ref, but the base ref's " +
+        'copy has no publish token at all — investigate before trusting this comparison.',
+    ];
+  }
+  if (b.malformed) {
+    return [`Publish token (base ref): ${b.malformed}. Investigate before trusting this comparison.`];
+  }
+
+  if (w.n === b.n) {
+    return [
+      `Publish token: the live view's rendered content changed since the base ref, but the ` +
+        `publish counter (data-published-as) stayed at ${w.n} on both sides. Run ` +
+        '`npm run stamp:publish-token` — never hand-edit the number — then commit the result.',
+    ];
+  }
+
+  return [];
 }
 
 // Strips tags and collapses whitespace, so a cell's text can be compared
@@ -1427,6 +1488,54 @@ export function resolveBaselineTexts(
   };
 }
 
+// #3116: reads the live view AT an arbitrary ref (the PR base, in CI) for
+// `--stamped-since`. Deliberately narrower than `resolveBaselineTexts` above:
+// no fetch (the caller — the CLI layer, or the workflow before invoking it —
+// is responsible for making `ref` resolvable locally; see the workflow's own
+// `git fetch --depth=1` step), one file, and THREE outcomes rather than
+// fetch-then-show's two, because "the file didn't exist yet at this ref" is
+// not a failure here (it's the newly-added-file case the issue calls out) —
+// it must not be folded into the same bucket as "the ref itself is garbage."
+//
+// `git show <ref>:<path>` exits 128 for BOTH "path missing at that ref" and
+// "ref doesn't resolve at all"; the only way to tell them apart is the
+// stderr text. Git's own C code uses TWO distinct messages for "missing at
+// that ref", not one: `fatal: path '%s' does not exist in '%s'` when the
+// path is absent everywhere the working tree can see, and `fatal: path '%s'
+// exists on disk, but not in '%s'` when it exists on disk in the CURRENT
+// working tree but wasn't tracked yet at <ref> — exactly the newly-added-file
+// shape this flag has to pass. Both are "missing"; anything else (an invalid
+// ref, a corrupt object, a timeout) falls through to 'error' and fails
+// closed, per the issue's explicit instruction that an unresolvable ref must
+// never read as "no change".
+export function resolveStampedSinceBaseline(repoRoot, liveViewPath, ref, gitRunner = runGitCommand) {
+  const result = gitRunner(['show', `${ref}:${liveViewPath}`], repoRoot);
+  if (result.error) {
+    return { status: 'error', text: null, message: `\`git show ${ref}:${liveViewPath}\` failed to run: ${result.error.message}` };
+  }
+  if (result.status !== 0) {
+    const stderr = typeof result.stderr === 'string' ? result.stderr : '';
+    if (stderr.includes('does not exist in') || stderr.includes('exists on disk, but not in')) {
+      return { status: 'missing', text: null, message: null };
+    }
+    return {
+      status: 'error',
+      text: null,
+      message:
+        `\`git show ${ref}:${liveViewPath}\` failed (exit ${result.status}): ` +
+        `${stderr.trim() || '(no stderr output)'}`,
+    };
+  }
+  if (typeof result.stdout !== 'string') {
+    return {
+      status: 'error',
+      text: null,
+      message: `\`git show ${ref}:${liveViewPath}\` produced no readable output.`,
+    };
+  }
+  return { status: 'ok', text: result.stdout, message: null };
+}
+
 // process.exit() terminates before Node flushes pending async stdout/stderr
 // writes (synchronous on Windows, ASYNCHRONOUS on Linux/macOS — see
 // scripts/build-release-zip.mjs's own die()/CliError comment for the fuller
@@ -1481,6 +1590,76 @@ function runCheckOnboxRegisterCli() {
     console.error('');
     return true;
   };
+
+  // --stamped-since <ref> (#3116): opt-in, invoked by CI with the PR's base
+  // sha. Answers ONE question — did the live view's rendered content change
+  // since <ref> without the publish counter moving — and stays independent
+  // of the register-vs-live-view comparison below: it reads neither REGISTER
+  // (no `read(REGISTER)` above this block, deliberately) nor does it require
+  // LIVE_VIEW to exist (a newly-added file has nothing to compare against;
+  // see the ENOENT handling below). No network fetch here — that would make
+  // the no-flag run's offline guarantee a lie if this block ever grew a
+  // dependency on it; the caller (the workflow, or an operator by hand) is
+  // responsible for making `ref` resolvable locally first.
+  const stampedSinceIdx = process.argv.indexOf('--stamped-since');
+  if (stampedSinceIdx !== -1) {
+    // Same "flag given twice" refusal as --against-published/--discharging
+    // above (well, below in file order, same convention): a second
+    // occurrence is silently dropped by `indexOf`, which would otherwise
+    // just run against the wrong ref with no warning.
+    if (process.argv.lastIndexOf('--stamped-since') !== stampedSinceIdx) {
+      console.error(
+        '--stamped-since was passed more than once — pass exactly one ref, e.g. ' +
+          '--stamped-since origin/main.',
+      );
+      throw new CliExitError(1);
+    }
+    const ref = process.argv[stampedSinceIdx + 1];
+    if (!ref) {
+      console.error('--stamped-since requires a value: a ref to compare against, e.g. a commit sha.');
+      throw new CliExitError(1);
+    }
+
+    let workingHtml;
+    try {
+      workingHtml = readFileSync(new URL(`../${LIVE_VIEW}`, import.meta.url), 'utf8');
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        // The file doesn't exist in the working tree. Deletion is not this
+        // check's business (per the issue) — pass.
+        console.log(`check:onbox-register --stamped-since: OK — ${LIVE_VIEW} does not exist.`);
+        return;
+      }
+      throw err;
+    }
+
+    const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+    const baseline = resolveStampedSinceBaseline(repoRoot, LIVE_VIEW, ref);
+    if (baseline.status === 'error') {
+      console.error(
+        `Publish token: could not read ${LIVE_VIEW} at ${ref} — ${baseline.message} An ` +
+          'unresolvable ref must never read as "no change"; fix the ref (or the fetch that ' +
+          'was meant to make it resolvable) and try again.',
+      );
+      throw new CliExitError(1);
+    }
+    if (baseline.status === 'missing') {
+      // Newly added at HEAD relative to `ref` — nothing to compare. Pass.
+      console.log(`check:onbox-register --stamped-since: OK — ${LIVE_VIEW} does not exist at ${ref}.`);
+      return;
+    }
+
+    const stampedSinceErrors = checkStampedSince({ workingHtml, baselineHtml: baseline.text });
+    const stampedSinceFailed = report(
+      `${LIVE_VIEW} changed since ${ref} without a fresh publish stamp`,
+      stampedSinceErrors,
+    );
+    if (!stampedSinceFailed) {
+      console.log(`check:onbox-register --stamped-since: OK — ${LIVE_VIEW} vs ${ref}.`);
+    }
+    if (stampedSinceFailed) throw new CliExitError(1);
+    return;
+  }
 
   const text = read(REGISTER);
 

--- a/scripts/check-onbox-register.mjs
+++ b/scripts/check-onbox-register.mjs
@@ -1524,10 +1524,11 @@ export function resolveBaselineTexts(
 // it must not be folded into the same bucket as "the ref itself is garbage."
 //
 // #3116 review finding 5: correctness depends on the working tree being
-// `merge(base, head)` — the merged state of the base ref into the current
+// `merge(base, head)` — the merged state of the current base tip into the current
 // branch. In CI this is guaranteed: `actions/checkout@v7` on a
 // pull_request event checks out `refs/pull/N/merge`, which is exactly that
-// virtual commit. On hand-run invocations from an un-rebased branch that has
+// virtual commit merged onto the base's current tip. The base ref itself is
+// available as HEAD^1. On hand-run invocations from an un-rebased branch that has
 // diverged from the base ref (not recommended, but possible), comparing
 // un-merged trees might report OK when they genuinely differ — the comparison
 // is only meaningful when the working tree contains the base ref's content.
@@ -1638,10 +1639,12 @@ function runCheckOnboxRegisterCli() {
   // responsible for making `ref` resolvable locally first.
   //
   // Correctness assumes the working tree is merge(base, head): the result of
-  // merging `ref` into the current branch. CI: actions/checkout@v7 guarantees
-  // this with refs/pull/N/merge. Hand-run: only meaningful from a rebased
-  // branch; comparing un-merged trees from an un-rebased branch may report
-  // OK when they genuinely differ.
+  // merging `ref` into the current branch. In CI, actions/checkout@v7 with
+  // fetch-depth: 2 checks out refs/pull/N/merge (the merge onto the current
+  // base tip), and the base ref is available as HEAD^1. Hand-run: the check is
+  // only meaningful when comparing the base ref against the merged state;
+  // comparing un-merged trees from an un-rebased branch may report OK when they
+  // genuinely differ.
   const stampedSinceIdx = process.argv.indexOf('--stamped-since');
   if (stampedSinceIdx !== -1) {
     // #3116 review finding 2: --stamped-since is incompatible with

--- a/scripts/check-onbox-register.mjs
+++ b/scripts/check-onbox-register.mjs
@@ -1518,17 +1518,17 @@ export function resolveBaselineTexts(
 // `--stamped-since`. Deliberately narrower than `resolveBaselineTexts` above:
 // no fetch (the caller — the CLI layer, or the workflow before invoking it —
 // is responsible for making `ref` resolvable locally; in CI, `actions/checkout@v7`
-// with `fetch-depth: 2` makes the merge base available as HEAD^1), one file, and THREE outcomes rather than
+// with `fetch-depth: 2` makes the base branch's tip -- the merge commit's first parent, NOT the merge-base -- available as HEAD^1), one file, and THREE outcomes rather than
 // fetch-then-show's two, because "the file didn't exist yet at this ref" is
 // not a failure here (it's the newly-added-file case the issue calls out) —
 // it must not be folded into the same bucket as "the ref itself is garbage."
 //
 // #3116 review finding 5: correctness depends on the working tree being
-// `merge(base, head)` — the merged state of the base ref merged onto the current
-// branch's HEAD. In CI this is guaranteed: `actions/checkout@v7` on a
-// pull_request event checks out `refs/pull/N/merge`, which is exactly the base
-// ref merged onto the current HEAD at that moment. The base ref itself is
-// available as HEAD^1. On hand-run invocations from a branch that has not been
+// `merge(base, head)` -- the PR head merged ONTO the base branch's current tip.
+// In CI this is guaranteed: `actions/checkout@v7` on a pull_request event
+// checks out `refs/pull/N/merge`, GitHub's `Merge <head> into <base>` commit,
+// rebuilt on the base's current tip. Its first parent is that tip, available
+// as HEAD^1 (the tip, not the merge-base). On hand-run invocations from a branch that has not been
 // merged or rebased onto the base ref (the opposite of recommended practice),
 // both failure modes occur: comparing un-merged trees might report OK when they
 // genuinely differ (false accept), or might report a difference that exists only
@@ -1640,10 +1640,10 @@ function runCheckOnboxRegisterCli() {
   // dependency on it; the caller (the workflow, or an operator by hand) is
   // responsible for making `ref` resolvable locally first.
   //
-  // Correctness assumes the working tree is merge(base, head): the base ref
-  // merged onto the current branch's HEAD. In CI, actions/checkout@v7 with
-  // fetch-depth: 2 checks out refs/pull/N/merge (the base ref merged onto the
-  // current HEAD at that moment), and the base ref is available as HEAD^1.
+  // Correctness assumes the working tree is merge(base, head): the PR head
+  // merged onto the base branch's tip. In CI, actions/checkout@v7 with
+  // fetch-depth: 2 checks out refs/pull/N/merge (`Merge <head> into <base>`,
+  // rebuilt on the base's current tip), whose first parent HEAD^1 is that tip.
   // Hand-run: bring the branch up to date with `ref` first (fetch, then merge
   // or rebase `ref` into the branch), or the check will give both false accepts
   // (un-merged content reads as unchanged) and false refuses (the base ref has

--- a/scripts/check-onbox-register.mjs
+++ b/scripts/check-onbox-register.mjs
@@ -594,6 +594,13 @@ export function checkStampedSince({ workingHtml, baselineHtml }) {
     return [`Publish token (base ref): ${b.malformed}. Investigate before trusting this comparison.`];
   }
 
+  if (w.n < b.n) {
+    return [
+      `Publish token: the live view's rendered content changed since the base ref, but the ` +
+        `publish counter is BEHIND (${w.n} vs ${b.n}). This is the "undo a bad fold" shape: ` +
+        `rebase or re-derive from the base ref; do not just bump the number.`,
+    ];
+  }
   if (w.n === b.n) {
     return [
       `Publish token: the live view's rendered content changed since the base ref, but the ` +
@@ -1380,7 +1387,16 @@ export function checkLiveView(
 // of erroring. See scripts/git-env.mjs's header for the full account.
 const GIT_TIMEOUT_MS = 15_000;
 function runGitCommand(args, cwd) {
-  return spawnSync('git', args, { cwd, encoding: 'utf8', timeout: GIT_TIMEOUT_MS, windowsHide: true, env: scrubGitEnv() });
+  // #3116 review finding 4: locale-pin git's stderr messages. Missing-path
+  // detection depends on specific English substrings from `git show`, and
+  // those strings are translated depending on the ambient LANG/LC_ALL. Setting
+  // LC_ALL: 'C' ensures consistent English messages regardless of the system's
+  // locale, so the check is deterministic rather than silently failing in
+  // non-English environments.
+  const env = scrubGitEnv();
+  env.LC_ALL = 'C';
+  env.LANG = 'C';
+  return spawnSync('git', args, { cwd, encoding: 'utf8', timeout: GIT_TIMEOUT_MS, windowsHide: true, env });
 }
 
 // #2199 review round 2: fetches `origin/main` FRESH before reading it,
@@ -1497,6 +1513,15 @@ export function resolveBaselineTexts(
 // not a failure here (it's the newly-added-file case the issue calls out) —
 // it must not be folded into the same bucket as "the ref itself is garbage."
 //
+// #3116 review finding 5: correctness depends on the working tree being
+// `merge(base, head)` — the merged state of the base ref into the current
+// branch. In CI this is guaranteed: `actions/checkout@v7` on a
+// pull_request event checks out `refs/pull/N/merge`, which is exactly that
+// virtual commit. On hand-run invocations from an un-rebased branch that has
+// diverged from the base ref (not recommended, but possible), comparing
+// un-merged trees might report OK when they genuinely differ — the comparison
+// is only meaningful when the working tree contains the base ref's content.
+//
 // `git show <ref>:<path>` exits 128 for BOTH "path missing at that ref" and
 // "ref doesn't resolve at all"; the only way to tell them apart is the
 // stderr text. Git's own C code uses TWO distinct messages for "missing at
@@ -1601,8 +1626,32 @@ function runCheckOnboxRegisterCli() {
   // the no-flag run's offline guarantee a lie if this block ever grew a
   // dependency on it; the caller (the workflow, or an operator by hand) is
   // responsible for making `ref` resolvable locally first.
+  //
+  // Correctness assumes the working tree is merge(base, head): the result of
+  // merging `ref` into the current branch. CI: actions/checkout@v7 guarantees
+  // this with refs/pull/N/merge. Hand-run: only meaningful from a rebased
+  // branch; comparing un-merged trees from an un-rebased branch may report
+  // OK when they genuinely differ.
   const stampedSinceIdx = process.argv.indexOf('--stamped-since');
   if (stampedSinceIdx !== -1) {
+    // #3116 review finding 2: --stamped-since is incompatible with
+    // --against-published and --discharging. Both are part of the
+    // pre-publish check, not the CI gate, so they cannot appear together.
+    // Refuse explicitly rather than silently ignoring them.
+    const againstPublishedIdx = process.argv.indexOf('--against-published');
+    const dischargingIdx = process.argv.indexOf('--discharging');
+    if (againstPublishedIdx !== -1 || dischargingIdx !== -1) {
+      const conflicting = [];
+      if (againstPublishedIdx !== -1) conflicting.push('--against-published');
+      if (dischargingIdx !== -1) conflicting.push('--discharging');
+      console.error(
+        `--stamped-since cannot be combined with ${conflicting.join(' and ')}. ` +
+          `--stamped-since is for CI (checks if content moved without a stamp); ` +
+          `${conflicting.join(' and ')} are for hand-run pre-publish checks. ` +
+          `Run them separately.`,
+      );
+      throw new CliExitError(1);
+    }
     // Same "flag given twice" refusal as --against-published/--discharging
     // above (well, below in file order, same convention): a second
     // occurrence is silently dropped by `indexOf`, which would otherwise

--- a/scripts/check-onbox-register.mjs
+++ b/scripts/check-onbox-register.mjs
@@ -1529,12 +1529,17 @@ export function resolveBaselineTexts(
 // checks out `refs/pull/N/merge`, GitHub's `Merge <head> into <base>` commit,
 // rebuilt on the base's current tip. Its first parent is that tip, available
 // as HEAD^1 (the tip, not the merge-base). On hand-run invocations from a branch,
-// pass origin/main (or your target ref) explicitly, never HEAD^1: after a local
-// `git merge origin/main`, HEAD^1 is your branch's own pre-merge tip, not the base
-// tip, so main's newer stamp is credited to your branch and an unstamped edit
-// passes. Un-merged against the real base, if main has published since your
-// branch opened, you get a false refuse with a misleading remedy instead. The
-// comparison is only meaningful when the working tree contains the ref's content.
+// pass origin/main (or your target ref) explicitly, never HEAD^1: outside CI's merge
+// commit, HEAD^1 is a commit on your own branch -- your previous commit, or after a
+// local `git merge origin/main` your own pre-merge tip -- and whenever it already
+// contains your unstamped edit, that edit is on both sides of the comparison and
+// passes. Un-merged against the real base, an unstamped edit is still refused,
+// correctly, but if main has stamped a higher counter since your branch opened the
+// message reads BEHIND and says rebase instead of stamp; and a branch that never
+// touched the live view is falsely refused whenever main's rendered content
+// changed. Merge the target in first. The comparison is only meaningful when the
+// working tree is merge(base, head) and `ref` is that base -- what CI's merge
+// commit is, and what merging the target in first gives you by hand.
 //
 // `git show <ref>:<path>` exits 128 for BOTH "path missing at that ref" and
 // "ref doesn't resolve at all"; the only way to tell them apart is the
@@ -1646,9 +1651,12 @@ function runCheckOnboxRegisterCli() {
   // fetch-depth: 2 checks out refs/pull/N/merge (`Merge <head> into <base>`,
   // rebuilt on the base's current tip), whose first parent HEAD^1 is that tip.
   // Hand-run: pass the target ref explicitly (e.g. origin/main), never HEAD^1.
-  // After a local merge, HEAD^1 is your branch's pre-merge tip, so main's newer
-  // stamp is credited to your branch and an unstamped edit passes. Un-merged, if
-  // main has published since your branch opened, you get a false refuse instead.
+  // Outside CI's merge commit, HEAD^1 is a commit on your own branch (your previous
+  // commit, or after a local merge your pre-merge tip); whenever it already contains
+  // your unstamped edit, that edit is on both sides and passes. Un-merged, your
+  // unstamped edit is still refused, correctly (BEHIND if main stamped a higher
+  // counter); a branch that never touched the live view is falsely refused if
+  // main's rendered content changed. Merge the target in first.
   const stampedSinceIdx = process.argv.indexOf('--stamped-since');
   if (stampedSinceIdx !== -1) {
     // #3116 review finding 2: --stamped-since is incompatible with

--- a/scripts/check-onbox-register.mjs
+++ b/scripts/check-onbox-register.mjs
@@ -608,6 +608,13 @@ export function checkStampedSince({ workingHtml, baselineHtml }) {
         '`npm run stamp:publish-token` — never hand-edit the number — then commit the result.',
     ];
   }
+  if (w.n > b.n && w.nonce === b.nonce) {
+    return [
+      `Publish token: the counter moved (${b.n} → ${w.n}), but the nonce stayed the same. ` +
+        `This is a hand-edited counter, bypassing the stamp command. Run ` +
+        '`npm run stamp:publish-token` — never hand-edit the number.',
+    ];
+  }
 
   return [];
 }

--- a/scripts/check-onbox-register.mjs
+++ b/scripts/check-onbox-register.mjs
@@ -1517,21 +1517,23 @@ export function resolveBaselineTexts(
 // #3116: reads the live view AT an arbitrary ref (the PR base, in CI) for
 // `--stamped-since`. Deliberately narrower than `resolveBaselineTexts` above:
 // no fetch (the caller — the CLI layer, or the workflow before invoking it —
-// is responsible for making `ref` resolvable locally; see the workflow's own
-// `git fetch --depth=1` step), one file, and THREE outcomes rather than
+// is responsible for making `ref` resolvable locally; in CI, `actions/checkout@v7`
+// with `fetch-depth: 2` makes the merge base available as HEAD^1), one file, and THREE outcomes rather than
 // fetch-then-show's two, because "the file didn't exist yet at this ref" is
 // not a failure here (it's the newly-added-file case the issue calls out) —
 // it must not be folded into the same bucket as "the ref itself is garbage."
 //
 // #3116 review finding 5: correctness depends on the working tree being
-// `merge(base, head)` — the merged state of the current base tip into the current
-// branch. In CI this is guaranteed: `actions/checkout@v7` on a
-// pull_request event checks out `refs/pull/N/merge`, which is exactly that
-// virtual commit merged onto the base's current tip. The base ref itself is
-// available as HEAD^1. On hand-run invocations from an un-rebased branch that has
-// diverged from the base ref (not recommended, but possible), comparing
-// un-merged trees might report OK when they genuinely differ — the comparison
-// is only meaningful when the working tree contains the base ref's content.
+// `merge(base, head)` — the merged state of the base ref merged onto the current
+// branch's HEAD. In CI this is guaranteed: `actions/checkout@v7` on a
+// pull_request event checks out `refs/pull/N/merge`, which is exactly the base
+// ref merged onto the current HEAD at that moment. The base ref itself is
+// available as HEAD^1. On hand-run invocations from a branch that has not been
+// merged or rebased onto the base ref (the opposite of recommended practice),
+// both failure modes occur: comparing un-merged trees might report OK when they
+// genuinely differ (false accept), or might report a difference that exists only
+// because the base ref has advanced (false refuse). The comparison is only
+// meaningful when the working tree contains the base ref's content.
 //
 // `git show <ref>:<path>` exits 128 for BOTH "path missing at that ref" and
 // "ref doesn't resolve at all"; the only way to tell them apart is the
@@ -1638,13 +1640,14 @@ function runCheckOnboxRegisterCli() {
   // dependency on it; the caller (the workflow, or an operator by hand) is
   // responsible for making `ref` resolvable locally first.
   //
-  // Correctness assumes the working tree is merge(base, head): the result of
-  // merging `ref` into the current branch. In CI, actions/checkout@v7 with
-  // fetch-depth: 2 checks out refs/pull/N/merge (the merge onto the current
-  // base tip), and the base ref is available as HEAD^1. Hand-run: the check is
-  // only meaningful when comparing the base ref against the merged state;
-  // comparing un-merged trees from an un-rebased branch may report OK when they
-  // genuinely differ.
+  // Correctness assumes the working tree is merge(base, head): the base ref
+  // merged onto the current branch's HEAD. In CI, actions/checkout@v7 with
+  // fetch-depth: 2 checks out refs/pull/N/merge (the base ref merged onto the
+  // current HEAD at that moment), and the base ref is available as HEAD^1.
+  // Hand-run: bring the branch up to date with `ref` first (fetch, then merge
+  // or rebase `ref` into the branch), or the check will give both false accepts
+  // (un-merged content reads as unchanged) and false refuses (the base ref has
+  // advanced and is detected as a difference).
   const stampedSinceIdx = process.argv.indexOf('--stamped-since');
   if (stampedSinceIdx !== -1) {
     // #3116 review finding 2: --stamped-since is incompatible with

--- a/scripts/check-onbox-register.mjs
+++ b/scripts/check-onbox-register.mjs
@@ -1529,12 +1529,12 @@ export function resolveBaselineTexts(
 // checks out `refs/pull/N/merge`, GitHub's `Merge <head> into <base>` commit,
 // rebuilt on the base's current tip. Its first parent is that tip, available
 // as HEAD^1 (the tip, not the merge-base). On hand-run invocations from a branch,
-// use origin/main (or your target ref) explicitly — if you pass HEAD^1 after a
-// local merge, it is your branch's pre-merge tip, not CI's merge-base, so the
-// check compares the live view against itself and passes unstamped edits. The
-// un-merged case against the real base gives a false refuse if main has published
-// since your branch opened, with a misleading remedy. The comparison is only
-// meaningful when the working tree contains the base ref's content.
+// pass origin/main (or your target ref) explicitly, never HEAD^1: after a local
+// `git merge origin/main`, HEAD^1 is your branch's own pre-merge tip, not the base
+// tip, so main's newer stamp is credited to your branch and an unstamped edit
+// passes. Un-merged against the real base, if main has published since your
+// branch opened, you get a false refuse with a misleading remedy instead. The
+// comparison is only meaningful when the working tree contains the ref's content.
 //
 // `git show <ref>:<path>` exits 128 for BOTH "path missing at that ref" and
 // "ref doesn't resolve at all"; the only way to tell them apart is the
@@ -1646,9 +1646,9 @@ function runCheckOnboxRegisterCli() {
   // fetch-depth: 2 checks out refs/pull/N/merge (`Merge <head> into <base>`,
   // rebuilt on the base's current tip), whose first parent HEAD^1 is that tip.
   // Hand-run: pass the target ref explicitly (e.g. origin/main), never HEAD^1.
-  // After a local merge, HEAD^1 is your branch's pre-merge tip, so the check
-  // compares the live view against itself and passes unstamped edits. If you
-  // don't merge locally, you get a false refuse with a misleading remedy.
+  // After a local merge, HEAD^1 is your branch's pre-merge tip, so main's newer
+  // stamp is credited to your branch and an unstamped edit passes. Un-merged, if
+  // main has published since your branch opened, you get a false refuse instead.
   const stampedSinceIdx = process.argv.indexOf('--stamped-since');
   if (stampedSinceIdx !== -1) {
     // #3116 review finding 2: --stamped-since is incompatible with

--- a/scripts/tests/check-onbox-register-cli-no-flags.test.mjs
+++ b/scripts/tests/check-onbox-register-cli-no-flags.test.mjs
@@ -68,6 +68,10 @@ function buildFixture({ registerText, liveViewHtml }) {
   mkdirSync(join(root, 'docs', 'testing'), { recursive: true });
   cpSync(join(SCRIPTS_DIR, 'check-onbox-register.mjs'), join(root, 'scripts', 'check-onbox-register.mjs'));
   cpSync(join(SCRIPTS_DIR, 'git-env.mjs'), join(root, 'scripts', 'git-env.mjs'));
+  // #3116: check-onbox-register.mjs now imports parsePublishToken/publishTokenRegex
+  // from publish-token.mjs (for --stamped-since) — a local dep this fixture's
+  // relative layout has to mirror, same as git-env.mjs and is-main-module.mjs.
+  cpSync(join(SCRIPTS_DIR, 'publish-token.mjs'), join(root, 'scripts', 'publish-token.mjs'));
   cpSync(join(SCRIPTS_DIR, 'lib', 'is-main-module.mjs'), join(root, 'scripts', 'lib', 'is-main-module.mjs'));
   writeFileSync(join(root, 'docs', 'testing', 'onbox-acceptance-register.md'), registerText, 'utf8');
   writeFileSync(

--- a/scripts/tests/check-onbox-register-stamped-since.test.mjs
+++ b/scripts/tests/check-onbox-register-stamped-since.test.mjs
@@ -85,6 +85,18 @@ test('checkStampedSince: content changed AND counter differs (higher) -> passes'
   assert.deepEqual(checkStampedSince({ workingHtml, baselineHtml }), []);
 });
 
+test('checkStampedSince: content changed, counter moved UP but nonce unchanged (hand-bumped) -> fails with hand-edit message', () => {
+  const workingHtml = page(6, 'nAAAAAA', '<p>changed</p>');  // counter 5→6, but nonce stayed nAAAAAA
+  const baselineHtml = page(5, 'nAAAAAA', '<p>original</p>');
+  const errors = checkStampedSince({ workingHtml, baselineHtml });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /hand-edited counter/i);
+  assert.match(errors[0], /5 → 6/);
+  assert.match(errors[0], /npm run stamp:publish-token/);
+  // Verify this message is distinct from the legitimate higher-counter message
+  assert.doesNotMatch(errors[0], /BEHIND/);
+});
+
 test('checkStampedSince: content changed, counter is BEHIND (lower than baseline) -> fails with distinct "behind" message', () => {
   const workingHtml = page(16, 'nBBBBBB', '<p>changed</p>');
   const baselineHtml = page(17, 'nAAAAAA', '<p>original</p>');

--- a/scripts/tests/check-onbox-register-stamped-since.test.mjs
+++ b/scripts/tests/check-onbox-register-stamped-since.test.mjs
@@ -93,7 +93,7 @@ test('checkStampedSince: content changed, counter moved UP but nonce unchanged (
   assert.match(errors[0], /hand-edited counter/i);
   assert.match(errors[0], /5 → 6/);
   assert.match(errors[0], /npm run stamp:publish-token/);
-  // Verify this message is distinct from the legitimate higher-counter message
+  // Verify this message is distinct from the BEHIND message
   assert.doesNotMatch(errors[0], /BEHIND/);
 });
 

--- a/scripts/tests/check-onbox-register-stamped-since.test.mjs
+++ b/scripts/tests/check-onbox-register-stamped-since.test.mjs
@@ -1,0 +1,425 @@
+// #3116: `--stamped-since <ref>` — did the live view's rendered content
+// change since <ref> without the publish counter moving. Three layers,
+// mirroring the split in check-onbox-register.mjs itself:
+//   1. `checkStampedSince` — pure, no git. Content/token comparison only.
+//   2. `resolveStampedSinceBaseline` — the git seam, with an injectable
+//      runner AND real-git coverage against throwaway repos (per CLAUDE.md's
+//      "a test's git spawns wrote to the real repo" incident: every git call
+//      here scrubs GIT_* env and runs in a temp dir, never this repo).
+//   3. The CLI flag itself, via a real spawned subprocess against a
+//      standalone fixture tree (mirroring
+//      check-onbox-register-cli-no-flags.test.mjs's own fixture pattern).
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, cpSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { checkStampedSince, resolveStampedSinceBaseline } from '../check-onbox-register.mjs';
+import { scrubGitEnvForThrowawayRepo } from '../git-env.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCRIPTS_DIR = resolve(HERE, '..');
+
+const token = (n, nonce) => `<div hidden data-published-as="${n}" data-publish-id="${nonce}"></div>`;
+const page = (n, nonce, body = '<p>hello</p>') =>
+  `<title>t</title>\n${token(n, nonce)}\n${body}\n`;
+
+// ---------------------------------------------------------------------------
+// 1. checkStampedSince — pure
+// ---------------------------------------------------------------------------
+
+test('checkStampedSince: identical content (token-only diff aside) passes even with equal counters', () => {
+  const workingHtml = page(5, 'nAAAAAA', '<p>same</p>');
+  const baselineHtml = page(5, 'nAAAAAA', '<p>same</p>');
+  assert.deepEqual(checkStampedSince({ workingHtml, baselineHtml }), []);
+});
+
+test('checkStampedSince: content identical except the token itself -> pass regardless of counter', () => {
+  const workingHtml = page(6, 'nBBBBBB', '<p>same</p>');
+  const baselineHtml = page(5, 'nAAAAAA', '<p>same</p>');
+  assert.deepEqual(checkStampedSince({ workingHtml, baselineHtml }), []);
+});
+
+// This one specifically requires the token to be BLANKED, not merely left
+// out of a coincidentally-passing counter comparison: same counter (5) on
+// both sides, same body, only the NONCE differs. If the token weren't
+// blanked before the content comparison, the nonce difference alone would
+// make `blankToken(...) !== blankToken(...)` true (a false "content
+// changed"), and — because the counters happen to be EQUAL here — the
+// function would then wrongly report a stamping failure on content that is,
+// per this check's own contract, unchanged.
+test('checkStampedSince: only the nonce differs (same counter, same body) -> pass, not a false content-changed', () => {
+  const workingHtml = page(5, 'nBBBBBB', '<p>same</p>');
+  const baselineHtml = page(5, 'nAAAAAA', '<p>same</p>');
+  assert.deepEqual(checkStampedSince({ workingHtml, baselineHtml }), []);
+});
+
+test('checkStampedSince: HTML comments are ignored, including the header comment and BEGIN GENERATED markers', () => {
+  const workingHtml = page(5, 'nAAAAAA', '<!-- header comment v2 --><!-- BEGIN GENERATED:x --><p>same</p><!-- END GENERATED:x -->');
+  const baselineHtml = page(5, 'nAAAAAA', '<!-- header comment v1 --><!-- BEGIN GENERATED:x --><p>same</p><!-- END GENERATED:x -->');
+  assert.deepEqual(checkStampedSince({ workingHtml, baselineHtml }), []);
+});
+
+test('checkStampedSince: content between the GENERATED markers DOES count as rendered content', () => {
+  const workingHtml = page(5, 'nAAAAAA', '<!-- BEGIN GENERATED:x -->16 owed<!-- END GENERATED:x -->');
+  const baselineHtml = page(5, 'nAAAAAA', '<!-- BEGIN GENERATED:x -->15 owed<!-- END GENERATED:x -->');
+  const errors = checkStampedSince({ workingHtml, baselineHtml });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /counter \(data-published-as\) stayed at 5/);
+});
+
+test('checkStampedSince: content changed, counter unchanged -> fails, names both the fix and both counter values', () => {
+  const workingHtml = page(5, 'nAAAAAA', '<p>changed</p>');
+  const baselineHtml = page(5, 'nAAAAAA', '<p>original</p>');
+  const errors = checkStampedSince({ workingHtml, baselineHtml });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /npm run stamp:publish-token/);
+  assert.match(errors[0], /stayed at 5/);
+});
+
+test('checkStampedSince: content changed AND counter differs -> passes', () => {
+  const workingHtml = page(6, 'nBBBBBB', '<p>changed</p>');
+  const baselineHtml = page(5, 'nAAAAAA', '<p>original</p>');
+  assert.deepEqual(checkStampedSince({ workingHtml, baselineHtml }), []);
+});
+
+test('checkStampedSince: content changed, working side has no token at all -> fails closed', () => {
+  const workingHtml = '<title>t</title>\n<p>changed, no token</p>\n';
+  const baselineHtml = page(5, 'nAAAAAA', '<p>original</p>');
+  const errors = checkStampedSince({ workingHtml, baselineHtml });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /no publish token at all/);
+});
+
+test('checkStampedSince: content changed, base-ref side has no token at all -> fails closed', () => {
+  const workingHtml = page(5, 'nAAAAAA', '<p>changed</p>');
+  const baselineHtml = '<title>t</title>\n<p>original, no token</p>\n';
+  const errors = checkStampedSince({ workingHtml, baselineHtml });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /base ref.*has no publish token/);
+});
+
+test('checkStampedSince: content changed, working token malformed (duplicated) -> fails closed', () => {
+  const workingHtml = `<title>t</title>\n${token(5, 'nAAAAAA')}\n${token(6, 'nBBBBBB')}\n<p>changed</p>\n`;
+  const baselineHtml = page(5, 'nAAAAAA', '<p>original</p>');
+  const errors = checkStampedSince({ workingHtml, baselineHtml });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /Publish token \(tracked\)/);
+});
+
+test('checkStampedSince: content changed, base-ref token malformed (bad counter) -> fails closed', () => {
+  const workingHtml = page(6, 'nBBBBBB', '<p>changed</p>');
+  const baselineHtml = `<title>t</title>\n<div hidden data-published-as="abc" data-publish-id="nAAAAAA"></div>\n<p>original</p>\n`;
+  const errors = checkStampedSince({ workingHtml, baselineHtml });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /Publish token \(base ref\)/);
+});
+
+// ---------------------------------------------------------------------------
+// 2a. resolveStampedSinceBaseline — injected runner (mirrors resolveBaselineTexts's own unit style)
+// ---------------------------------------------------------------------------
+
+test('resolveStampedSinceBaseline: a clean git show -> status ok, text is stdout', () => {
+  const fakeRunner = (args) => {
+    assert.deepEqual(args, ['show', 'abc123:docs/live.html']);
+    return { status: 0, stdout: '<p>content</p>' };
+  };
+  const result = resolveStampedSinceBaseline('/fake/repo', 'docs/live.html', 'abc123', fakeRunner);
+  assert.deepEqual(result, { status: 'ok', text: '<p>content</p>', message: null });
+});
+
+test('resolveStampedSinceBaseline: "does not exist in" stderr -> status missing, not an error', () => {
+  const fakeRunner = () => ({
+    status: 128,
+    stdout: '',
+    stderr: "fatal: path 'docs/live.html' does not exist in 'abc123'",
+  });
+  const result = resolveStampedSinceBaseline('/fake/repo', 'docs/live.html', 'abc123', fakeRunner);
+  assert.equal(result.status, 'missing');
+  assert.equal(result.text, null);
+});
+
+test('resolveStampedSinceBaseline: an unresolvable ref -> status error (fails closed, never "missing")', () => {
+  const fakeRunner = () => ({
+    status: 128,
+    stdout: '',
+    stderr: "fatal: invalid object name 'not-a-ref'.",
+  });
+  const result = resolveStampedSinceBaseline('/fake/repo', 'docs/live.html', 'not-a-ref', fakeRunner);
+  assert.equal(result.status, 'error');
+  assert.match(result.message, /invalid object name/);
+});
+
+test('resolveStampedSinceBaseline: a spawn error (git missing, or a timeout) -> status error', () => {
+  const fakeRunner = () => ({ error: new Error('spawn git ENOENT') });
+  const result = resolveStampedSinceBaseline('/fake/repo', 'docs/live.html', 'abc123', fakeRunner);
+  assert.equal(result.status, 'error');
+  assert.match(result.message, /ENOENT/);
+});
+
+// ---------------------------------------------------------------------------
+// 2b. resolveStampedSinceBaseline — REAL git, throwaway repos
+// ---------------------------------------------------------------------------
+
+const LIVE = 'docs/live.html';
+const cleanEnv = () => scrubGitEnvForThrowawayRepo();
+
+const runner = (args, cwd) => {
+  try {
+    const stdout = execFileSync('git', args, { cwd, encoding: 'utf8', stdio: 'pipe', env: cleanEnv(), windowsHide: true });
+    return { status: 0, stdout };
+  } catch (err) {
+    return { status: err.status ?? 1, stdout: err.stdout ?? '', stderr: err.stderr ?? '', error: err.code === 'ENOENT' ? err : undefined };
+  }
+};
+
+const git = (repo, ...args) =>
+  execFileSync('git', args, { cwd: repo, stdio: 'pipe', env: cleanEnv(), windowsHide: true });
+
+function newRepo() {
+  const repo = mkdtempSync(join(tmpdir(), 'stamped-since-git-'));
+  git(repo, 'init', '-q', '-b', 'main');
+  git(repo, 'config', 'user.email', 'test@example.com');
+  git(repo, 'config', 'user.name', 'Test');
+  git(repo, 'config', 'commit.gpgsign', 'false');
+  return repo;
+}
+
+function writeLive(repo, content) {
+  mkdirSync(join(repo, 'docs'), { recursive: true });
+  writeFileSync(join(repo, LIVE), content);
+}
+
+test('git: resolveStampedSinceBaseline reads the real file content at a real ref', () => {
+  const repo = newRepo();
+  try {
+    writeLive(repo, page(1, 'nBASE00', '<p>v1</p>'));
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-qm', 'base');
+    const baseSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf8', env: cleanEnv(), windowsHide: true }).trim();
+
+    writeLive(repo, page(2, 'nNEXT00', '<p>v2</p>'));
+    git(repo, 'commit', '-qam', 'next');
+
+    const atBase = resolveStampedSinceBaseline(repo, LIVE, baseSha, runner);
+    assert.equal(atBase.status, 'ok');
+    assert.match(atBase.text, /v1/);
+    assert.match(atBase.text, /nBASE00/);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('git: resolveStampedSinceBaseline reports "missing" for a file added after the ref, real git', () => {
+  const repo = newRepo();
+  try {
+    writeFileSync(join(repo, 'unrelated.txt'), 'x');
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-qm', 'base, no live view yet');
+    const baseSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf8', env: cleanEnv(), windowsHide: true }).trim();
+
+    writeLive(repo, page(1, 'nNEW0000', '<p>brand new</p>'));
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-qm', 'add live view');
+
+    const result = resolveStampedSinceBaseline(repo, LIVE, baseSha, runner);
+    assert.equal(result.status, 'missing');
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('git: resolveStampedSinceBaseline fails closed (status error) for a ref that does not resolve, real git', () => {
+  const repo = newRepo();
+  try {
+    writeLive(repo, page(1, 'nBASE00', '<p>v1</p>'));
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-qm', 'base');
+
+    const result = resolveStampedSinceBaseline(repo, LIVE, 'totally-not-a-real-ref', runner);
+    assert.equal(result.status, 'error');
+    assert.match(result.message, /totally-not-a-real-ref/);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 3. CLI, real subprocess, standalone fixture tree (mirrors
+//    check-onbox-register-cli-no-flags.test.mjs's own fixture builder)
+// ---------------------------------------------------------------------------
+
+function buildCliFixture() {
+  const root = mkdtempSync(join(tmpdir(), 'onbox-stamped-since-cli-'));
+  mkdirSync(join(root, 'scripts', 'lib'), { recursive: true });
+  mkdirSync(join(root, 'docs', 'testing'), { recursive: true });
+  cpSync(join(SCRIPTS_DIR, 'check-onbox-register.mjs'), join(root, 'scripts', 'check-onbox-register.mjs'));
+  cpSync(join(SCRIPTS_DIR, 'git-env.mjs'), join(root, 'scripts', 'git-env.mjs'));
+  cpSync(join(SCRIPTS_DIR, 'publish-token.mjs'), join(root, 'scripts', 'publish-token.mjs'));
+  cpSync(join(SCRIPTS_DIR, 'lib', 'is-main-module.mjs'), join(root, 'scripts', 'lib', 'is-main-module.mjs'));
+  return root;
+}
+
+function runFixtureCli(root, args) {
+  return spawnSync(process.execPath, [join(root, 'scripts', 'check-onbox-register.mjs'), ...args], {
+    cwd: root,
+    encoding: 'utf8',
+    timeout: 30000,
+    windowsHide: true,
+  });
+}
+
+const LIVE_VIEW_REL = join('docs', 'testing', 'onbox-acceptance-register-live-view.html');
+
+test('CLI --stamped-since, real subprocess: unstamped content drift exits 1', () => {
+  const root = buildCliFixture();
+  try {
+    git(root, 'init', '-q', '-b', 'main');
+    git(root, 'config', 'user.email', 'test@example.com');
+    git(root, 'config', 'user.name', 'Test');
+    git(root, 'config', 'commit.gpgsign', 'false');
+    writeFileSync(join(root, LIVE_VIEW_REL), page(5, 'nAAAAAA', '<p>original</p>'), 'utf8');
+    git(root, 'add', '-A');
+    git(root, 'commit', '-qm', 'base');
+    const baseSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8', env: cleanEnv(), windowsHide: true }).trim();
+
+    // Edit content WITHOUT re-stamping.
+    writeFileSync(join(root, LIVE_VIEW_REL), page(5, 'nAAAAAA', '<p>changed</p>'), 'utf8');
+
+    const r = runFixtureCli(root, ['--stamped-since', baseSha]);
+    assert.equal(r.status, 1, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    assert.match(r.stdout + r.stderr, /npm run stamp:publish-token/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('CLI --stamped-since, real subprocess: content changed AND stamped exits 0', () => {
+  const root = buildCliFixture();
+  try {
+    git(root, 'init', '-q', '-b', 'main');
+    git(root, 'config', 'user.email', 'test@example.com');
+    git(root, 'config', 'user.name', 'Test');
+    git(root, 'config', 'commit.gpgsign', 'false');
+    writeFileSync(join(root, LIVE_VIEW_REL), page(5, 'nAAAAAA', '<p>original</p>'), 'utf8');
+    git(root, 'add', '-A');
+    git(root, 'commit', '-qm', 'base');
+    const baseSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8', env: cleanEnv(), windowsHide: true }).trim();
+
+    writeFileSync(join(root, LIVE_VIEW_REL), page(6, 'nBBBBBB', '<p>changed</p>'), 'utf8');
+
+    const r = runFixtureCli(root, ['--stamped-since', baseSha]);
+    assert.equal(r.status, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    assert.match(r.stdout, /OK/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('CLI --stamped-since, real subprocess: no content change (token-only bump) exits 0', () => {
+  const root = buildCliFixture();
+  try {
+    git(root, 'init', '-q', '-b', 'main');
+    git(root, 'config', 'user.email', 'test@example.com');
+    git(root, 'config', 'user.name', 'Test');
+    git(root, 'config', 'commit.gpgsign', 'false');
+    writeFileSync(join(root, LIVE_VIEW_REL), page(5, 'nAAAAAA', '<p>unchanged</p>'), 'utf8');
+    git(root, 'add', '-A');
+    git(root, 'commit', '-qm', 'base');
+    const baseSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8', env: cleanEnv(), windowsHide: true }).trim();
+
+    // Bump only the token; body unchanged.
+    writeFileSync(join(root, LIVE_VIEW_REL), page(6, 'nBBBBBB', '<p>unchanged</p>'), 'utf8');
+
+    const r = runFixtureCli(root, ['--stamped-since', baseSha]);
+    assert.equal(r.status, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('CLI --stamped-since, real subprocess: file newly added since the ref exits 0', () => {
+  const root = buildCliFixture();
+  try {
+    git(root, 'init', '-q', '-b', 'main');
+    git(root, 'config', 'user.email', 'test@example.com');
+    git(root, 'config', 'user.name', 'Test');
+    git(root, 'config', 'commit.gpgsign', 'false');
+    writeFileSync(join(root, 'unrelated.txt'), 'x', 'utf8');
+    git(root, 'add', '-A');
+    git(root, 'commit', '-qm', 'base, no live view yet');
+    const baseSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8', env: cleanEnv(), windowsHide: true }).trim();
+
+    writeFileSync(join(root, LIVE_VIEW_REL), page(1, 'nNEW0000', '<p>brand new</p>'), 'utf8');
+
+    const r = runFixtureCli(root, ['--stamped-since', baseSha]);
+    assert.equal(r.status, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('CLI --stamped-since, real subprocess: an unresolvable ref exits 1, never reads as "no change"', () => {
+  const root = buildCliFixture();
+  try {
+    git(root, 'init', '-q', '-b', 'main');
+    git(root, 'config', 'user.email', 'test@example.com');
+    git(root, 'config', 'user.name', 'Test');
+    git(root, 'config', 'commit.gpgsign', 'false');
+    writeFileSync(join(root, LIVE_VIEW_REL), page(5, 'nAAAAAA', '<p>content</p>'), 'utf8');
+    git(root, 'add', '-A');
+    git(root, 'commit', '-qm', 'base');
+
+    const r = runFixtureCli(root, ['--stamped-since', 'not-a-real-ref']);
+    assert.equal(r.status, 1, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    assert.match(r.stdout + r.stderr, /unresolvable ref must never read as "no change"/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('CLI --stamped-since, real subprocess: missing working-tree file exits 0', () => {
+  const root = buildCliFixture();
+  try {
+    git(root, 'init', '-q', '-b', 'main');
+    git(root, 'config', 'user.email', 'test@example.com');
+    git(root, 'config', 'user.name', 'Test');
+    git(root, 'config', 'commit.gpgsign', 'false');
+    writeFileSync(join(root, 'unrelated.txt'), 'x', 'utf8');
+    git(root, 'add', '-A');
+    git(root, 'commit', '-qm', 'base');
+    const baseSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8', env: cleanEnv(), windowsHide: true }).trim();
+    // No live-view file ever written in the working tree.
+
+    const r = runFixtureCli(root, ['--stamped-since', baseSha]);
+    assert.equal(r.status, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('CLI --stamped-since, real subprocess: no value given -> refused, exit 1', () => {
+  const root = buildCliFixture();
+  try {
+    writeFileSync(join(root, 'docs', 'testing', 'onbox-acceptance-register-live-view.html'), page(1, 'nAAAAAA'), 'utf8');
+    const r = runFixtureCli(root, ['--stamped-since']);
+    assert.equal(r.status, 1, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    assert.match(r.stdout + r.stderr, /requires a value/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('CLI --stamped-since, real subprocess: passed twice -> refused, exit 1', () => {
+  const root = buildCliFixture();
+  try {
+    writeFileSync(join(root, 'docs', 'testing', 'onbox-acceptance-register-live-view.html'), page(1, 'nAAAAAA'), 'utf8');
+    const r = runFixtureCli(root, ['--stamped-since', 'HEAD', '--stamped-since', 'HEAD~1']);
+    assert.equal(r.status, 1, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    assert.match(r.stdout + r.stderr, /more than once/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/tests/check-onbox-register-stamped-since.test.mjs
+++ b/scripts/tests/check-onbox-register-stamped-since.test.mjs
@@ -79,9 +79,26 @@ test('checkStampedSince: content changed, counter unchanged -> fails, names both
   assert.match(errors[0], /stayed at 5/);
 });
 
-test('checkStampedSince: content changed AND counter differs -> passes', () => {
+test('checkStampedSince: content changed AND counter differs (higher) -> passes', () => {
   const workingHtml = page(6, 'nBBBBBB', '<p>changed</p>');
   const baselineHtml = page(5, 'nAAAAAA', '<p>original</p>');
+  assert.deepEqual(checkStampedSince({ workingHtml, baselineHtml }), []);
+});
+
+test('checkStampedSince: content changed, counter is BEHIND (lower than baseline) -> fails with distinct "behind" message', () => {
+  const workingHtml = page(16, 'nBBBBBB', '<p>changed</p>');
+  const baselineHtml = page(17, 'nAAAAAA', '<p>original</p>');
+  const errors = checkStampedSince({ workingHtml, baselineHtml });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /BEHIND.*16 vs 17/i);
+  assert.match(errors[0], /rebase or re-derive/);
+  // Verify this message is distinct from the equal-counter message
+  assert.doesNotMatch(errors[0], /stamp:publish-token/);
+});
+
+test('checkStampedSince: lower counter with same content stays green (no change detected)', () => {
+  const workingHtml = page(16, 'nBBBBBB', '<p>same</p>');
+  const baselineHtml = page(17, 'nAAAAAA', '<p>same</p>');
   assert.deepEqual(checkStampedSince({ workingHtml, baselineHtml }), []);
 });
 
@@ -419,6 +436,30 @@ test('CLI --stamped-since, real subprocess: passed twice -> refused, exit 1', ()
     const r = runFixtureCli(root, ['--stamped-since', 'HEAD', '--stamped-since', 'HEAD~1']);
     assert.equal(r.status, 1, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
     assert.match(r.stdout + r.stderr, /more than once/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('CLI --stamped-since, real subprocess: combined with --against-published -> refused, exit 1', () => {
+  const root = buildCliFixture();
+  try {
+    writeFileSync(join(root, 'docs', 'testing', 'onbox-acceptance-register-live-view.html'), page(1, 'nAAAAAA'), 'utf8');
+    const r = runFixtureCli(root, ['--stamped-since', 'HEAD', '--against-published', '/tmp/fake.html']);
+    assert.equal(r.status, 1, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    assert.match(r.stdout + r.stderr, /cannot be combined with --against-published/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('CLI --stamped-since, real subprocess: combined with --discharging -> refused, exit 1', () => {
+  const root = buildCliFixture();
+  try {
+    writeFileSync(join(root, 'docs', 'testing', 'onbox-acceptance-register-live-view.html'), page(1, 'nAAAAAA'), 'utf8');
+    const r = runFixtureCli(root, ['--stamped-since', 'HEAD', '--discharging', 'A1']);
+    assert.equal(r.status, 1, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    assert.match(r.stdout + r.stderr, /cannot be combined with --discharging/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/tests/onbox-register-check-workflow-wiring.test.mjs
+++ b/scripts/tests/onbox-register-check-workflow-wiring.test.mjs
@@ -1,0 +1,84 @@
+// Pins the wiring fix for #3116: the stamped-since check compares against the
+// merge commit's first parent (HEAD^1), not the stale github.event.pull_request.base.sha.
+//
+// Pass 4 changed the wiring from `--stamped-since ${{ github.event.pull_request.base.sha }}`
+// to `--stamped-since HEAD^1` with `fetch-depth: 2` so that the base ref is available.
+// Prior to the fix, CI silently compared against a base.sha that was stale whenever
+// another PR had merged in the meantime, so a PR would report "OK" on a change that had
+// differed from main for up to 27 commits (pass 4 observed exactly that). The wiring
+// test exists because reverting to base.sha would pass silently — the predicate would
+// still work on the intended cases, but on the actual cases where main had published
+// since this PR opened, it would report OK for the violation it exists to catch.
+//
+// This test also pins the paired if: condition (see pr-issue-link-workflow-wiring.test.mjs's
+// job-level if: guard for the reasoning — the required-status-context shape — plus
+// #3116's own comment in the workflow) and the fetch-depth wiring that makes HEAD^1 available.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { readNormalized } from '../lib/read-normalized.mjs';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const workflowPath = resolve(repoRoot, '.github', 'workflows', 'onbox-register-check.yml');
+// readNormalized, not a bare readFileSync: the assertions below scan for a literal '\n'
+// after a YAML key, which misses on a CRLF checkout (#2291).
+const source = readNormalized(workflowPath);
+
+test('the checkout step sets fetch-depth: 2 so HEAD^1 is available', () => {
+  const checkoutMatch = source.match(/- name: Checkout\n((?: {8}.*\n|\n)*)/);
+  assert.ok(checkoutMatch, "step 'Checkout' not found — did it get renamed?");
+  const checkoutBody = checkoutMatch[1];
+
+  assert.match(
+    checkoutBody,
+    /fetch-depth:\s*2/,
+    'checkout step does not set fetch-depth: 2 — without it, HEAD^1 (the merge ' +
+      'commit\'s first parent) is not available and `git show HEAD^1:...` fails',
+  );
+});
+
+test('the stamped-since check runs with --stamped-since HEAD^1, not a stale base.sha', () => {
+  const stampStepMatch = source.match(
+    /- name: Check the live view was re-stamped if its content changed\n((?: {8}.*\n|\n)*)/,
+  );
+  assert.ok(
+    stampStepMatch,
+    'step "Check the live view was re-stamped if its content changed" not found — did it get renamed?',
+  );
+  const stampStepBody = stampStepMatch[1];
+
+  // The bug was base.sha staying at its value when the PR opened, while the merge ref
+  // followed main. When another PR merged in the meantime, CI would silently compare
+  // against a base that was now 27 commits behind, and report OK on unstamped edits
+  // that differed from main (pass 4 observed 3 consecutive runs with this).
+  assert.doesNotMatch(
+    source,
+    /pull_request\.base\.sha/,
+    'workflow file contains "pull_request.base.sha" — this is stale (base.sha stays at ' +
+      'the value when the PR opened, while the merge ref follows main). Use HEAD^1 instead',
+  );
+
+  assert.match(
+    stampStepBody,
+    /run:\s*node scripts\/check-onbox-register\.mjs --stamped-since HEAD\^1/,
+    'stamp step does not run `--stamped-since HEAD^1` — it compares against a stale ' +
+      'base.sha or is missing the flag entirely',
+  );
+});
+
+test('the stamped-since step is skipped with !cancelled() so it runs even if an earlier step fails', () => {
+  const stampStepMatch = source.match(
+    /- name: Check the live view was re-stamped if its content changed\n((?: {8}.*\n|\n)*)/,
+  );
+  assert.ok(stampStepMatch, "step 'Check the live view was re-stamped...' not found");
+  const stampStepBody = stampStepMatch[1];
+
+  assert.match(
+    stampStepBody,
+    /if:\s*\$\{\{\s*!cancelled\(\)\s*&&\s*github\.event_name\s*==\s*'pull_request'\s*\}\}/,
+    'stamp step\'s `if:` does not include `!cancelled()` — if an earlier step fails, ' +
+      'this check would be skipped instead of evaluating and reporting the issue',
+  );
+});


### PR DESCRIPTION
## Summary

The on-box register's live view carries a publish token — `data-published-as`
/ `data-publish-id`, written only by `npm run stamp:publish-token`. It orders
publishes of the register's artifact and lets an operator tell *"the live page
is ahead of me"* from *"the live page is behind"* in one line. Stamping it is
mandatory per the register's own step 0, and **nothing enforced it.**

This adds an opt-in `--stamped-since <ref>` to
`scripts/check-onbox-register.mjs`, invoked by `onbox-register-check.yml` with HEAD^1 (the merge commit's first parent). If the live view's *rendered* content changed since the base
and the counter did not move, the check **reports** the issue and names
`npm run stamp:publish-token`. **The check is not currently a required merge
gate** (see #3138 for the enforcement decision).

### Why now — it has already cost real time, twice

**#3076** folded rows A37/B2/D1 out and merged unstamped. Tracked and published
both read `13` while their contents had diverged, so the register's own one-line
disambiguator was uninformative and the diagnosis needed a manual byte-diff —
exactly what #2599/A41 built the token to replace. Fixed by #3114 / PR #3115.

It then happened **again while this PR was being written**: #3061 merged with an
A106 row added and no stamp, so `main`'s live view now carries A106 at token 16
— the artifact published at 16 does not show that row.

### The predicate, and why the obvious one is wrong

Content comparison strips HTML comments (the file header and the
`<!-- BEGIN GENERATED:... -->` markers are not rendered; the counts *between*
them are) and blanks the token's own attribute values. Identical → pass. Different
→ require `data-published-as` to be **strictly greater than the base ref's value**.

The predicate is: fail if `counter < base`, fail if `counter === base`, fail if
`counter > base AND nonce unchanged` (hand-edited counter; `stamp-publish-token`
always mints a fresh nonce). Anything else passes.

That matters because a check asking merely *"does this PR touch the live view
and also change the token?"* would have passed #3076, #3061 and #3063, because
a stamp commit anywhere in a branch's history proves nothing about its tip. Only
comparison against the base catches an unstamped edit landed after an earlier
stamp — and needing the base ref is what forced the flag design over folding this
into the no-flag run, which deliberately compares only the two tracked files and
must keep working offline.

Fails closed on a missing or malformed token on either side, and on any `git
show` failure other than "path absent at that ref" — an unresolvable ref must
never read as "no change".

## Test plan

- **31 new tests** in `scripts/tests/check-onbox-register-stamped-since.test.mjs`
  — pure-function, injected-git-runner, real throwaway git repos, and
  real-subprocess CLI. All green (`node --test`, 31/31).
- **Mutation-verified.** Every test was checked against a deliberately broken
  implementation. Independently re-confirmed on review: disabling the `<` branch
  reddens 1 test; `<` → `<=` reddens 3 tests; `<` → `>` reddens 3 tests. The new
  nonce-check branch (counter moved up, nonce unchanged) is guarded by its own
  dedicated test and fails when disabled.
- `npm run lint` and `npm run typecheck` clean.
- Driven by hand on this branch: unedited → exit 0; live view edited without a
  re-stamp → exit 1 naming the counter and the fix; edit reverted.

### Found in passing, fixed here

`check-onbox-register-cli-no-flags.test.mjs` builds a throwaway fixture by
copying the checker plus its local deps. The new `publish-token.mjs` import made
that list incomplete (`ERR_MODULE_NOT_FOUND`); added, one line.

### Not in scope

Enforcing that the artifact was actually **republished** — that needs network a
required check cannot have. It stays procedure (register "Live view" step 4).

Release notes skipped deliberately: CI/tooling only, no user- or
operator-visible delta.

Closes #3116

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Q4SxN46A8ktP28T7NwEKz

