### PR TITLE
fix(ops): add index.html and styles.css to vitest forceRerunTriggers

### DIFF
--- a/src/test/force-rerun-triggers.test.ts
+++ b/src/test/force-rerun-triggers.test.ts
@@ -70,6 +70,18 @@ const COVERED = [
   { rel: 'vite.config.ts', file: 'the vite build config' },
   { rel: 'src/test/setup.ts', file: 'the injected test-setup file' },
   { rel: 'openapi.yaml', file: 'the API contract' },
+  /* #2051 — src/lib/api.ts and api-types.ts are near-universal transitive
+     imports; without the triggers, a diff to either selects 330 of 332 files
+     anyway, so forcing the full run adds only ~2 files of marginal cost. */
+  { rel: 'src/lib/api.ts', file: 'the API utils' },
+  { rel: 'src/lib/api-types.ts', file: 'the generated OpenAPI types' },
+  /* #2889 — src/index-html-fonts.test.ts readFile()s index.html at runtime
+     with no module-graph edge, and src/test/dark-mode-css.test.ts +
+     src/styles-neutrals.test.ts readFileSync() src/styles.css directly.
+     Without these triggers, vitest --changed selects zero tests for index.html
+     and only src/main.test.tsx (missing both guards) for src/styles.css. */
+  { rel: 'index.html', file: 'the app shell' },
+  { rel: 'src/styles.css', file: 'the design tokens' },
 ];
 
 /* Real files that must NOT match. More than one shape, so widening a dead
@@ -79,6 +91,8 @@ const NOT_COVERED = [
   { rel: 'src/main.tsx', file: 'an ordinary source file' },
   { rel: 'tsconfig.json', file: 'a JSON file that is not a manifest' },
   { rel: 'apps/android/pubspec.yaml', file: 'a YAML file that is not the contract' },
+  { rel: 'public/fonts/fonts.css', file: 'a different CSS file' },
+  { rel: 'docs/testing/onbox-acceptance-register-live-view.html', file: 'a different HTML file' },
 ];
 
 const crossProduct = (files: typeof COVERED) =>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -113,6 +113,18 @@ export default defineConfig({
          files. */
       '{**/src/lib/api.ts,**/.*/**/src/lib/api.ts}',
       '{**/src/lib/api-types.ts,**/.*/**/src/lib/api-types.ts}',
+      /* #2889 — src/index-html-fonts.test.ts (the #698 self-hosted-fonts
+         guard) readFile()s index.html at RUNTIME and neither imports it nor
+         has any module-graph edge to it, so `vitest --changed` would never
+         select it for an index.html-only diff. Same story for styles.css:
+         src/test/dark-mode-css.test.ts and src/styles-neutrals.test.ts both
+         readFileSync() it directly. Both files are also in
+         scripts/verify-cache.mjs's `test` step `extraFiles`, which is what
+         forces the whole-suite CI cache to invalidate on either — this
+         entry closes the matching gap in vitest's own --changed selection
+         so a local/targeted run doesn't silently skip the guards. */
+      '{**/index.html,**/.*/**/index.html}',
+      '{**/styles.css,**/.*/**/styles.css}',
     ],
     /* One retry to absorb transient jsdom/timer flakes inside a single
        verify run instead of forcing a full pre-push re-execution. See

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -116,13 +116,16 @@ export default defineConfig({
       /* #2889 — src/index-html-fonts.test.ts (the #698 self-hosted-fonts
          guard) readFile()s index.html at RUNTIME and neither imports it nor
          has any module-graph edge to it, so `vitest --changed` would never
-         select it for an index.html-only diff. Same story for styles.css:
+         select it for an index.html-only diff. src/styles.css is different:
+         src/main.tsx imports it (so the module-graph edge exists), but
          src/test/dark-mode-css.test.ts and src/styles-neutrals.test.ts both
-         readFileSync() it directly. Both files are also in
-         scripts/verify-cache.mjs's `test` step `extraFiles`, which is what
-         forces the whole-suite CI cache to invalidate on either — this
-         entry closes the matching gap in vitest's own --changed selection
-         so a local/targeted run doesn't silently skip the guards. */
+         readFileSync() it directly with no module-graph path from the change
+         to the guard, creating a partial-selection gap that would miss both
+         guards. Both files are in scope for the `test` step — index.html via
+         its `extraFiles` entry, src/styles.css via globs: ['src/**'] — but
+         that only schedules the step; it is `--changed` inside the run that
+         then selects zero/one test file. These triggers are what force the
+         full run, closing the matching gap in vitest's own selection. */
       '{**/index.html,**/.*/**/index.html}',
       '{**/styles.css,**/.*/**/styles.css}',
     ],


### PR DESCRIPTION
Closes #2889

## Decision

Per #2889's filed options, this is option (1): add `index.html` and
`styles.css` directly to `vitest.config.ts`'s `forceRerunTriggers`. This is
the real decision CLAUDE.md's #2867 reserved, made deliberately, not a
mechanical widening. The generic `extraFiles`-vs-`forceRerunTriggers`
reconciliation (option 2) and the full `ci-scope.mjs` reconciliation from
#2853 (option 3) remain future work if this class of gap recurs a third time.

## What changed

`vitest.config.ts`'s `forceRerunTriggers` array gained two brace-alternation
entries, matching the existing format used by the lockfile/openapi.yaml/api.ts
precedent entries:

```
'{**/index.html,**/.*/**/index.html}',
'{**/styles.css,**/.*/**/styles.css}',
```

No other `forceRerunTriggers` entries were touched or removed — this is a
pure addition.

Also fixed in the same PR, found in passing during review:
`src/test/force-rerun-triggers.test.ts` had zero coverage for either new
entry (and, pre-existing, for the #2051 `src/lib/api.ts`/`api-types.ts`
entries too) — a narrowed or over-widened pattern would have gone
undetected. Added `COVERED`/`NOT_COVERED` cases for all four.

## Test plan (measured, not assumed — re-verified independently at review time)

Before the fix, `index.html`/`styles.css`-only diffs selected zero relevant
tests via `vitest --changed`/`vitest related`, silently skipping the guards
that assert against those files. This was re-verified independently during
review against this branch's pre-fix head:

- `npx vitest related index.html --run` — before the fix, reported "No test
  files found"; after, correctly selects `src/index-html-fonts.test.ts` (the
  #698 self-hosted-fonts guard).
- `npx vitest related styles.css --run` — selects both dedicated styles.css
  guard tests, `src/test/dark-mode-css.test.ts` and
  `src/styles-neutrals.test.ts`.

`src/test/force-rerun-triggers.test.ts` (56 tests: 9 `COVERED` cases × 4
checkout shapes + 5 `NOT_COVERED` cases × 4) independently pins that both new
`forceRerunTriggers` entries actually match at every checkout shape the guard
supports, and that narrowing or over-widening either pattern is caught.

On the CI-scheduling question raised during review: `index.html` is directly
listed in `scripts/verify-cache.mjs`'s `test`-step `extraFiles`;
`src/styles.css` is covered there via that same step's `globs: ['src/**']`
instead — an asymmetry, not a shared mechanism. Either way, `extraFiles`/
`globs` only gate whether `npm run verify`'s local cache reruns the `test`
step **at all**; they do not affect which individual test files vitest's own
`--changed` selects **within** that step once it runs. That selection is
exactly what `forceRerunTriggers` controls, and is the actual gap this PR
closes — CI's `verify.yml` and a local `--changed` run both rely on it.

## Release notes

This is a documentation + test-infrastructure fix (no new user-facing behavior, no
operator-visible change). Skip release-notes entries per CLAUDE.md before-shipping
step 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
