### PR TITLE
chore(ops): wire check:register-citations into verify.yml

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -63,12 +63,16 @@ name: Verify
 #
 # No `paths-ignore` here (deliberately removed — see design spec): keeping it
 # while this is a required status check would deadlock every docs-only PR,
-# since a required check that never fires blocks merge forever. Every leg's
+# since a required check that never fires blocks merge forever. Most legs'
 # own `if:` scope condition already evaluates false for a docs-only diff, so
-# every job still completes in roughly the time of "Setup Node + deps" alone
-# and the aggregator reports green — no deadlock, negligible added time. Same
-# reasoning is why no job gates on PR `draft` status either — a draft-gated
-# required check would deadlock every draft PR the same way.
+# most jobs still complete in roughly the time of "Setup Node + deps" alone
+# and the aggregator reports green — no deadlock, negligible added time.
+# ONE exception: `check:register-citations` (see #3122) runs unconditionally,
+# since citations can appear in any file and diff-scope cannot predict whether
+# one broke; this step still runs on docs-only diffs, but remains negligible
+# (a few seconds), so overall timing is unaffected. Same reasoning is why no
+# job gates on PR `draft` status either — a draft-gated required check would
+# deadlock every draft PR the same way.
 
 on:
   pull_request:
@@ -215,8 +219,8 @@ jobs:
         if: fromJSON(needs.detect.outputs.scopes).step_check_budget_poll || fromJSON(needs.detect.outputs.scopes).shared
         run: npm run check:budget-poll
 
-      # Register-citation check (unconditional — see #3122: the checker
-      # scans the WHOLE tree for citations, so no diff-scope reliably
+      # Register-citation check (unconditional — see #3122 and #3140): the
+      # checker scans the WHOLE tree for citations, so no diff-scope reliably
       # predicts whether one broke; must run on every PR, docs-only included.
       # leg: check:register-citations
       - name: Register citation check

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -222,7 +222,7 @@ jobs:
       # Register-citation check (unconditional — see #3122 and #3140): the
       # checker scans the WHOLE tree for citations, so no diff-scope reliably
       # predicts whether one broke; must run on every PR, docs-only included.
-      # leg: check:register-citations
+      # (No scope gate: dedicated guard in workflow-wiring.test.mjs, not via parseLegs())
       - name: Register citation check
         run: npm run check:register-citations
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -215,6 +215,13 @@ jobs:
         if: fromJSON(needs.detect.outputs.scopes).step_check_budget_poll || fromJSON(needs.detect.outputs.scopes).shared
         run: npm run check:budget-poll
 
+      # Register-citation check (unconditional — see #3122: the checker
+      # scans the WHOLE tree for citations, so no diff-scope reliably
+      # predicts whether one broke; must run on every PR, docs-only included.
+      # leg: check:register-citations
+      - name: Register citation check
+        run: npm run check:register-citations
+
       # #2434 → #2779: npm audit against the root lockfile, gated so it only
       # runs on a root package-lock.json diff (or a shared/global change).
       # leg: audit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1013,8 +1013,9 @@ OS blocks the public-beta release, so you no longer fire cross-OS by hand
 before a release. `cross-os.yml` (`workflow_dispatch` + twice-weekly cron on
 `main`) stays as the between-releases pulse + ad-hoc cross-OS/mobile run.
 Docs-only PRs still complete `verify.yml` in seconds rather than deadlocking
-the required check — every leg's own scope condition is false for a
-docs-only diff, so the job just does env setup and reports green (see
+the required check — most legs' scope conditions evaluate false for a
+docs-only diff; one step (`check:register-citations`, PR #3134) runs
+unconditionally. Either way, the job completes in seconds and reports green (see
 [docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md](docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md)
 for why `paths-ignore` was deliberately removed rather than kept).
 See [docs/features/215-ci-label-gated-verify.md](docs/features/215-ci-label-gated-verify.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -576,9 +576,11 @@ A PR whose changed-file set lives entirely under `docs/**`, root-level
 deliberately removed — see
 [docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md](docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md)
 for why: keeping it while the check is required would deadlock every
-docs-only PR forever). Every leg's own scope condition evaluates false for
-a docs-only diff, though, so the job completes in roughly the time of "Setup
-Node + deps" alone (~20-40s) and reports green — the gate stays "PR required
+docs-only PR forever). Most legs' own scope conditions evaluate false for a
+docs-only diff, though; one step (`check:register-citations`, added via PR
+#3134) runs unconditionally. Either way, the job still completes in roughly
+the time of "Setup Node + deps" alone (~20-40s) and reports green — the gate
+stays "PR required
 + title valid + no conflicts + a fast green required check", not the 10-15
 min full battery. Rationale and the exact glob list for the underlying
 scope-matching (unrelated to the removed `paths-ignore`):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -580,10 +580,9 @@ docs-only PR forever). Most legs' own scope conditions evaluate false for a
 docs-only diff, though; one step (`check:register-citations`, added via PR
 #3134) runs unconditionally. Either way, the job still completes in roughly
 the time of "Setup Node + deps" alone (~20-40s) and reports green — the gate
-stays "PR required
-+ title valid + no conflicts + a fast green required check", not the 10-15
-min full battery. Rationale and the exact glob list for the underlying
-scope-matching (unrelated to the removed `paths-ignore`):
+stays "PR required + title valid + no conflicts + a fast green required check",
+not the 10-15 min full battery. Rationale and the exact glob list for the
+underlying scope-matching (unrelated to the removed `paths-ignore`):
 [docs/features/archive/101-docs-only-ci-skip.md](docs/features/archive/101-docs-only-ci-skip.md).
 
 The same file-set test also skips the **local** pre-push `test:sidecar`

--- a/scripts/check-register-citations.mjs
+++ b/scripts/check-register-citations.mjs
@@ -16,23 +16,21 @@
 // (1) `scripts/tests/check-register-citations.test.mjs`'s CLI-integration
 // tests, run as part of `npm run test:hooks`; and
 // (2) `.github/workflows/verify.yml`'s unconditional `check:register-citations`
-// step (wired in PR #3134, closing #3122).
+// step (PR #3134 closes the CI-wiring gap at #3122; other surfaces remain at #3140).
 //
-// CI WIRING (closed): The dedicated `.github/workflows/verify.yml` step now
-// exists (see `.github/workflows/verify.yml` lines ~218-223); it runs
-// unconditionally on every PR, including docs-only diffs, because citations
-// can live in any file and diff-scope cannot reliably predict whether one
-// broke.
+// CI WIRING (closed): The dedicated `.github/workflows/verify.yml` "Register
+// citation check" step now exists; it runs unconditionally on every PR,
+// including docs-only diffs, because citations can live in any file and
+// diff-scope cannot reliably predict whether one broke.
 //
-// LOCAL WIRING (open, tracked at #3140): The checker is still NOT invoked
-// from `npm run verify` or `npm run test:all` locally, or from any git hook.
-// Those remaining integration points are tracked separately at #3140.
-// The challenge: this checker's real-tree run scans essentially every tracked
-// file, so declaring it as a `test:hooks` input would make that step
-// un-cacheable for everyone, defeating the scope-gating `verify-cache.mjs`
-// exists for. The right fix is a design decision about whether to add a
-// dedicated local step, and if so, whether it belongs in `verify` or wrapped
-// elsewhere — not something to wire in blind here.
+// LOCAL WIRING (open, tracked at #3140): The checker IS reachable locally as
+// part of `npm run test:hooks` (which `npm run verify` and `npm run test:all`
+// both run), via the test suite `scripts/tests/check-register-citations.test.mjs`
+// that spawns the checker CLI against the real tree. However, `test:hooks`'s own
+// input globs don't span the whole tree, so on a diff outside those globs, the
+// step can be marked `[cached]`/skipped rather than actually re-scanning. A
+// dedicated local step that runs unconditionally (independent of scope) is
+// tracked separately at #3140.
 //
 // Four checks, ordered by precision (least to most likely to need
 // judgment):

--- a/scripts/check-register-citations.mjs
+++ b/scripts/check-register-citations.mjs
@@ -11,30 +11,28 @@
 // claim living on several surfaces, with only some of them corrected. This
 // script exists to make that mechanical instead of eyeballed.
 //
-// WIRING GAP, stated explicitly rather than left implicit (pass-9 review of
-// PR #2630, finding AA): `package.json`'s `check:register-citations` script
-// is invoked from exactly one place today —
-// `scripts/tests/check-register-citations.test.mjs`'s own CLI-integration
-// tests, run as part of `npm run test:hooks`. That means this checker only
-// actually EXERCISES on a diff `verify-cache.mjs`'s `test:hooks` step
-// considers in-scope: `docs/testing/**`, the register itself, `CLAUDE.md`,
-// and `scripts/**` — NOT `docs/features/**`, `docs/superpowers/**`,
-// `src/**`, `server/**`, or `e2e/**`, even though a citation can live in any
-// of those and this checker's own real-tree run scans every one of them.
-// There is no dedicated `.github/workflows/*.yml` step for this checker the
-// way the sibling `check-onbox-register.mjs` has
-// (`onbox-register-check.yml`) — `#2629`'s option 3 ("catches rot at PR
-// time") is not fully true yet: rot in a file outside `test:hooks`' own
-// scope is caught only the NEXT time some in-scope file changes too, or on
-// a manual `npm run check:register-citations`. Widening `test:hooks`'
-// inputs to the whole tree isn't the fix — this checker's own real-tree run
-// reads essentially every tracked file, so declaring that as a `test:hooks`
-// input would make the step un-cacheable for everyone, defeating the
-// scope-gating `verify-cache.mjs` exists for. The right fix is a dedicated
-// CI step (mirroring `onbox-register-check.yml`) that always runs this
-// checker regardless of diff scope — a genuine design decision (schedule,
-// gating, whether it belongs in `verify.yml` or its own workflow), not
-// something to wire in blind here; tracked at `#2721`.
+// WIRING STATUS (updated 2026-09-10, PR #3134): `package.json`'s
+// `check:register-citations` script is now invoked from TWO places:
+// (1) `scripts/tests/check-register-citations.test.mjs`'s CLI-integration
+// tests, run as part of `npm run test:hooks`; and
+// (2) `.github/workflows/verify.yml`'s unconditional `check:register-citations`
+// step (wired in PR #3134, closing #3122).
+//
+// CI WIRING (closed): The dedicated `.github/workflows/verify.yml` step now
+// exists (see `.github/workflows/verify.yml` lines ~218-223); it runs
+// unconditionally on every PR, including docs-only diffs, because citations
+// can live in any file and diff-scope cannot reliably predict whether one
+// broke.
+//
+// LOCAL WIRING (open, tracked at #3140): The checker is still NOT invoked
+// from `npm run verify` or `npm run test:all` locally, or from any git hook.
+// Those remaining integration points are tracked separately at #3140.
+// The challenge: this checker's real-tree run scans essentially every tracked
+// file, so declaring it as a `test:hooks` input would make that step
+// un-cacheable for everyone, defeating the scope-gating `verify-cache.mjs`
+// exists for. The right fix is a design decision about whether to add a
+// dedicated local step, and if so, whether it belongs in `verify` or wrapped
+// elsewhere — not something to wire in blind here.
 //
 // Four checks, ordered by precision (least to most likely to need
 // judgment):

--- a/scripts/check-register-citations.mjs
+++ b/scripts/check-register-citations.mjs
@@ -23,14 +23,15 @@
 // including docs-only diffs, because citations can live in any file and
 // diff-scope cannot reliably predict whether one broke.
 //
-// LOCAL WIRING (open, tracked at #3140): The checker IS reachable locally as
-// part of `npm run test:hooks` (which `npm run verify` and `npm run test:all`
-// both run), via the test suite `scripts/tests/check-register-citations.test.mjs`
-// that spawns the checker CLI against the real tree. However, `test:hooks`'s own
-// input globs don't span the whole tree, so on a diff outside those globs, the
-// step can be marked `[cached]`/skipped rather than actually re-scanning. A
-// dedicated local step that runs unconditionally (independent of scope) is
-// tracked separately at #3140.
+// LOCAL WIRING (open, tracked at #3140): The checker IS reachable locally via
+// two paths: (1) `npm run verify` reaches it via `test:hooks` (which is scope-gated
+// in verify-cache.mjs, so it can be marked `[cached]`/skipped on out-of-scope diffs);
+// and (2) `npm run test:all` and `npm run verify:quick` invoke test:hooks directly
+// with NO caching, so the checker runs unconditionally as part of every local
+// `test:all`/`verify:quick` invocation. The actual decision at #3140 is narrower:
+// whether `npm run verify` itself (beyond test:all) should also have an
+// unconditional/uncached local leg (independent of scope-gating), and whether
+// a git hook should wire it.
 //
 // Four checks, ordered by precision (least to most likely to need
 // judgment):

--- a/scripts/tests/workflow-wiring.test.mjs
+++ b/scripts/tests/workflow-wiring.test.mjs
@@ -1553,14 +1553,26 @@ test('register citation check: must be unconditional (no if: guard) — issue #3
   const stepBlock = stepLines.join('\n');
 
   // Assertion 1: Step must NOT contain any `if:` at any indentation.
-  // Use the same ifConditions pattern as the rest of this file: extract all
-  // if: lines (including block scalars), and assert none are found.
+  // Standalone regex check (not using the shared ifConditions helper, which handles
+  // block scalars; this step is simple enough that a direct regex suffices).
   const ifMatches = stepBlock.match(/^\s*if:/m);
   assert.ok(
     !ifMatches,
     'Register citation check step must be unconditional (must have no `if:` guard). ' +
       'This step scans the whole tree for citations (#3122), so no diff-scope can ' +
       'reliably predict coverage. It must run on every PR, including docs-only.',
+  );
+
+  // Assertion 1b: Step must NOT contain `continue-on-error:` either.
+  // If a future PR adds `continue-on-error: true`, the step will run but if it exits
+  // 1 on a broken citation, the job continues anyway and reports success — silently
+  // reopening #3122. This assertion catches that regression.
+  const continueOnErrorMatches = stepBlock.match(/^\s*continue-on-error:\s*/mi);
+  assert.ok(
+    !continueOnErrorMatches,
+    'Register citation check step must not have `continue-on-error:` set. ' +
+      'If this step fails on a broken citation, the job must fail so it is caught by CI. ' +
+      'Adding `continue-on-error: true` would silently reopen #3122.',
   );
 
   // Assertion 2: Step MUST contain the exact run command (as a complete value).

--- a/scripts/tests/workflow-wiring.test.mjs
+++ b/scripts/tests/workflow-wiring.test.mjs
@@ -1499,35 +1499,77 @@ test('register citation check: must be unconditional (no if: guard) — issue #3
   // step would silently reopen #3122 (broken register citation outside test:hooks'
   // scope never caught by CI). This test goes RED if that happens.
   //
-  // Mutation proof: adding any `if:` condition to the step makes this test fail.
+  // Mutation-robust guard: extracts the step's YAML block by indentation
+  // (not by a literal substring search), then asserts:
+  // 1. The step exists and its name is found
+  // 2. The step contains NO `if:` line at any indentation > the step's own
+  // 3. The step contains the EXACT `run: npm run check:register-citations` command
+  //
+  // Scenarios caught: script rename (step not found → throws), `if:` added
+  // before or after `run:`, folded block scalar `if: >-`, reindentation,
+  // `run: "true"` (command neutered).
 
-  // Find the step by exact name, looking for the pattern:
-  // - name: Register citation check
-  //   run: (no if: line in between)
-  const stepMatch = source.match(
-    /- name: Register citation check\n(?:\s*[^\n]*\n)?(?:\s*if:|\s*run:)/m,
-  );
+  const yamlLines = source.split('\n');
+  let stepStartIdx = -1;
+  let stepIndent = -1;
+
+  // Find the step by its "- name: Register citation check" line
+  for (let i = 0; i < yamlLines.length; i += 1) {
+    if (/^\s*- name: Register citation check\s*$/.test(yamlLines[i])) {
+      stepStartIdx = i;
+      const m = /^(\s*)/.exec(yamlLines[i]);
+      stepIndent = m[1].length;
+      break;
+    }
+  }
 
   assert.ok(
-    stepMatch,
-    'Register citation check step not found in lint-and-checks job',
+    stepStartIdx >= 0,
+    'Register citation check step (- name: Register citation check) not found in workflow',
   );
 
-  // The step must NOT have an `if:` condition between its name and run.
-  // Extract the section from "- name: Register citation check" through
-  // the next "run:" (which must be immediately next, with no if: between them).
-  const stepSection = source.slice(
-    source.indexOf('- name: Register citation check'),
-    source.indexOf('run: npm run check:register-citations') + 50,
-  );
+  // Extract the step's YAML block: all lines from stepStartIdx until we hit
+  // a line at equal or lesser indentation (next sibling step or job).
+  const stepLines = [yamlLines[stepStartIdx]];
+  for (let i = stepStartIdx + 1; i < yamlLines.length; i += 1) {
+    const line = yamlLines[i];
+    const lineIndent = /^(\s*)/.exec(line)[1].length;
 
-  // Assert the step has NO `if:` line anywhere in its definition.
-  // The section should contain "- name:" and "run:", but NOT "if:".
-  assert.doesNotMatch(
-    stepSection,
-    /^\s*if:/m,
+    // Empty lines belong to the step
+    if (line.trim() === '') {
+      stepLines.push(line);
+      continue;
+    }
+
+    // Stop when indentation returns to the step's level or less
+    if (lineIndent <= stepIndent) {
+      break;
+    }
+
+    // More indented: part of this step
+    stepLines.push(line);
+  }
+
+  const stepBlock = stepLines.join('\n');
+
+  // Assertion 1: Step must NOT contain any `if:` at any indentation.
+  // Use the same ifConditions pattern as the rest of this file: extract all
+  // if: lines (including block scalars), and assert none are found.
+  const ifMatches = stepBlock.match(/^\s*if:/m);
+  assert.ok(
+    !ifMatches,
     'Register citation check step must be unconditional (must have no `if:` guard). ' +
       'This step scans the whole tree for citations (#3122), so no diff-scope can ' +
       'reliably predict coverage. It must run on every PR, including docs-only.',
+  );
+
+  // Assertion 2: Step MUST contain the exact run command (as a complete value).
+  // This ensures the step still executes the checker, not something like `run: "true"`
+  // or a renamed script like `run: npm run check:register-citations-renamed`.
+  const runMatch = /^\s*run:\s*npm run check:register-citations\s*$/m.test(stepBlock);
+  assert.ok(
+    runMatch,
+    'Register citation check step must execute `npm run check:register-citations`, ' +
+      'not a neutered or renamed command.',
   );
 });

--- a/scripts/tests/workflow-wiring.test.mjs
+++ b/scripts/tests/workflow-wiring.test.mjs
@@ -1490,3 +1490,44 @@ test('leg-result check: cancelled/failed/skipped bucketing is present and all th
     'exit condition does not check all three arrays (CANCELLED, FAILED, SKIPPED)',
   );
 });
+
+test('register citation check: must be unconditional (no if: guard) — issue #3122', () => {
+  // The register-citation checker scans the WHOLE tree for citations, so no
+  // diff-scope reliably predicts whether one broke. The step MUST run on every
+  // PR (including docs-only), unconditionally. A future PR that "helpfully"
+  // adds `if: fromJSON(needs.detect.outputs.scopes).something || ...` to this
+  // step would silently reopen #3122 (broken register citation outside test:hooks'
+  // scope never caught by CI). This test goes RED if that happens.
+  //
+  // Mutation proof: adding any `if:` condition to the step makes this test fail.
+
+  // Find the step by exact name, looking for the pattern:
+  // - name: Register citation check
+  //   run: (no if: line in between)
+  const stepMatch = source.match(
+    /- name: Register citation check\n(?:\s*[^\n]*\n)?(?:\s*if:|\s*run:)/m,
+  );
+
+  assert.ok(
+    stepMatch,
+    'Register citation check step not found in lint-and-checks job',
+  );
+
+  // The step must NOT have an `if:` condition between its name and run.
+  // Extract the section from "- name: Register citation check" through
+  // the next "run:" (which must be immediately next, with no if: between them).
+  const stepSection = source.slice(
+    source.indexOf('- name: Register citation check'),
+    source.indexOf('run: npm run check:register-citations') + 50,
+  );
+
+  // Assert the step has NO `if:` line anywhere in its definition.
+  // The section should contain "- name:" and "run:", but NOT "if:".
+  assert.doesNotMatch(
+    stepSection,
+    /^\s*if:/m,
+    'Register citation check step must be unconditional (must have no `if:` guard). ' +
+      'This step scans the whole tree for citations (#3122), so no diff-scope can ' +
+      'reliably predict coverage. It must run on every PR, including docs-only.',
+  );
+});


### PR DESCRIPTION
## Summary
- Adds an unconditional `check:register-citations` step to verify.yml's
  lint-and-checks job, closing the gap where a broken register-row citation
  outside test:hooks' own scope (docs/features/**, src/**, server/**, e2e/**)
  was never caught by CI.

## Test plan
- [x] New step runs `npm run check:register-citations`, no `if:` scope-gate
- [x] Verified NOT folded into the path-filtered onbox-register-check.yml
- [x] Mutation: broke a real citation (pointed it at a nonexistent register
      row), confirmed check:register-citations catches it, reverted, clean
- [x] npm run check:register-citations passes on the tree as committed

## Not applicable
- **Release notes (before-shipping step 5)**: skipped — CI-only change, no
  shippable user- or operator-visible delta.
- **On-box acceptance (before-shipping step 3)**: skipped — this wires an
  existing, already-tested script into CI; nothing here requires real
  hardware to prove.

Refs #3122 — this PR closes the CI-workflow gap #3122 named, but #3122 also
named a `test:all`/`verify` step and a git hook as unwired surfaces; those
carry a real design decision (how an always-run, whole-tree-scanning check
fits `verify-cache.mjs`'s scope-gated-and-cached `STEPS[]` convention, and
ops-2997's "hooks run no battery" shape) and are tracked separately in #3140
rather than decided here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
