### PR TITLE
fix(server): pass the engine to stage 2 in attribution eval runs

### DIFF
--- a/server/src/analyzer/attribution-eval/run-eval.test.ts
+++ b/server/src/analyzer/attribution-eval/run-eval.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { evalFixture, rosterToStage1, familyBreakdown, aggStage, aggregateFixture, rosterAliasMap, scoreStage, type StageScore, type ReviewScore, type FixtureResult } from './run-eval.js';
 import type { LabelledChapter } from './schema.js';
 import type { RosterSnapshot } from './roster-schema.js';
 import type { SentenceOutput } from '../../handoff/schemas.js';
+import * as analysisModule from '../../routes/analysis.js';
 
 const roster: RosterSnapshot = { characters: [
   { id: 'narrator', name: 'Narrator' },
@@ -171,6 +172,45 @@ describe('evalFixture', () => {
     expect('reviewed' in res).toBe(false);
     expect(res.final.recall).toBeCloseTo(1);
   });
+
+  describe('engine parameter mapping to attributeChapterStage2', () => {
+    let attributeChapterStage2Spy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      attributeChapterStage2Spy = vi.spyOn(analysisModule, 'attributeChapterStage2');
+    });
+
+    afterEach(() => {
+      attributeChapterStage2Spy.mockRestore();
+    });
+
+    it('passes qwen engine as "local" to attributeChapterStage2', async () => {
+      // Call with engine: 'qwen', which should be mapped to 'local' when passed to attributeChapterStage2
+      await evalFixture({
+        analyzer: fakeAnalyzer,
+        manuscriptId: 'm', title: 'T', truth, roster, chapterId: 44,
+        stageCall: { language: 'en' } as never,
+        engine: 'qwen',
+      });
+
+      // Verify that attributeChapterStage2 was called with engine: 'local'
+      expect(attributeChapterStage2Spy).toHaveBeenCalledWith(expect.objectContaining({ engine: 'local' }));
+    });
+
+    it('passes gemma engine as "gemini" to attributeChapterStage2', async () => {
+      // Call with engine: 'gemma', which should be mapped to 'gemini' when passed to attributeChapterStage2
+      await evalFixture({
+        analyzer: fakeAnalyzer,
+        manuscriptId: 'm', title: 'T', truth, roster, chapterId: 44,
+        stageCall: { language: 'en' } as never,
+        engine: 'gemma',
+      });
+
+      // Verify that attributeChapterStage2 was called with engine: 'gemini'
+      expect(attributeChapterStage2Spy).toHaveBeenCalledWith(expect.objectContaining({ engine: 'gemini' }));
+    });
+  });
+
 });
 
 describe('evalFixture — reviewed char-stage (opt-in)', () => {

--- a/server/src/analyzer/attribution-eval/run-eval.ts
+++ b/server/src/analyzer/attribution-eval/run-eval.ts
@@ -185,6 +185,10 @@ export async function evalFixture(opts: {
     reasons: Array<{ index: number; reason: string; bucket: string }>;
   } | null = null;
 
+  // Map eval engine ('qwen'/'gemma') to the budget engine ('local'/'gemini').
+  // Used by both stage2 (chunk sizing) and review (if enabled).
+  const chunkEngine = opts.engine === 'qwen' ? 'local' : 'gemini';
+
   const result = await attributeChapterStage2({
     analyzer: opts.analyzer,
     manuscriptId: opts.manuscriptId,
@@ -193,6 +197,7 @@ export async function evalFixture(opts: {
     chapter: { id: opts.chapterId, title: `Chapter ${opts.chapterId}`, body: opts.truth.chapterText },
     stageCall: opts.stageCall,
     escalationAnalyzer: opts.escalationAnalyzer ?? null,
+    engine: chunkEngine,
     onStages: (s) => { stages = s; },
   }); // no `as never` — the opts object is fully typed, so `s` gets its proper type
 
@@ -211,7 +216,6 @@ export async function evalFixture(opts: {
   if (!opts.review) return base;
 
   const finalSentences = result.sentences;
-  const chunkEngine = opts.engine === 'qwen' ? 'local' : 'gemini';
 
   // Roster carrying gender/aliases (no `role` — RosterSnapshot has no such field,
   // and production's stringified cast has no per-character role either; see


### PR DESCRIPTION
## Summary

`evalFixture` (`server/src/analyzer/attribution-eval/run-eval.ts`) called `attributeChapterStage2` without `engine`. `resolveStage2ChunkCharBudget(undefined, body)` takes its non-local branch, so a `qwen` (local Ollama) eval sized stage-2 chunks with the Gemini cloud budget — unlike a production local run and unlike the same function's review stage, which already mapped `qwen → local` / `gemma → gemini`.

The mapping is now derived once, before stage 2, and passed to both stage 2 and the review stage. An eval with no engine still resolves to `gemini`, which takes the same cloud branch the missing engine did, so that case is unchanged.

Found in passing while planning #3084 wave 2 (capacity pinning).

No release-notes entry: the attribution eval is a developer tool with no user- or operator-visible effect.

## Test plan

- [x] New `run-eval.test.ts` cases: `passes qwen engine as "local" to attributeChapterStage2` and `passes gemma engine as "gemini" to attributeChapterStage2` — red before the fix, green after.
- [x] Mutation proof: removing `engine: chunkEngine` from the stage-2 call turns both red again.
- [x] All 142 tests across the 17 `attribution-eval` test files pass.

Closes #3196
Refs #3084

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DFfsAoY1LtxjDgnGPSZkc
