### PR TITLE
docs(scripts,docs,ci): correct two contradicted --stamped-since sentences and a stale comment

### DIFF
--- a/.github/workflows/onbox-register-check.yml
+++ b/.github/workflows/onbox-register-check.yml
@@ -12,7 +12,7 @@ on:
       # change to either side has to fire it — a live-view-only edit is exactly
       # the shape that drifts the published page away from the markdown.
       - 'docs/testing/onbox-acceptance-register-live-view.html'
-      # Fire on any scripts/* change (and the workflow file itself) so editing
+      # Fire on any scripts/**/*.mjs change (and the workflow file itself) so editing
       # the checkers or their transitive dependencies exercises them against the
       # real register. The transitive local-import graph is under-listed on the
       # third attempt to enumerate it (#1847, #2216, #3055 hit this exact shape

--- a/docs/testing/onbox-acceptance-register.md
+++ b/docs/testing/onbox-acceptance-register.md
@@ -83,7 +83,7 @@ over the other. The check reads the base ref's copy and the working tree's,
 which CI makes `merge(base, head)`, and **reports** an unstamped change in
 content (see #3138 for the decision whether to enforce it as a merge gate).
 In CI, `<ref>` is `HEAD^1` (the base branch's tip at merge time). **By hand,
-never pass `HEAD^1`**: outside CI's merge commit it is not the base your branch
+never pass `HEAD^1`**: outside CI's merge commit it need not be the base your branch
 will merge onto, so the check can fail to catch an unstamped edit — for example
 when `HEAD^1` already contains the edit, or when a stamp main landed in between
 is credited to your branch. Instead, merge the target in and pass it explicitly

--- a/scripts/check-onbox-register.mjs
+++ b/scripts/check-onbox-register.mjs
@@ -1529,19 +1529,20 @@ export function resolveBaselineTexts(
 // checks out `refs/pull/N/merge`, GitHub's `Merge <head> into <base>` commit,
 // rebuilt on the base's current tip. Its first parent is that tip, available
 // as HEAD^1 (the tip, not the merge-base). By hand, never pass HEAD^1: outside
-// CI's merge commit it is not the base your branch will merge onto (it may be,
-// for example, your previous commit, your own pre-merge tip, or after a
-// fast-forward main's previous tip), so the comparison runs against the wrong
+// CI's merge commit it need not be the base your branch will merge onto (it may
+// be, for example, your previous commit, your own pre-merge tip, or after a
+// fast-forward main's previous tip), so the comparison can run against the wrong
 // tree. That can fail to catch an unstamped edit -- for example when HEAD^1
 // already contains the edit, or when a stamp main landed in between is credited
 // to your branch. Pass the target ref explicitly after merging it in
 // (`git fetch origin && git merge origin/main`, then `--stamped-since
 // origin/main`): that is CI's comparison. Un-merged against the target, the
-// result mixes main's changes with yours: an unstamped edit is still refused,
-// but the message can read BEHIND when main's counter is higher than your
-// branch's, and a branch that never touched the live view can be refused
-// because of main's change. The comparison is only meaningful when the working
-// tree is merge(base, head) and `ref` is that base.
+// result mixes main's changes with yours: an unstamped edit is still refused
+// unless main's counter is now lower than your branch's, the message can read
+// BEHIND when main's counter is higher than your branch's, and a branch that
+// never touched the live view can be refused because of main's change. The
+// comparison is only meaningful when the working tree is merge(base, head) and
+// `ref` is that base.
 //
 // `git show <ref>:<path>` exits 128 for BOTH "path missing at that ref" and
 // "ref doesn't resolve at all"; the only way to tell them apart is the
@@ -1652,8 +1653,8 @@ function runCheckOnboxRegisterCli() {
   // merged onto the base branch's tip. In CI, actions/checkout@v7 with
   // fetch-depth: 2 checks out refs/pull/N/merge (`Merge <head> into <base>`,
   // rebuilt on the base's current tip), whose first parent HEAD^1 is that tip.
-  // Hand-run: never pass HEAD^1. Outside CI's merge commit it is not the base your
-  // branch will merge onto, so the check can fail to catch an unstamped edit (for
+  // Hand-run: never pass HEAD^1. Outside CI's merge commit it need not be the base
+  // your branch will merge onto, so the check can fail to catch an unstamped edit (for
   // example when HEAD^1 already contains it, or when a stamp main landed in
   // between is credited to your branch). Merge the target in, then pass it
   // explicitly -- that is CI's comparison. Un-merged, the result mixes main's


### PR DESCRIPTION
## Summary

After PR #3133 merged, I ran a narrow review (pass 8) of `4abd5de7`, the one commit that had merged without review. It found two sentences in the `--stamped-since` hand-run guidance that measured shipped-CLI scenarios contradict, plus one comment the PR made stale. All three are prose. **No code, test, CI behaviour, or live-view change.**

- **F1 🟡.** "Outside CI's merge commit `HEAD^1` **is not** the base your branch will merge onto" is sometimes false. When a branch is one commit ahead of an unmoved main, or has fast-forwarded and then committed (rows b0, u6, b0x), `HEAD^1` is the same SHA as `main`. It now reads "need not be", and the header comment says "can run against the wrong tree".
  - Sites: `docs/testing/onbox-acceptance-register.md`, the `resolveStampedSinceBaseline` header comment, and the CLI block comment in `scripts/check-onbox-register.mjs`.
  - The "never pass `HEAD^1`" instruction itself is unchanged.
- **F2 🟡.** "Un-merged against the target … an unstamped edit is still refused" is false in one case (row r1). If main's counter drops below the branch's (main restores an older live view), the un-merged run returns OK. It now reads "…still refused unless main's counter is now lower than your branch's".
  - Site: a code comment only.
- **Stale comment (chore).** `onbox-register-check.yml` said "Fire on any scripts/* change", but the path filter is `scripts/**/*.mjs`.

Full measured rows are in pass 8 on #3133.

## Test plan

- The diff is comment/doc lines only. `node --check scripts/check-onbox-register.mjs` passes.
- These test files stay green, and none asserts the replaced wording:
  - `check-onbox-register-stamped-since.test.mjs` (31)
  - `onbox-register-check-workflow-wiring.test.mjs` (3)
  - `check-onbox-register-cli-no-flags.test.mjs`
- `npm run check:onbox-register`, `build-register-live-view.mjs --check` and `--stamped-since origin/main` all pass. The register edit is in unrendered prose, so the live view's content is unchanged and no re-stamp or republish is owed.
- No new automated test: the change is prose only, with no behaviour to regress. The claims were verified against 25 shipped-CLI scenario rows in pass 8.

Release notes skipped deliberately: this is docs/comments only, with no user- or operator-visible effect. No on-box acceptance applies.

Closes #3162

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Q4SxN46A8ktP28T7NwEKz
