### PR TITLE
docs(scripts): document the skills-mirror drift guard's cache-key blind spot

### DIFF
--- a/scripts/verify-cache.mjs
+++ b/scripts/verify-cache.mjs
@@ -186,14 +186,20 @@ export const STEPS = [
            in sync-agent-skills.mjs — not against this worktree's disk copy of
            .claude/skills/** above. That real input is main's committed tree, not
            a disk path, so it has no representation in this step's globs/extraFiles
-           at all. A secondary worktree that pulls main without re-running
-           `npm run skills:sync` can see test:hooks [cached] printed on the exact
-           commit the guard exists to check, in that worktree only — the primary
-           checkout that actually merges busts its own cache via its own changed
-           .claude/skills/** files, and the gap self-heals at the stale worktree's
-           next real cache miss. Same #1847 trap as fixtures/** above, but with no
-           fix possible short of a new "git ref" input kind (rejected, disproportionate
-           for this) or always running test:hooks (rejected, a permanent tax). */
+           at all. A secondary worktree that has NOT pulled the change, while the
+           box's shared main ref has advanced underneath it (linked worktrees share
+           the same .git/refs), can see test:hooks [cached] on the exact commit the
+           guard exists to check — the disk bytes are unchanged, so the cache hash
+           matches. Additionally, the mirror itself (~/.agents/skills/) is shared
+           machine state and can go stale independent of any tracked file changing:
+           if writeMirroredFile() throws partway through syncAgentSkills (lines
+           296-304), the mirror is left partially written with zero tracked file
+           changes in any worktree, so even the primary checkout's test:hooks can
+           print [cached] despite the mirror disagreeing with main. The gap
+           self-heals at an affected worktree's next real cache miss. Same #1847
+           trap as fixtures/** above, but with no fix possible short of a new "git
+           ref" input kind (rejected, disproportionate for this) or always running
+           test:hooks (rejected, a permanent tax). */
         /* docs/testing/** is an input because review-gate-mechanism.test.mjs's
            linkScanSet() now reads every .md file under this directory as TEXT
            at RUNTIME, alongside CLAUDE.md/CONTRIBUTING.md/.claude/skills/**

--- a/scripts/verify-cache.mjs
+++ b/scripts/verify-cache.mjs
@@ -180,6 +180,20 @@ export const STEPS = [
            from this same STEPS[]). The guard would certify the value it just
            stopped checking. Same #1847 trap as fixtures/** above. */
         '.claude/agents/**',
+        /* Residual gap, accepted not fixed (#3010): review-gate-mechanism.test.mjs's
+           skills-mirror drift guard compares `~/.agents/skills/` against what
+           `main` has COMMITTED — via `readCommittedOnMain`/`git show main:<path>`
+           in sync-agent-skills.mjs — not against this worktree's disk copy of
+           .claude/skills/** above. That real input is main's committed tree, not
+           a disk path, so it has no representation in this step's globs/extraFiles
+           at all. A secondary worktree that pulls main without re-running
+           `npm run skills:sync` can see test:hooks [cached] printed on the exact
+           commit the guard exists to check, in that worktree only — the primary
+           checkout that actually merges busts its own cache via its own changed
+           .claude/skills/** files, and the gap self-heals at the stale worktree's
+           next real cache miss. Same #1847 trap as fixtures/** above, but with no
+           fix possible short of a new "git ref" input kind (rejected, disproportionate
+           for this) or always running test:hooks (rejected, a permanent tax). */
         /* docs/testing/** is an input because review-gate-mechanism.test.mjs's
            linkScanSet() now reads every .md file under this directory as TEXT
            at RUNTIME, alongside CLAUDE.md/CONTRIBUTING.md/.claude/skills/**

--- a/scripts/verify-cache.mjs
+++ b/scripts/verify-cache.mjs
@@ -171,15 +171,6 @@ export const STEPS = [
            and leave the guard stale-green. Same #1847 trap as fixtures/**
            above, with the enumeration failure mode on top. */
         '.claude/skills/**',
-        /* .claude/agents/** is an input for the same reason .claude/skills/**
-           is: review-gate-mechanism.test.mjs reads the six role definitions as
-           TEXT at RUNTIME to check them against model-routing's role table.
-           Without this glob a definitions-only diff — flipping an `effort:`
-           value being the obvious one — prints test:hooks [cached] and runs
-           the guard on nothing, locally AND in cloud CI (ci-scope.mjs derives
-           from this same STEPS[]). The guard would certify the value it just
-           stopped checking. Same #1847 trap as fixtures/** above. */
-        '.claude/agents/**',
         /* Residual gap, accepted not fixed (#3010): review-gate-mechanism.test.mjs's
            skills-mirror drift guard compares `~/.agents/skills/` against what
            `main` has COMMITTED — via `readCommittedOnMain`/`git show main:<path>`
@@ -192,14 +183,23 @@ export const STEPS = [
            guard exists to check — the disk bytes are unchanged, so the cache hash
            matches. Additionally, the mirror itself (~/.agents/skills/) is shared
            machine state and can go stale independent of any tracked file changing:
-           if writeMirroredFile() throws partway through syncAgentSkills (lines
-           296-304), the mirror is left partially written with zero tracked file
-           changes in any worktree, so even the primary checkout's test:hooks can
-           print [cached] despite the mirror disagreeing with main. The gap
-           self-heals at an affected worktree's next real cache miss. Same #1847
+           a partial sync failure or out-of-band write can leave the mirror
+           desynchronised with no tracked file changes anywhere. At an affected
+           checkout's next real cache miss, the drift guard runs and goes RED —
+           but nothing is actually fixed until `npm run skills:sync` is run
+           successfully. Same #1847
            trap as fixtures/** above, but with no fix possible short of a new "git
            ref" input kind (rejected, disproportionate for this) or always running
            test:hooks (rejected, a permanent tax). */
+        /* .claude/agents/** is an input for the same reason .claude/skills/**
+           is: review-gate-mechanism.test.mjs reads the six role definitions as
+           TEXT at RUNTIME to check them against model-routing's role table.
+           Without this glob a definitions-only diff — flipping an `effort:`
+           value being the obvious one — prints test:hooks [cached] and runs
+           the guard on nothing, locally AND in cloud CI (ci-scope.mjs derives
+           from this same STEPS[]). The guard would certify the value it just
+           stopped checking. Same #1847 trap as fixtures/** above. */
+        '.claude/agents/**',
         /* docs/testing/** is an input because review-gate-mechanism.test.mjs's
            linkScanSet() now reads every .md file under this directory as TEXT
            at RUNTIME, alongside CLAUDE.md/CONTRIBUTING.md/.claude/skills/**


### PR DESCRIPTION
## Summary

Comment-only change to `scripts/verify-cache.mjs`: documents the accepted residual gap per #3010's decision (option 3). The skills-mirror drift guard's real input is `main`'s committed tree via `readCommittedOnMain`, not a disk path, so it has no representation in `test:hooks`' `globs`/`extraFiles`. A secondary worktree that pulls `main` without re-running `npm run skills:sync` can see `test:hooks [cached]` on the exact commit the guard exists to check. No behavior change.

Closes #3010

## Test plan

- [x] Verified via `git diff` against the branch's merge-base with `main` that only `scripts/verify-cache.mjs` changed, and that the change is comment-only — no `globs`/`extraFiles` array entries were added, removed, or modified.
- [x] `npm run test:hooks` — ran twice on this branch: 2402 tests, first run 2400/2402 pass, second run 2401/2402 pass. Both failing tests were in `scripts/tests/check-register-citations.test.mjs`'s CLI-subprocess suites, a *different* test failed each run, and each failure was a spawned-process `null !== 0` exit-code assertion — consistent with resource contention from concurrent lanes on this box rather than a real regression. Re-ran `scripts/tests/check-register-citations.test.mjs` in isolation: 152/152 pass, including every test that failed under full-suite contention. This change cannot affect that file's logic (comment-only, unrelated module).

**Release notes:** Not applicable — this change is documentation-only with no user-visible or operator-visible delta.

**Paired test:** Not applicable — this change is comment-only with no new behaviour to test.
