### PR TITLE
chore(ops): pin forceRerunTriggers to each guard's own scan-target export via drift check

### DIFF
--- a/server/src/force-rerun-triggers.test.ts
+++ b/server/src/force-rerun-triggers.test.ts
@@ -250,10 +250,14 @@ const SLOW_NOT_COVERED = [
 /* #3085: state-language.guard.test.ts's new trigger deliberately covers the
    whole server/src/** tree, so "an ordinary server source file" is no longer
    a valid not-covered case for the MAIN config — matching it is the point.
-   Swap in a file outside every guard's declared scope instead. */
+   Swap in files outside every guard's declared scope instead — one for each
+   major extension type (non-source, source-extension) so widening a trigger
+   to a broad glob (e.g. ** + any-extension) is caught rather than only the
+   crudest widening. */
 const MAIN_NOT_COVERED = [
   ...NOT_COVERED,
   { rel: 'CONTRIBUTING.md', file: 'an ordinary repo file outside every guard scope', base: REPO_ROOT },
+  { rel: 'src/lib/account-defaults.ts', file: 'a frontend source file outside every guard scope', base: REPO_ROOT },
 ];
 
 const crossProduct = (covered: typeof MAIN_COVERED) =>
@@ -307,6 +311,22 @@ describe('server/vitest.config.ts forceRerunTriggers', () => {
       `{**/${ENGINE_LANGUAGE_COVERAGE_GUARD_SCAN_GLOB},` +
       `**/.*/**/${ENGINE_LANGUAGE_COVERAGE_GUARD_SCAN_GLOB}}`;
     expect(mainTriggers).toContain(expected);
+  });
+
+  /* coqui-residency-policy.guard.test.ts (#1932, side-18) reads
+     server/src/tts/synthesise-chapter.ts at RUNTIME — the file is importable
+     but the guard doesn't import it, it scans its source text for eviction
+     policy cross-references, so there is no module-graph edge from the guard
+     to this file. The new broad server/src/** trigger added in #3085 now
+     covers this file, making the specific entry able to be deleted without
+     failing this test suite — but the guard still declares
+     synthesise-chapter.ts as its own scope. This exact-entry pin guards against
+     the entry being silently deleted on the assumption that the broader trigger
+     handles it (it does, today, but the guard's scope is still the specific
+     file). */
+  it('main forceRerunTriggers has the exact entry for coqui-residency-policy.guard.test.ts synthesise-chapter.ts (#3085)', () => {
+    const coquiSynthesiseEntry = '{**/server/src/tts/synthesise-chapter.ts,**/.*/**/server/src/tts/synthesise-chapter.ts}';
+    expect(mainTriggers).toContain(coquiSynthesiseEntry);
   });
 
   /* Only entries 1, 4 and 6 have their OWN literal brace-glob trigger to pin

--- a/server/src/force-rerun-triggers.test.ts
+++ b/server/src/force-rerun-triggers.test.ts
@@ -30,6 +30,7 @@ import { existsSync } from 'node:fs';
 import { relative, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { COQUI_RESIDENCY_POLICY_GUARD_SCAN_GLOBS } from './tts/coqui-residency-policy.guard-targets.js';
+import { STATE_LANGUAGE_GUARD_SCAN_GLOB } from './workspace/state-language.guard-targets.js';
 
 const SERVER_ROOT = resolve(__dirname, '..');
 const REPO_ROOT = resolve(SERVER_ROOT, '..');
@@ -170,6 +171,18 @@ const MAIN_COVERED = [
      #1847 runtime-read trap as the entries above. */
   { rel: 'src/analyzer/rate-limit.ts', file: 'the rate-limit dynamic-reader lookup', base: SERVER_ROOT },
   { rel: 'src/tts/segment-asr-qa.ts', file: 'the per-language maxWer dynamic-reader lookup', base: SERVER_ROOT },
+  /* state-language.guard.test.ts (#3085): a tree-wide scanner —
+     collectSourceFiles(SRC_ROOT) reads every non-test .ts file under
+     server/src/** at RUNTIME, no module-graph edge to any of them. The rel
+     path below is DERIVED from STATE_LANGUAGE_GUARD_SCAN_GLOB (the same
+     constant the guard itself imports), not a second hand-typed literal that
+     happens to agree with it today — so this assertion and the guard's
+     declared scope can never independently drift. */
+  {
+    rel: STATE_LANGUAGE_GUARD_SCAN_GLOB.replace(/\*\*$/, 'index.ts'),
+    file: 'a file under the state-language guard scan scope (STATE_LANGUAGE_GUARD_SCAN_GLOB)',
+    base: REPO_ROOT,
+  },
 ];
 
 const SLOW_COVERED = [
@@ -181,9 +194,24 @@ const SLOW_COVERED = [
    trigger to something like `**` + a suffix glob is caught rather than only
    the crudest `**`. */
 const NOT_COVERED = [
-  { rel: 'src/index.ts', file: 'an ordinary server source file', base: SERVER_ROOT },
   { rel: 'tsconfig.json', file: 'a JSON file that is not a manifest', base: REPO_ROOT },
   { rel: 'apps/android/pubspec.yaml', file: 'a YAML file that is not the contract', base: REPO_ROOT },
+];
+
+/* The slow config's triggers are untouched by #3085, so an ordinary server
+   source file is still a valid not-covered case there. */
+const SLOW_NOT_COVERED = [
+  ...NOT_COVERED,
+  { rel: 'src/index.ts', file: 'an ordinary server source file', base: SERVER_ROOT },
+];
+
+/* #3085: state-language.guard.test.ts's new trigger deliberately covers the
+   whole server/src/** tree, so "an ordinary server source file" is no longer
+   a valid not-covered case for the MAIN config — matching it is the point.
+   Swap in a file outside every guard's declared scope instead. */
+const MAIN_NOT_COVERED = [
+  ...NOT_COVERED,
+  { rel: 'CONTRIBUTING.md', file: 'an ordinary repo file outside every guard scope', base: REPO_ROOT },
 ];
 
 const crossProduct = (covered: typeof MAIN_COVERED) =>
@@ -210,10 +238,22 @@ describe('server/vitest.config.ts forceRerunTriggers', () => {
     },
   );
 
+  /* #3085: the file-coverage case above only proves the CURRENT scope is
+     covered — narrowing STATE_LANGUAGE_GUARD_SCAN_GLOB to a subtree (e.g.
+     'server/src/tts/**') would still pass it, because a narrower scope is
+     still a subset of the real (unchanged) trigger below. This assertion
+     checks the trigger array contains the EXACT brace-glob built from the
+     imported constant, so narrowing OR widening the constant without
+     updating vitest.config.ts's literal entry to match is caught either way. */
+  it('main forceRerunTriggers has the exact entry derived from STATE_LANGUAGE_GUARD_SCAN_GLOB (#3085)', () => {
+    const expected = `{**/${STATE_LANGUAGE_GUARD_SCAN_GLOB},**/.*/**/${STATE_LANGUAGE_GUARD_SCAN_GLOB}}`;
+    expect(mainTriggers).toContain(expected);
+  });
+
   /* Guards against "fixing" a dead trigger by widening it to something that
      matches everything — that would force a full run on every diff and
      quietly undo the point of --changed. */
-  it.each(crossProduct(NOT_COVERED))('does not match $file from $shape', ({ rel, base, root }) => {
+  it.each(crossProduct(MAIN_NOT_COVERED))('does not match $file from $shape', ({ rel, base, root }) => {
     expect(matchesTrigger(mainTriggers, absPathUnder(root, base, rel))).toBe(false);
   });
 });
@@ -226,7 +266,7 @@ describe('server/vitest.config.slow.ts forceRerunTriggers', () => {
     },
   );
 
-  it.each(crossProduct(NOT_COVERED))('does not match $file from $shape', ({ rel, base, root }) => {
+  it.each(crossProduct(SLOW_NOT_COVERED))('does not match $file from $shape', ({ rel, base, root }) => {
     expect(matchesTrigger(slowTriggers, absPathUnder(root, base, rel))).toBe(false);
   });
 });

--- a/server/src/force-rerun-triggers.test.ts
+++ b/server/src/force-rerun-triggers.test.ts
@@ -31,6 +31,9 @@ import { relative, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { COQUI_RESIDENCY_POLICY_GUARD_SCAN_GLOBS } from './tts/coqui-residency-policy.guard-targets.js';
 import { STATE_LANGUAGE_GUARD_SCAN_GLOB } from './workspace/state-language.guard-targets.js';
+import { SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS } from './spawn-windows-hide.guard-targets.js';
+import { CAST_LOCK_GUARD_SCAN_GLOB } from './workspace/cast-lock.guard-targets.js';
+import { ENGINE_LANGUAGE_COVERAGE_GUARD_SCAN_GLOB } from './tts/engine-language-coverage.guard-targets.js';
 
 const SERVER_ROOT = resolve(__dirname, '..');
 const REPO_ROOT = resolve(SERVER_ROOT, '..');
@@ -105,26 +108,43 @@ const MAIN_COVERED = [
   { rel: 'vitest.config.slow.ts', file: 'the slow-tier config', base: SERVER_ROOT },
   /* Pins the `vite` half of the brace. Without a case for it, narrowing the
      trigger to `vitest.config.ts` would leave every assertion green while
-     silently dropping coverage for the vite build config. */
+     silently dropping coverage for the vite build config. Also one of the
+     concrete root files SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS[5] names
+     (#3085) — its coverage here doubles as that guard's file-coverage case. */
   { rel: 'vite.config.ts', file: 'the vite build config', base: REPO_ROOT },
   { rel: 'openapi.yaml', file: 'the API contract', base: REPO_ROOT },
-  /* #2567 review round 3: spawn-windows-hide.test.ts (this suite) reads
-     these trees as TEXT at RUNTIME to scan for a missing windowsHide —
-     no module-graph edge, so a diff confined to any of them selected zero
-     tests under `vitest run --changed` before these triggers existed. */
-  { rel: 'scripts/verify-cache.mjs', file: 'an arbitrary scripts/** file', base: REPO_ROOT },
+  /* #2567 review round 3, re-derived from SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS
+     (#3085): spawn-windows-hide.test.ts (this suite) reads these trees as
+     TEXT at RUNTIME to scan for a missing windowsHide — no module-graph
+     edge, so a diff confined to any of them selected zero tests under
+     `vitest run --changed` before these triggers existed. Each `rel` below
+     is DERIVED from the guard's own declared scope, not a second hand-typed
+     literal that happens to agree with it today. */
   {
-    rel: 'server/tts-sidecar/scripts/install-ort.mjs',
-    file: 'a server/tts-sidecar/scripts/** file (via the scripts/** trigger)',
+    rel: SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS[1].replace(/\*\*$/, 'verify-cache.mjs'),
+    file: 'an arbitrary scripts/** file (SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS)',
     base: REPO_ROOT,
   },
   {
-    rel: 'pinokio-scripts/lib/resolve-release.js',
-    file: 'a pinokio-scripts/** file',
+    rel: SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS[2].replace(/\*\*$/, 'install-ort.mjs'),
+    file: 'a server/tts-sidecar/scripts/** file (via the scripts/** trigger; SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS)',
     base: REPO_ROOT,
   },
-  { rel: 'e2e/global-teardown.ts', file: 'the e2e Playwright teardown', base: REPO_ROOT },
-  { rel: 'launch.mjs', file: 'the versioned-dir launcher', base: REPO_ROOT },
+  {
+    rel: SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS[3].replace(/\*\*$/, 'resolve-release.js'),
+    file: 'a pinokio-scripts/** file (SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS)',
+    base: REPO_ROOT,
+  },
+  {
+    rel: SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS[4],
+    file: 'the e2e Playwright teardown (SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS)',
+    base: REPO_ROOT,
+  },
+  {
+    rel: SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS[6],
+    file: 'the versioned-dir launcher (SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS)',
+    base: REPO_ROOT,
+  },
   /* #2588 pass-2 review: venv-migration.test.ts (this suite) reads BOTH of these
      at RUNTIME — .gitattributes to assert the requirements/*.txt LF pin rule is
      declared, the requirements files themselves to assert the pin materialised
@@ -164,8 +184,30 @@ const MAIN_COVERED = [
      generation.ts at RUNTIME (readFileSync + a TypeScript parse) to scan for
      the resolveEligibleEngines(...) call site; the same #1847 runtime-read
      trap as the entries above, since the guard scans the file's source text
-     rather than importing it. */
-  { rel: 'src/routes/generation.ts', file: 'the generation route (resolveEligibleEngines call site)', base: SERVER_ROOT },
+     rather than importing it. The rel path below is DERIVED from
+     ENGINE_LANGUAGE_COVERAGE_GUARD_SCAN_GLOB (#3085), the same constant the
+     guard itself declares, not a second hand-typed literal that happens to
+     agree with it today. */
+  {
+    rel: ENGINE_LANGUAGE_COVERAGE_GUARD_SCAN_GLOB,
+    file: 'the generation route (resolveEligibleEngines call site)',
+    base: REPO_ROOT,
+  },
+  /* cast-lock.guard.test.ts (#3085): a tree-wide scanner — collectSourceFiles
+     (SRC_ROOT) reads every non-test .ts file under server/src/** at RUNTIME,
+     no module-graph edge to any of them. The rel path below is DERIVED from
+     CAST_LOCK_GUARD_SCAN_GLOB (the same constant the guard itself imports),
+     not a second hand-typed literal that happens to agree with it today —
+     so this assertion and the guard's declared scope can never
+     independently drift. Same underlying glob text as
+     STATE_LANGUAGE_GUARD_SCAN_GLOB below (both guards' real scope IS the
+     whole server/src/** tree), sourced from cast-lock's own constant so the
+     two guards' declarations are verified independently. */
+  {
+    rel: CAST_LOCK_GUARD_SCAN_GLOB.replace(/\*\*$/, 'index.ts'),
+    file: 'a file under the cast-lock guard scan scope (CAST_LOCK_GUARD_SCAN_GLOB)',
+    base: REPO_ROOT,
+  },
   /* #3139/#3146: registry-knob-read.guard.test.ts reads these two files' source
      text at RUNTIME to verify its DECLARED_DYNAMIC_READERS claims — the same
      #1847 runtime-read trap as the entries above. */
@@ -247,6 +289,48 @@ describe('server/vitest.config.ts forceRerunTriggers', () => {
      updating vitest.config.ts's literal entry to match is caught either way. */
   it('main forceRerunTriggers has the exact entry derived from STATE_LANGUAGE_GUARD_SCAN_GLOB (#3085)', () => {
     const expected = `{**/${STATE_LANGUAGE_GUARD_SCAN_GLOB},**/.*/**/${STATE_LANGUAGE_GUARD_SCAN_GLOB}}`;
+    expect(mainTriggers).toContain(expected);
+  });
+
+  /* Same check as above, independently sourced from cast-lock's own
+     constant — both guards' real scope happens to be the whole
+     server/src/** tree today, and each is verified against
+     server/vitest.config.ts on its own terms rather than assuming the two
+     can never diverge. */
+  it('main forceRerunTriggers has the exact entry derived from CAST_LOCK_GUARD_SCAN_GLOB (#3085)', () => {
+    const expected = `{**/${CAST_LOCK_GUARD_SCAN_GLOB},**/.*/**/${CAST_LOCK_GUARD_SCAN_GLOB}}`;
+    expect(mainTriggers).toContain(expected);
+  });
+
+  it('main forceRerunTriggers has the exact entry derived from ENGINE_LANGUAGE_COVERAGE_GUARD_SCAN_GLOB (#3085)', () => {
+    const expected =
+      `{**/${ENGINE_LANGUAGE_COVERAGE_GUARD_SCAN_GLOB},` +
+      `**/.*/**/${ENGINE_LANGUAGE_COVERAGE_GUARD_SCAN_GLOB}}`;
+    expect(mainTriggers).toContain(expected);
+  });
+
+  /* Only entries 1, 4 and 6 have their OWN literal brace-glob trigger to pin
+     exactly (NOTE: don't write the glob text itself, globstar-slash, inline
+     in a block comment — see the "don't write the glob text" note in
+     server/vitest.config.ts for why that closes the comment early):
+       - [0], scope index 0, is the same literal glob
+         STATE_LANGUAGE_GUARD_SCAN_GLOB's exact-entry check above already
+         pins.
+       - [2], the tts-sidecar scripts subtree, has no entry of its own — it
+         rides the broader [1] entry (the top-level scripts subtree), which
+         matches any path with a 'scripts' segment anywhere (see that
+         entry's own comment in server/vitest.config.ts); the file-coverage
+         case above already proves that reuse still covers it.
+       - [3], the pinokio-scripts lib subtree, similarly rides a broader
+         pinokio-scripts entry, not one scoped to its lib subfolder.
+       - [5], vite.config.ts, is covered by the vitest/vite config brace, a
+         different shape this simple form doesn't match — its own
+         MAIN_COVERED entry (the vite build config case) is that guard's
+         proof instead. */
+  it.each(
+    [1, 4, 6].map((i) => SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS[i]),
+  )('main forceRerunTriggers has the exact entry derived from SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS entry %s (#3085)', (glob) => {
+    const expected = `{**/${glob},**/.*/**/${glob}}`;
     expect(mainTriggers).toContain(expected);
   });
 

--- a/server/src/spawn-windows-hide.guard-targets.ts
+++ b/server/src/spawn-windows-hide.guard-targets.ts
@@ -1,0 +1,42 @@
+/** The real scan scope of spawn-windows-hide.test.ts (#3085): unlike
+    state-language.guard.test.ts / cast-lock.guard.test.ts, this guard reads
+    from SEVERAL independent trees, not one — see the file's own header for
+    the three-scan breakdown. Each entry below is a repo-root-relative glob
+    or literal path, in the same brace-glob style
+    `server/vitest.config.ts`'s other `forceRerunTriggers` entries use, so
+    `force-rerun-triggers.test.ts` can check the real `forceRerunTriggers`
+    array against the SAME constant the guard itself declares, instead of a
+    second, independently-maintained literal.
+
+      - 'server/src/**'                — direct + indirect spawn scans, AND
+        the dev-machine *.test.ts invariant (all three read this tree).
+      - 'scripts/**'                   — recursive, includes scripts/tests/.
+      - 'server/tts-sidecar/scripts/**'
+      - 'pinokio-scripts/lib/**'
+      - 'e2e/global-teardown.ts'       — EXTERNAL_FILES_MANUAL's one entry.
+      - 'vite.config.ts', 'launch.mjs' — two of the concrete files
+        externalFilesFloor()'s REPO_ROOT non-recursive .mjs/.ts scan finds
+        today, named individually because each already carries its own
+        forceRerunTriggers entry for an unrelated reason (the vite/vitest
+        config brace, the launcher trigger) that this guard's coverage can
+        reuse rather than duplicate.
+
+    NOT total coverage of the guard's real scan: externalFilesFloor() ALSO
+    walks REPO_ROOT non-recursively for ANY `.mjs`/`.ts` file there (today
+    that additionally includes eslint.config.mjs, playwright.config.ts,
+    playwright.marketing.config.ts, vitest.config.wire-fixtures.ts), and a
+    brand-new root file joins that scan automatically. A `**` prefix cannot
+    express "root-level only, not nested" without also matching every `.ts`
+    file anywhere in the repo, which would defeat `--changed` outright — the
+    exact failure `force-rerun-triggers.test.ts`'s MAIN_NOT_COVERED cases
+    guard against. This gap is pre-existing (it predates #3085) and is
+    named here rather than silently implied closed. */
+export const SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS = [
+  'server/src/**',
+  'scripts/**',
+  'server/tts-sidecar/scripts/**',
+  'pinokio-scripts/lib/**',
+  'e2e/global-teardown.ts',
+  'vite.config.ts',
+  'launch.mjs',
+] as const;

--- a/server/src/spawn-windows-hide.test.ts
+++ b/server/src/spawn-windows-hide.test.ts
@@ -248,7 +248,7 @@ function applyExclusions(files: string[], exclusions: string[]): string[] {
    - scripts/ recursive, .mjs/.cjs/.js, INCLUDING scripts/tests/ (previously
      excluded — that exclusion let an unguarded module-load-time pwsh spawn
      in cross-os-ffmpeg-install.test.mjs pop a visible window on every
-     `npm run test:hooks` run; see externalFilesFloor()'s scripts/ comment)
+     `npm run test:hooks` run)
    - server/tts-sidecar/scripts/ recursive, .mjs
    - pinokio-scripts/lib/ recursive, .js/.mjs
 

--- a/server/src/spawn-windows-hide.test.ts
+++ b/server/src/spawn-windows-hide.test.ts
@@ -152,15 +152,17 @@ const INDIRECT_RE = /\bspawnFn\s*\(/g;
 
 const REPO_ROOT = join(SRC_ROOT, '..', '..');
 
-/* The three external scan roots used by externalFilesFloor() — declared at
-   module scope (not as local consts inside the function) so the scan target and
-   the test's assertion of the scan target both read the same binding.
-   This pins the two independently so an edit that adds a fourth root to
-   externalFilesFloor() fails the test rather than silently agreeing with a
-   stale constant. */
-const EXTERNAL_SCRIPTS_DIR = join(REPO_ROOT, 'scripts');
-const EXTERNAL_TTS_DIR = join(REPO_ROOT, 'server', 'tts-sidecar', 'scripts');
-const EXTERNAL_PINOKIO_DIR = join(REPO_ROOT, 'pinokio-scripts', 'lib');
+/* The external scan roots used by externalFilesFloor() — declared at
+   module scope as a single array that both externalFilesFloor() and the test
+   read from. This ensures that adding a fourth root to the function makes the
+   test fail (proving the root is genuinely scanned), rather than silently
+   agreeing with a stale test array. The test asserts exhaustiveness via toEqual,
+   so any added root is immediately caught. */
+const EXTERNAL_SCAN_ROOTS = [
+  { dir: join(REPO_ROOT, 'scripts'), extensions: ['.mjs', '.cjs', '.js'] },
+  { dir: join(REPO_ROOT, 'server', 'tts-sidecar', 'scripts'), extensions: ['.mjs'] },
+  { dir: join(REPO_ROOT, 'pinokio-scripts', 'lib'), extensions: ['.js', '.mjs'] },
+] as const;
 
 /* Helper: recursively list files matching given extensions under a directory.
    Skips node_modules, dist, and .git subtrees. */
@@ -262,24 +264,14 @@ function externalFilesFloor(): string[] {
     }
   }
 
-  // scripts/ recursive, .mjs/.cjs/.js, INCLUDING scripts/tests/ (the old
-  // exclusion of scripts/tests/ was itself the bug: those test files spawn
-  // real child processes as part of their own test logic, and a spawn there
-  // missing windowsHide pops its own visible console/PowerShell window when
-  // run under a parent with no console of its own (e.g. `npm run test:hooks`,
-  // which spawns `node --test scripts/tests/*.test.mjs` WITH windowsHide) —
-  // see cross-os-ffmpeg-install.test.mjs's module-load-time pwsh probe, the
-  // worst offender this exclusion let slip through).
-  const scriptsFiles = listFilesRecursive(EXTERNAL_SCRIPTS_DIR, ['.mjs', '.cjs', '.js']);
-
-  // server/tts-sidecar/scripts/ recursive, .mjs
-  const ttsFiles = listFilesRecursive(EXTERNAL_TTS_DIR, ['.mjs']);
-
-  // pinokio-scripts/lib/ recursive, .js/.mjs
-  const pinokioFiles = listFilesRecursive(EXTERNAL_PINOKIO_DIR, ['.js', '.mjs']);
+  // Scan the configured external roots using the module-level EXTERNAL_SCAN_ROOTS array.
+  // This ensures the test can verify exhaustively that all configured roots are scanned.
+  const externalCandidates = EXTERNAL_SCAN_ROOTS.flatMap((root) =>
+    listFilesRecursive(root.dir, [...root.extensions]),
+  );
 
   // Combine all candidates
-  const candidates = [...rootFiles, ...scriptsFiles, ...ttsFiles, ...pinokioFiles];
+  const candidates = [...rootFiles, ...externalCandidates];
   const filtered = filterSpawningFiles(candidates);
 
   // Concatenate manual entries
@@ -508,16 +500,11 @@ describe('windowsHide invariant (no flashing console windows in prod)', () => {
     // guard's scope can never independently drift.
     const toRepoRel = (p: string) => relative(REPO_ROOT, p).split(sep).join('/');
 
-    // Check that the external directory roots match the declared globs.
-    // These are hoisted to module scope so externalFilesFloor() and this test
-    // both read the same binding — an added fourth root fails this exhaustive
+    // Check that the external directory roots (from EXTERNAL_SCAN_ROOTS) match
+    // the declared globs. externalFilesFloor() and this test both read the same
+    // EXTERNAL_SCAN_ROOTS binding — an added fourth root fails this exhaustive
     // toEqual check rather than being silently ignored.
-    const externalRoots = [
-      EXTERNAL_SCRIPTS_DIR,
-      EXTERNAL_TTS_DIR,
-      EXTERNAL_PINOKIO_DIR,
-    ];
-    const externalRootsRel = externalRoots.map(toRepoRel);
+    const externalRootsRel = EXTERNAL_SCAN_ROOTS.map((r) => toRepoRel(r.dir));
     const expectedExternalRootsRel = [
       SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS[1].replace(/\/\*\*$/, ''),
       SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS[2].replace(/\/\*\*$/, ''),

--- a/server/src/spawn-windows-hide.test.ts
+++ b/server/src/spawn-windows-hide.test.ts
@@ -29,9 +29,10 @@
  *      module-load-time pwsh probe). */
 
 import { readdirSync, readFileSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, relative, sep } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS } from './spawn-windows-hide.guard-targets.js';
 
 /* Characters after which a `/` is far more likely to be opening a regex
    literal than dividing two values — a narrow, deliberately incomplete
@@ -492,6 +493,37 @@ describe('windowsHide invariant (no flashing console windows in prod)', () => {
   const serverFiles = listSourceFiles(SRC_ROOT).filter((f) =>
     readFileSync(f, 'utf8').includes('child_process'),
   );
+
+  it('scan scope matches the declared SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS (#3085)', () => {
+    // Ties this guard's ACTUAL scan roots to the scope it DECLARES via the
+    // sibling module — the same constant force-rerun-triggers.test.ts checks
+    // its forceRerunTriggers entries against — so the two statements of this
+    // guard's scope can never independently drift.
+    const scriptsDir = join(REPO_ROOT, 'scripts');
+    const ttsDir = join(REPO_ROOT, 'server', 'tts-sidecar', 'scripts');
+    const pinokioDir = join(REPO_ROOT, 'pinokio-scripts', 'lib');
+    const toRepoRel = (p: string) => relative(REPO_ROOT, p).split(sep).join('/');
+
+    expect(toRepoRel(SRC_ROOT)).toBe(
+      SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS[0].replace(/\/\*\*$/, ''),
+    );
+    expect(toRepoRel(scriptsDir)).toBe(
+      SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS[1].replace(/\/\*\*$/, ''),
+    );
+    expect(toRepoRel(ttsDir)).toBe(SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS[2].replace(/\/\*\*$/, ''));
+    expect(toRepoRel(pinokioDir)).toBe(
+      SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS[3].replace(/\/\*\*$/, ''),
+    );
+    expect(EXTERNAL_FILES_MANUAL.map(toRepoRel)).toEqual([SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS[4]]);
+
+    // The two named root files are checked against the guard's own
+    // dynamically-discovered floor, not re-derived here, so a rename that
+    // drops either from the real scan is caught rather than silently
+    // agreeing with a stale constant.
+    const floorRel = EXTERNAL_FILES_FLOOR.map(toRepoRel);
+    expect(floorRel).toContain(SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS[5]);
+    expect(floorRel).toContain(SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS[6]);
+  });
 
   it('finds at least the known ffmpeg/sidecar spawners (scan is wired up)', () => {
     /* Guard against the scan silently matching nothing (e.g. a refactor that

--- a/server/src/spawn-windows-hide.test.ts
+++ b/server/src/spawn-windows-hide.test.ts
@@ -152,6 +152,16 @@ const INDIRECT_RE = /\bspawnFn\s*\(/g;
 
 const REPO_ROOT = join(SRC_ROOT, '..', '..');
 
+/* The three external scan roots used by externalFilesFloor() — declared at
+   module scope (not as local consts inside the function) so the scan target and
+   the test's assertion of the scan target both read the same binding.
+   This pins the two independently so an edit that adds a fourth root to
+   externalFilesFloor() fails the test rather than silently agreeing with a
+   stale constant. */
+const EXTERNAL_SCRIPTS_DIR = join(REPO_ROOT, 'scripts');
+const EXTERNAL_TTS_DIR = join(REPO_ROOT, 'server', 'tts-sidecar', 'scripts');
+const EXTERNAL_PINOKIO_DIR = join(REPO_ROOT, 'pinokio-scripts', 'lib');
+
 /* Helper: recursively list files matching given extensions under a directory.
    Skips node_modules, dist, and .git subtrees. */
 function listFilesRecursive(dir: string, extensions: string[]): string[] {
@@ -260,16 +270,13 @@ function externalFilesFloor(): string[] {
   // which spawns `node --test scripts/tests/*.test.mjs` WITH windowsHide) —
   // see cross-os-ffmpeg-install.test.mjs's module-load-time pwsh probe, the
   // worst offender this exclusion let slip through).
-  const scriptsDir = join(REPO_ROOT, 'scripts');
-  const scriptsFiles = listFilesRecursive(scriptsDir, ['.mjs', '.cjs', '.js']);
+  const scriptsFiles = listFilesRecursive(EXTERNAL_SCRIPTS_DIR, ['.mjs', '.cjs', '.js']);
 
   // server/tts-sidecar/scripts/ recursive, .mjs
-  const ttsDir = join(REPO_ROOT, 'server', 'tts-sidecar', 'scripts');
-  const ttsFiles = listFilesRecursive(ttsDir, ['.mjs']);
+  const ttsFiles = listFilesRecursive(EXTERNAL_TTS_DIR, ['.mjs']);
 
   // pinokio-scripts/lib/ recursive, .js/.mjs
-  const pinokioDir = join(REPO_ROOT, 'pinokio-scripts', 'lib');
-  const pinokioFiles = listFilesRecursive(pinokioDir, ['.js', '.mjs']);
+  const pinokioFiles = listFilesRecursive(EXTERNAL_PINOKIO_DIR, ['.js', '.mjs']);
 
   // Combine all candidates
   const candidates = [...rootFiles, ...scriptsFiles, ...ttsFiles, ...pinokioFiles];
@@ -499,20 +506,27 @@ describe('windowsHide invariant (no flashing console windows in prod)', () => {
     // sibling module — the same constant force-rerun-triggers.test.ts checks
     // its forceRerunTriggers entries against — so the two statements of this
     // guard's scope can never independently drift.
-    const scriptsDir = join(REPO_ROOT, 'scripts');
-    const ttsDir = join(REPO_ROOT, 'server', 'tts-sidecar', 'scripts');
-    const pinokioDir = join(REPO_ROOT, 'pinokio-scripts', 'lib');
     const toRepoRel = (p: string) => relative(REPO_ROOT, p).split(sep).join('/');
+
+    // Check that the external directory roots match the declared globs.
+    // These are hoisted to module scope so externalFilesFloor() and this test
+    // both read the same binding — an added fourth root fails this exhaustive
+    // toEqual check rather than being silently ignored.
+    const externalRoots = [
+      EXTERNAL_SCRIPTS_DIR,
+      EXTERNAL_TTS_DIR,
+      EXTERNAL_PINOKIO_DIR,
+    ];
+    const externalRootsRel = externalRoots.map(toRepoRel);
+    const expectedExternalRootsRel = [
+      SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS[1].replace(/\/\*\*$/, ''),
+      SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS[2].replace(/\/\*\*$/, ''),
+      SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS[3].replace(/\/\*\*$/, ''),
+    ];
+    expect(externalRootsRel).toEqual(expectedExternalRootsRel);
 
     expect(toRepoRel(SRC_ROOT)).toBe(
       SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS[0].replace(/\/\*\*$/, ''),
-    );
-    expect(toRepoRel(scriptsDir)).toBe(
-      SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS[1].replace(/\/\*\*$/, ''),
-    );
-    expect(toRepoRel(ttsDir)).toBe(SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS[2].replace(/\/\*\*$/, ''));
-    expect(toRepoRel(pinokioDir)).toBe(
-      SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS[3].replace(/\/\*\*$/, ''),
     );
     expect(EXTERNAL_FILES_MANUAL.map(toRepoRel)).toEqual([SPAWN_WINDOWS_HIDE_GUARD_SCAN_GLOBS[4]]);
 

--- a/server/src/tts/engine-language-coverage.guard-targets.ts
+++ b/server/src/tts/engine-language-coverage.guard-targets.ts
@@ -1,0 +1,11 @@
+/** The real scan scope of engine-language-coverage.guard.test.ts's third
+    assertion: it reads `server/src/routes/generation.ts` at runtime
+    (readFileSync + a TypeScript parse) to scan for the
+    `resolveEligibleEngines(...)` call site, rather than importing it. No
+    module-graph edge exists to that file for that reason, so vitest's
+    `--changed` cannot select this guard on its diff — this constant,
+    expressed relative to the repo root in the same brace-glob style
+    `server/vitest.config.ts`'s other `forceRerunTriggers` entries use, is
+    the single source of truth `force-rerun-triggers.test.ts` checks against,
+    so the two can never independently drift (#3085). */
+export const ENGINE_LANGUAGE_COVERAGE_GUARD_SCAN_GLOB = 'server/src/routes/generation.ts';

--- a/server/src/tts/engine-language-coverage.guard.test.ts
+++ b/server/src/tts/engine-language-coverage.guard.test.ts
@@ -108,18 +108,30 @@
 
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as ts from 'typescript';
 import { allLanguageEntries } from './language-registry.js';
 import { ENGINE_LANGUAGE_SUPPORT } from './voice-mapping.js';
 import { resolveEligibleEngines } from './language.js';
 import { ALL_TTS_ENGINES } from './model-keys.js';
+import { ENGINE_LANGUAGE_COVERAGE_GUARD_SCAN_GLOB } from './engine-language-coverage.guard-targets.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const GENERATION_ROUTE_PATH = join(__dirname, '..', 'routes', 'generation.ts');
+const REPO_ROOT = join(__dirname, '..', '..', '..');
 
 describe('engine/registry language coverage (#3059)', () => {
+  it('scan scope matches the declared ENGINE_LANGUAGE_COVERAGE_GUARD_SCAN_GLOB (#3085)', () => {
+    // Ties this guard's ACTUAL scan target (GENERATION_ROUTE_PATH, read by
+    // the third `it` below) to the scope it DECLARES via the sibling
+    // module — the same constant force-rerun-triggers.test.ts checks its
+    // forceRerunTriggers entry against — so the two statements of this
+    // guard's scope can never independently drift.
+    const actualRel = relative(REPO_ROOT, GENERATION_ROUTE_PATH).split(sep).join('/');
+    expect(actualRel).toBe(ENGINE_LANGUAGE_COVERAGE_GUARD_SCAN_GLOB);
+  });
+
   it('every validated non-English language is covered by ENGINE_LANGUAGE_SUPPORT.coqui', () => {
     const coquiLanguages = ENGINE_LANGUAGE_SUPPORT.coqui;
     if (coquiLanguages === '*') {

--- a/server/src/workspace/cast-lock.guard-targets.ts
+++ b/server/src/workspace/cast-lock.guard-targets.ts
@@ -1,0 +1,10 @@
+/** The real scan scope of cast-lock.guard.test.ts: every non-test `.ts` file
+    under `server/src` is read at runtime (readFileSync via
+    `collectSourceFiles`) and scanned for `writeJsonAtomic(castJsonPath(` /
+    `rm(castJsonPath(` call sites. No module-graph edge exists to any of
+    these files, so vitest's `--changed` cannot select this guard on their
+    diff — this constant, expressed relative to the repo root in the same
+    brace-glob style `server/vitest.config.ts`'s other `forceRerunTriggers`
+    entries use, is the single source of truth `force-rerun-triggers.test.ts`
+    checks against, so the two can never independently drift (#3085). */
+export const CAST_LOCK_GUARD_SCAN_GLOB = 'server/src/**';

--- a/server/src/workspace/cast-lock.guard.test.ts
+++ b/server/src/workspace/cast-lock.guard.test.ts
@@ -246,9 +246,11 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { dirname, join, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as ts from 'typescript';
+import { CAST_LOCK_GUARD_SCAN_GLOB } from './cast-lock.guard-targets.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SRC_ROOT = join(__dirname, '..'); // server/src
+const REPO_ROOT = join(SRC_ROOT, '..', '..');
 
 /** Every non-test `.ts` file under `server/src`, recursively. */
 function collectSourceFiles(dir: string, out: string[] = []): string[] {
@@ -592,6 +594,17 @@ const ALLOWED_UNLOCKED = new Map<string, { writes: number; rms: number; why: str
 ]);
 
 describe('cast.json write lock — static guard (#1981 Task 12)', () => {
+  it('scan scope matches the declared CAST_LOCK_GUARD_SCAN_GLOB (#3085)', () => {
+    // Ties this guard's ACTUAL scan target (SRC_ROOT, walked by
+    // collectSourceFiles) to the scope it DECLARES via the sibling module —
+    // the same constant force-rerun-triggers.test.ts checks its
+    // forceRerunTriggers entry against — so the two statements of this
+    // guard's scope can never independently drift.
+    const declaredRoot = CAST_LOCK_GUARD_SCAN_GLOB.replace(/\/\*\*$/, '');
+    const actualRoot = relative(REPO_ROOT, SRC_ROOT).split(sep).join('/');
+    expect(actualRoot).toBe(declaredRoot);
+  });
+
   it('every writeJsonAtomic(castJsonPath(...)) / rm(castJsonPath(...)) site sits inside withCastLock/withCastLocks, except the pinned allowlist', () => {
     const files = collectSourceFiles(SRC_ROOT);
     const problems: string[] = [];

--- a/server/src/workspace/state-language.guard-targets.ts
+++ b/server/src/workspace/state-language.guard-targets.ts
@@ -1,0 +1,10 @@
+/** The real scan scope of state-language.guard.test.ts: every non-test `.ts`
+    file under `server/src` is read at runtime (readFileSync via
+    `collectSourceFiles`) and scanned for `stateJsonPath(`/`writeJsonAtomic(`
+    call sites. No module-graph edge exists to any of these files, so
+    vitest's `--changed` cannot select this guard on their diff — this
+    constant, expressed relative to the repo root in the same brace-glob
+    style `server/vitest.config.ts`'s other `forceRerunTriggers` entries use,
+    is the single source of truth `force-rerun-triggers.test.ts` checks
+    against, so the two can never independently drift (#3085). */
+export const STATE_LANGUAGE_GUARD_SCAN_GLOB = 'server/src/**';

--- a/server/src/workspace/state-language.guard.test.ts
+++ b/server/src/workspace/state-language.guard.test.ts
@@ -74,9 +74,11 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync, readdirSync } from 'node:fs';
 import { dirname, join, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { STATE_LANGUAGE_GUARD_SCAN_GLOB } from './state-language.guard-targets.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SRC_ROOT = join(__dirname, '..'); // server/src
+const REPO_ROOT = join(SRC_ROOT, '..', '..');
 const SEAM_FILE = 'workspace/state-migrate.ts';
 
 /** Every non-test `.ts` file under `server/src`, recursively. */
@@ -303,6 +305,17 @@ const G3_FLOOR_SITES = 35;
 const G3_FLOOR_FILES = 19;
 
 describe('state.json write seam — static guard (#2246 Task 7)', () => {
+  it('scan scope matches the declared STATE_LANGUAGE_GUARD_SCAN_GLOB (#3085)', () => {
+    // Ties this guard's ACTUAL scan target (SRC_ROOT, walked by
+    // collectSourceFiles) to the scope it DECLARES via the sibling module —
+    // the same constant force-rerun-triggers.test.ts checks its
+    // forceRerunTriggers entry against — so the two statements of this
+    // guard's scope can never independently drift.
+    const declaredRoot = STATE_LANGUAGE_GUARD_SCAN_GLOB.replace(/\/\*\*$/, '');
+    const actualRoot = relative(REPO_ROOT, SRC_ROOT).split(sep).join('/');
+    expect(actualRoot).toBe(declaredRoot);
+  });
+
   it('G1: no writeJsonAtomic in a stateJsonPath-mentioning file, except the seam and the pinned other-JSON allowlist', () => {
     const files = collectSourceFiles(SRC_ROOT);
     const problems: string[] = [];

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -283,7 +283,7 @@ export default defineConfig({
          independently drift. Deliberately broad: this guard's real scan
          target is the whole tree, so almost any server source change forces
          a full --changed rerun — that is the cost of the tree-wide scan, not
-         a defect (#3085's chosen design, option 2).
+         a defect (#3085's chosen design).
 
          cast-lock.guard.test.ts (also #3085) is the SAME shape of scanner
          over the SAME tree — its own declared scope,

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -249,7 +249,11 @@ export default defineConfig({
          `vitest run --changed` to follow. Without this trigger, a
          generation.ts-only diff selects zero tests from this suite and the
          guard never runs in the scoped CI leg — silent on exactly the
-         call-site change it exists to catch. */
+         call-site change it exists to catch. This entry's literal text is
+         checked against server/src/tts/engine-language-coverage.guard-
+         targets.ts's ENGINE_LANGUAGE_COVERAGE_GUARD_SCAN_GLOB (#3085), the
+         same constant the guard itself imports, so the two can never
+         independently drift. */
       '{**/server/src/routes/generation.ts,**/.*/**/server/src/routes/generation.ts}',
       /* registry-knob-read.guard.test.ts (#3139/#3146): imports registry.ts
          directly, so a new/changed knob there is already selected by the
@@ -279,7 +283,19 @@ export default defineConfig({
          independently drift. Deliberately broad: this guard's real scan
          target is the whole tree, so almost any server source change forces
          a full --changed rerun — that is the cost of the tree-wide scan, not
-         a defect (#3085's chosen design, option 2). */
+         a defect (#3085's chosen design, option 2).
+
+         cast-lock.guard.test.ts (also #3085) is the SAME shape of scanner
+         over the SAME tree — its own declared scope,
+         server/src/workspace/cast-lock.guard-targets.ts's
+         CAST_LOCK_GUARD_SCAN_GLOB, happens to equal this entry's glob text
+         today, so it rides this one trigger rather than needing a second,
+         textually-identical entry; force-rerun-triggers.test.ts checks this
+         entry against BOTH guards' constants independently. Also part of
+         spawn-windows-hide.guard-targets.ts's SPAWN_WINDOWS_HIDE_GUARD_SCAN_
+         GLOBS[0] for the same reason — three independent guards, one
+         trigger, because their real scan target is textually the same
+         tree. */
       '{**/server/src/**,**/.*/**/server/src/**}',
     ],
     pool: 'forks',

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -269,6 +269,18 @@ export default defineConfig({
          properly, by having guards export their own scan targets. */
       '{**/server/src/analyzer/rate-limit.ts,**/.*/**/server/src/analyzer/rate-limit.ts}',
       '{**/server/src/tts/segment-asr-qa.ts,**/.*/**/server/src/tts/segment-asr-qa.ts}',
+      /* state-language.guard.test.ts (#3085): a tree-wide scanner —
+         collectSourceFiles(SRC_ROOT) reads every non-test .ts file under
+         server/src/** at RUNTIME (readFileSync), so there is no module-graph
+         edge from the guard to any file it scans. Its declared scope lives in
+         server/src/workspace/state-language.guard-targets.ts
+         (STATE_LANGUAGE_GUARD_SCAN_GLOB), which force-rerun-triggers.test.ts
+         imports and checks THIS entry against, so the two can never
+         independently drift. Deliberately broad: this guard's real scan
+         target is the whole tree, so almost any server source change forces
+         a full --changed rerun — that is the cost of the tree-wide scan, not
+         a defect (#3085's chosen design, option 2). */
+      '{**/server/src/**,**/.*/**/server/src/**}',
     ],
     pool: 'forks',
     /* Vitest 4 removed `poolOptions`; `poolOptions.forks.maxForks` is now the


### PR DESCRIPTION
## Summary
- state-language.guard.test.ts, spawn-windows-hide.test.ts,
  cast-lock.guard.test.ts, and engine-language-coverage.guard.test.ts each
  now export their own real scan-target scope from a sibling module.
- server/vitest.config.ts's forceRerunTriggers covers all four from those
  exports; force-rerun-triggers.test.ts checks the real triggers against
  the SAME exported constants, so a guard's scope and its CI trigger can
  no longer independently drift (#3085).
- coqui-residency-policy.guard.test.ts (same runtime-scanning shape) was
  NOT converted in this PR — flagged as a follow-up (#3170), not silently dropped.

## Test plan
- [x] 4 mutations, each showing force-rerun-triggers.test.ts catch a
      deliberately-wrong scope constant, then reverted
- [x] npm run test:server passes (1 pre-existing, unrelated flaky failure in
      library-cast-override.test.ts's AB/BA deadlock race test, untouched by
      this branch; all 5 in-scope files — force-rerun-triggers.test.ts,
      state-language.guard.test.ts, spawn-windows-hide.test.ts,
      cast-lock.guard.test.ts, engine-language-coverage.guard.test.ts —
      pass cleanly: 120/120)
- [x] npm run typecheck passes

## Release notes
N/A — internal test/guard infrastructure with no user- or operator-visible effect.

Closes #3085

🤖 Generated with [Claude Code](https://claude.com/claude-code)
